### PR TITLE
chore: release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-03-28
+
+### Fixed
+
+- **Timestamp display offset**: Timestamps from logs written on machines in different timezones (e.g., UTC+8) now display correctly, matching the original CMTrace behavior. Previously, the app converted UTC epoch millis back to the viewer's local timezone, causing an 8-hour (or other) offset.
+- **24h/12h time format refresh**: Date/time format preferences are now refreshed from the Windows registry when the app regains focus, so switching between 24-hour and AM/PM in Windows Settings takes effect without restarting the app.
+
 ## [1.0.0] - 2026-03-28
 
 ### Highlights

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmtrace-open",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Open-source CMTrace log viewer with built-in Intune diagnostics",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "cmtrace-open"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "criterion",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmtrace-open"
-version = "1.0.0"
+version = "1.0.1"
 description = "Open-source CMTrace log viewer with Intune diagnostics"
 authors = ["Adam Gell"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CMTrace Open",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.cmtrace.open",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Bump version to 1.0.1 across `package.json`, `tauri.conf.json`, `Cargo.toml`
- Update CHANGELOG with 1.0.1 fixes: timestamp display offset and 24h/12h format refresh

## Test plan
- [ ] CI passes (cargo check, clippy, tsc, Tauri build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)