### PR TITLE
Add entry count, position indicator, and severity totals to status bar

### DIFF
--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -649,14 +649,14 @@ fn windows_known_log_sources() -> Vec<KnownSourceMetadata> {
 }
 
 fn build_known_log_sources() -> Vec<KnownSourceMetadata> {
-    let mut sources: Vec<KnownSourceMetadata> = Vec::new();
-
     #[cfg(target_os = "windows")]
     {
-        sources.extend(windows_known_log_sources());
+        windows_known_log_sources()
     }
-
-    sources
+    #[cfg(not(target_os = "windows"))]
+    {
+        Vec::new()
+    }
 }
 
 /// Return known platform log source metadata.

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   getActiveSourceLabel,
   getBaseName,
@@ -15,6 +16,41 @@ import {
   useUiStore,
 } from "../../stores/ui-store";
 import { useIntuneStore } from "../../stores/intune-store";
+import type { LogEntry } from "../../types/log";
+
+interface SeverityCounts {
+  errors: number;
+  warnings: number;
+  info: number;
+}
+
+function computeSeverityCounts(entries: LogEntry[]): SeverityCounts {
+  let errors = 0;
+  let warnings = 0;
+  let info = 0;
+  for (const entry of entries) {
+    switch (entry.severity) {
+      case "Error":
+        errors++;
+        break;
+      case "Warning":
+        warnings++;
+        break;
+      case "Info":
+        info++;
+        break;
+    }
+  }
+  return { errors, warnings, info };
+}
+
+function formatSeverityCounts(counts: SeverityCounts): string {
+  const parts: string[] = [];
+  if (counts.errors > 0) parts.push(`${counts.errors} error${counts.errors === 1 ? "" : "s"}`);
+  if (counts.warnings > 0) parts.push(`${counts.warnings} warning${counts.warnings === 1 ? "" : "s"}`);
+  parts.push(`${counts.info} info`);
+  return parts.join(", ");
+}
 
 export function StatusBar() {
   const entries = useLogStore((s) => s.entries);
@@ -42,6 +78,19 @@ export function StatusBar() {
   const filteredIds = useFilterStore((s) => s.filteredIds);
   const isFiltering = useFilterStore((s) => s.isFiltering);
   const filterError = useFilterStore((s) => s.filterError);
+
+  const severityCounts = useMemo(() => computeSeverityCounts(entries), [entries]);
+
+  const displayEntries = useMemo(() => {
+    if (!filteredIds) return entries;
+    return entries.filter((entry) => filteredIds.has(entry.id));
+  }, [entries, filteredIds]);
+
+  const selectedPosition = useMemo(() => {
+    if (selectedId === null || displayEntries.length === 0) return null;
+    const index = displayEntries.findIndex((e) => e.id === selectedId);
+    return index === -1 ? null : index + 1;
+  }, [displayEntries, selectedId]);
 
   let elapsedText = "";
   if (activeView === "log" && selectedId !== null && entries.length > 0) {
@@ -97,11 +146,20 @@ export function StatusBar() {
       leftParts.push(elapsedText);
     }
 
+    const positionText =
+      selectedPosition !== null
+        ? `Entry ${selectedPosition} of ${displayEntries.length}`
+        : null;
+
+    const severityText =
+      entries.length > 0 ? formatSeverityCounts(severityCounts) : null;
+
     const logStatusText =
       entries.length > 0
         ? [
-          `${entries.length} entries`,
+          positionText ?? `${displayEntries.length} entries`,
           `${totalLines} lines`,
+          severityText,
           `${formatDetected ?? "Unknown"} format`,
           parserDisplay?.provenanceLabel,
           parserDisplay?.qualityLabel,

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -16,7 +16,6 @@ import {
   useUiStore,
 } from "../../stores/ui-store";
 import { useIntuneStore } from "../../stores/intune-store";
-import type { LogEntry } from "../../types/log";
 
 interface SeverityCounts {
   errors: number;
@@ -24,31 +23,11 @@ interface SeverityCounts {
   info: number;
 }
 
-function computeSeverityCounts(entries: LogEntry[]): SeverityCounts {
-  let errors = 0;
-  let warnings = 0;
-  let info = 0;
-  for (const entry of entries) {
-    switch (entry.severity) {
-      case "Error":
-        errors++;
-        break;
-      case "Warning":
-        warnings++;
-        break;
-      case "Info":
-        info++;
-        break;
-    }
-  }
-  return { errors, warnings, info };
-}
-
 function formatSeverityCounts(counts: SeverityCounts): string {
   const parts: string[] = [];
   if (counts.errors > 0) parts.push(`${counts.errors} error${counts.errors === 1 ? "" : "s"}`);
   if (counts.warnings > 0) parts.push(`${counts.warnings} warning${counts.warnings === 1 ? "" : "s"}`);
-  parts.push(`${counts.info} info`);
+  if (counts.info > 0) parts.push(`${counts.info} info`);
   return parts.join(", ");
 }
 
@@ -79,18 +58,32 @@ export function StatusBar() {
   const isFiltering = useFilterStore((s) => s.isFiltering);
   const filterError = useFilterStore((s) => s.filterError);
 
-  const severityCounts = useMemo(() => computeSeverityCounts(entries), [entries]);
+  const { filteredCount, severityCounts, selectedPosition } = useMemo(() => {
+    let errors = 0;
+    let warnings = 0;
+    let info = 0;
+    let counter = 0;
+    let position: number | null = null;
 
-  const displayEntries = useMemo(() => {
-    if (!filteredIds) return entries;
-    return entries.filter((entry) => filteredIds.has(entry.id));
-  }, [entries, filteredIds]);
+    for (const entry of entries) {
+      if (filteredIds && !filteredIds.has(entry.id)) continue;
+      counter++;
+      switch (entry.severity) {
+        case "Error": errors++; break;
+        case "Warning": warnings++; break;
+        case "Info": info++; break;
+      }
+      if (selectedId !== null && entry.id === selectedId) {
+        position = counter;
+      }
+    }
 
-  const selectedPosition = useMemo(() => {
-    if (selectedId === null || displayEntries.length === 0) return null;
-    const index = displayEntries.findIndex((e) => e.id === selectedId);
-    return index === -1 ? null : index + 1;
-  }, [displayEntries, selectedId]);
+    return {
+      filteredCount: counter,
+      severityCounts: { errors, warnings, info },
+      selectedPosition: selectedId !== null ? position : null,
+    };
+  }, [entries, filteredIds, selectedId]);
 
   let elapsedText = "";
   if (activeView === "log" && selectedId !== null && entries.length > 0) {
@@ -148,16 +141,16 @@ export function StatusBar() {
 
     const positionText =
       selectedPosition !== null
-        ? `Entry ${selectedPosition} of ${displayEntries.length}`
+        ? `Entry ${selectedPosition} of ${filteredCount}`
         : null;
 
     const severityText =
-      entries.length > 0 ? formatSeverityCounts(severityCounts) : null;
+      filteredCount > 0 ? formatSeverityCounts(severityCounts) : null;
 
     const logStatusText =
       entries.length > 0
         ? [
-          positionText ?? `${displayEntries.length} entries`,
+          positionText ?? `${filteredCount} entries`,
           `${totalLines} lines`,
           severityText,
           `${formatDetected ?? "Unknown"} format`,

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -58,31 +58,50 @@ export function StatusBar() {
   const isFiltering = useFilterStore((s) => s.isFiltering);
   const filterError = useFilterStore((s) => s.filterError);
 
-  const { filteredCount, severityCounts, selectedPosition } = useMemo(() => {
+  const { filteredCount, severityCounts } = useMemo(() => {
     let errors = 0;
     let warnings = 0;
     let info = 0;
     let counter = 0;
-    let position: number | null = null;
 
     for (const entry of entries) {
       if (filteredIds && !filteredIds.has(entry.id)) continue;
       counter++;
       switch (entry.severity) {
-        case "Error": errors++; break;
-        case "Warning": warnings++; break;
-        case "Info": info++; break;
-      }
-      if (selectedId !== null && entry.id === selectedId) {
-        position = counter;
+        case "Error":
+          errors++;
+          break;
+        case "Warning":
+          warnings++;
+          break;
+        case "Info":
+          info++;
+          break;
       }
     }
 
     return {
       filteredCount: counter,
       severityCounts: { errors, warnings, info },
-      selectedPosition: selectedId !== null ? position : null,
     };
+  }, [entries, filteredIds]);
+
+  const selectedPosition = useMemo(() => {
+    if (selectedId === null) {
+      return null;
+    }
+
+    let counter = 0;
+
+    for (const entry of entries) {
+      if (filteredIds && !filteredIds.has(entry.id)) continue;
+      counter++;
+      if (entry.id === selectedId) {
+        return counter;
+      }
+    }
+
+    return null;
   }, [entries, filteredIds, selectedId]);
 
   let elapsedText = "";


### PR DESCRIPTION
Implements feature 4.3 from the roadmap. The status bar now shows:
- Current selected entry position (e.g. "Entry 5 of 42") when a row is selected
- Severity breakdown (errors, warnings, info counts) alongside existing metrics
- Filtered entry count that respects active filters

https://claude.ai/code/session_01Pvrn9dATx98JpdRAXDsTjf