### PR TITLE
Consolidate GUID resolution and expose registry to frontend

### DIFF
--- a/src-tauri/benches/intune_pipeline.rs
+++ b/src-tauri/benches/intune_pipeline.rs
@@ -26,7 +26,7 @@ fn bench_intune_pipeline(c: &mut Criterion) {
     validate_fixture(&fixture, &source_file, &content);
 
     let lines = app_lib::intune::ime_parser::parse_ime_content(&content);
-    let events = app_lib::intune::event_tracker::extract_events(&lines, &source_file);
+    let events = app_lib::intune::event_tracker::extract_events(&lines, &source_file, &app_lib::intune::guid_registry::GuidRegistry::new());
 
     let mut group = c.benchmark_group("intune_pipeline");
 
@@ -60,9 +60,11 @@ fn bench_intune_pipeline(c: &mut Criterion) {
         BenchmarkId::new("event_extraction", fixture.logical_record_count),
         |b| {
             b.iter(|| {
+                let registry = app_lib::intune::guid_registry::GuidRegistry::new();
                 let events = app_lib::intune::event_tracker::extract_events(
                     black_box(lines.as_slice()),
                     black_box(&source_file),
+                    &registry,
                 );
                 assert_eq!(events.len(), fixture.expected_event_count, "Expected one paired content-download event per app");
                 black_box(events)
@@ -91,9 +93,11 @@ fn bench_intune_pipeline(c: &mut Criterion) {
         BenchmarkId::new("downloads", fixture.logical_record_count),
         |b| {
             b.iter(|| {
+                let dl_registry = app_lib::intune::guid_registry::GuidRegistry::new();
                 let downloads = app_lib::intune::download_stats::extract_downloads(
                     black_box(lines.as_slice()),
                     black_box(&source_file),
+                    &dl_registry,
                 );
                 assert_eq!(downloads.len(), fixture.expected_download_count, "Expected one download summary per app");
                 black_box(downloads)
@@ -113,13 +117,13 @@ fn bench_intune_pipeline(c: &mut Criterion) {
                 let lines = app_lib::intune::ime_parser::parse_ime_content(&content);
                 assert_eq!(lines.len(), fixture.logical_record_count, "Expected IME parse to emit one logical record per synthetic line");
 
-                let events = app_lib::intune::event_tracker::extract_events(&lines, &source_file);
+                let events = app_lib::intune::event_tracker::extract_events(&lines, &source_file, &app_lib::intune::guid_registry::GuidRegistry::new());
                 assert_eq!(events.len(), fixture.expected_event_count, "Expected one paired content-download event per app");
 
                 let timeline = app_lib::intune::timeline::build_timeline(events);
                 assert_eq!(timeline.len(), fixture.expected_timeline_count, "Expected timeline to preserve one event per app after deduplication");
 
-                let downloads = app_lib::intune::download_stats::extract_downloads(&lines, &source_file);
+                let downloads = app_lib::intune::download_stats::extract_downloads(&lines, &source_file, &app_lib::intune::guid_registry::GuidRegistry::new());
                 assert_eq!(downloads.len(), fixture.expected_download_count, "Expected one download summary per app");
 
                 black_box((timeline, downloads))
@@ -136,13 +140,13 @@ fn validate_fixture(fixture: &common::IntuneBenchFixture, source_file: &str, con
     let lines = app_lib::intune::ime_parser::parse_ime_content(content);
     assert_eq!(lines.len(), fixture.logical_record_count, "Expected all synthetic IME logical records to parse");
 
-    let events = app_lib::intune::event_tracker::extract_events(&lines, source_file);
+    let events = app_lib::intune::event_tracker::extract_events(&lines, source_file, &app_lib::intune::guid_registry::GuidRegistry::new());
     assert_eq!(events.len(), fixture.expected_event_count, "Expected one paired content-download event per app");
 
     let timeline = app_lib::intune::timeline::build_timeline(events);
     assert_eq!(timeline.len(), fixture.expected_timeline_count, "Expected timeline deduplication to preserve one event per app");
 
-    let downloads = app_lib::intune::download_stats::extract_downloads(&lines, source_file);
+    let downloads = app_lib::intune::download_stats::extract_downloads(&lines, source_file, &app_lib::intune::guid_registry::GuidRegistry::new());
     assert_eq!(downloads.len(), fixture.expected_download_count, "Expected one download summary per app");
 }
 

--- a/src-tauri/src/commands/intune.rs
+++ b/src-tauri/src/commands/intune.rs
@@ -157,6 +157,7 @@ fn analyze_intune_logs_blocking(
     for processed_file in &processed_files {
         guid_registry.merge(&processed_file.guid_registry);
     }
+    let guid_registry_map = guid_registry.to_serializable();
 
     let mut all_events = Vec::new();
     let mut all_downloads = Vec::new();
@@ -332,6 +333,7 @@ fn analyze_intune_logs_blocking(
             repeated_failures,
             evidence_bundle,
             event_log_analysis,
+            guid_registry: guid_registry_map,
         });
     }
 
@@ -410,6 +412,7 @@ fn analyze_intune_logs_blocking(
         repeated_failures,
         evidence_bundle,
         event_log_analysis,
+        guid_registry: guid_registry_map,
     })
 }
 
@@ -663,8 +666,8 @@ fn analyze_intune_source_file(
         for (guid, entry) in file_guid_registry.iter() {
             eprintln!("  guid={} name=\"{}\" source={:?}", guid, entry.name, entry.source);
         }
-        let file_events = event_tracker::extract_events(&lines, &source_file);
-        let file_downloads = download_stats::extract_downloads(&lines, &source_file);
+        let file_events = event_tracker::extract_events(&lines, &source_file, &file_guid_registry);
+        let file_downloads = download_stats::extract_downloads(&lines, &source_file, &file_guid_registry);
         let file_timestamp_bounds = build_timestamp_bounds(&file_events, &file_downloads);
 
         (

--- a/src-tauri/src/intune/download_stats.rs
+++ b/src-tauri/src/intune/download_stats.rs
@@ -4,9 +4,7 @@ use std::path::Path;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-use super::guid_registry::{
-    extract_json_field, setup_file_name, APP_ID_JSON_RE, APP_NAME_JSON_RE, SETUP_FILE_JSON_RE,
-};
+use super::guid_registry::{extract_app_id, extract_app_name, is_fallback_name, GuidRegistry};
 use super::ime_parser::ImeLine;
 use super::models::DownloadStat;
 
@@ -68,9 +66,12 @@ static DURATION_RE: Lazy<Regex> = Lazy::new(|| {
     )
     .unwrap()
 });
-// APP_ID_JSON_RE, APP_NAME_JSON_RE, SETUP_FILE_JSON_RE imported from guid_registry
 
-pub fn extract_downloads(lines: &[ImeLine], source_file: &str) -> Vec<DownloadStat> {
+pub fn extract_downloads(
+    lines: &[ImeLine],
+    source_file: &str,
+    registry: &GuidRegistry,
+) -> Vec<DownloadStat> {
     let source_kind = classify_download_source(source_file);
     if source_kind == DownloadSourceKind::Unsupported {
         return Vec::new();
@@ -101,6 +102,7 @@ pub fn extract_downloads(lines: &[ImeLine], source_file: &str) -> Vec<DownloadSt
                 &analysis,
                 timestamp,
                 false,
+                registry,
             ) {
                 downloads.push(stat);
             }
@@ -131,6 +133,7 @@ pub fn extract_downloads(lines: &[ImeLine], source_file: &str) -> Vec<DownloadSt
                 &analysis,
                 timestamp,
                 true,
+                registry,
             ) {
                 downloads.push(stat);
             }
@@ -145,6 +148,7 @@ pub fn extract_downloads(lines: &[ImeLine], source_file: &str) -> Vec<DownloadSt
                 &analysis,
                 timestamp,
                 false,
+                registry,
             ) {
                 downloads.push(stat);
             }
@@ -153,14 +157,25 @@ pub fn extract_downloads(lines: &[ImeLine], source_file: &str) -> Vec<DownloadSt
 
     for partial in active.into_values() {
         if partial.saw_failure_signal || partial.saw_retry_signal {
+            let cid = partial
+                .content_id
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string());
+            let raw_name = partial
+                .display_name
+                .clone()
+                .unwrap_or_else(|| short_id(&cid));
+            let name = if is_fallback_name(&raw_name) {
+                registry
+                    .resolve(&cid)
+                    .map(|n| n.to_string())
+                    .unwrap_or(raw_name)
+            } else {
+                raw_name
+            };
             downloads.push(DownloadStat {
-                content_id: partial
-                    .content_id
-                    .clone()
-                    .unwrap_or_else(|| "unknown".to_string()),
-                name: partial.display_name.clone().unwrap_or_else(|| {
-                    short_id(partial.content_id.as_deref().unwrap_or("unknown"))
-                }),
+                content_id: cid,
+                name,
                 size_bytes: partial.size_bytes.unwrap_or(0),
                 speed_bps: partial.speed_bps.unwrap_or(0.0),
                 do_percentage: partial.do_percentage.unwrap_or(0.0),
@@ -288,52 +303,20 @@ fn classify_download_source(source_file: &str) -> DownloadSourceKind {
 }
 
 fn extract_content_id(msg: &str) -> Option<String> {
-    if let Some(value) = extract_json_field(msg, "\"AppId\":\"", "\"") {
-        return Some(value.to_string());
-    }
-    if let Some(value) = extract_json_field(msg, "\\\"AppId\\\":\\\"", "\\\"") {
-        return Some(value.to_string());
-    }
-
-    CONTENT_ID_RE
-        .captures(msg)
-        .and_then(|captures| captures.get(1))
-        .map(|value| value.as_str().to_string())
-        .or_else(|| {
-            APP_ID_JSON_RE
-                .captures(msg)
-                .and_then(|captures| captures.get(1))
-                .map(|value| value.as_str().to_string())
-        })
+    // Primary: shared extraction from guid_registry (handles AppId, Id, etc.)
+    extract_app_id(msg).or_else(|| {
+        // Fallback: download-specific broader pattern (e.g. "content id: <GUID>")
+        CONTENT_ID_RE
+            .captures(msg)
+            .and_then(|captures| captures.get(1))
+            .map(|value| value.as_str().to_string())
+    })
 }
 
 fn extract_display_name(msg: &str) -> Option<String> {
-    if let Some(value) = extract_json_field(msg, "\"ApplicationName\":\"", "\"") {
-        return Some(value.to_string());
-    }
-    if let Some(value) = extract_json_field(msg, "\\\"ApplicationName\\\":\\\"", "\\\"") {
-        return Some(value.to_string());
-    }
-    if let Some(value) = extract_json_field(msg, "\"SetUpFilePath\":\"", "\"") {
-        return Some(setup_file_name(value));
-    }
-    if let Some(value) = extract_json_field(msg, "\\\"SetUpFilePath\\\":\\\"", "\\\"") {
-        return Some(setup_file_name(value));
-    }
-
-    APP_NAME_JSON_RE
-        .captures(msg)
-        .and_then(|captures| captures.get(1))
-        .map(|value| value.as_str().to_string())
-        .or_else(|| {
-            SETUP_FILE_JSON_RE
-                .captures(msg)
-                .and_then(|captures| captures.get(1))
-                .map(|value| setup_file_name(value.as_str()))
-        })
+    // Delegates to shared extraction in guid_registry (handles ApplicationName, Name, SetUpFilePath)
+    extract_app_name(msg)
 }
-
-// extract_json_field and setup_file_name imported from guid_registry
 
 fn apply_download_analysis(
     download: &mut PartialDownload,
@@ -417,6 +400,7 @@ fn finalize_download(
     analysis: &DownloadLineAnalysis,
     timestamp: Option<&str>,
     success: bool,
+    registry: &GuidRegistry,
 ) -> Option<DownloadStat> {
     let mut partial = partial.unwrap_or_else(|| {
         PartialDownload::new(
@@ -439,12 +423,24 @@ fn finalize_download(
         return None;
     }
 
+    // Resolve display name: use existing name if it's a real name,
+    // otherwise try the GUID registry, otherwise fall back to short ID
+    let raw_name = partial
+        .display_name
+        .clone()
+        .unwrap_or_else(|| short_id(&resolved_content_id));
+    let name = if is_fallback_name(&raw_name) {
+        registry
+            .resolve(&resolved_content_id)
+            .map(|n| n.to_string())
+            .unwrap_or(raw_name)
+    } else {
+        raw_name
+    };
+
     Some(DownloadStat {
-        content_id: resolved_content_id.clone(),
-        name: partial
-            .display_name
-            .clone()
-            .unwrap_or_else(|| short_id(&resolved_content_id)),
+        content_id: resolved_content_id,
+        name,
         size_bytes: partial.size_bytes.unwrap_or(0),
         speed_bps: partial.speed_bps.unwrap_or(0.0),
         do_percentage: partial.do_percentage.unwrap_or(0.0),
@@ -465,6 +461,10 @@ fn short_id(id: &str) -> String {
 mod tests {
     use super::*;
 
+    fn empty_registry() -> GuidRegistry {
+        GuidRegistry::new()
+    }
+
     #[test]
     fn completed_download_is_recorded() {
         let lines = vec![
@@ -484,7 +484,7 @@ mod tests {
             },
         ];
 
-        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log");
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &empty_registry());
         assert_eq!(downloads.len(), 1);
         assert!(downloads[0].success);
         assert_eq!(downloads[0].size_bytes, 5242880);
@@ -509,7 +509,7 @@ mod tests {
             },
         ];
 
-        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log");
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &empty_registry());
         assert_eq!(downloads.len(), 1);
         assert!(!downloads[0].success);
     }
@@ -525,7 +525,7 @@ mod tests {
             component: None,
         }];
 
-        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log");
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &empty_registry());
         assert!(downloads.is_empty());
     }
 
@@ -548,7 +548,7 @@ mod tests {
             },
         ];
 
-        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log");
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &empty_registry());
         assert_eq!(downloads.len(), 1);
         assert!(!downloads[0].success);
     }
@@ -563,7 +563,7 @@ mod tests {
             component: None,
         }];
 
-        let downloads = extract_downloads(&lines, "C:/Logs/IntuneManagementExtension.log");
+        let downloads = extract_downloads(&lines, "C:/Logs/IntuneManagementExtension.log", &empty_registry());
         assert!(downloads.is_empty());
     }
 
@@ -577,7 +577,7 @@ mod tests {
             component: None,
         }];
 
-        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log");
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &empty_registry());
         assert!(downloads.is_empty());
     }
 
@@ -600,7 +600,7 @@ mod tests {
             },
         ];
 
-        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log");
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &empty_registry());
         assert_eq!(downloads.len(), 1);
         assert_eq!(
             downloads[0].content_id,
@@ -613,10 +613,12 @@ mod tests {
     fn escaped_json_fields_are_extracted_without_normalization() {
         let message = r#"Download completed successfully RequestPayload: {\"AppId\":\"a1b2c3d4-e5f6-7890-abcd-ef1234567890\",\"ApplicationName\":\"Contoso App\",\"SetUpFilePath\":\"C:\\Cache\\setup.exe\"}"#;
 
+        // extract_content_id delegates to guid_registry::extract_app_id + CONTENT_ID_RE fallback
         assert_eq!(
             extract_content_id(message).as_deref(),
             Some("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
         );
+        // extract_display_name delegates to guid_registry::extract_app_name
         assert_eq!(
             extract_display_name(message).as_deref(),
             Some("Contoso App")

--- a/src-tauri/src/intune/event_tracker.rs
+++ b/src-tauri/src/intune/event_tracker.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
+use super::guid_registry::{self, GuidRegistry, GUID_RE};
 use super::ime_parser::ImeLine;
 use super::models::{IntuneEvent, IntuneEventType, IntuneStatus};
 
@@ -136,10 +137,7 @@ static ESP_RE: Lazy<Regex> = Lazy::new(|| {
 });
 static SYNC_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r#"(?i)(?:sync\s+session|check-in|SyncSession)"#).unwrap());
-static GUID_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"#)
-        .unwrap()
-});
+// GUID_RE imported from guid_registry
 static ERROR_CODE_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
         r#"(?i)(?:error\s*(?:code)?|exit\s*code(?:\s+of\s+the\s+script)?|hresult|hr|result|return\s*code)\s*(?:is|[=:])\s*(0x[0-9a-fA-F]+|-?\d+)"#,
@@ -280,14 +278,20 @@ impl AppWorkloadMatchFlags {
     }
 }
 
-pub fn extract_events(lines: &[ImeLine], source_file: &str) -> Vec<IntuneEvent> {
+pub fn extract_events(
+    lines: &[ImeLine],
+    source_file: &str,
+    registry: &GuidRegistry,
+) -> Vec<IntuneEvent> {
     let mut events = Vec::new();
     let mut next_id = 0u64;
     let source_kind = classify_source_kind(source_file);
 
     for line in lines {
         if source_kind == ImeSourceKind::AppWorkload {
-            if let Some(event) = extract_appworkload_event(line, source_file, next_id) {
+            if let Some(event) =
+                extract_appworkload_event(line, source_file, next_id, registry)
+            {
                 events.push(event);
                 next_id += 1;
             }
@@ -298,9 +302,18 @@ pub fn extract_events(lines: &[ImeLine], source_file: &str) -> Vec<IntuneEvent> 
             continue;
         };
 
-        let guid = extract_guid(&line.message);
+        // Try primary extract_guid, fall back to guid_registry::extract_app_id
+        let guid = extract_guid(&line.message)
+            .or_else(|| guid_registry::extract_app_id(&line.message));
         let status = determine_status(&line.message, source_kind);
-        let name = build_event_name(&event_type, &guid, &line.message, source_kind);
+        let raw_name = build_event_name(&event_type, &guid, &line.message, source_kind);
+
+        // Inline enrichment: resolve GUID suffix immediately if possible
+        let name = match guid.as_deref() {
+            Some(g) => registry.enrich_event_name(&raw_name, g).unwrap_or(raw_name),
+            None => raw_name,
+        };
+
         let detail = line.message.clone();
 
         events.push(IntuneEvent {
@@ -331,6 +344,7 @@ fn extract_appworkload_event(
     line: &ImeLine,
     source_file: &str,
     next_id: u64,
+    registry: &GuidRegistry,
 ) -> Option<IntuneEvent> {
     let msg = line.message.as_str();
     if contains_any_ascii_case_insensitive(
@@ -363,9 +377,16 @@ fn extract_appworkload_event(
         return None;
     };
 
-    let guid = extract_guid(msg);
+    // Try primary extract_guid, fall back to guid_registry::extract_app_id
+    let guid = extract_guid(msg).or_else(|| guid_registry::extract_app_id(msg));
     let status = determine_appworkload_status(msg, flags);
-    let name = build_appworkload_name(&event_type, &guid, msg, flags);
+    let raw_name = build_appworkload_name(&event_type, &guid, msg, flags);
+
+    // Inline enrichment: resolve GUID suffix immediately if possible
+    let name = match guid.as_deref() {
+        Some(g) => registry.enrich_event_name(&raw_name, g).unwrap_or(raw_name),
+        None => raw_name,
+    };
 
     Some(IntuneEvent {
         id: next_id,
@@ -1219,6 +1240,10 @@ fn parse_event_timestamp(value: &str) -> Option<chrono::DateTime<chrono::Utc>> {
 mod tests {
     use super::*;
 
+    fn empty_registry() -> GuidRegistry {
+        GuidRegistry::new()
+    }
+
     fn line(message: &str, timestamp: &str, line_number: u32) -> ImeLine {
         ImeLine {
             line_number,
@@ -1240,6 +1265,7 @@ mod tests {
                 component: None,
             }],
             "C:/Logs/AppActionProcessor.log",
+            &empty_registry(),
         );
 
         assert_eq!(events.len(), 1);
@@ -1266,6 +1292,7 @@ mod tests {
                 1,
             )],
             "C:/Logs/AppWorkload.log",
+            &empty_registry(),
         );
 
         assert_eq!(events.len(), 1);
@@ -1282,6 +1309,7 @@ mod tests {
                 1,
             )],
             "C:/Logs/AppActionProcessor.log",
+            &empty_registry(),
         );
 
         assert_eq!(events.len(), 1);
@@ -1298,6 +1326,7 @@ mod tests {
                 1,
             )],
             "C:/Logs/AgentExecutor.log",
+            &empty_registry(),
         );
 
         assert_eq!(events.len(), 1);
@@ -1321,6 +1350,7 @@ mod tests {
                 ),
             ],
             "C:/Logs/AgentExecutor.log",
+            &empty_registry(),
         );
 
         assert!(events.is_empty());
@@ -1335,6 +1365,7 @@ mod tests {
                 1,
             )],
             "C:/Logs/ClientHealth.log",
+            &empty_registry(),
         );
 
         assert_eq!(events.len(), 1);
@@ -1352,6 +1383,7 @@ mod tests {
                 1,
             )],
             "C:/Logs/ClientHealth.log",
+            &empty_registry(),
         );
 
         assert!(events.is_empty());
@@ -1366,6 +1398,7 @@ mod tests {
                 1,
             )],
             "C:/Logs/ClientCertCheck.log",
+            &empty_registry(),
         );
 
         assert_eq!(events.len(), 1);
@@ -1383,6 +1416,7 @@ mod tests {
                 1,
             )],
             "C:/Logs/DeviceHealthMonitoring.log",
+            &empty_registry(),
         );
 
         assert_eq!(events.len(), 1);
@@ -1403,6 +1437,7 @@ mod tests {
                 1,
             )],
             "C:/Logs/Sensor.log",
+            &empty_registry(),
         );
 
         assert_eq!(events.len(), 1);
@@ -1420,6 +1455,7 @@ mod tests {
                 1,
             )],
             "C:/Logs/Win32AppInventory.log",
+            &empty_registry(),
         );
 
         assert_eq!(events.len(), 1);
@@ -1437,6 +1473,7 @@ mod tests {
                 1,
             )],
             "C:/Logs/Win32AppInventory.log",
+            &empty_registry(),
         );
 
         assert!(events.is_empty());
@@ -1458,6 +1495,7 @@ mod tests {
                 ),
             ],
             "C:/Logs/IntuneManagementExtension.log",
+            &empty_registry(),
         );
 
         assert_eq!(events.len(), 1);
@@ -1481,6 +1519,7 @@ mod tests {
                 ),
             ],
             "C:/Logs/AppWorkload.log",
+            &empty_registry(),
         );
 
         assert_eq!(events.len(), 1);

--- a/src-tauri/src/intune/guid_registry.rs
+++ b/src-tauri/src/intune/guid_registry.rs
@@ -716,4 +716,39 @@ mod tests {
         assert_eq!(strip_short_guid_suffix("Some Name (not-hex...)"), None);
         assert_eq!(strip_short_guid_suffix("Some Name (not a guid)"), None);
     }
+
+    #[test]
+    fn to_serializable_preserves_entries_and_sources() {
+        let mut reg = GuidRegistry::new();
+        reg.ingest_lines(&[
+            line(r#"Processing app: {"AppId":"aaaa1111-2222-3333-4444-555566667777","ApplicationName":"Contoso App"}"#),
+            line(r#"Download started: {"AppId":"bbbb1111-2222-3333-4444-555566667777","SetUpFilePath":"C:\\Cache\\installer.exe"}"#),
+        ]);
+
+        let map = reg.to_serializable();
+        assert_eq!(map.len(), 2);
+
+        let contoso = &map["aaaa1111-2222-3333-4444-555566667777"];
+        assert_eq!(contoso.name, "Contoso App");
+        assert_eq!(contoso.source, GuidNameSource::ApplicationName);
+
+        let installer = &map["bbbb1111-2222-3333-4444-555566667777"];
+        assert_eq!(installer.name, "installer.exe");
+        assert_eq!(installer.source, GuidNameSource::SetUpFilePath);
+
+        // Verify JSON serialization contract
+        let json = serde_json::to_value(&map).expect("serialize registry map");
+        assert_eq!(
+            json["aaaa1111-2222-3333-4444-555566667777"]["name"].as_str(),
+            Some("Contoso App")
+        );
+        assert_eq!(
+            json["aaaa1111-2222-3333-4444-555566667777"]["source"].as_str(),
+            Some("ApplicationName")
+        );
+        assert_eq!(
+            json["bbbb1111-2222-3333-4444-555566667777"]["source"].as_str(),
+            Some("SetUpFilePath")
+        );
+    }
 }

--- a/src-tauri/src/intune/guid_registry.rs
+++ b/src-tauri/src/intune/guid_registry.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use once_cell::sync::Lazy;
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 
 use super::ime_parser::ImeLine;
 
@@ -16,7 +17,7 @@ pub(crate) static SETUP_FILE_JSON_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r#"\"SetUpFilePath\"\s*:\s*\"([^\"]+)\""#).unwrap());
 
 /// Generic GUID pattern for secondary extraction.
-static GUID_RE: Lazy<Regex> = Lazy::new(|| {
+pub(crate) static GUID_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
         r#"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"#,
     )
@@ -47,7 +48,7 @@ pub(crate) fn setup_file_name(path: &str) -> String {
 // ── GUID registry types ─────────────────────────────────────────────────────
 
 /// Indicates where a GUID→name association was found, ranked by confidence.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum GuidNameSource {
     /// `"SetUpFilePath"` — lowest confidence (just a filename)
     SetUpFilePath = 0,
@@ -166,6 +167,30 @@ impl GuidRegistry {
     pub fn iter(&self) -> impl Iterator<Item = (&String, &GuidEntry)> {
         self.entries.iter()
     }
+
+    /// Convert to a serializable map for the frontend.
+    pub fn to_serializable(&self) -> HashMap<String, GuidRegistryEntry> {
+        self.entries
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    GuidRegistryEntry {
+                        name: v.name.clone(),
+                        source: v.source.clone(),
+                    },
+                )
+            })
+            .collect()
+    }
+}
+
+/// Serializable entry for the frontend GUID registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GuidRegistryEntry {
+    pub name: String,
+    pub source: GuidNameSource,
 }
 
 // ── Private extraction helpers ───────────────────────────────────────────────
@@ -231,7 +256,7 @@ fn extract_all_field_values(msg: &str, prefix: &str, suffix: &str) -> Vec<String
 ///
 /// Checks (in order): `"AppId"`, `"Id"`, then falls back to a generic
 /// GUID regex when a name field is also present on the same line.
-fn extract_app_id(msg: &str) -> Option<String> {
+pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
     // Try "AppId" — direct and escaped JSON
     if let Some(value) = extract_json_field(msg, "\"AppId\":\"", "\"") {
         return Some(value.to_string());
@@ -285,8 +310,13 @@ fn has_name_field(msg: &str) -> bool {
         || msg.contains("SetUpFilePath")
 }
 
+/// Extract a display name, discarding the confidence source.
+pub(crate) fn extract_app_name(msg: &str) -> Option<String> {
+    extract_app_name_with_source(msg).map(|(name, _)| name)
+}
+
 /// Extract a display name along with its confidence source.
-fn extract_app_name_with_source(msg: &str) -> Option<(String, GuidNameSource)> {
+pub(crate) fn extract_app_name_with_source(msg: &str) -> Option<(String, GuidNameSource)> {
     // ApplicationName (highest confidence)
     if let Some(value) = extract_json_field(msg, "\"ApplicationName\":\"", "\"") {
         return Some((value.to_string(), GuidNameSource::ApplicationName));
@@ -330,7 +360,7 @@ fn extract_app_name_with_source(msg: &str) -> Option<(String, GuidNameSource)> {
 }
 
 /// Detect whether a name is a fallback like "Download (guid)" or "Download: id".
-fn is_fallback_name(name: &str) -> bool {
+pub(crate) fn is_fallback_name(name: &str) -> bool {
     name.starts_with("Download (") || name.starts_with("Download:")
 }
 

--- a/src-tauri/src/intune/models.rs
+++ b/src-tauri/src/intune/models.rs
@@ -1,4 +1,8 @@
+use std::collections::HashMap;
+
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
+
+use super::guid_registry::GuidRegistryEntry;
 
 /// Artifact count summary retained from an evidence bundle manifest.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -523,6 +527,9 @@ pub struct IntuneAnalysisResult {
     /// Parsed and correlated Windows Event Log data from evidence bundle .evtx files.
     #[serde(default)]
     pub event_log_analysis: Option<EventLogAnalysis>,
+    /// Global GUID→app-name registry for frontend display (tooltips, lookup panel).
+    #[serde(default)]
+    pub guid_registry: HashMap<String, GuidRegistryEntry>,
 }
 
 impl Serialize for IntuneAnalysisResult {
@@ -530,7 +537,7 @@ impl Serialize for IntuneAnalysisResult {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("IntuneAnalysisResult", 11)?;
+        let mut state = serializer.serialize_struct("IntuneAnalysisResult", 12)?;
         state.serialize_field("events", &self.events)?;
         state.serialize_field("downloads", &self.downloads)?;
         state.serialize_field("summary", &self.summary)?;
@@ -542,6 +549,7 @@ impl Serialize for IntuneAnalysisResult {
         state.serialize_field("repeatedFailures", &self.repeated_failures)?;
         state.serialize_field("evidenceBundle", &self.evidence_bundle)?;
         state.serialize_field("eventLogAnalysis", &self.event_log_analysis)?;
+        state.serialize_field("guidRegistry", &self.guid_registry)?;
         state.end()
     }
 }
@@ -569,6 +577,8 @@ pub struct IntuneSummary {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::{
         EvidenceBundleArtifactCounts, EvidenceBundleMetadata, IntuneAnalysisResult,
         IntuneDiagnosticsConfidence, IntuneDiagnosticsCoverage, IntuneSummary,
@@ -603,6 +613,7 @@ mod tests {
             diagnostics_confidence: IntuneDiagnosticsConfidence::default(),
             repeated_failures: Vec::new(),
             event_log_analysis: None,
+            guid_registry: HashMap::new(),
             evidence_bundle: Some(EvidenceBundleMetadata {
                 manifest_path: "bundle-root/manifest.json".to_string(),
                 notes_path: Some("bundle-root/notes.md".to_string()),

--- a/src-tauri/tests/bench_parse.rs
+++ b/src-tauri/tests/bench_parse.rs
@@ -28,12 +28,13 @@ fn synthetic_intune_benchmark_fixture_matches_pipeline_counts() {
     assert_eq!(content.len(), bench_file.file_size_bytes, "Expected synthetic IME fixture size to remain stable");
     assert_eq!(lines.len(), bench_file.logical_record_count, "Expected all IME logical records parsed");
 
-    let events = app_lib::intune::event_tracker::extract_events(&lines, &path);
+    let registry = app_lib::intune::guid_registry::GuidRegistry::new();
+    let events = app_lib::intune::event_tracker::extract_events(&lines, &path, &registry);
     assert_eq!(events.len(), bench_file.expected_event_count, "Expected one paired content-download event per app");
 
     let timeline = app_lib::intune::timeline::build_timeline(events);
     assert_eq!(timeline.len(), bench_file.expected_timeline_count, "Expected timeline deduplication to preserve one event per app");
 
-    let downloads = app_lib::intune::download_stats::extract_downloads(&lines, &path);
+    let downloads = app_lib::intune::download_stats::extract_downloads(&lines, &path, &registry);
     assert_eq!(downloads.len(), bench_file.expected_download_count, "Expected one download summary per app");
 }

--- a/src/types/intune.ts
+++ b/src/types/intune.ts
@@ -226,6 +226,13 @@ export interface IntuneAnalysisState {
   progress: IntuneAnalysisProgress | null;
 }
 
+export type GuidNameSource = "SetUpFilePath" | "NameField" | "ApplicationName";
+
+export interface GuidRegistryEntry {
+  name: string;
+  source: GuidNameSource;
+}
+
 export interface IntuneAnalysisResult {
   events: IntuneEvent[];
   downloads: DownloadStat[];
@@ -238,6 +245,7 @@ export interface IntuneAnalysisResult {
   repeatedFailures: IntuneRepeatedFailureGroup[];
   evidenceBundle?: EvidenceBundleMetadata | null;
   eventLogAnalysis?: EventLogAnalysis | null;
+  guidRegistry: Record<string, GuidRegistryEntry>;
 }
 
 export interface IntuneResultMetadata {


### PR DESCRIPTION
## Changes

- **Version bump**: Update Cargo.lock to 0.6.0-pre1
- **GUID registry consolidation**: Extract common GUID-to-app-name resolution logic into shared functions in `guid_registry.rs`:
  - `extract_app_id()` — unified AppId/Id extraction
  - `extract_app_name()` — unified ApplicationName/Name/SetUpFilePath extraction
  - `is_fallback_name()` — detect placeholder names like "Download (guid)"
  - `enrich_event_name()` — resolve GUID suffixes in event names

- **API updates**: Pass `GuidRegistry` reference to:
  - `event_tracker::extract_events()`
  - `download_stats::extract_downloads()`
  - All test cases and benchmarks

- **Frontend exposure**: Add `guid_registry` field to `IntuneAnalysisResult` with serializable `GuidRegistryEntry` entries
- **TypeScript types**: Define `GuidNameSource` and `GuidRegistryEntry` interfaces in intune.ts
- **Name enrichment**: Automatically resolve GUID suffixes in event names during extraction using the registry

This enables the frontend to display resolved app names in tooltips and lookup panels.