### PR TITLE
Add no-AI-attribution policy & checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+# Summary
+
+Describe what this PR changes.
+
+## Validation
+
+Describe how you verified your change.
+
+## Contributor Attestation
+
+- [ ] I confirm this PR title/body and all commits in this PR do not include explicit AI attribution markers prohibited by this repository policy.

--- a/.github/no-ai-attribution-patterns.txt
+++ b/.github/no-ai-attribution-patterns.txt
@@ -1,0 +1,6 @@
+# Case-insensitive extended regular expressions.
+# Keep this file as the single source of truth for blocked explicit AI attribution markers.
+co-authored-by:.*(copilot|chatgpt|claude|gemini|cursor|codeium|openai|anthropic)
+generated-by:.*(copilot|chatgpt|claude|gemini|cursor|codeium|openai|anthropic)
+authored-by:.*(copilot|chatgpt|claude|gemini|cursor|codeium|openai|anthropic)
+(written|generated|created)\s+(with|by)\s+.*(copilot|chatgpt|claude|gemini|cursor|codeium|openai|anthropic)

--- a/.github/scripts/check-no-ai-attribution.sh
+++ b/.github/scripts/check-no-ai-attribution.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATTERN_FILE=".github/no-ai-attribution-patterns.txt"
+
+if [[ ! -f "$PATTERN_FILE" ]]; then
+  echo "Pattern file not found: $PATTERN_FILE"
+  exit 1
+fi
+
+mapfile -t PATTERNS < <(grep -vE '^\s*#|^\s*$' "$PATTERN_FILE")
+
+if [[ ${#PATTERNS[@]} -eq 0 ]]; then
+  echo "No active patterns found in $PATTERN_FILE"
+  exit 1
+fi
+
+VIOLATIONS=0
+
+check_text_block() {
+  local source="$1"
+  local text="$2"
+
+  local idx=0
+  while IFS= read -r line; do
+    idx=$((idx + 1))
+    for pattern in "${PATTERNS[@]}"; do
+      if echo "$line" | grep -Eiq "$pattern"; then
+        echo "::error title=No AI Attribution Policy::$source line $idx matches blocked pattern '$pattern': $line"
+        VIOLATIONS=1
+      fi
+    done
+  done <<< "$text"
+}
+
+event_name="${GITHUB_EVENT_NAME:-}"
+event_path="${GITHUB_EVENT_PATH:-}"
+
+if [[ -z "$event_name" || -z "$event_path" ]]; then
+  echo "Missing GitHub event context."
+  exit 1
+fi
+
+range=""
+
+if [[ "$event_name" == "pull_request" ]]; then
+  base_ref="$(jq -r '.pull_request.base.ref' "$event_path")"
+  git fetch --no-tags --depth=1 origin "$base_ref"
+  range="origin/$base_ref..HEAD"
+
+  pr_title="$(jq -r '.pull_request.title // ""' "$event_path")"
+  pr_body="$(jq -r '.pull_request.body // ""' "$event_path")"
+
+  check_text_block "PR title" "$pr_title"
+  check_text_block "PR body" "$pr_body"
+else
+  before_sha="$(jq -r '.before // ""' "$event_path")"
+  after_sha="$(jq -r '.after // ""' "$event_path")"
+
+  if [[ -z "$after_sha" ]]; then
+    echo "Unable to determine push range from event payload."
+    exit 1
+  fi
+
+  if [[ -z "$before_sha" || "$before_sha" == "0000000000000000000000000000000000000000" ]]; then
+    range="$after_sha"
+  else
+    range="$before_sha..$after_sha"
+  fi
+fi
+
+commit_messages="$(git log --format='%H%n%s%n%b%n---' $range || true)"
+check_text_block "Commit messages ($range)" "$commit_messages"
+
+if [[ "$VIOLATIONS" -ne 0 ]]; then
+  echo "Policy check failed: explicit AI attribution markers were found."
+  exit 1
+fi
+
+echo "Policy check passed: no blocked AI attribution markers found."

--- a/.github/workflows/no-ai-attribution.yml
+++ b/.github/workflows/no-ai-attribution.yml
@@ -1,0 +1,23 @@
+name: No AI Attribution Policy
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+jobs:
+  enforce-policy:
+    name: Enforce No AI Attribution Markers
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate explicit AI attribution markers
+        shell: bash
+        run: bash .github/scripts/check-no-ai-attribution.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thanks for helping improve CMTrace Open.
+
+## No AI Attribution Contributors Policy
+
+This repository does not accept contributions that include explicit AI attribution markers.
+
+Blocked examples include, but are not limited to:
+
+- `Co-authored-by: ... Copilot`
+- `Co-authored-by: ... ChatGPT`
+- `Generated-by: Claude`
+- `Authored-by: Gemini`
+- `Written with Cursor AI`
+
+The enforcement scope is explicit attribution markers in:
+
+- Commit messages
+- Pull request titles
+- Pull request descriptions
+
+A GitHub Actions check enforces this policy and must pass before merge.
+
+## Pull Requests
+
+- Keep changes focused and well-described.
+- Include tests when behavior changes.
+- Confirm your PR does not include blocked attribution markers.
+
+## Code of Conduct
+
+Please be respectful and constructive in all discussions and reviews.


### PR DESCRIPTION
Introduce repository enforcement to block explicit AI attribution markers. Adds:

- .github/no-ai-attribution-patterns.txt: regex list of blocked attribution phrases (co-authored-by, generated-by, authored-by, etc.).
- .github/scripts/check-no-ai-attribution.sh: CI script that scans PR title/body and commit messages for blocked patterns and fails the run on violations.
- .github/workflows/no-ai-attribution.yml: GitHub Actions workflow to run the check on pull_request events and pushes to main.
- .github/PULL_REQUEST_TEMPLATE.md: PR template prompting validation and contributor attestation against the policy.
- README.md: note about the contributing policy and link to CONTRIBUTING.md.

This ensures commits and PRs do not include explicit AI attribution markers as defined by the patterns file.