### PR TITLE
fix: Copilot review fixes + cargo-deny config

### DIFF
--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -5,8 +5,10 @@ ignore = []
 allow = [
     "MIT",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "BSL-1.0",
     "ISC",
     "Zlib",
     "Unicode-3.0",
@@ -14,6 +16,7 @@ allow = [
     "MPL-2.0",
     "OpenSSL",
     "CC0-1.0",
+    "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.8
 


### PR DESCRIPTION
## Summary

Post-merge fixes for PRs #62 and #63:

- Fix invalid CSS alpha on Fluent UI token values (color-mix instead of hex suffix)
- Fix formatDuration rounding bug (could show "60s")
- Add keyboard accessibility to EventTimelineRow (tabIndex + onKeyDown)
- Add path traversal protection for bundle manifest paths
- Add descriptive `.expect()` messages to panther parser regex
- Fix `deny.toml` for cargo-deny v0.17+ (remove all deprecated keys)
- Use `taiki-e/install-action` for cargo-deny in CI
- Add `type="button"` to non-submit buttons
- Remove outline:none for keyboard focus visibility
- Replace hardcoded rgba white with theme token for dark mode

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run test` — 77 tests pass
- [x] `cargo check` + `cargo test` + `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)