### PR TITLE
fix: don't auto-scroll when clicking a visible log row

### DIFF
--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -66,6 +66,8 @@ export function LogListView() {
 
   const parentRef = useRef<HTMLDivElement>(null);
   const isAtBottomRef = useRef(true);
+  /** When true, the next selectedEntryIndex change should NOT auto-scroll (user clicked a visible row). */
+  const suppressScrollRef = useRef(false);
 
   // Apply user column order, then filter by showDetails
   const orderedColumns = useMemo(
@@ -137,6 +139,10 @@ export function LogListView() {
 
   useEffect(() => {
     if (selectedEntryIndex < 0) return;
+    if (suppressScrollRef.current) {
+      suppressScrollRef.current = false;
+      return;
+    }
     virtualizer.scrollToIndex(selectedEntryIndex, { align: "center" });
   }, [selectedEntryIndex, virtualizer]);
 
@@ -367,7 +373,7 @@ export function LogListView() {
                   severityPalette={severityPalette}
                   highlightText={highlightText}
                   highlightCaseSensitive={highlightCaseSensitive}
-                  onClick={selectEntry}
+                  onClick={(id) => { suppressScrollRef.current = true; selectEntry(id); }}
                   onErrorCodeClick={handleErrorCodeClick}
                 />
               </div>

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -373,7 +373,7 @@ export function LogListView() {
                   severityPalette={severityPalette}
                   highlightText={highlightText}
                   highlightCaseSensitive={highlightCaseSensitive}
-                  onClick={(id) => { suppressScrollRef.current = true; selectEntry(id); }}
+                  onClick={(id) => { if (id !== selectedId) { suppressScrollRef.current = true; } selectEntry(id); }}
                   onErrorCodeClick={handleErrorCodeClick}
                 />
               </div>


### PR DESCRIPTION
## Summary

Clicking a row in the log list was triggering `scrollToIndex` with `align: "center"`, which jumped the viewport even when the clicked row was already visible. This was reported as unexpected behavior in #33.

**Fix:** Added a `suppressScrollRef` flag that's set before click-originated selections, so the scroll-to-selection effect skips when the user clicked a row. Programmatic navigation (find next/prev, keyboard arrows, deployment workspace links) still scrolls to the target as expected.

## Test plan

- [ ] Open a log file with many entries
- [ ] Click a row that's already visible — view should NOT scroll
- [ ] Use Ctrl+F and find next — view should scroll to the match
- [ ] Use keyboard arrows to navigate — view should scroll when selection goes off-screen
- [ ] Click "Open in Log Viewer" from deployment workspace — view should scroll to error line

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)