### PR TITLE
chore(deps): upgrade TypeScript 5.9.3 → 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cmtrace-open",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cmtrace-open",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-components": "^9.73.3",
@@ -25,7 +25,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.4",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.2",
         "vite": "^7.3.1"
       }
     },
@@ -3715,9 +3715,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "vite": "^7.3.1"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrades `typescript` from `^5.9.3` to `^6.0.2`
- `npx tsc --noEmit` passes with zero errors — no source or tsconfig changes needed
- Replaces #45 which was closed because CI never verified the typecheck

## Test plan

- [x] `npx tsc --noEmit` passes locally (zero errors)
- [ ] CI pipeline (`cmtrace-ci.yml`) passes: TypeScript Check + Tauri builds

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)