### PR TITLE
fix: cross-reference scheduled tasks with enrollment registry for MDM detection

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "cmtrace-open"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "criterion",

--- a/src-tauri/src/commands/dsregcmd.rs
+++ b/src-tauri/src/commands/dsregcmd.rs
@@ -63,8 +63,11 @@ pub fn analyze_dsregcmd(
         result.proxy_evidence = registry::load_proxy_evidence(bp);
         result.enrollment_evidence = registry::load_enrollment_evidence(bp);
         result.active_evidence = load_active_evidence_from_bundle(bp);
+        result.scheduled_task_evidence = load_scheduled_task_evidence_from_bundle(bp);
         result.event_log_analysis = load_event_log_from_bundle(bp);
     }
+
+    apply_enrollment_cross_reference(&mut result);
 
     // Run extended diagnostics (Phase 2, 3, 4) after all evidence is loaded
     let mut extended = rules::build_extended_diagnostics(&result);
@@ -120,6 +123,43 @@ fn load_event_log_from_bundle(
     std::fs::read_to_string(&path)
         .ok()
         .and_then(|json| serde_json::from_str(&json).ok())
+}
+
+fn load_scheduled_task_evidence_from_bundle(
+    bundle_path: &Path,
+) -> Option<crate::dsregcmd::DsregcmdScheduledTaskEvidence> {
+    let path = bundle_path
+        .join("evidence")
+        .join("scheduled-tasks")
+        .join("enterprise-mgmt-tasks.json");
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|json| serde_json::from_str(&json).ok())
+}
+
+/// Cross-reference enrollment registry entries with scheduled task GUIDs
+/// to upgrade `mdm_enrolled` when dsregcmd output lacks MDM URLs.
+fn apply_enrollment_cross_reference(result: &mut DsregcmdAnalysisResult) {
+    if result.derived.mdm_enrolled.is_some() {
+        return;
+    }
+    if let (Some(enrollment), Some(tasks)) = (
+        &result.enrollment_evidence,
+        &result.scheduled_task_evidence,
+    ) {
+        let confirmed = enrollment.enrollments.iter().any(|e| {
+            e.enrollment_state == Some(1)
+                && e.guid.as_ref().is_some_and(|g| {
+                    tasks
+                        .enterprise_mgmt_guids
+                        .iter()
+                        .any(|t| t.eq_ignore_ascii_case(g))
+                })
+        });
+        if confirmed {
+            result.derived.mdm_enrolled = Some(true);
+        }
+    }
 }
 
 #[tauri::command]
@@ -384,6 +424,18 @@ fn stage_live_capture_bundle(stdout: &str) -> Result<LiveCaptureBundle, String> 
         }
     }
 
+    // Phase 5: Scheduled task evidence (EnterpriseMgmt GUIDs)
+    let scheduled_task_evidence = collect_enterprise_mgmt_task_guids();
+    let evidence_scheduled_tasks = bundle_path.join("evidence").join("scheduled-tasks");
+    if fs::create_dir_all(&evidence_scheduled_tasks).is_ok() {
+        if let Ok(json) = serde_json::to_string_pretty(&scheduled_task_evidence) {
+            let _ = fs::write(
+                evidence_scheduled_tasks.join("enterprise-mgmt-tasks.json"),
+                json,
+            );
+        }
+    }
+
     Ok(LiveCaptureBundle {
         bundle_path,
         evidence_file_path,
@@ -538,6 +590,73 @@ fn export_live_registry_evidence(registry_root: &Path) {
             }
         }
     }
+}
+
+#[cfg(target_os = "windows")]
+fn collect_enterprise_mgmt_task_guids() -> crate::dsregcmd::DsregcmdScheduledTaskEvidence {
+    use regex::Regex;
+
+    let mut evidence = crate::dsregcmd::DsregcmdScheduledTaskEvidence::default();
+
+    let schtasks_path = match resolve_system32_binary("schtasks.exe") {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("event=dsregcmd_schtasks_skipped reason={e}");
+            return evidence;
+        }
+    };
+
+    let output = match std::process::Command::new(&schtasks_path)
+        .args([
+            "/query",
+            "/TN",
+            r"\Microsoft\Windows\EnterpriseMgmt",
+            "/FO",
+            "LIST",
+        ])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("event=dsregcmd_schtasks_failed error={e}");
+            return evidence;
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        eprintln!(
+            "event=dsregcmd_schtasks_failed exit_code={} stderr={}",
+            output.status.code().unwrap_or_default(),
+            stderr
+        );
+        return evidence;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let guid_re = Regex::new(r"\{[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}")
+        .expect("valid GUID regex");
+
+    let mut seen = std::collections::HashSet::new();
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("TaskName:") {
+            continue;
+        }
+        for cap in guid_re.find_iter(trimmed) {
+            let guid = cap.as_str().to_string();
+            if seen.insert(guid.to_ascii_uppercase()) {
+                evidence.enterprise_mgmt_guids.push(guid);
+            }
+        }
+    }
+
+    eprintln!(
+        "event=dsregcmd_schtasks_complete guid_count={}",
+        evidence.enterprise_mgmt_guids.len()
+    );
+
+    evidence
 }
 
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/commands/dsregcmd.rs
+++ b/src-tauri/src/commands/dsregcmd.rs
@@ -67,7 +67,7 @@ pub fn analyze_dsregcmd(
         result.event_log_analysis = load_event_log_from_bundle(bp);
     }
 
-    apply_enrollment_cross_reference(&mut result);
+    rules::apply_enrollment_cross_reference(&mut result);
 
     // Run extended diagnostics (Phase 2, 3, 4) after all evidence is loaded
     let mut extended = rules::build_extended_diagnostics(&result);
@@ -137,30 +137,6 @@ fn load_scheduled_task_evidence_from_bundle(
         .and_then(|json| serde_json::from_str(&json).ok())
 }
 
-/// Cross-reference enrollment registry entries with scheduled task GUIDs
-/// to upgrade `mdm_enrolled` when dsregcmd output lacks MDM URLs.
-fn apply_enrollment_cross_reference(result: &mut DsregcmdAnalysisResult) {
-    if result.derived.mdm_enrolled.is_some() {
-        return;
-    }
-    if let (Some(enrollment), Some(tasks)) = (
-        &result.enrollment_evidence,
-        &result.scheduled_task_evidence,
-    ) {
-        let confirmed = enrollment.enrollments.iter().any(|e| {
-            e.enrollment_state == Some(1)
-                && e.guid.as_ref().is_some_and(|g| {
-                    tasks
-                        .enterprise_mgmt_guids
-                        .iter()
-                        .any(|t| t.eq_ignore_ascii_case(g))
-                })
-        });
-        if confirmed {
-            result.derived.mdm_enrolled = Some(true);
-        }
-    }
-}
 
 #[tauri::command]
 pub fn capture_dsregcmd() -> Result<DsregcmdCaptureResult, String> {

--- a/src-tauri/src/dsregcmd/mod.rs
+++ b/src-tauri/src/dsregcmd/mod.rs
@@ -10,7 +10,7 @@ pub use models::{
     DsregcmdDerived, DsregcmdDiagnosticInsight, DsregcmdEnrollmentEntry,
     DsregcmdEnrollmentEvidence, DsregcmdEvidenceSource, DsregcmdFacts, DsregcmdJoinType,
     DsregcmdOsVersionEvidence, DsregcmdPolicyEvidenceValue, DsregcmdProxyEvidence,
-    DsregcmdScpQueryResult, DsregcmdWhfbPolicyEvidence,
+    DsregcmdScheduledTaskEvidence, DsregcmdScpQueryResult, DsregcmdWhfbPolicyEvidence,
 };
 
 pub fn analyze_text(input: &str) -> Result<DsregcmdAnalysisResult, String> {

--- a/src-tauri/src/dsregcmd/models.rs
+++ b/src-tauri/src/dsregcmd/models.rs
@@ -293,6 +293,7 @@ pub struct DsregcmdProxyEvidence {
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DsregcmdEnrollmentEntry {
+    pub guid: Option<String>,
     pub upn: Option<String>,
     pub provider_id: Option<String>,
     pub enrollment_state: Option<u32>,
@@ -335,6 +336,13 @@ pub struct DsregcmdActiveEvidence {
     pub scp_query: Option<DsregcmdScpQueryResult>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DsregcmdScheduledTaskEvidence {
+    #[serde(default)]
+    pub enterprise_mgmt_guids: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DsregcmdAnalysisResult {
@@ -352,6 +360,8 @@ pub struct DsregcmdAnalysisResult {
     pub enrollment_evidence: Option<DsregcmdEnrollmentEvidence>,
     #[serde(default)]
     pub active_evidence: Option<DsregcmdActiveEvidence>,
+    #[serde(default)]
+    pub scheduled_task_evidence: Option<DsregcmdScheduledTaskEvidence>,
     #[serde(default)]
     pub event_log_analysis: Option<EventLogAnalysis>,
 }

--- a/src-tauri/src/dsregcmd/registry.rs
+++ b/src-tauri/src/dsregcmd/registry.rs
@@ -227,7 +227,14 @@ pub fn load_enrollment_evidence(bundle_path: &Path) -> Option<DsregcmdEnrollment
             continue;
         }
 
+        let guid = key_path
+            .rfind('{')
+            .and_then(|start| {
+                key_path.rfind('}').map(|end| key_path[start..=end].to_string())
+            });
+
         enrollments.push(DsregcmdEnrollmentEntry {
+            guid,
             upn: extract_string_value(values, "UPN"),
             provider_id: extract_string_value(values, "ProviderID"),
             enrollment_state: extract_dword_value(values, "EnrollmentState"),
@@ -819,5 +826,26 @@ mod tests {
         assert_eq!(evidence.enrollment_count, 2);
         assert_eq!(evidence.enrollments.len(), 2);
         assert!(evidence.enrollments.iter().any(|e| e.upn.as_deref() == Some("user@contoso.com")));
+
+        // Verify GUID extraction
+        let user_entry = evidence
+            .enrollments
+            .iter()
+            .find(|e| e.upn.as_deref() == Some("user@contoso.com"))
+            .expect("user enrollment entry");
+        assert_eq!(
+            user_entry.guid.as_deref(),
+            Some("{11111111-2222-3333-4444-555555555555}")
+        );
+
+        let admin_entry = evidence
+            .enrollments
+            .iter()
+            .find(|e| e.upn.as_deref() == Some("admin@contoso.com"))
+            .expect("admin enrollment entry");
+        assert_eq!(
+            admin_entry.guid.as_deref(),
+            Some("{22222222-3333-4444-5555-666666666666}")
+        );
     }
 }

--- a/src-tauri/src/dsregcmd/rules.rs
+++ b/src-tauri/src/dsregcmd/rules.rs
@@ -35,6 +35,7 @@ pub fn analyze_facts(facts: DsregcmdFacts, raw_input: &str) -> DsregcmdAnalysisR
         proxy_evidence: None,
         enrollment_evidence: None,
         active_evidence: None,
+        scheduled_task_evidence: None,
         event_log_analysis: None,
     }
 }
@@ -1657,6 +1658,48 @@ pub fn build_extended_diagnostics(
         }
     }
 
+    // MDM confirmed via registry cross-reference (no dsregcmd MDM URLs)
+    let mdm_urls_absent = result.facts.management_details.mdm_url.is_none()
+        && result.facts.management_details.mdm_compliance_url.is_none();
+    if result.derived.mdm_enrolled == Some(true) && mdm_urls_absent {
+        let mut evidence_lines = Vec::new();
+        if let Some(ref enrollment) = result.enrollment_evidence {
+            for entry in &enrollment.enrollments {
+                if entry.enrollment_state == Some(1) {
+                    let guid_display = entry.guid.as_deref().unwrap_or("(unknown)");
+                    let upn_display = entry.upn.as_deref().unwrap_or("(no UPN)");
+                    evidence_lines.push(format!(
+                        "GUID: {} — UPN: {} — EnrollmentState: 1",
+                        guid_display, upn_display
+                    ));
+                }
+            }
+        }
+        if let Some(ref tasks) = result.scheduled_task_evidence {
+            evidence_lines.push(format!(
+                "EnterpriseMgmt scheduled task GUIDs: {}",
+                if tasks.enterprise_mgmt_guids.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    tasks.enterprise_mgmt_guids.join(", ")
+                }
+            ));
+        }
+        diagnostics.push(issue(
+            "mdm-confirmed-via-registry",
+            IntuneDiagnosticSeverity::Info,
+            "configuration",
+            "MDM enrollment confirmed via scheduled tasks and registry",
+            "The dsregcmd output does not contain MDM URLs, but the device has active enrollment entries in the registry whose GUIDs match scheduled tasks under \\Microsoft\\Windows\\EnterpriseMgmt. This confirms the device is MDM-enrolled.",
+            evidence_lines,
+            vec![
+                "The dsregcmd MDM URL fields are tenant-dependent and often absent on enrolled devices.".to_string(),
+                "The registry cross-reference with scheduled tasks provides a definitive enrollment signal.".to_string(),
+            ],
+            Vec::new(),
+        ));
+    }
+
     diagnostics
 }
 
@@ -2847,5 +2890,106 @@ mod tests {
         let ids: Vec<&str> = analysis.diagnostics.iter().map(|i| i.id.as_str()).collect();
 
         assert!(!ids.contains(&"scp-tenant-mismatch-hint"), "should not fire without tenant ID");
+    }
+
+    #[test]
+    fn mdm_confirmed_via_registry_diagnostic_fires_when_cross_referenced() {
+        use crate::dsregcmd::models::{
+            DsregcmdEnrollmentEntry, DsregcmdEnrollmentEvidence,
+            DsregcmdScheduledTaskEvidence,
+        };
+        use super::build_extended_diagnostics;
+
+        let facts = parse_dsregcmd(NOT_JOINED_SAMPLE).expect("parse sample");
+        let mut result = analyze_facts(facts, NOT_JOINED_SAMPLE);
+
+        // Simulate enrollment evidence with state=1 and matching task GUID
+        result.enrollment_evidence = Some(DsregcmdEnrollmentEvidence {
+            enrollment_count: 1,
+            enrollments: vec![DsregcmdEnrollmentEntry {
+                guid: Some("{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE}".to_string()),
+                upn: Some("user@contoso.com".to_string()),
+                provider_id: Some("MS DM Server".to_string()),
+                enrollment_state: Some(1),
+            }],
+        });
+        result.scheduled_task_evidence = Some(DsregcmdScheduledTaskEvidence {
+            enterprise_mgmt_guids: vec![
+                "{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE}".to_string(),
+            ],
+        });
+
+        // Simulate the cross-reference upgrading mdm_enrolled
+        assert_eq!(result.derived.mdm_enrolled, None);
+        // Apply same logic as command handler
+        if result.derived.mdm_enrolled.is_none() {
+            if let (Some(enrollment), Some(tasks)) = (
+                &result.enrollment_evidence,
+                &result.scheduled_task_evidence,
+            ) {
+                let confirmed = enrollment.enrollments.iter().any(|e| {
+                    e.enrollment_state == Some(1)
+                        && e.guid.as_ref().is_some_and(|g| {
+                            tasks.enterprise_mgmt_guids.iter().any(|t| t.eq_ignore_ascii_case(g))
+                        })
+                });
+                if confirmed {
+                    result.derived.mdm_enrolled = Some(true);
+                }
+            }
+        }
+        assert_eq!(result.derived.mdm_enrolled, Some(true));
+
+        let extended = build_extended_diagnostics(&result);
+        assert!(
+            extended.iter().any(|d| d.id == "mdm-confirmed-via-registry"),
+            "should fire mdm-confirmed-via-registry diagnostic"
+        );
+    }
+
+    #[test]
+    fn mdm_not_confirmed_without_matching_scheduled_task() {
+        use crate::dsregcmd::models::{
+            DsregcmdEnrollmentEntry, DsregcmdEnrollmentEvidence,
+            DsregcmdScheduledTaskEvidence,
+        };
+
+        let facts = parse_dsregcmd(NOT_JOINED_SAMPLE).expect("parse sample");
+        let mut result = analyze_facts(facts, NOT_JOINED_SAMPLE);
+
+        // Enrollment state=1 but GUID doesn't match any scheduled task
+        result.enrollment_evidence = Some(DsregcmdEnrollmentEvidence {
+            enrollment_count: 1,
+            enrollments: vec![DsregcmdEnrollmentEntry {
+                guid: Some("{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE}".to_string()),
+                upn: Some("user@contoso.com".to_string()),
+                provider_id: Some("MS DM Server".to_string()),
+                enrollment_state: Some(1),
+            }],
+        });
+        result.scheduled_task_evidence = Some(DsregcmdScheduledTaskEvidence {
+            enterprise_mgmt_guids: vec![
+                "{99999999-8888-7777-6666-555555555555}".to_string(),
+            ],
+        });
+
+        // Cross-reference should NOT upgrade because GUIDs don't match
+        if result.derived.mdm_enrolled.is_none() {
+            if let (Some(enrollment), Some(tasks)) = (
+                &result.enrollment_evidence,
+                &result.scheduled_task_evidence,
+            ) {
+                let confirmed = enrollment.enrollments.iter().any(|e| {
+                    e.enrollment_state == Some(1)
+                        && e.guid.as_ref().is_some_and(|g| {
+                            tasks.enterprise_mgmt_guids.iter().any(|t| t.eq_ignore_ascii_case(g))
+                        })
+                });
+                if confirmed {
+                    result.derived.mdm_enrolled = Some(true);
+                }
+            }
+        }
+        assert_eq!(result.derived.mdm_enrolled, None, "should stay None when GUIDs don't match");
     }
 }

--- a/src-tauri/src/dsregcmd/rules.rs
+++ b/src-tauri/src/dsregcmd/rules.rs
@@ -1529,6 +1529,31 @@ fn build_diagnostics(
     diagnostics
 }
 
+/// Cross-reference enrollment registry entries with scheduled task GUIDs
+/// to upgrade `mdm_enrolled` when dsregcmd output lacks MDM URLs.
+pub fn apply_enrollment_cross_reference(result: &mut DsregcmdAnalysisResult) {
+    if result.derived.mdm_enrolled.is_some() {
+        return;
+    }
+    if let (Some(enrollment), Some(tasks)) = (
+        &result.enrollment_evidence,
+        &result.scheduled_task_evidence,
+    ) {
+        let confirmed = enrollment.enrollments.iter().any(|e| {
+            e.enrollment_state == Some(1)
+                && e.guid.as_ref().is_some_and(|g| {
+                    tasks
+                        .enterprise_mgmt_guids
+                        .iter()
+                        .any(|t| t.eq_ignore_ascii_case(g))
+                })
+        });
+        if confirmed {
+            result.derived.mdm_enrolled = Some(true);
+        }
+    }
+}
+
 /// Extended diagnostics based on registry evidence collected in Phase 2.
 pub fn build_extended_diagnostics(
     result: &DsregcmdAnalysisResult,
@@ -1663,19 +1688,23 @@ pub fn build_extended_diagnostics(
         && result.facts.management_details.mdm_compliance_url.is_none();
     if result.derived.mdm_enrolled == Some(true) && mdm_urls_absent {
         let mut evidence_lines = Vec::new();
-        if let Some(ref enrollment) = result.enrollment_evidence {
+        if let (Some(ref enrollment), Some(ref tasks)) =
+            (&result.enrollment_evidence, &result.scheduled_task_evidence)
+        {
             for entry in &enrollment.enrollments {
-                if entry.enrollment_state == Some(1) {
+                let guid_matched = entry.enrollment_state == Some(1)
+                    && entry.guid.as_ref().is_some_and(|g| {
+                        tasks.enterprise_mgmt_guids.iter().any(|t| t.eq_ignore_ascii_case(g))
+                    });
+                if guid_matched {
                     let guid_display = entry.guid.as_deref().unwrap_or("(unknown)");
                     let upn_display = entry.upn.as_deref().unwrap_or("(no UPN)");
                     evidence_lines.push(format!(
-                        "GUID: {} — UPN: {} — EnrollmentState: 1",
+                        "GUID: {} — UPN: {} — EnrollmentState: 1 — matched scheduled task",
                         guid_display, upn_display
                     ));
                 }
             }
-        }
-        if let Some(ref tasks) = result.scheduled_task_evidence {
             evidence_lines.push(format!(
                 "EnterpriseMgmt scheduled task GUIDs: {}",
                 if tasks.enterprise_mgmt_guids.is_empty() {
@@ -2898,12 +2927,11 @@ mod tests {
             DsregcmdEnrollmentEntry, DsregcmdEnrollmentEvidence,
             DsregcmdScheduledTaskEvidence,
         };
-        use super::build_extended_diagnostics;
+        use super::{apply_enrollment_cross_reference, build_extended_diagnostics};
 
         let facts = parse_dsregcmd(NOT_JOINED_SAMPLE).expect("parse sample");
         let mut result = analyze_facts(facts, NOT_JOINED_SAMPLE);
 
-        // Simulate enrollment evidence with state=1 and matching task GUID
         result.enrollment_evidence = Some(DsregcmdEnrollmentEvidence {
             enrollment_count: 1,
             enrollments: vec![DsregcmdEnrollmentEntry {
@@ -2919,25 +2947,8 @@ mod tests {
             ],
         });
 
-        // Simulate the cross-reference upgrading mdm_enrolled
         assert_eq!(result.derived.mdm_enrolled, None);
-        // Apply same logic as command handler
-        if result.derived.mdm_enrolled.is_none() {
-            if let (Some(enrollment), Some(tasks)) = (
-                &result.enrollment_evidence,
-                &result.scheduled_task_evidence,
-            ) {
-                let confirmed = enrollment.enrollments.iter().any(|e| {
-                    e.enrollment_state == Some(1)
-                        && e.guid.as_ref().is_some_and(|g| {
-                            tasks.enterprise_mgmt_guids.iter().any(|t| t.eq_ignore_ascii_case(g))
-                        })
-                });
-                if confirmed {
-                    result.derived.mdm_enrolled = Some(true);
-                }
-            }
-        }
+        apply_enrollment_cross_reference(&mut result);
         assert_eq!(result.derived.mdm_enrolled, Some(true));
 
         let extended = build_extended_diagnostics(&result);
@@ -2953,6 +2964,7 @@ mod tests {
             DsregcmdEnrollmentEntry, DsregcmdEnrollmentEvidence,
             DsregcmdScheduledTaskEvidence,
         };
+        use super::apply_enrollment_cross_reference;
 
         let facts = parse_dsregcmd(NOT_JOINED_SAMPLE).expect("parse sample");
         let mut result = analyze_facts(facts, NOT_JOINED_SAMPLE);
@@ -2974,22 +2986,7 @@ mod tests {
         });
 
         // Cross-reference should NOT upgrade because GUIDs don't match
-        if result.derived.mdm_enrolled.is_none() {
-            if let (Some(enrollment), Some(tasks)) = (
-                &result.enrollment_evidence,
-                &result.scheduled_task_evidence,
-            ) {
-                let confirmed = enrollment.enrollments.iter().any(|e| {
-                    e.enrollment_state == Some(1)
-                        && e.guid.as_ref().is_some_and(|g| {
-                            tasks.enterprise_mgmt_guids.iter().any(|t| t.eq_ignore_ascii_case(g))
-                        })
-                });
-                if confirmed {
-                    result.derived.mdm_enrolled = Some(true);
-                }
-            }
-        }
+        apply_enrollment_cross_reference(&mut result);
         assert_eq!(result.derived.mdm_enrolled, None, "should stay None when GUIDs don't match");
     }
 }

--- a/src/components/dsregcmd/DsregcmdWorkspace.tsx
+++ b/src/components/dsregcmd/DsregcmdWorkspace.tsx
@@ -1211,18 +1211,69 @@ function getFactGroups(
                       ? ("warn" as const)
                       : ("good" as const),
               },
-              ...result.enrollmentEvidence.enrollments.map((e, i) => ({
-                label: `Enrollment ${i + 1}`,
-                value: [
-                  e.upn ?? "(no UPN)",
-                  e.providerId ?? "(no provider)",
-                  e.enrollmentState != null
-                    ? `state=${e.enrollmentState}`
-                    : "",
-                ]
-                  .filter(Boolean)
-                  .join(" — "),
-              })),
+              ...result.enrollmentEvidence.enrollments.map((e, i) => {
+                const hasTaskMatch =
+                  e.guid != null &&
+                  result.scheduledTaskEvidence?.enterpriseMgmtGuids?.some(
+                    (t) => t.toLowerCase() === e.guid!.toLowerCase(),
+                  );
+                return {
+                  label: `Enrollment ${i + 1}`,
+                  value: [
+                    e.guid ?? "(no GUID)",
+                    e.upn ?? "(no UPN)",
+                    e.providerId ?? "(no provider)",
+                    e.enrollmentState != null
+                      ? `state=${e.enrollmentState}`
+                      : "",
+                    hasTaskMatch ? "task-matched" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" — "),
+                  tone:
+                    e.enrollmentState === 1 && hasTaskMatch
+                      ? ("good" as const)
+                      : undefined,
+                };
+              }),
+            ]),
+          },
+        ]
+      : []),
+    ...(result.scheduledTaskEvidence?.enterpriseMgmtGuids?.length
+      ? [
+          {
+            id: "enterprise-mgmt-tasks",
+            title: "Enterprise Management Tasks",
+            caption:
+              "Scheduled task GUIDs under \\Microsoft\\Windows\\EnterpriseMgmt, cross-referenced with enrollment registry entries.",
+            rows: withNotReportedMetadata([
+              {
+                label: "Task GUID Count",
+                value: String(
+                  result.scheduledTaskEvidence.enterpriseMgmtGuids.length,
+                ),
+              },
+              ...result.scheduledTaskEvidence.enterpriseMgmtGuids.map(
+                (guid) => {
+                  const matchingEnrollment =
+                    result.enrollmentEvidence?.enrollments.find(
+                      (e) =>
+                        e.guid?.toLowerCase() === guid.toLowerCase(),
+                    );
+                  const enrolled =
+                    matchingEnrollment?.enrollmentState === 1;
+                  return {
+                    label: guid,
+                    value: matchingEnrollment
+                      ? `Registry match — ${matchingEnrollment.upn ?? "(no UPN)"} — state=${matchingEnrollment.enrollmentState}`
+                      : "No matching enrollment registry entry",
+                    tone: enrolled
+                      ? ("good" as const)
+                      : ("neutral" as const),
+                  };
+                },
+              ),
             ]),
           },
         ]

--- a/src/components/dsregcmd/DsregcmdWorkspace.tsx
+++ b/src/components/dsregcmd/DsregcmdWorkspace.tsx
@@ -1211,31 +1211,36 @@ function getFactGroups(
                       ? ("warn" as const)
                       : ("good" as const),
               },
-              ...result.enrollmentEvidence.enrollments.map((e, i) => {
-                const hasTaskMatch =
-                  e.guid != null &&
-                  result.scheduledTaskEvidence?.enterpriseMgmtGuids?.some(
-                    (t) => t.toLowerCase() === e.guid!.toLowerCase(),
-                  );
-                return {
-                  label: `Enrollment ${i + 1}`,
-                  value: [
-                    e.guid ?? "(no GUID)",
-                    e.upn ?? "(no UPN)",
-                    e.providerId ?? "(no provider)",
-                    e.enrollmentState != null
-                      ? `state=${e.enrollmentState}`
-                      : "",
-                    hasTaskMatch ? "task-matched" : "",
-                  ]
-                    .filter(Boolean)
-                    .join(" — "),
-                  tone:
-                    e.enrollmentState === 1 && hasTaskMatch
-                      ? ("good" as const)
-                      : undefined,
-                };
-              }),
+              ...(() => {
+                const taskGuidSet = new Set(
+                  (result.scheduledTaskEvidence?.enterpriseMgmtGuids ?? []).map(
+                    (g) => g.toLowerCase(),
+                  ),
+                );
+                return result.enrollmentEvidence!.enrollments.map((e, i) => {
+                  const guidLower = e.guid?.toLowerCase();
+                  const hasTaskMatch =
+                    guidLower != null && taskGuidSet.has(guidLower);
+                  return {
+                    label: `Enrollment ${i + 1}`,
+                    value: [
+                      e.guid ?? "(no GUID)",
+                      e.upn ?? "(no UPN)",
+                      e.providerId ?? "(no provider)",
+                      e.enrollmentState != null
+                        ? `state=${e.enrollmentState}`
+                        : "",
+                      hasTaskMatch ? "task-matched" : "",
+                    ]
+                      .filter(Boolean)
+                      .join(" — "),
+                    tone:
+                      e.enrollmentState === 1 && hasTaskMatch
+                        ? ("good" as const)
+                        : undefined,
+                  };
+                });
+              })(),
             ]),
           },
         ]
@@ -1247,34 +1252,47 @@ function getFactGroups(
             title: "Enterprise Management Tasks",
             caption:
               "Scheduled task GUIDs under \\Microsoft\\Windows\\EnterpriseMgmt, cross-referenced with enrollment registry entries.",
-            rows: withNotReportedMetadata([
-              {
-                label: "Task GUID Count",
-                value: String(
-                  result.scheduledTaskEvidence.enterpriseMgmtGuids.length,
-                ),
-              },
-              ...result.scheduledTaskEvidence.enterpriseMgmtGuids.map(
-                (guid) => {
-                  const matchingEnrollment =
-                    result.enrollmentEvidence?.enrollments.find(
-                      (e) =>
-                        e.guid?.toLowerCase() === guid.toLowerCase(),
-                    );
-                  const enrolled =
-                    matchingEnrollment?.enrollmentState === 1;
-                  return {
-                    label: guid,
-                    value: matchingEnrollment
-                      ? `Registry match — ${matchingEnrollment.upn ?? "(no UPN)"} — state=${matchingEnrollment.enrollmentState}`
-                      : "No matching enrollment registry entry",
-                    tone: enrolled
-                      ? ("good" as const)
-                      : ("neutral" as const),
-                  };
+            rows: (() => {
+              const enrollments =
+                result.enrollmentEvidence?.enrollments ?? [];
+              const enrollmentByGuid = new Map<
+                string,
+                (typeof enrollments)[number]
+              >();
+              for (const enrollment of enrollments) {
+                const key = enrollment.guid?.toLowerCase();
+                if (key && !enrollmentByGuid.has(key)) {
+                  enrollmentByGuid.set(key, enrollment);
+                }
+              }
+              return withNotReportedMetadata([
+                {
+                  label: "Task GUID Count",
+                  value: String(
+                    result.scheduledTaskEvidence.enterpriseMgmtGuids
+                      .length,
+                  ),
                 },
-              ),
-            ]),
+                ...result.scheduledTaskEvidence.enterpriseMgmtGuids.map(
+                  (guid) => {
+                    const matchingEnrollment = enrollmentByGuid.get(
+                      guid.toLowerCase(),
+                    );
+                    const enrolled =
+                      matchingEnrollment?.enrollmentState === 1;
+                    return {
+                      label: guid,
+                      value: matchingEnrollment
+                        ? `Registry match — ${matchingEnrollment.upn ?? "(no UPN)"} — state=${matchingEnrollment.enrollmentState}`
+                        : "No matching enrollment registry entry",
+                      tone: enrolled
+                        ? ("good" as const)
+                        : ("neutral" as const),
+                    };
+                  },
+                ),
+              ]);
+            })(),
           },
         ]
       : []),

--- a/src/types/dsregcmd.ts
+++ b/src/types/dsregcmd.ts
@@ -232,6 +232,7 @@ export interface DsregcmdProxyEvidence {
 }
 
 export interface DsregcmdEnrollmentEntry {
+  guid: string | null;
   upn: string | null;
   providerId: string | null;
   enrollmentState: number | null;
@@ -265,6 +266,10 @@ export interface DsregcmdActiveEvidence {
   scpQuery: DsregcmdScpQueryResult | null;
 }
 
+export interface DsregcmdScheduledTaskEvidence {
+  enterpriseMgmtGuids: string[];
+}
+
 export interface DsregcmdAnalysisResult {
   facts: DsregcmdFacts;
   derived: DsregcmdDerived;
@@ -274,6 +279,7 @@ export interface DsregcmdAnalysisResult {
   proxyEvidence: DsregcmdProxyEvidence | null;
   enrollmentEvidence: DsregcmdEnrollmentEvidence | null;
   activeEvidence: DsregcmdActiveEvidence | null;
+  scheduledTaskEvidence: DsregcmdScheduledTaskEvidence | null;
   eventLogAnalysis: import("./event-log").EventLogAnalysis | null;
 }
 


### PR DESCRIPTION
## Summary

- **Bug**: DSRegCmd workspace showed "MDM enrolled: Unknown" when `dsregcmd /status` lacked MDM URLs, even on Intune-managed devices. MDM URLs are tenant-dependent and often absent.
- **Fix**: Collects GUIDs from scheduled tasks under `\Microsoft\Windows\EnterpriseMgmt` (via `schtasks /query`) and cross-references them with `HKLM\SOFTWARE\Microsoft\Enrollments`. When a GUID matches in both places AND `EnrollmentState=1`, `mdmEnrolled` is upgraded to `true`.
- Adds new "Enterprise Management Tasks" evidence card in the DSRegCmd workspace showing GUID cross-reference results
- Adds `mdm-confirmed-via-registry` info diagnostic explaining how enrollment was confirmed

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — 327 tests pass (2 new cross-reference tests)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual test on Windows: Intune-managed device where `dsregcmd /status` lacks MDM URLs should now show "MDM enrolled: Yes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)