### PR TITLE
feat: add business category grouping to Intune dashboard

### DIFF
--- a/src-tauri/src/intune/models.rs
+++ b/src-tauri/src/intune/models.rs
@@ -103,6 +103,32 @@ pub enum IntuneEventType {
     Other,
 }
 
+/// High-level business category grouping Intune event types into admin-facing domains.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum IntuneBusinessCategory {
+    Devices,
+    Apps,
+    Configurations,
+    Compliance,
+    Sync,
+    Other,
+}
+
+impl IntuneBusinessCategory {
+    pub fn from_event_type(event_type: &IntuneEventType) -> Self {
+        match event_type {
+            IntuneEventType::Esp => Self::Devices,
+            IntuneEventType::Win32App
+            | IntuneEventType::WinGetApp
+            | IntuneEventType::ContentDownload => Self::Apps,
+            IntuneEventType::PolicyEvaluation => Self::Configurations,
+            IntuneEventType::Remediation | IntuneEventType::PowerShellScript => Self::Compliance,
+            IntuneEventType::SyncSession => Self::Sync,
+            IntuneEventType::Other => Self::Other,
+        }
+    }
+}
+
 /// Status of an Intune operation.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum IntuneStatus {

--- a/src/components/intune/CategoryCards.tsx
+++ b/src/components/intune/CategoryCards.tsx
@@ -1,0 +1,229 @@
+import { useMemo } from "react";
+import { tokens } from "@fluentui/react-components";
+import { useIntuneStore } from "../../stores/intune-store";
+import type { IntuneBusinessCategory, IntuneEvent } from "../../types/intune";
+import { BUSINESS_CATEGORIES, getBusinessCategory } from "../../types/intune";
+
+interface CategoryStat {
+  category: IntuneBusinessCategory;
+  total: number;
+  failed: number;
+  succeeded: number;
+}
+
+const CATEGORY_DISPLAY: Record<
+  IntuneBusinessCategory,
+  { label: string; color: string; icon: string }
+> = {
+  Devices: { label: "Devices", color: "#0ea5e9", icon: "\u{1F5A5}" },
+  Apps: { label: "Applications", color: "#8b5cf6", icon: "\u{1F4E6}" },
+  Configurations: { label: "Configurations", color: "#f97316", icon: "\u2699\uFE0F" },
+  Compliance: { label: "Compliance", color: "#22c55e", icon: "\u2705" },
+  Sync: { label: "Sync Status", color: "#06b6d4", icon: "\u{1F504}" },
+  Other: { label: "Other", color: "#6b7280", icon: "\u2026" },
+};
+
+function computeCategoryStats(events: IntuneEvent[]): CategoryStat[] {
+  const counts = new Map<IntuneBusinessCategory, { total: number; failed: number; succeeded: number }>();
+
+  for (const category of BUSINESS_CATEGORIES) {
+    counts.set(category, { total: 0, failed: 0, succeeded: 0 });
+  }
+
+  for (const event of events) {
+    const category = getBusinessCategory(event.eventType);
+    const stat = counts.get(category)!;
+    stat.total += 1;
+    if (event.status === "Failed" || event.status === "Timeout") {
+      stat.failed += 1;
+    } else if (event.status === "Success") {
+      stat.succeeded += 1;
+    }
+  }
+
+  return BUSINESS_CATEGORIES.map((category) => ({
+    category,
+    ...counts.get(category)!,
+  }));
+}
+
+export function CategoryCards({ events }: { events: IntuneEvent[] }) {
+  const drillIntoCategory = useIntuneStore((s) => s.drillIntoCategory);
+  const stats = useMemo(() => computeCategoryStats(events), [events]);
+  const nonEmptyStats = stats.filter((s) => s.total > 0);
+  const emptyStats = stats.filter((s) => s.total === 0);
+
+  if (events.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "20px",
+          color: tokens.colorNeutralForeground3,
+          textAlign: "center",
+          fontSize: "13px",
+        }}
+      >
+        No Intune events available to categorize.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "16px", overflow: "auto", height: "100%" }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+          gap: "12px",
+          maxWidth: "900px",
+        }}
+      >
+        {nonEmptyStats.map((stat) => {
+          const display = CATEGORY_DISPLAY[stat.category];
+          const successRate =
+            stat.total > 0
+              ? Math.round((stat.succeeded / stat.total) * 100)
+              : 0;
+
+          return (
+            <button
+              key={stat.category}
+              onClick={() => drillIntoCategory(stat.category)}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "8px",
+                padding: "14px 16px",
+                border: `1px solid ${tokens.colorNeutralStroke2}`,
+                borderRadius: "8px",
+                backgroundColor: tokens.colorNeutralBackground1,
+                cursor: "pointer",
+                textAlign: "left",
+                transition: "border-color 0.15s, box-shadow 0.15s",
+                borderLeft: `4px solid ${display.color}`,
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.borderColor = display.color;
+                e.currentTarget.style.boxShadow = `0 2px 8px ${display.color}22`;
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.borderColor = tokens.colorNeutralStroke2;
+                e.currentTarget.style.borderLeftColor = display.color;
+                e.currentTarget.style.boxShadow = "none";
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                }}
+              >
+                <span style={{ fontSize: "18px" }}>{display.icon}</span>
+                <span
+                  style={{
+                    fontSize: "14px",
+                    fontWeight: 600,
+                    color: tokens.colorNeutralForeground1,
+                  }}
+                >
+                  {display.label}
+                </span>
+              </div>
+
+              <div
+                style={{
+                  display: "flex",
+                  gap: "12px",
+                  alignItems: "baseline",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: "24px",
+                    fontWeight: 700,
+                    color: tokens.colorNeutralForeground1,
+                    lineHeight: 1,
+                  }}
+                >
+                  {stat.total}
+                </span>
+                <span
+                  style={{
+                    fontSize: "11px",
+                    color: tokens.colorNeutralForeground3,
+                  }}
+                >
+                  event{stat.total !== 1 ? "s" : ""}
+                </span>
+              </div>
+
+              <div
+                style={{
+                  display: "flex",
+                  gap: "10px",
+                  fontSize: "11px",
+                  fontWeight: 500,
+                }}
+              >
+                {stat.failed > 0 && (
+                  <span style={{ color: "#ef4444" }}>
+                    {stat.failed} failed
+                  </span>
+                )}
+                {stat.succeeded > 0 && (
+                  <span style={{ color: "#22c55e" }}>
+                    {stat.succeeded} success
+                  </span>
+                )}
+                <span style={{ color: tokens.colorNeutralForeground3 }}>
+                  {successRate}% success rate
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {emptyStats.length > 0 && (
+        <div
+          style={{
+            marginTop: "16px",
+            display: "flex",
+            gap: "8px",
+            flexWrap: "wrap",
+            alignItems: "center",
+          }}
+        >
+          <span
+            style={{
+              fontSize: "11px",
+              color: tokens.colorNeutralForeground3,
+              fontWeight: 600,
+              textTransform: "uppercase",
+            }}
+          >
+            No activity:
+          </span>
+          {emptyStats.map((stat) => {
+            const display = CATEGORY_DISPLAY[stat.category];
+            return (
+              <span
+                key={stat.category}
+                style={{
+                  fontSize: "11px",
+                  color: tokens.colorNeutralForeground3,
+                  backgroundColor: tokens.colorNeutralBackground3,
+                  padding: "2px 8px",
+                  borderRadius: "999px",
+                }}
+              >
+                {display.icon} {display.label}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/intune/EventTimeline.tsx
+++ b/src/components/intune/EventTimeline.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../lib/log-accessibility";
 import { useUiStore } from "../../stores/ui-store";
 import type { IntuneEvent, IntuneStatus, IntuneEventType } from "../../types/intune";
+import { getBusinessCategory } from "../../types/intune";
 import { useIntuneStore } from "../../stores/intune-store";
 
 const STATUS_COLORS: Record<IntuneStatus, string> = {
@@ -43,6 +44,7 @@ export function EventTimeline({ events }: EventTimelineProps) {
   const sourceFiles = useIntuneStore((s) => s.sourceFiles);
   const filterEventType = useIntuneStore((s) => s.filterEventType);
   const filterStatus = useIntuneStore((s) => s.filterStatus);
+  const filterBusinessCategory = useIntuneStore((s) => s.filterBusinessCategory);
   const showSourceFileLabel = sourceFiles.length > 1 && timelineScope.filePath == null;
 
   const logListFontSize = useUiStore((s) => s.logListFontSize);
@@ -59,6 +61,9 @@ export function EventTimeline({ events }: EventTimelineProps) {
       if (timelineScope.filePath != null && e.sourceFile !== timelineScope.filePath) {
         return false;
       }
+      if (filterBusinessCategory !== "All" && getBusinessCategory(e.eventType) !== filterBusinessCategory) {
+        return false;
+      }
       if (filterEventType !== "All" && e.eventType !== filterEventType) {
         return false;
       }
@@ -67,7 +72,7 @@ export function EventTimeline({ events }: EventTimelineProps) {
       }
       return true;
     });
-  }, [events, filterEventType, filterStatus, timelineScope.filePath]);
+  }, [events, filterEventType, filterStatus, filterBusinessCategory, timelineScope.filePath]);
 
   useEffect(() => {
     if (selectedEventId == null) {

--- a/src/components/intune/IntuneDashboard.tsx
+++ b/src/components/intune/IntuneDashboard.tsx
@@ -4,6 +4,7 @@ import { useIntuneStore } from "../../stores/intune-store";
 import { useAppActions } from "../layout/Toolbar";
 import { EventTimeline } from "./EventTimeline";
 import { DownloadStats } from "./DownloadStats";
+import { CategoryCards } from "./CategoryCards";
 import type {
   DownloadStat,
   IntuneDiagnosticCategory,
@@ -23,13 +24,15 @@ import type {
   IntuneTimeWindowPreset,
   IntuneTimestampBounds,
 } from "../../types/intune";
+import { getBusinessCategory } from "../../types/intune";
 
-type TabId = "timeline" | "downloads" | "summary";
+type TabId = "timeline" | "downloads" | "summary" | "categories";
 
 const TAB_LABELS: Record<TabId, string> = {
   timeline: "Timeline",
   downloads: "Downloads",
   summary: "Summary",
+  categories: "Categories",
 };
 
 export function IntuneDashboard() {
@@ -50,8 +53,10 @@ export function IntuneDashboard() {
   const setTimeWindow = useIntuneStore((s) => s.setTimeWindow);
   const filterEventType = useIntuneStore((s) => s.filterEventType);
   const filterStatus = useIntuneStore((s) => s.filterStatus);
+  const filterBusinessCategory = useIntuneStore((s) => s.filterBusinessCategory);
   const setFilterEventType = useIntuneStore((s) => s.setFilterEventType);
   const setFilterStatus = useIntuneStore((s) => s.setFilterStatus);
+  const setFilterBusinessCategory = useIntuneStore((s) => s.setFilterBusinessCategory);
   const { commandState, openSourceFileDialog, openSourceFolderDialog } = useAppActions();
 
   const timeWindowAnchor = useMemo(
@@ -78,12 +83,16 @@ export function IntuneDashboard() {
       timeline: filteredEventsByTime.length > 0,
       downloads: filteredDownloadsByTime.length > 0,
       summary: summary != null,
+      categories: filteredEventsByTime.length > 0,
     }),
     [filteredDownloadsByTime.length, filteredEventsByTime.length, summary]
   );
 
   const filteredEventCount = useMemo(() => {
     return filteredEventsByTime.filter((event) => {
+      if (filterBusinessCategory !== "All" && getBusinessCategory(event.eventType) !== filterBusinessCategory) {
+        return false;
+      }
       if (filterEventType !== "All" && event.eventType !== filterEventType) {
         return false;
       }
@@ -92,9 +101,9 @@ export function IntuneDashboard() {
       }
       return true;
     }).length;
-  }, [filteredEventsByTime, filterEventType, filterStatus]);
+  }, [filteredEventsByTime, filterEventType, filterStatus, filterBusinessCategory]);
 
-  const hasActiveFilters = filterEventType !== "All" || filterStatus !== "All";
+  const hasActiveFilters = filterEventType !== "All" || filterStatus !== "All" || filterBusinessCategory !== "All";
 
   useEffect(() => {
     if (!availableTabs[activeTab]) {
@@ -260,7 +269,7 @@ export function IntuneDashboard() {
               label={TAB_LABELS[tabId]}
               active={activeTab === tabId}
               disabled={isAnalyzing || !availableTabs[tabId]}
-              count={tabId === "timeline" ? filteredEventsByTime.length : tabId === "downloads" ? filteredDownloadsByTime.length : summary ? 1 : 0}
+              count={tabId === "timeline" ? filteredEventsByTime.length : tabId === "downloads" ? filteredDownloadsByTime.length : tabId === "categories" ? filteredEventsByTime.length : summary ? 1 : 0}
               onClick={() => setActiveTab(tabId)}
             />
           ))}
@@ -367,6 +376,7 @@ export function IntuneDashboard() {
               onClick={() => {
                 setFilterEventType("All");
                 setFilterStatus("All");
+                setFilterBusinessCategory("All");
               }}
               disabled={!hasActiveFilters || isAnalyzing}
               style={{
@@ -385,6 +395,39 @@ export function IntuneDashboard() {
             <span style={{ fontSize: "11px", color: "#64748b", fontWeight: 500, marginLeft: "4px" }}>
               {filteredEventCount}/{filteredEventsByTime.length}
             </span>
+            {filterBusinessCategory !== "All" && (
+              <>
+                <div style={{ width: "1px", height: "16px", backgroundColor: "#cbd5e1", margin: "0 2px" }} />
+                <span
+                  style={{
+                    fontSize: "11px",
+                    color: "#1d4ed8",
+                    backgroundColor: "#eff6ff",
+                    border: "1px solid #93c5fd",
+                    borderRadius: "999px",
+                    padding: "3px 8px",
+                    fontWeight: 600,
+                  }}
+                >
+                  Category: {filterBusinessCategory}
+                </span>
+                <button
+                  onClick={() => setFilterBusinessCategory("All")}
+                  disabled={isAnalyzing}
+                  style={{
+                    fontSize: "10px",
+                    padding: "2px 6px",
+                    border: "1px solid #d1d5db",
+                    borderRadius: "3px",
+                    backgroundColor: "#fff",
+                    color: "#1e293b",
+                    cursor: isAnalyzing ? "not-allowed" : "pointer",
+                  }}
+                >
+                  Clear
+                </button>
+              </>
+            )}
             {timelineScope.filePath && (
               <>
                 <div style={{ width: "1px", height: "16px", backgroundColor: "#cbd5e1", margin: "0 2px" }} />
@@ -505,6 +548,7 @@ export function IntuneDashboard() {
           <>
             {activeTab === "timeline" && <EventTimeline events={filteredEventsByTime} />}
             {activeTab === "downloads" && <DownloadStats downloads={filteredDownloadsByTime} />}
+            {activeTab === "categories" && <CategoryCards events={filteredEventsByTime} />}
             {activeTab === "summary" && summary && (
               <SummaryView
                 summary={filteredSummary}

--- a/src/stores/intune-store.ts
+++ b/src/stores/intune-store.ts
@@ -12,6 +12,7 @@ import type {
   IntuneAnalysisProgressEvent,
   IntuneAnalysisSourceKind,
   IntuneAnalysisState,
+  IntuneBusinessCategory,
   IntuneDiagnosticInsight,
   IntuneDiagnosticsConfidence,
   IntuneDiagnosticsCoverage,
@@ -29,7 +30,7 @@ import type {
   IntuneTimestampBounds,
 } from "../types/intune";
 
-export type IntuneWorkspaceTab = "timeline" | "downloads" | "summary";
+export type IntuneWorkspaceTab = "timeline" | "downloads" | "summary" | "categories";
 
 function buildSourceContext(
   sourceFile: string | null,
@@ -177,6 +178,7 @@ interface IntuneState {
   timeWindow: IntuneTimeWindowPreset;
   filterEventType: IntuneEventType | "All";
   filterStatus: IntuneStatus | "All";
+  filterBusinessCategory: IntuneBusinessCategory | "All";
   eventLogFilterChannel: EventLogChannel | "All";
   eventLogFilterSeverity: EventLogSeverity | "All";
   activeTab: IntuneWorkspaceTab;
@@ -204,6 +206,8 @@ interface IntuneState {
   setTimeWindow: (preset: IntuneTimeWindowPreset) => void;
   setFilterEventType: (type_: IntuneEventType | "All") => void;
   setFilterStatus: (status: IntuneStatus | "All") => void;
+  setFilterBusinessCategory: (category: IntuneBusinessCategory | "All") => void;
+  drillIntoCategory: (category: IntuneBusinessCategory) => void;
   setEventLogFilterChannel: (channel: EventLogChannel | "All") => void;
   setEventLogFilterSeverity: (severity: EventLogSeverity | "All") => void;
   selectEventLogEntry: (id: number | null) => void;
@@ -217,6 +221,7 @@ const defaultInteractionState = {
   timeWindow: "all" as const,
   filterEventType: "All" as const,
   filterStatus: "All" as const,
+  filterBusinessCategory: "All" as IntuneBusinessCategory | "All",
   eventLogFilterChannel: "All" as EventLogChannel | "All",
   eventLogFilterSeverity: "All" as EventLogSeverity | "All",
   activeTab: "timeline" as const,
@@ -426,6 +431,9 @@ export const useIntuneStore = create<IntuneState>((set) => ({
   setTimeWindow: (preset) => set({ timeWindow: preset }),
   setFilterEventType: (type_) => set({ filterEventType: type_ }),
   setFilterStatus: (status) => set({ filterStatus: status }),
+  setFilterBusinessCategory: (category) => set({ filterBusinessCategory: category }),
+  drillIntoCategory: (category) =>
+    set({ filterBusinessCategory: category, activeTab: "timeline" }),
   setEventLogFilterChannel: (channel) => set({ eventLogFilterChannel: channel }),
   setEventLogFilterSeverity: (severity) => set({ eventLogFilterSeverity: severity }),
   selectEventLogEntry: (id) => set({ selectedEventLogEntryId: id }),

--- a/src/types/intune.ts
+++ b/src/types/intune.ts
@@ -20,6 +20,39 @@ export type IntuneStatus =
   | "Timeout"
   | "Unknown";
 
+export type IntuneBusinessCategory =
+  | "Devices"
+  | "Apps"
+  | "Configurations"
+  | "Compliance"
+  | "Sync"
+  | "Other";
+
+export const BUSINESS_CATEGORY_MAP: Record<IntuneEventType, IntuneBusinessCategory> = {
+  Esp: "Devices",
+  Win32App: "Apps",
+  WinGetApp: "Apps",
+  ContentDownload: "Apps",
+  PolicyEvaluation: "Configurations",
+  Remediation: "Compliance",
+  PowerShellScript: "Compliance",
+  SyncSession: "Sync",
+  Other: "Other",
+};
+
+export const BUSINESS_CATEGORIES: IntuneBusinessCategory[] = [
+  "Devices",
+  "Apps",
+  "Configurations",
+  "Compliance",
+  "Sync",
+  "Other",
+];
+
+export function getBusinessCategory(eventType: IntuneEventType): IntuneBusinessCategory {
+  return BUSINESS_CATEGORY_MAP[eventType];
+}
+
 export interface IntuneEvent {
   id: number;
   eventType: IntuneEventType;


### PR DESCRIPTION
## Summary
- Ports the categorization UX concept from Intune-Log-Reader-for-Windows into CMTrace Open
- Adds a new **Categories** tab to the Intune diagnostics workspace with summary cards for Devices, Apps, Configurations, Compliance, Sync, and Other
- Each card shows event count, failure count, and success rate
- Clicking a card drills into the Timeline tab with a category filter applied
- Category filter chip with clear button shown in the Timeline toolbar

## Category mapping
| Category | Event Types |
|----------|------------|
| Devices | ESP |
| Apps | Win32App, WinGetApp, ContentDownload |
| Configurations | PolicyEvaluation |
| Compliance | Remediation, PowerShellScript |
| Sync | SyncSession |
| Other | Other |

## Files changed
- `src-tauri/src/intune/models.rs` — Rust-side `IntuneBusinessCategory` enum
- `src/types/intune.ts` — TypeScript types + mapping
- `src/stores/intune-store.ts` — Category filter state + drill-down action
- `src/components/intune/CategoryCards.tsx` — New category cards component
- `src/components/intune/IntuneDashboard.tsx` — Categories tab + filter chip
- `src/components/intune/EventTimeline.tsx` — Respects category filter

## Test plan
- [ ] Build TypeScript (`npx tsc --noEmit`) — passes
- [ ] Build Rust (`cargo check`) — passes
- [ ] Load Intune logs and verify Categories tab appears with correct counts
- [ ] Click a category card and verify Timeline filters to that category
- [ ] Verify category filter chip appears with clear button
- [ ] Verify Reset button clears category filter alongside type/status filters
- [ ] Verify existing Timeline filters work alongside category filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)