### PR TITLE
fix: use original log timestamps for display instead of UTC conversion

### DIFF
--- a/src/lib/date-time-format.ts
+++ b/src/lib/date-time-format.ts
@@ -28,6 +28,14 @@ export async function initializeDateTimeFormatting(): Promise<void> {
   }
 }
 
+export async function refreshDateTimeFormatting(): Promise<void> {
+  try {
+    cachedPreferences = await getSystemDateTimePreferences();
+  } catch {
+    // Keep existing cached preferences on refresh failure
+  }
+}
+
 export function formatDisplayDateTime(value: DateLikeValue): string | null {
   const parsed = parseDisplayDateTime(value);
   if (!parsed) {
@@ -59,7 +67,7 @@ export function formatDisplayTime(value: DateLikeValue): string | null {
 }
 
 export function formatLogEntryTimestamp(entry: Pick<LogEntry, "timestamp" | "timestampDisplay">): string | null {
-  return formatDisplayDateTime(entry.timestamp ?? entry.timestampDisplay);
+  return formatDisplayDateTime(entry.timestampDisplay ?? entry.timestamp);
 }
 
 export function parseDisplayDateTime(value: DateLikeValue): Date | null {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,8 @@ import App from "./App";
 import { useAppMenu } from "./hooks/use-app-menu";
 import { getThemeById } from "./lib/themes";
 import { useUiStore } from "./stores/ui-store";
-import { initializeDateTimeFormatting } from "./lib/date-time-format";
+import { initializeDateTimeFormatting, refreshDateTimeFormatting } from "./lib/date-time-format";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 
 const RootWrapper = import.meta.env.DEV ? React.Fragment : React.StrictMode;
 
@@ -23,6 +24,18 @@ function AppRoot() {
   useEffect(() => {
     // Dismiss splash screen once the app has mounted
     dismissSplash();
+  }, []);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    getCurrentWindow()
+      .onFocusChanged(({ payload: focused }) => {
+        if (focused) void refreshDateTimeFormatting();
+      })
+      .then((fn) => {
+        unlisten = fn;
+      });
+    return () => unlisten?.();
   }, []);
 
   return <App />;


### PR DESCRIPTION
## Summary
- **8-hour timestamp offset**: Fixed by preferring `timestampDisplay` (original log-file local time) over `timestamp` (UTC millis) for display formatting. The original CMTrace shows timestamps as-is from the log, with no timezone conversion — we now match that behavior. UTC millis are still used for sorting and elapsed-time calculations.
- **Stale 24h/12h format**: Date/time format preferences are now refreshed from the Windows registry on window focus, so changing between 24-hour and AM/PM in Windows Settings takes effect without restarting the app.

## Test plan
- [ ] Open a CCM log file written on a machine with a different UTC offset — timestamps should match the original CMTrace
- [ ] Switch Windows time format between 12h and 24h, alt-tab back to the app — format should update
- [ ] Verify elapsed time in status bar still calculates correctly
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)