### PR TITLE
feat: multi-file selection, drag-drop, and CLI opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.0-pre1] - 2026-03-24
+## [0.6.0] - 2026-03-24
 
 ### Highlights
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmtrace-open",
-  "version": "0.6.0-pre1",
+  "version": "0.6.0",
   "private": true,
   "description": "Open-source CMTrace log viewer with built-in Intune diagnostics",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmtrace-open"
-version = "0.6.0-pre1"
+version = "0.6.0"
 description = "Open-source CMTrace log viewer with Intune diagnostics"
 authors = ["Adam Gell"]
 license = "MIT"

--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -419,7 +419,7 @@ pub fn write_text_output_file(path: String, contents: String) -> Result<(), Stri
 /// with the file paths as command-line arguments. This command retrieves those
 /// paths so the frontend can open them. Consumed on the first call.
 #[tauri::command]
-pub fn get_initial_file_path(state: State<'_, AppState>) -> Result<Vec<String>, String> {
+pub fn get_initial_file_paths(state: State<'_, AppState>) -> Result<Vec<String>, String> {
     let mut guard = state.initial_file_paths.lock().map_err(|e| e.to_string())?;
     let paths = std::mem::take(&mut *guard);
     Ok(paths)

--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -412,17 +412,17 @@ pub fn write_text_output_file(path: String, contents: String) -> Result<(), Stri
     fs::write(&path, contents).map_err(|error| format!("failed to write file {}: {}", path, error))
 }
 
-/// Returns the file path passed as a CLI argument at startup via OS file association.
+/// Returns file paths passed as CLI arguments at startup via OS file association.
 ///
-/// When the user opens a `.log` or `.lo_` file with CMTrace Open (e.g. by
-/// double-clicking it in Explorer or right-clicking and choosing "Open with"),
-/// the OS launches the application with the file path as a command-line
-/// argument. This command retrieves that path so the frontend can open it.
-/// The path is consumed on the first call so it is only processed once.
+/// When the user opens `.log` files with CMTrace Open (e.g. by selecting
+/// multiple files and choosing "Open with"), the OS launches the application
+/// with the file paths as command-line arguments. This command retrieves those
+/// paths so the frontend can open them. Consumed on the first call.
 #[tauri::command]
-pub fn get_initial_file_path(state: State<'_, AppState>) -> Result<Option<String>, String> {
-    let mut guard = state.initial_file_path.lock().map_err(|e| e.to_string())?;
-    Ok(guard.take())
+pub fn get_initial_file_path(state: State<'_, AppState>) -> Result<Vec<String>, String> {
+    let mut guard = state.initial_file_paths.lock().map_err(|e| e.to_string())?;
+    let paths = std::mem::take(&mut *guard);
+    Ok(paths)
 }
 
 fn normalize_path_string(path: &Path) -> String {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,7 +58,7 @@ pub fn run() {
             commands::file_ops::get_known_log_sources,
             commands::file_ops::inspect_path_kind,
             commands::file_ops::write_text_output_file,
-            commands::file_ops::get_initial_file_path,
+            commands::file_ops::get_initial_file_paths,
             commands::system_preferences::get_system_date_time_preferences,
             commands::parsing::start_tail,
             commands::parsing::stop_tail,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,19 +11,23 @@ mod watcher;
 
 use state::app_state::AppState;
 
-/// Returns the first non-flag CLI argument as a potential file path.
+/// Returns all non-flag CLI arguments as potential file paths.
 ///
 /// When the OS opens the application via a file association (e.g. double-clicking
-/// a `.log` file), the file path is passed as the first positional argument.
+/// a `.log` file), the file path is passed as a positional argument.
+/// Multiple files can be passed (e.g. `cmtraceopen file1.log file2.log`).
 /// Flags (arguments starting with `-`) are skipped so that internal Tauri or
-/// platform arguments do not get misidentified as a file path.
-fn get_initial_file_path_from_args() -> Option<String> {
-    std::env::args().skip(1).find(|arg| !arg.starts_with('-'))
+/// platform arguments do not get misidentified as file paths.
+fn get_initial_file_paths_from_args() -> Vec<String> {
+    std::env::args()
+        .skip(1)
+        .filter(|arg| !arg.starts_with('-'))
+        .collect()
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let initial_file_path = get_initial_file_path_from_args();
+    let initial_file_paths = get_initial_file_paths_from_args();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
@@ -40,7 +44,7 @@ pub fn run() {
 
             Ok(())
         })
-        .manage(AppState::new(initial_file_path))
+        .manage(AppState::new(initial_file_paths))
         .invoke_handler(tauri::generate_handler![
             commands::file_association::get_file_association_prompt_status,
             commands::file_association::associate_log_files_with_app,

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -21,23 +21,23 @@ pub struct AppState {
     pub open_files: Mutex<HashMap<PathBuf, OpenFile>>,
     /// Active tail-watching sessions keyed by file path
     pub tail_sessions: Mutex<HashMap<PathBuf, TailSession>>,
-    /// File path passed as a CLI argument at startup via OS file association.
-    /// Consumed (cleared) on first retrieval so it is only processed once.
-    pub initial_file_path: Mutex<Option<String>>,
+    /// File paths passed as CLI arguments at startup via OS file association.
+    /// Consumed (cleared) on first retrieval so they are only processed once.
+    pub initial_file_paths: Mutex<Vec<String>>,
 }
 
 impl AppState {
-    pub fn new(initial_file_path: Option<String>) -> Self {
+    pub fn new(initial_file_paths: Vec<String>) -> Self {
         Self {
             open_files: Mutex::new(HashMap::new()),
             tail_sessions: Mutex::new(HashMap::new()),
-            initial_file_path: Mutex::new(initial_file_path),
+            initial_file_paths: Mutex::new(initial_file_paths),
         }
     }
 }
 
 impl Default for AppState {
     fn default() -> Self {
-        Self::new(None)
+        Self::new(Vec::new())
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CMTrace Open",
-  "version": "0.6.0-pre1",
+  "version": "0.6.0",
   "identifier": "com.cmtrace.open",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -517,8 +517,10 @@ export function useAppActions(): AppActionHandlers {
       return;
     }
 
+    const isLogWorkspace = activeWorkspace === "log";
+
     const selected = await open({
-      multiple: true,
+      multiple: isLogWorkspace,
       filters: getOpenFileDialogFilters(activeWorkspace),
     });
 

--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -518,21 +518,26 @@ export function useAppActions(): AppActionHandlers {
     }
 
     const selected = await open({
-      multiple: false,
+      multiple: true,
       filters: getOpenFileDialogFilters(activeWorkspace),
     });
 
-    const filePath = normalizeDialogSelection(selected);
+    if (!selected) return;
 
-    if (!filePath) {
-      return;
+    // Normalize: open() returns string | string[] | null depending on multiple flag
+    const paths = Array.isArray(selected) ? selected : [selected];
+    if (paths.length === 0) return;
+
+    if (paths.length === 1) {
+      await openSourceForWorkspace(
+        { kind: "file", path: paths[0] },
+        "app-actions.open-file",
+        activeWorkspace
+      );
+    } else {
+      const { loadFilesAsLogSource } = await import("../../lib/log-source");
+      await loadFilesAsLogSource(paths);
     }
-
-    await openSourceForWorkspace(
-      { kind: "file", path: filePath },
-      "app-actions.open-file",
-      activeWorkspace
-    );
   }, [activeWorkspace, commandState.canOpenSources, openSourceForWorkspace]);
 
   const openSourceFolderDialog = useCallback(async () => {

--- a/src/hooks/use-drag-drop.ts
+++ b/src/hooks/use-drag-drop.ts
@@ -2,11 +2,12 @@ import { useEffect } from "react";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { useAppActions } from "../components/layout/Toolbar";
 import { loadFilesAsLogSource } from "../lib/log-source";
+import { useUiStore } from "../stores/ui-store";
 
 /**
  * Hook that handles file/folder drag-and-drop onto the application window.
  * Single file/folder drops route through the active workspace's source-loading flow.
- * Multiple file drops merge into an aggregate view.
+ * Multiple file drops merge into an aggregate log view (log workspace only).
  */
 export function useDragDrop() {
   const { openPathForActiveWorkspace } = useAppActions();
@@ -28,7 +29,13 @@ export function useDragDrop() {
         if (paths.length === 1) {
           await openPathForActiveWorkspace(paths[0]);
         } else {
-          await loadFilesAsLogSource(paths);
+          const activeWorkspace = useUiStore.getState().activeWorkspace;
+          if (activeWorkspace === "log") {
+            await loadFilesAsLogSource(paths);
+          } else {
+            // Non-log workspaces don't support multi-file; open the first path
+            await openPathForActiveWorkspace(paths[0]);
+          }
         }
       } catch (error) {
         console.error("[drag-drop] failed to open dropped paths", {

--- a/src/hooks/use-drag-drop.ts
+++ b/src/hooks/use-drag-drop.ts
@@ -1,10 +1,12 @@
 import { useEffect } from "react";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { useAppActions } from "../components/layout/Toolbar";
+import { loadFilesAsLogSource } from "../lib/log-source";
 
 /**
  * Hook that handles file/folder drag-and-drop onto the application window.
- * It routes dropped paths through the active workspace's source-loading flow.
+ * Single file/folder drops route through the active workspace's source-loading flow.
+ * Multiple file drops merge into an aggregate view.
  */
 export function useDragDrop() {
   const { openPathForActiveWorkspace } = useAppActions();
@@ -22,13 +24,15 @@ export function useDragDrop() {
         return;
       }
 
-      const droppedPath = paths[0];
-
       try {
-        await openPathForActiveWorkspace(droppedPath);
+        if (paths.length === 1) {
+          await openPathForActiveWorkspace(paths[0]);
+        } else {
+          await loadFilesAsLogSource(paths);
+        }
       } catch (error) {
-        console.error("[drag-drop] failed to open dropped path", {
-          droppedPath,
+        console.error("[drag-drop] failed to open dropped paths", {
+          pathCount: paths.length,
           error,
         });
       }

--- a/src/hooks/use-file-association.ts
+++ b/src/hooks/use-file-association.ts
@@ -1,37 +1,42 @@
 import { useEffect } from "react";
-import { getInitialFilePath } from "../lib/commands";
-import { loadPathAsLogSource } from "../lib/log-source";
+import { getInitialFilePaths } from "../lib/commands";
+import { loadPathAsLogSource, loadFilesAsLogSource } from "../lib/log-source";
 import { useFilterStore } from "../stores/filter-store";
 import { useUiStore } from "../stores/ui-store";
 
 /**
- * Hook that handles a file path passed via OS file association at app startup.
+ * Hook that handles file paths passed via OS file association at app startup.
  *
- * When the user opens a `.log` or `.lo_` file with CMTrace Open (e.g. by
- * double-clicking it or right-clicking and choosing "Open with"), the OS
- * launches the application with the file path as a CLI argument.  This hook
- * retrieves that path on mount and routes it through the shared source-loading
- * flow, reusing the same logic as drag-and-drop file opens.
+ * When the user opens `.log` files with CMTrace Open (e.g. by selecting
+ * multiple files and choosing "Open with"), the OS launches the application
+ * with the file paths as CLI arguments. This hook retrieves those paths on
+ * mount and routes them through the appropriate loading flow — single-file
+ * for one path, aggregate merge for multiple.
  */
 export function useFileAssociation() {
   const clearFilter = useFilterStore((s) => s.clearFilter);
 
   useEffect(() => {
-    getInitialFilePath()
-      .then((filePath) => {
-        if (!filePath) {
+    getInitialFilePaths()
+      .then(async (paths) => {
+        if (paths.length === 0) {
           return;
         }
 
         useUiStore.getState().ensureLogViewVisible("file-association.path-open");
         clearFilter();
 
-        return loadPathAsLogSource(filePath, {
-          fallbackToFolder: false,
-        });
+        if (paths.length === 1) {
+          await loadPathAsLogSource(paths[0], {
+            fallbackToFolder: false,
+          });
+          return;
+        }
+
+        await loadFilesAsLogSource(paths);
       })
       .catch((error) => {
-        console.error("[file-association] failed to open initial file path", {
+        console.error("[file-association] failed to open initial file paths", {
           error,
         });
       });

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -221,7 +221,7 @@ export async function loadDsregcmdSource(
 }
 
 export async function getInitialFilePaths(): Promise<string[]> {
-  return invokeCommand<string[]>("get_initial_file_path");
+  return invokeCommand<string[]>("get_initial_file_paths");
 }
 
 export async function getFileAssociationPromptStatus(): Promise<FileAssociationPromptStatus> {

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -220,8 +220,8 @@ export async function loadDsregcmdSource(
   });
 }
 
-export async function getInitialFilePath(): Promise<string | null> {
-  return invokeCommand<string | null>("get_initial_file_path");
+export async function getInitialFilePaths(): Promise<string[]> {
+  return invokeCommand<string[]>("get_initial_file_path");
 }
 
 export async function getFileAssociationPromptStatus(): Promise<FileAssociationPromptStatus> {

--- a/src/lib/log-source.ts
+++ b/src/lib/log-source.ts
@@ -9,6 +9,7 @@ import {
 import { useLogStore, setCachedTabSnapshot, getCachedTabSnapshot } from "../stores/log-store";
 import { getColumnsForParser, getColumnsForAggregate } from "./column-config";
 import { useUiStore, type TabSourceContext } from "../stores/ui-store";
+import { useFilterStore } from "../stores/filter-store";
 import type {
   FolderEntry,
   KnownSourceMetadata,
@@ -590,6 +591,10 @@ export async function loadFilesAsLogSource(paths: string[]): Promise<void> {
 
   const state = useLogStore.getState();
 
+  // Clean up current state before starting the parse
+  await stopCurrentTailIfNeeded(null);
+  useFilterStore.getState().clearFilter();
+
   state.setLoading(true);
   state.setFolderLoadProgress({ current: 0, total: paths.length, currentFile: "" });
   state.setSourceStatus({
@@ -641,8 +646,10 @@ export async function loadFilesAsLogSource(paths: string[]): Promise<void> {
       allEntries[i] = { ...allEntries[i], id: i };
     }
 
-    // Build a synthetic "multi-file" source
-    const source: LogSource = { kind: "file", path: paths[0] };
+    // Derive a common parent folder for the multi-file source so the sidebar
+    // treats this as folder-like and refresh/reload work correctly.
+    const commonDir = getCommonDirectory(paths);
+    const source: LogSource = { kind: "folder", path: commonDir };
 
     // Build sidebar entries from the file list
     const folderEntries: FolderEntry[] = results.map((r) => ({
@@ -661,6 +668,7 @@ export async function loadFilesAsLogSource(paths: string[]): Promise<void> {
     state.setEntries(allEntries);
     state.setFormatDetected(null);
     state.setParserSelection(null);
+    state.setBundleMetadata(null);
     state.setTotalLines(totalLines);
     state.setByteOffset(0);
     const aggregateColumns = getColumnsForAggregate(
@@ -681,6 +689,31 @@ export async function loadFilesAsLogSource(paths: string[]): Promise<void> {
     state.setLoading(false);
     state.setFolderLoadProgress(null);
   }
+}
+
+/** Derive the longest common directory prefix from a list of file paths. */
+function getCommonDirectory(paths: string[]): string {
+  if (paths.length === 0) return "";
+  if (paths.length === 1) {
+    const parts = paths[0].split(/[\\/]/);
+    parts.pop(); // remove filename
+    return parts.join("/") || "/";
+  }
+
+  const split = paths.map((p) => p.split(/[\\/]/));
+  const minLen = Math.min(...split.map((s) => s.length));
+  let common = 0;
+  for (let i = 0; i < minLen; i++) {
+    if (split.every((s) => s[i] === split[0][i])) {
+      common = i + 1;
+    } else {
+      break;
+    }
+  }
+
+  // At minimum, return the directory portion (exclude the filename segment)
+  const commonParts = split[0].slice(0, common);
+  return commonParts.join("/") || "/";
 }
 
 export async function loadPathAsLogSource(

--- a/src/lib/log-source.ts
+++ b/src/lib/log-source.ts
@@ -575,6 +575,114 @@ async function restoreFolderContext(
   }
 }
 
+/**
+ * Load multiple files as a merged aggregate view.
+ * Reuses the same batch-parse + merge logic as folder loading.
+ */
+export async function loadFilesAsLogSource(paths: string[]): Promise<void> {
+  if (paths.length === 0) return;
+
+  // Single file — use normal single-file flow
+  if (paths.length === 1) {
+    await loadPathAsLogSource(paths[0], { fallbackToFolder: false });
+    return;
+  }
+
+  const state = useLogStore.getState();
+
+  state.setLoading(true);
+  state.setFolderLoadProgress({ current: 0, total: paths.length, currentFile: "" });
+  state.setSourceStatus({
+    kind: "loading",
+    message: `Parsing ${paths.length} files...`,
+    detail: "Files are being parsed in parallel",
+  });
+
+  const startTime = performance.now();
+
+  try {
+    const results = await parseFilesBatch(paths);
+    const parseMs = Math.round(performance.now() - startTime);
+
+    // Cache each file for instant tab switching
+    for (const result of results) {
+      const fileColumns = getColumnsForParser(result.parserSelection.parser);
+      setCachedTabSnapshot(result.filePath, {
+        entries: result.entries,
+        formatDetected: result.formatDetected,
+        parserSelection: result.parserSelection,
+        totalLines: result.totalLines,
+        byteOffset: result.byteOffset,
+        selectedSourceFilePath: result.filePath,
+        sourceOpenMode: "single-file",
+        activeColumns: fileColumns,
+      });
+    }
+
+    // Build aggregate view
+    const allEntries: LogEntry[] = [];
+    const aggregateFiles: import("../types/log").AggregateParsedFileResult[] = [];
+    let totalLines = 0;
+
+    for (const result of results) {
+      allEntries.push(...result.entries);
+      totalLines += result.totalLines;
+      aggregateFiles.push({
+        filePath: result.filePath,
+        totalLines: result.totalLines,
+        parseErrors: result.parseErrors,
+        fileSize: result.fileSize,
+        byteOffset: result.byteOffset,
+      });
+    }
+
+    // Re-assign sequential IDs
+    for (let i = 0; i < allEntries.length; i++) {
+      allEntries[i] = { ...allEntries[i], id: i };
+    }
+
+    // Build a synthetic "multi-file" source
+    const source: LogSource = { kind: "file", path: paths[0] };
+
+    // Build sidebar entries from the file list
+    const folderEntries: FolderEntry[] = results.map((r) => ({
+      path: r.filePath,
+      name: r.filePath.split(/[\\/]/).pop() ?? r.filePath,
+      isDir: false,
+      sizeBytes: r.fileSize,
+      modifiedUnixMs: 0,
+    }));
+
+    state.setActiveSource(source);
+    state.setSourceEntries(folderEntries);
+    state.setSelectedSourceFilePath(null);
+    state.setSourceOpenMode("aggregate-folder");
+    state.setAggregateFiles(aggregateFiles);
+    state.setEntries(allEntries);
+    state.setFormatDetected(null);
+    state.setParserSelection(null);
+    state.setTotalLines(totalLines);
+    state.setByteOffset(0);
+    const aggregateColumns = getColumnsForAggregate(
+      results.map((r) => r.parserSelection.parser)
+    );
+    state.setActiveColumns(aggregateColumns);
+    state.selectEntry(null);
+    state.setFolderLoadProgress(null);
+
+    useUiStore.getState().ensureLogViewVisible("multi-file-open");
+
+    state.setSourceStatus({
+      kind: "loaded",
+      message: `Loaded ${aggregateFiles.length} files.`,
+      detail: `Parsed in ${parseMs} ms (parallel).`,
+    });
+  } finally {
+    state.setLoading(false);
+    state.setFolderLoadProgress(null);
+  }
+}
+
 export async function loadPathAsLogSource(
   path: string,
   options: LoadPathAsLogSourceOptions = {}


### PR DESCRIPTION
## Summary

Adds multi-file opening via three input paths (#22):

- **File dialog**: `multiple: true` — Shift/Ctrl+click to select multiple files
- **Drag-drop**: drop several files at once (was only handling the first file)
- **CLI**: `cmtraceopen file1.log file2.log` opens all files as a merged view

When multiple files are selected, they're parsed in parallel via `parseFilesBatch` (Rayon) and merged into an aggregate view — same as folder loading. Single-file opens are unchanged.

## Changes

**Backend (Rust):**
- `get_initial_file_path_from_args()` → `get_initial_file_paths_from_args()` — collects all non-flag CLI args
- `AppState.initial_file_path` → `initial_file_paths: Vec<String>`
- `get_initial_file_path` IPC returns `Vec<String>`

**Frontend (TypeScript):**
- New `loadFilesAsLogSource(paths)` in `log-source.ts` — reuses batch-parse + merge pattern
- `Toolbar.tsx` file dialog uses `multiple: true`
- `use-drag-drop.ts` handles all dropped paths
- `use-file-association.ts` handles multiple CLI paths

## Test plan

- [ ] Open file dialog, select one file — works as before
- [ ] Open file dialog, Shift+click to select multiple files — merged aggregate view
- [ ] Drag one file onto window — opens normally
- [ ] Drag multiple files onto window — merged aggregate view with file list in sidebar
- [ ] Launch from CLI: `cmtraceopen file1.log file2.log` — merged view on startup

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)