### PR TITLE
feat: add column sorting to Intune Diagnostics workspace

### DIFF
--- a/src-tauri/src/commands/intune.rs
+++ b/src-tauri/src/commands/intune.rs
@@ -1028,7 +1028,7 @@ fn synthesize_downloads_from_events(events: &[IntuneEvent]) -> Vec<DownloadStat>
             duration_secs: last.duration_secs.unwrap_or(0.0),
             success,
             timestamp,
-            timestamp_epoch: None,
+            timestamp_epoch: last.start_time_epoch.or(last.end_time_epoch),
         });
     }
 

--- a/src-tauri/src/commands/intune.rs
+++ b/src-tauri/src/commands/intune.rs
@@ -1028,6 +1028,7 @@ fn synthesize_downloads_from_events(events: &[IntuneEvent]) -> Vec<DownloadStat>
             duration_secs: last.duration_secs.unwrap_or(0.0),
             success,
             timestamp,
+            timestamp_epoch: None,
         });
     }
 
@@ -1419,6 +1420,8 @@ mod tests {
                 detail: "Script failed".to_string(),
                 source_file: "C:/Logs/AgentExecutor.log".to_string(),
                 line_number: 12,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 2,
@@ -1433,6 +1436,8 @@ mod tests {
                 detail: "Applicability pending".to_string(),
                 source_file: "C:/Logs/AppActionProcessor.log".to_string(),
                 line_number: 18,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 3,
@@ -1447,6 +1452,8 @@ mod tests {
                 detail: "Hash validation failed after staging cached content".to_string(),
                 source_file: "C:/Logs/AppWorkload.log".to_string(),
                 line_number: 22,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 4,
@@ -1461,6 +1468,8 @@ mod tests {
                 detail: "Installer execution failed with error code: 0x80070005".to_string(),
                 source_file: "C:/Logs/AppWorkload.log".to_string(),
                 line_number: 28,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
         ];
         let downloads = vec![DownloadStat {
@@ -1472,6 +1481,7 @@ mod tests {
             duration_secs: 5.0,
             success: false,
             timestamp: Some("01-15-2024 10:00:00.000".to_string()),
+            timestamp_epoch: None,
         }];
         let summary = IntuneSummary {
             total_events: 4,
@@ -1546,6 +1556,8 @@ mod tests {
                 detail: "Installer execution failed with error code: 0x80070005".to_string(),
                 source_file: "C:/Logs/AppWorkload.log".to_string(),
                 line_number: 12,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 2,
@@ -1560,6 +1572,8 @@ mod tests {
                 detail: "Installer execution failed with error code: 0x80070005".to_string(),
                 source_file: "C:/Logs/AppWorkload-1.log".to_string(),
                 line_number: 18,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
         ];
 
@@ -1615,6 +1629,8 @@ mod tests {
             detail: "download failed".to_string(),
             source_file: "C:/Logs/AppWorkload.log".to_string(),
             line_number: 8,
+            start_time_epoch: None,
+            end_time_epoch: None,
         }];
         let downloads = vec![DownloadStat {
             content_id: "content-1".to_string(),
@@ -1625,6 +1641,7 @@ mod tests {
             duration_secs: 5.0,
             success: false,
             timestamp: Some("01-15-2024 10:00:00.000".to_string()),
+            timestamp_epoch: None,
         }];
 
         let finalized = finalize_coverage(coverage, &events, &downloads);
@@ -1682,6 +1699,8 @@ mod tests {
                         detail: "install failed".to_string(),
                         source_file: "C:/Logs/IntuneManagementExtension.log".to_string(),
                         line_number: 12,
+                        start_time_epoch: None,
+                        end_time_epoch: None,
                     }],
                     &[],
                 ),
@@ -1706,6 +1725,8 @@ mod tests {
                 detail: "install failed".to_string(),
                 source_file: "C:/Logs/IntuneManagementExtension.log".to_string(),
                 line_number: 12,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 2,
@@ -1720,6 +1741,8 @@ mod tests {
                 detail: "install in progress".to_string(),
                 source_file: "C:/Logs/IntuneManagementExtension.log".to_string(),
                 line_number: 20,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
         ];
 
@@ -1746,6 +1769,8 @@ mod tests {
             detail: "Content download stalled with no progress".to_string(),
             source_file: "C:/Logs/AppWorkload.log".to_string(),
             line_number: 15,
+            start_time_epoch: None,
+            end_time_epoch: None,
         }];
 
         let summary = build_summary(&events, &[]);
@@ -1772,6 +1797,8 @@ mod tests {
                 detail: "The client health report was sent successfully. Done.".to_string(),
                 source_file: "C:/Logs/ClientHealth.log".to_string(),
                 line_number: 10,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 2,
@@ -1786,6 +1813,8 @@ mod tests {
                 detail: "Computing delta inventory...Done. Add count = 2, Modify count = 0, Delete count = 2".to_string(),
                 source_file: "C:/Logs/Win32AppInventory.log".to_string(),
                 line_number: 18,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 3,
@@ -1800,6 +1829,8 @@ mod tests {
                 detail: "MDM certs found in LocalMachine count: 0".to_string(),
                 source_file: "C:/Logs/ClientCertCheck.log".to_string(),
                 line_number: 4,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
         ];
 
@@ -1826,6 +1857,8 @@ mod tests {
                 detail: "Starting content download".to_string(),
                 source_file: "C:/Logs/AppWorkload.log".to_string(),
                 line_number: 8,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 2,
@@ -1840,6 +1873,8 @@ mod tests {
                 detail: "Hash validation failed after staging cached content".to_string(),
                 source_file: "C:/Logs/AppWorkload.log".to_string(),
                 line_number: 12,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
         ];
         let downloads = vec![DownloadStat {
@@ -1851,6 +1886,7 @@ mod tests {
             duration_secs: 5.0,
             success: false,
             timestamp: Some("01-15-2024 10:00:05.000".to_string()),
+            timestamp_epoch: None,
         }];
 
         let summary = build_summary(&events, &downloads);

--- a/src-tauri/src/commands/intune.rs
+++ b/src-tauri/src/commands/intune.rs
@@ -1019,6 +1019,11 @@ fn synthesize_downloads_from_events(events: &[IntuneEvent]) -> Vec<DownloadStat>
             .clone()
             .or_else(|| last.end_time.clone());
 
+        let timestamp_epoch = timestamp
+            .as_deref()
+            .and_then(timeline::parse_timestamp)
+            .map(|dt| dt.and_utc().timestamp_millis());
+
         downloads.push(DownloadStat {
             content_id: content_id.clone(),
             name,
@@ -1028,7 +1033,7 @@ fn synthesize_downloads_from_events(events: &[IntuneEvent]) -> Vec<DownloadStat>
             duration_secs: last.duration_secs.unwrap_or(0.0),
             success,
             timestamp,
-            timestamp_epoch: last.start_time_epoch.or(last.end_time_epoch),
+            timestamp_epoch,
         });
     }
 

--- a/src-tauri/src/intune/download_stats.rs
+++ b/src-tauri/src/intune/download_stats.rs
@@ -219,6 +219,7 @@ pub fn extract_downloads(
                 duration_secs: partial.duration_secs.unwrap_or(0.0),
                 success: false,
                 timestamp: partial.last_timestamp.or(partial.start_time),
+                timestamp_epoch: None,
             });
         }
     }
@@ -487,6 +488,7 @@ fn finalize_download(
             .map(|value| value.to_string())
             .or(partial.last_timestamp)
             .or(partial.start_time),
+        timestamp_epoch: None,
     })
 }
 

--- a/src-tauri/src/intune/download_stats.rs
+++ b/src-tauri/src/intune/download_stats.rs
@@ -6,6 +6,7 @@ use regex::Regex;
 use super::guid_registry::{extract_app_id, extract_app_name, is_fallback_name, GuidRegistry};
 use super::ime_parser::ImeLine;
 use super::models::DownloadStat;
+use super::timeline::parse_timestamp;
 use std::sync::OnceLock;
 
 fn download_re() -> &'static Regex {
@@ -210,6 +211,7 @@ pub fn extract_downloads(
             } else {
                 raw_name
             };
+            let ts = partial.last_timestamp.or(partial.start_time);
             downloads.push(DownloadStat {
                 content_id: cid,
                 name,
@@ -218,8 +220,8 @@ pub fn extract_downloads(
                 do_percentage: partial.do_percentage.unwrap_or(0.0),
                 duration_secs: partial.duration_secs.unwrap_or(0.0),
                 success: false,
-                timestamp: partial.last_timestamp.or(partial.start_time),
-                timestamp_epoch: None,
+                timestamp_epoch: ts.as_deref().and_then(parse_timestamp).map(|dt| dt.and_utc().timestamp_millis()),
+                timestamp: ts,
             });
         }
     }
@@ -476,6 +478,11 @@ fn finalize_download(
         raw_name
     };
 
+    let ts = timestamp
+        .map(|value| value.to_string())
+        .or(partial.last_timestamp)
+        .or(partial.start_time);
+
     Some(DownloadStat {
         content_id: resolved_content_id,
         name,
@@ -484,11 +491,8 @@ fn finalize_download(
         do_percentage: partial.do_percentage.unwrap_or(0.0),
         duration_secs: partial.duration_secs.unwrap_or(0.0),
         success,
-        timestamp: timestamp
-            .map(|value| value.to_string())
-            .or(partial.last_timestamp)
-            .or(partial.start_time),
-        timestamp_epoch: None,
+        timestamp_epoch: ts.as_deref().and_then(parse_timestamp).map(|dt| dt.and_utc().timestamp_millis()),
+        timestamp: ts,
     })
 }
 
@@ -646,6 +650,30 @@ mod tests {
             "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         );
         assert_eq!(downloads[0].name, "Contoso App");
+    }
+
+    #[test]
+    fn completed_download_has_timestamp_epoch() {
+        let lines = vec![
+            ImeLine {
+                line_number: 1,
+                timestamp: Some("01-15-2024 10:00:00.000".to_string()),
+                timestamp_utc: None,
+                message: "Starting content download for app id: a1b2c3d4-e5f6-7890-abcd-ef1234567890".to_string(),
+                component: None,
+            },
+            ImeLine {
+                line_number: 2,
+                timestamp: Some("01-15-2024 10:00:05.000".to_string()),
+                timestamp_utc: None,
+                message: "Download completed successfully. Content size: 5242880 bytes, speed: 1048576 Bps, Delivery Optimization: 75.5%".to_string(),
+                component: None,
+            },
+        ];
+
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &empty_registry());
+        assert_eq!(downloads.len(), 1);
+        assert!(downloads[0].timestamp_epoch.is_some(), "timestamp_epoch should be populated");
     }
 
     #[test]

--- a/src-tauri/src/intune/event_tracker.rs
+++ b/src-tauri/src/intune/event_tracker.rs
@@ -467,6 +467,8 @@ pub fn extract_events(
             detail,
             source_file: source_file.to_string(),
             line_number: line.line_number,
+            start_time_epoch: None,
+            end_time_epoch: None,
         });
         next_id += 1;
     }
@@ -539,6 +541,8 @@ fn extract_appworkload_event(
         detail: build_detail(msg),
         source_file: source_file.to_string(),
         line_number: line.line_number,
+        start_time_epoch: None,
+        end_time_epoch: None,
     })
 }
 

--- a/src-tauri/src/intune/models.rs
+++ b/src-tauri/src/intune/models.rs
@@ -146,6 +146,10 @@ pub struct IntuneEvent {
     pub source_file: String,
     /// Line number in source file
     pub line_number: u32,
+    /// Start time as milliseconds since Unix epoch (pre-computed for fast frontend sorting)
+    pub start_time_epoch: Option<i64>,
+    /// End time as milliseconds since Unix epoch (pre-computed for fast frontend sorting)
+    pub end_time_epoch: Option<i64>,
 }
 
 /// Download statistics for a content download event.
@@ -168,6 +172,8 @@ pub struct DownloadStat {
     pub success: bool,
     /// Timestamp
     pub timestamp: Option<String>,
+    /// Timestamp as milliseconds since Unix epoch (pre-computed for fast frontend sorting)
+    pub timestamp_epoch: Option<i64>,
 }
 
 /// Inclusive timestamp bounds captured from analyzed content.

--- a/src-tauri/src/intune/timeline.rs
+++ b/src-tauri/src/intune/timeline.rs
@@ -328,6 +328,8 @@ mod tests {
                 detail: "later".to_string(),
                 source_file: "b.log".to_string(),
                 line_number: 2,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 1,
@@ -342,6 +344,8 @@ mod tests {
                 detail: "earlier".to_string(),
                 source_file: "a.log".to_string(),
                 line_number: 1,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
         ])
         .expect("timestamp bounds");
@@ -366,6 +370,8 @@ mod tests {
                 detail: "later".to_string(),
                 source_file: "b.log".to_string(),
                 line_number: 2,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 1,
@@ -380,6 +386,8 @@ mod tests {
                 detail: "earlier".to_string(),
                 source_file: "a.log".to_string(),
                 line_number: 1,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
         ];
 
@@ -402,6 +410,8 @@ mod tests {
                 detail: "later".to_string(),
                 source_file: "b.log".to_string(),
                 line_number: 2,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 1,
@@ -416,6 +426,8 @@ mod tests {
                 detail: "earlier".to_string(),
                 source_file: "a.log".to_string(),
                 line_number: 1,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
         ]);
 
@@ -438,6 +450,8 @@ mod tests {
             detail: "same".to_string(),
             source_file: "a.log".to_string(),
             line_number: 1,
+            start_time_epoch: None,
+            end_time_epoch: None,
         };
 
         let timeline = build_timeline(vec![event.clone(), event]);
@@ -459,6 +473,8 @@ mod tests {
             detail: "Hash validation failed after staging cached content".to_string(),
             source_file: "C:/Logs/AppWorkload.log".to_string(),
             line_number: 12,
+            start_time_epoch: None,
+            end_time_epoch: None,
         };
 
         let mut rotated = event.clone();
@@ -486,6 +502,8 @@ mod tests {
                 detail: "later".to_string(),
                 source_file: "b.log".to_string(),
                 line_number: 2,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
             IntuneEvent {
                 id: 99,
@@ -500,6 +518,8 @@ mod tests {
                 detail: "earlier".to_string(),
                 source_file: "a.log".to_string(),
                 line_number: 1,
+                start_time_epoch: None,
+                end_time_epoch: None,
             },
         ]);
 

--- a/src-tauri/src/intune/timeline.rs
+++ b/src-tauri/src/intune/timeline.rs
@@ -48,9 +48,21 @@ pub fn build_timeline(events: Vec<IntuneEvent>) -> Vec<IntuneEvent> {
             .then_with(|| a.event.name.cmp(&b.event.name))
     });
 
-    // Re-assign sequential IDs
+    // Re-assign sequential IDs and populate epoch timestamps
     for (i, entry) in timeline.iter_mut().enumerate() {
         entry.event.id = i as u64;
+        entry.event.start_time_epoch = entry
+            .event
+            .start_time
+            .as_deref()
+            .and_then(parse_timestamp)
+            .map(|dt| dt.and_utc().timestamp_millis());
+        entry.event.end_time_epoch = entry
+            .event
+            .end_time
+            .as_deref()
+            .and_then(parse_timestamp)
+            .map(|dt| dt.and_utc().timestamp_millis());
     }
 
     timeline.into_iter().map(|entry| entry.event).collect()
@@ -484,6 +496,52 @@ mod tests {
 
         let timeline = build_timeline(vec![event, rotated]);
         assert_eq!(timeline.len(), 1);
+    }
+
+    #[test]
+    fn build_timeline_populates_epoch_fields() {
+        let timeline = build_timeline(vec![
+            IntuneEvent {
+                id: 0,
+                event_type: IntuneEventType::Win32App,
+                name: "Test".to_string(),
+                guid: None,
+                status: IntuneStatus::Success,
+                start_time: Some("01-15-2024 10:30:00.000".to_string()),
+                end_time: Some("01-15-2024 10:35:00.000".to_string()),
+                duration_secs: Some(300.0),
+                error_code: None,
+                detail: "test".to_string(),
+                source_file: "a.log".to_string(),
+                line_number: 1,
+                start_time_epoch: None,
+                end_time_epoch: None,
+            },
+            IntuneEvent {
+                id: 1,
+                event_type: IntuneEventType::Win32App,
+                name: "NoTime".to_string(),
+                guid: None,
+                status: IntuneStatus::Pending,
+                start_time: None,
+                end_time: None,
+                duration_secs: None,
+                error_code: None,
+                detail: "no time".to_string(),
+                source_file: "b.log".to_string(),
+                line_number: 1,
+                start_time_epoch: None,
+                end_time_epoch: None,
+            },
+        ]);
+
+        let timed = &timeline[1]; // sorted after NoTime (which has None timestamp)
+        assert!(timed.start_time_epoch.is_some(), "start_time_epoch should be populated");
+        assert!(timed.end_time_epoch.is_some(), "end_time_epoch should be populated");
+
+        let untimed = &timeline[0]; // None timestamps sort first
+        assert!(untimed.start_time_epoch.is_none());
+        assert!(untimed.end_time_epoch.is_none());
     }
 
     #[test]

--- a/src/components/intune/DownloadStats.tsx
+++ b/src/components/intune/DownloadStats.tsx
@@ -35,34 +35,38 @@ export function DownloadStats({ downloads }: DownloadStatsProps) {
 
   const sortedDownloads = useMemo(() => {
     return [...downloads].sort((a, b) => {
-      let cmp = 0;
       switch (downloadSortField) {
-        case "name":
-          cmp = a.name.localeCompare(b.name);
-          break;
-        case "size":
-          cmp = a.sizeBytes - b.sizeBytes;
-          break;
-        case "speed":
-          cmp = a.speedBps - b.speedBps;
-          break;
-        case "doPercentage":
-          cmp = a.doPercentage - b.doPercentage;
-          break;
-        case "duration":
-          cmp = a.durationSecs - b.durationSecs;
-          break;
+        case "name": {
+          const cmp = a.name.localeCompare(b.name);
+          return downloadSortDirection === "asc" ? cmp : -cmp;
+        }
+        case "size": {
+          const cmp = a.sizeBytes - b.sizeBytes;
+          return downloadSortDirection === "asc" ? cmp : -cmp;
+        }
+        case "speed": {
+          const cmp = a.speedBps - b.speedBps;
+          return downloadSortDirection === "asc" ? cmp : -cmp;
+        }
+        case "doPercentage": {
+          const cmp = a.doPercentage - b.doPercentage;
+          return downloadSortDirection === "asc" ? cmp : -cmp;
+        }
+        case "duration": {
+          const cmp = a.durationSecs - b.durationSecs;
+          return downloadSortDirection === "asc" ? cmp : -cmp;
+        }
         case "timestamp": {
           const aTime = a.timestampEpoch;
           const bTime = b.timestampEpoch;
-          if (aTime == null && bTime == null) cmp = 0;
-          else if (aTime == null) cmp = 1;
-          else if (bTime == null) cmp = -1;
-          else cmp = aTime - bTime;
-          break;
+          if (aTime == null && bTime != null) return 1;
+          if (aTime != null && bTime == null) return -1;
+          if (aTime == null && bTime == null) return 0;
+          return downloadSortDirection === "asc" ? aTime! - bTime! : bTime! - aTime!;
         }
+        default:
+          return 0;
       }
-      return downloadSortDirection === "asc" ? cmp : -cmp;
     });
   }, [downloads, downloadSortField, downloadSortDirection]);
 

--- a/src/components/intune/DownloadStats.tsx
+++ b/src/components/intune/DownloadStats.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import { tokens } from "@fluentui/react-components";
 import { LOG_UI_FONT_FAMILY, LOG_MONOSPACE_FONT_FAMILY } from "../../lib/log-accessibility";
 import type { DownloadStat } from "../../types/intune";
 import { formatDisplayDateTime } from "../../lib/date-time-format";
+import { compareDownloads } from "../../lib/intune-sort";
 import { useIntuneStore } from "../../stores/intune-store";
 import type { DownloadSortField } from "../../stores/intune-store";
 
@@ -34,40 +35,9 @@ export function DownloadStats({ downloads }: DownloadStatsProps) {
   }, [downloads]);
 
   const sortedDownloads = useMemo(() => {
-    return [...downloads].sort((a, b) => {
-      switch (downloadSortField) {
-        case "name": {
-          const cmp = a.name.localeCompare(b.name);
-          return downloadSortDirection === "asc" ? cmp : -cmp;
-        }
-        case "size": {
-          const cmp = a.sizeBytes - b.sizeBytes;
-          return downloadSortDirection === "asc" ? cmp : -cmp;
-        }
-        case "speed": {
-          const cmp = a.speedBps - b.speedBps;
-          return downloadSortDirection === "asc" ? cmp : -cmp;
-        }
-        case "doPercentage": {
-          const cmp = a.doPercentage - b.doPercentage;
-          return downloadSortDirection === "asc" ? cmp : -cmp;
-        }
-        case "duration": {
-          const cmp = a.durationSecs - b.durationSecs;
-          return downloadSortDirection === "asc" ? cmp : -cmp;
-        }
-        case "timestamp": {
-          const aTime = a.timestampEpoch;
-          const bTime = b.timestampEpoch;
-          if (aTime == null && bTime != null) return 1;
-          if (aTime != null && bTime == null) return -1;
-          if (aTime == null && bTime == null) return 0;
-          return downloadSortDirection === "asc" ? aTime! - bTime! : bTime! - aTime!;
-        }
-        default:
-          return 0;
-      }
-    });
+    return [...downloads].sort((a, b) =>
+      compareDownloads(a, b, downloadSortField, downloadSortDirection)
+    );
   }, [downloads, downloadSortField, downloadSortDirection]);
 
   const sortIndicator = (field: DownloadSortField) =>
@@ -80,6 +50,24 @@ export function DownloadStats({ downloads }: DownloadStatsProps) {
       setDownloadSortField(field);
     }
   };
+
+  const handleHeaderKeyDown = useCallback(
+    (e: React.KeyboardEvent, field: DownloadSortField) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleHeaderClick(field);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [downloadSortField],
+  );
+
+  const ariaSort = (field: DownloadSortField): "ascending" | "descending" | "none" =>
+    downloadSortField === field
+      ? downloadSortDirection === "asc"
+        ? "ascending"
+        : "descending"
+      : "none";
 
   if (downloads.length === 0) {
     return (
@@ -129,12 +117,12 @@ export function DownloadStats({ downloads }: DownloadStatsProps) {
               }}
             >
               <th style={thStyle}>Status</th>
-              <th style={{ ...thStyle, cursor: "pointer" }} onClick={() => handleHeaderClick("name")}>Content{sortIndicator("name")}</th>
-              <th style={{ ...thStyle, textAlign: "right", width: "80px", cursor: "pointer" }} onClick={() => handleHeaderClick("size")}>Size{sortIndicator("size")}</th>
-              <th style={{ ...thStyle, textAlign: "right", width: "90px", cursor: "pointer" }} onClick={() => handleHeaderClick("speed")}>Speed{sortIndicator("speed")}</th>
-              <th style={{ ...thStyle, width: "120px", cursor: "pointer" }} onClick={() => handleHeaderClick("doPercentage")}>DO %{sortIndicator("doPercentage")}</th>
-              <th style={{ ...thStyle, textAlign: "right", width: "70px", cursor: "pointer" }} onClick={() => handleHeaderClick("duration")}>Dur.{sortIndicator("duration")}</th>
-              <th style={{ ...thStyle, width: "130px", cursor: "pointer" }} onClick={() => handleHeaderClick("timestamp")}>Timestamp{sortIndicator("timestamp")}</th>
+              <th style={{ ...thStyle, cursor: "pointer" }} tabIndex={0} aria-sort={ariaSort("name")} onClick={() => handleHeaderClick("name")} onKeyDown={(e) => handleHeaderKeyDown(e, "name")}>Content{sortIndicator("name")}</th>
+              <th style={{ ...thStyle, textAlign: "right", width: "80px", cursor: "pointer" }} tabIndex={0} aria-sort={ariaSort("size")} onClick={() => handleHeaderClick("size")} onKeyDown={(e) => handleHeaderKeyDown(e, "size")}>Size{sortIndicator("size")}</th>
+              <th style={{ ...thStyle, textAlign: "right", width: "90px", cursor: "pointer" }} tabIndex={0} aria-sort={ariaSort("speed")} onClick={() => handleHeaderClick("speed")} onKeyDown={(e) => handleHeaderKeyDown(e, "speed")}>Speed{sortIndicator("speed")}</th>
+              <th style={{ ...thStyle, width: "120px", cursor: "pointer" }} tabIndex={0} aria-sort={ariaSort("doPercentage")} onClick={() => handleHeaderClick("doPercentage")} onKeyDown={(e) => handleHeaderKeyDown(e, "doPercentage")}>DO %{sortIndicator("doPercentage")}</th>
+              <th style={{ ...thStyle, textAlign: "right", width: "70px", cursor: "pointer" }} tabIndex={0} aria-sort={ariaSort("duration")} onClick={() => handleHeaderClick("duration")} onKeyDown={(e) => handleHeaderKeyDown(e, "duration")}>Dur.{sortIndicator("duration")}</th>
+              <th style={{ ...thStyle, width: "130px", cursor: "pointer" }} tabIndex={0} aria-sort={ariaSort("timestamp")} onClick={() => handleHeaderClick("timestamp")} onKeyDown={(e) => handleHeaderKeyDown(e, "timestamp")}>Timestamp{sortIndicator("timestamp")}</th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/intune/DownloadStats.tsx
+++ b/src/components/intune/DownloadStats.tsx
@@ -3,12 +3,19 @@ import { tokens } from "@fluentui/react-components";
 import { LOG_UI_FONT_FAMILY, LOG_MONOSPACE_FONT_FAMILY } from "../../lib/log-accessibility";
 import type { DownloadStat } from "../../types/intune";
 import { formatDisplayDateTime } from "../../lib/date-time-format";
+import { useIntuneStore } from "../../stores/intune-store";
+import type { DownloadSortField } from "../../stores/intune-store";
 
 interface DownloadStatsProps {
   downloads: DownloadStat[];
 }
 
 export function DownloadStats({ downloads }: DownloadStatsProps) {
+  const downloadSortField = useIntuneStore((s) => s.downloadSortField);
+  const downloadSortDirection = useIntuneStore((s) => s.downloadSortDirection);
+  const setDownloadSortField = useIntuneStore((s) => s.setDownloadSortField);
+  const toggleDownloadSortDirection = useIntuneStore((s) => s.toggleDownloadSortDirection);
+
   const aggregate = useMemo(() => {
     let success = 0;
     let failed = 0;
@@ -25,6 +32,50 @@ export function DownloadStats({ downloads }: DownloadStatsProps) {
 
     return { success, failed, totalBytes };
   }, [downloads]);
+
+  const sortedDownloads = useMemo(() => {
+    return [...downloads].sort((a, b) => {
+      let cmp = 0;
+      switch (downloadSortField) {
+        case "name":
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case "size":
+          cmp = a.sizeBytes - b.sizeBytes;
+          break;
+        case "speed":
+          cmp = a.speedBps - b.speedBps;
+          break;
+        case "doPercentage":
+          cmp = a.doPercentage - b.doPercentage;
+          break;
+        case "duration":
+          cmp = a.durationSecs - b.durationSecs;
+          break;
+        case "timestamp": {
+          const aTime = a.timestampEpoch;
+          const bTime = b.timestampEpoch;
+          if (aTime == null && bTime == null) cmp = 0;
+          else if (aTime == null) cmp = 1;
+          else if (bTime == null) cmp = -1;
+          else cmp = aTime - bTime;
+          break;
+        }
+      }
+      return downloadSortDirection === "asc" ? cmp : -cmp;
+    });
+  }, [downloads, downloadSortField, downloadSortDirection]);
+
+  const sortIndicator = (field: DownloadSortField) =>
+    downloadSortField === field ? (downloadSortDirection === "asc" ? " ▲" : " ▼") : "";
+
+  const handleHeaderClick = (field: DownloadSortField) => {
+    if (downloadSortField === field) {
+      toggleDownloadSortDirection();
+    } else {
+      setDownloadSortField(field);
+    }
+  };
 
   if (downloads.length === 0) {
     return (
@@ -74,16 +125,16 @@ export function DownloadStats({ downloads }: DownloadStatsProps) {
               }}
             >
               <th style={thStyle}>Status</th>
-              <th style={thStyle}>Content</th>
-              <th style={{ ...thStyle, textAlign: "right", width: "80px" }}>Size</th>
-              <th style={{ ...thStyle, textAlign: "right", width: "90px" }}>Speed</th>
-              <th style={{ ...thStyle, width: "120px" }}>DO %</th>
-              <th style={{ ...thStyle, textAlign: "right", width: "70px" }}>Dur.</th>
-              <th style={{ ...thStyle, width: "130px" }}>Timestamp</th>
+              <th style={{ ...thStyle, cursor: "pointer" }} onClick={() => handleHeaderClick("name")}>Content{sortIndicator("name")}</th>
+              <th style={{ ...thStyle, textAlign: "right", width: "80px", cursor: "pointer" }} onClick={() => handleHeaderClick("size")}>Size{sortIndicator("size")}</th>
+              <th style={{ ...thStyle, textAlign: "right", width: "90px", cursor: "pointer" }} onClick={() => handleHeaderClick("speed")}>Speed{sortIndicator("speed")}</th>
+              <th style={{ ...thStyle, width: "120px", cursor: "pointer" }} onClick={() => handleHeaderClick("doPercentage")}>DO %{sortIndicator("doPercentage")}</th>
+              <th style={{ ...thStyle, textAlign: "right", width: "70px", cursor: "pointer" }} onClick={() => handleHeaderClick("duration")}>Dur.{sortIndicator("duration")}</th>
+              <th style={{ ...thStyle, width: "130px", cursor: "pointer" }} onClick={() => handleHeaderClick("timestamp")}>Timestamp{sortIndicator("timestamp")}</th>
             </tr>
           </thead>
           <tbody>
-            {downloads.map((dl, i) => (
+            {sortedDownloads.map((dl, i) => (
               <tr
                 key={`${dl.contentId}-${dl.timestamp ?? i}-${i}`}
                 style={{

--- a/src/components/intune/EventTimeline.tsx
+++ b/src/components/intune/EventTimeline.tsx
@@ -10,6 +10,15 @@ import type { IntuneEvent } from "../../types/intune";
 import { useIntuneStore } from "../../stores/intune-store";
 import { EventTimelineRow, getFileName } from "./EventTimelineRow";
 
+const STATUS_RANK: Record<string, number> = {
+  Failed: 0,
+  Timeout: 1,
+  InProgress: 2,
+  Pending: 3,
+  Success: 4,
+  Unknown: 5,
+};
+
 interface EventTimelineProps {
   events: IntuneEvent[];
 }
@@ -50,47 +59,39 @@ export function EventTimeline({ events }: EventTimelineProps) {
   }, [events, filterEventType, filterStatus, timelineScope.filePath]);
 
   const sortedEvents = useMemo(() => {
-    const statusRank: Record<string, number> = {
-      Failed: 0,
-      Timeout: 1,
-      InProgress: 2,
-      Pending: 3,
-      Success: 4,
-      Unknown: 5,
-    };
-
     return [...filteredEvents].sort((a, b) => {
-      let cmp = 0;
       switch (sortField) {
         case "time": {
           const aTime = a.startTimeEpoch;
           const bTime = b.startTimeEpoch;
-          if (aTime == null && bTime == null) cmp = 0;
-          else if (aTime == null) cmp = 1;
-          else if (bTime == null) cmp = -1;
-          else cmp = aTime - bTime;
-          break;
+          if (aTime == null && bTime != null) return 1;
+          if (aTime != null && bTime == null) return -1;
+          if (aTime == null && bTime == null) return 0;
+          return sortDirection === "asc" ? aTime! - bTime! : bTime! - aTime!;
         }
-        case "name":
-          cmp = a.name.localeCompare(b.name);
-          break;
-        case "type":
-          cmp = a.eventType.localeCompare(b.eventType);
-          break;
-        case "status":
-          cmp = (statusRank[a.status] ?? 5) - (statusRank[b.status] ?? 5);
-          break;
+        case "name": {
+          const cmp = a.name.localeCompare(b.name);
+          return sortDirection === "asc" ? cmp : -cmp;
+        }
+        case "type": {
+          const cmp = a.eventType.localeCompare(b.eventType);
+          return sortDirection === "asc" ? cmp : -cmp;
+        }
+        case "status": {
+          const cmp = (STATUS_RANK[a.status] ?? 5) - (STATUS_RANK[b.status] ?? 5);
+          return sortDirection === "asc" ? cmp : -cmp;
+        }
         case "duration": {
           const aDur = a.durationSecs;
           const bDur = b.durationSecs;
-          if (aDur == null && bDur == null) cmp = 0;
-          else if (aDur == null) cmp = 1;
-          else if (bDur == null) cmp = -1;
-          else cmp = aDur - bDur;
-          break;
+          if (aDur == null && bDur != null) return 1;
+          if (aDur != null && bDur == null) return -1;
+          if (aDur == null && bDur == null) return 0;
+          return sortDirection === "asc" ? aDur! - bDur! : bDur! - aDur!;
         }
+        default:
+          return 0;
       }
-      return sortDirection === "asc" ? cmp : -cmp;
     });
   }, [filteredEvents, sortField, sortDirection]);
 

--- a/src/components/intune/EventTimeline.tsx
+++ b/src/components/intune/EventTimeline.tsx
@@ -21,6 +21,8 @@ export function EventTimeline({ events }: EventTimelineProps) {
   const sourceFiles = useIntuneStore((s) => s.sourceFiles);
   const filterEventType = useIntuneStore((s) => s.filterEventType);
   const filterStatus = useIntuneStore((s) => s.filterStatus);
+  const sortField = useIntuneStore((s) => s.sortField);
+  const sortDirection = useIntuneStore((s) => s.sortDirection);
   const showSourceFileLabel = sourceFiles.length > 1 && timelineScope.filePath == null;
 
   const logListFontSize = useUiStore((s) => s.logListFontSize);
@@ -47,29 +49,74 @@ export function EventTimeline({ events }: EventTimelineProps) {
     });
   }, [events, filterEventType, filterStatus, timelineScope.filePath]);
 
+  const sortedEvents = useMemo(() => {
+    const statusRank: Record<string, number> = {
+      Failed: 0,
+      Timeout: 1,
+      InProgress: 2,
+      Pending: 3,
+      Success: 4,
+      Unknown: 5,
+    };
+
+    return [...filteredEvents].sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case "time": {
+          const aTime = a.startTimeEpoch;
+          const bTime = b.startTimeEpoch;
+          if (aTime == null && bTime == null) cmp = 0;
+          else if (aTime == null) cmp = 1;
+          else if (bTime == null) cmp = -1;
+          else cmp = aTime - bTime;
+          break;
+        }
+        case "name":
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case "type":
+          cmp = a.eventType.localeCompare(b.eventType);
+          break;
+        case "status":
+          cmp = (statusRank[a.status] ?? 5) - (statusRank[b.status] ?? 5);
+          break;
+        case "duration": {
+          const aDur = a.durationSecs;
+          const bDur = b.durationSecs;
+          if (aDur == null && bDur == null) cmp = 0;
+          else if (aDur == null) cmp = 1;
+          else if (bDur == null) cmp = -1;
+          else cmp = aDur - bDur;
+          break;
+        }
+      }
+      return sortDirection === "asc" ? cmp : -cmp;
+    });
+  }, [filteredEvents, sortField, sortDirection]);
+
   useEffect(() => {
     if (selectedEventId == null) {
       return;
     }
 
-    const selectedStillVisible = filteredEvents.some((e) => e.id === selectedEventId);
+    const selectedStillVisible = sortedEvents.some((e) => e.id === selectedEventId);
     if (!selectedStillVisible) {
       selectEvent(null);
     }
-  }, [filteredEvents, selectEvent, selectedEventId]);
+  }, [sortedEvents, selectEvent, selectedEventId]);
 
   const parentRef = useRef<HTMLDivElement>(null);
   const selectedIndex = useMemo(
-    () => filteredEvents.findIndex((event) => event.id === selectedEventId),
-    [filteredEvents, selectedEventId]
+    () => sortedEvents.findIndex((event) => event.id === selectedEventId),
+    [sortedEvents, selectedEventId]
   );
 
   const virtualizer = useVirtualizer({
-    count: filteredEvents.length,
+    count: sortedEvents.length,
     getScrollElement: () => parentRef.current,
     estimateSize: (index) =>
-      filteredEvents[index]?.id === selectedEventId ? expandedRowEstimate : collapsedRowEstimate,
-    getItemKey: (index) => filteredEvents[index]?.id ?? index,
+      sortedEvents[index]?.id === selectedEventId ? expandedRowEstimate : collapsedRowEstimate,
+    getItemKey: (index) => sortedEvents[index]?.id ?? index,
     overscan: 10,
   });
 
@@ -94,7 +141,7 @@ export function EventTimeline({ events }: EventTimelineProps) {
     );
   }
 
-  if (filteredEvents.length === 0) {
+  if (sortedEvents.length === 0) {
     return (
       <div style={{ padding: "20px", color: tokens.colorNeutralForeground3, textAlign: "center", fontSize: `${fontSize}px`, fontFamily: LOG_UI_FONT_FAMILY }}>
         {timelineScope.filePath
@@ -109,7 +156,7 @@ export function EventTimeline({ events }: EventTimelineProps) {
     <div
       ref={parentRef}
       role="listbox"
-      aria-label={`Intune event timeline — ${filteredEvents.length} events`}
+      aria-label={`Intune event timeline — ${sortedEvents.length} events`}
       style={{
         overflowY: "auto",
         height: "100%",
@@ -135,7 +182,7 @@ export function EventTimeline({ events }: EventTimelineProps) {
           }}
         >
           {virtualRows.map((virtualRow) => {
-            const event = filteredEvents[virtualRow.index];
+            const event = sortedEvents[virtualRow.index];
             return (
               <EventTimelineRow
                 key={virtualRow.key}

--- a/src/components/intune/EventTimeline.tsx
+++ b/src/components/intune/EventTimeline.tsx
@@ -7,17 +7,9 @@ import {
 } from "../../lib/log-accessibility";
 import { useUiStore } from "../../stores/ui-store";
 import type { IntuneEvent } from "../../types/intune";
+import { compareEvents } from "../../lib/intune-sort";
 import { useIntuneStore } from "../../stores/intune-store";
 import { EventTimelineRow, getFileName } from "./EventTimelineRow";
-
-const STATUS_RANK: Record<string, number> = {
-  Failed: 0,
-  Timeout: 1,
-  InProgress: 2,
-  Pending: 3,
-  Success: 4,
-  Unknown: 5,
-};
 
 interface EventTimelineProps {
   events: IntuneEvent[];
@@ -59,40 +51,9 @@ export function EventTimeline({ events }: EventTimelineProps) {
   }, [events, filterEventType, filterStatus, timelineScope.filePath]);
 
   const sortedEvents = useMemo(() => {
-    return [...filteredEvents].sort((a, b) => {
-      switch (sortField) {
-        case "time": {
-          const aTime = a.startTimeEpoch;
-          const bTime = b.startTimeEpoch;
-          if (aTime == null && bTime != null) return 1;
-          if (aTime != null && bTime == null) return -1;
-          if (aTime == null && bTime == null) return 0;
-          return sortDirection === "asc" ? aTime! - bTime! : bTime! - aTime!;
-        }
-        case "name": {
-          const cmp = a.name.localeCompare(b.name);
-          return sortDirection === "asc" ? cmp : -cmp;
-        }
-        case "type": {
-          const cmp = a.eventType.localeCompare(b.eventType);
-          return sortDirection === "asc" ? cmp : -cmp;
-        }
-        case "status": {
-          const cmp = (STATUS_RANK[a.status] ?? 5) - (STATUS_RANK[b.status] ?? 5);
-          return sortDirection === "asc" ? cmp : -cmp;
-        }
-        case "duration": {
-          const aDur = a.durationSecs;
-          const bDur = b.durationSecs;
-          if (aDur == null && bDur != null) return 1;
-          if (aDur != null && bDur == null) return -1;
-          if (aDur == null && bDur == null) return 0;
-          return sortDirection === "asc" ? aDur! - bDur! : bDur! - aDur!;
-        }
-        default:
-          return 0;
-      }
-    });
+    return [...filteredEvents].sort((a, b) =>
+      compareEvents(a, b, sortField, sortDirection)
+    );
   }, [filteredEvents, sortField, sortDirection]);
 
   useEffect(() => {

--- a/src/components/intune/IntuneDashboardNavBar.tsx
+++ b/src/components/intune/IntuneDashboardNavBar.tsx
@@ -9,6 +9,7 @@ import type {
   IntuneSummary,
   IntuneTimeWindowPreset,
 } from "../../types/intune";
+import type { IntuneSortField } from "../../stores/intune-store";
 import { selectStyle, getFileName } from "./intune-dashboard-utils";
 
 type TabId = "timeline" | "downloads" | "summary";
@@ -44,6 +45,10 @@ export function IntuneDashboardNavBar({
   const filterStatus = useIntuneStore((s) => s.filterStatus);
   const setFilterEventType = useIntuneStore((s) => s.setFilterEventType);
   const setFilterStatus = useIntuneStore((s) => s.setFilterStatus);
+  const sortField = useIntuneStore((s) => s.sortField);
+  const sortDirection = useIntuneStore((s) => s.sortDirection);
+  const setSortField = useIntuneStore((s) => s.setSortField);
+  const toggleSortDirection = useIntuneStore((s) => s.toggleSortDirection);
 
   const availableTabs = useMemo(
     () => ({
@@ -214,6 +219,38 @@ export function IntuneDashboardNavBar({
           <span style={{ fontSize: "11px", color: tokens.colorNeutralForeground3, fontWeight: 500, marginLeft: "4px" }}>
             {filteredEventCount}/{filteredEventsByTime.length}
           </span>
+          <div style={{ width: "1px", height: "16px", backgroundColor: tokens.colorNeutralStroke2, margin: "0 2px" }} />
+          <span style={{ fontSize: "10px", color: tokens.colorNeutralForeground3, fontWeight: 600, textTransform: "uppercase" }}>Sort:</span>
+          <select
+            value={sortField}
+            onChange={(e) => setSortField(e.target.value as IntuneSortField)}
+            style={selectStyle}
+            disabled={isAnalyzing}
+          >
+            <option value="time">Time</option>
+            <option value="name">Name</option>
+            <option value="type">Type</option>
+            <option value="status">Status</option>
+            <option value="duration">Duration</option>
+          </select>
+          <button
+            type="button"
+            onClick={toggleSortDirection}
+            disabled={isAnalyzing}
+            title={sortDirection === "asc" ? "Ascending" : "Descending"}
+            style={{
+              fontSize: "12px",
+              padding: "2px 6px",
+              border: `1px solid ${tokens.colorNeutralStroke2}`,
+              borderRadius: "3px",
+              backgroundColor: tokens.colorNeutralCardBackground,
+              color: tokens.colorNeutralForeground1,
+              cursor: isAnalyzing ? "not-allowed" : "pointer",
+              lineHeight: 1,
+            }}
+          >
+            {sortDirection === "asc" ? "▲" : "▼"}
+          </button>
           {timelineScope.filePath && (
             <>
               <div style={{ width: "1px", height: "16px", backgroundColor: tokens.colorNeutralStroke2, margin: "0 2px" }} />

--- a/src/lib/intune-sort.ts
+++ b/src/lib/intune-sort.ts
@@ -1,0 +1,93 @@
+import type { IntuneEvent, DownloadStat } from "../types/intune";
+import { STATUS_RANK } from "../types/intune";
+import type { IntuneSortField, DownloadSortField } from "../stores/intune-store";
+
+export type SortDirection = "asc" | "desc";
+
+/**
+ * Compare two IntuneEvent records by the given sort field and direction.
+ * Null values sort last regardless of direction.
+ */
+export function compareEvents(
+  a: IntuneEvent,
+  b: IntuneEvent,
+  field: IntuneSortField,
+  direction: SortDirection,
+): number {
+  switch (field) {
+    case "time": {
+      const aTime = a.startTimeEpoch;
+      const bTime = b.startTimeEpoch;
+      if (aTime == null && bTime != null) return 1;
+      if (aTime != null && bTime == null) return -1;
+      if (aTime == null && bTime == null) return 0;
+      return direction === "asc" ? aTime! - bTime! : bTime! - aTime!;
+    }
+    case "name": {
+      const cmp = a.name.localeCompare(b.name);
+      return direction === "asc" ? cmp : -cmp;
+    }
+    case "type": {
+      const cmp = a.eventType.localeCompare(b.eventType);
+      return direction === "asc" ? cmp : -cmp;
+    }
+    case "status": {
+      const cmp = (STATUS_RANK[a.status] ?? 5) - (STATUS_RANK[b.status] ?? 5);
+      return direction === "asc" ? cmp : -cmp;
+    }
+    case "duration": {
+      const aDur = a.durationSecs;
+      const bDur = b.durationSecs;
+      if (aDur == null && bDur != null) return 1;
+      if (aDur != null && bDur == null) return -1;
+      if (aDur == null && bDur == null) return 0;
+      return direction === "asc" ? aDur! - bDur! : bDur! - aDur!;
+    }
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Compare two DownloadStat records by the given sort field and direction.
+ * Null values sort last regardless of direction.
+ */
+export function compareDownloads(
+  a: DownloadStat,
+  b: DownloadStat,
+  field: DownloadSortField,
+  direction: SortDirection,
+): number {
+  switch (field) {
+    case "name": {
+      const cmp = a.name.localeCompare(b.name);
+      return direction === "asc" ? cmp : -cmp;
+    }
+    case "size": {
+      const cmp = a.sizeBytes - b.sizeBytes;
+      return direction === "asc" ? cmp : -cmp;
+    }
+    case "speed": {
+      const cmp = a.speedBps - b.speedBps;
+      return direction === "asc" ? cmp : -cmp;
+    }
+    case "doPercentage": {
+      const cmp = a.doPercentage - b.doPercentage;
+      return direction === "asc" ? cmp : -cmp;
+    }
+    case "duration": {
+      const cmp = a.durationSecs - b.durationSecs;
+      return direction === "asc" ? cmp : -cmp;
+    }
+    case "timestamp": {
+      const aTime = a.timestampEpoch;
+      const bTime = b.timestampEpoch;
+      if (aTime == null && bTime != null) return 1;
+      if (aTime != null && bTime == null) return -1;
+      if (aTime == null && bTime == null) return 0;
+      return direction === "asc" ? aTime! - bTime! : bTime! - aTime!;
+    }
+    default:
+      return 0;
+  }
+}

--- a/src/stores/intune-store.test.ts
+++ b/src/stores/intune-store.test.ts
@@ -41,8 +41,8 @@ describe("intune-store", () => {
         detail: "Installed successfully",
         sourceFile: "intune.log",
         lineNumber: 100,
-        startTimeEpoch: 1743206400,
-        endTimeEpoch: 1743206700,
+        startTimeEpoch: 1743206400000,
+        endTimeEpoch: 1743206700000,
       };
 
       const summary = {

--- a/src/stores/intune-store.test.ts
+++ b/src/stores/intune-store.test.ts
@@ -41,6 +41,8 @@ describe("intune-store", () => {
         detail: "Installed successfully",
         sourceFile: "intune.log",
         lineNumber: 100,
+        startTimeEpoch: 1743206400,
+        endTimeEpoch: 1743206700,
       };
 
       const summary = {

--- a/src/stores/intune-store.ts
+++ b/src/stores/intune-store.ts
@@ -30,6 +30,9 @@ import type {
 } from "../types/intune";
 
 export type IntuneWorkspaceTab = "timeline" | "downloads" | "summary";
+export type IntuneSortField = "time" | "name" | "type" | "status" | "duration";
+export type DownloadSortField = "name" | "size" | "speed" | "doPercentage" | "duration" | "timestamp";
+export type SortDirection = "asc" | "desc";
 
 function buildSourceContext(
   sourceFile: string | null,
@@ -180,6 +183,10 @@ interface IntuneState {
   eventLogFilterChannel: EventLogChannel | "All";
   eventLogFilterSeverity: EventLogSeverity | "All";
   activeTab: IntuneWorkspaceTab;
+  sortField: IntuneSortField;
+  sortDirection: SortDirection;
+  downloadSortField: DownloadSortField;
+  downloadSortDirection: SortDirection;
   resultRevision: number;
 
   beginAnalysis: (
@@ -208,6 +215,10 @@ interface IntuneState {
   setEventLogFilterSeverity: (severity: EventLogSeverity | "All") => void;
   selectEventLogEntry: (id: number | null) => void;
   setActiveTab: (tab: IntuneWorkspaceTab) => void;
+  setSortField: (field: IntuneSortField) => void;
+  toggleSortDirection: () => void;
+  setDownloadSortField: (field: DownloadSortField) => void;
+  toggleDownloadSortDirection: () => void;
   clear: () => void;
 }
 
@@ -220,6 +231,10 @@ const defaultInteractionState = {
   eventLogFilterChannel: "All" as EventLogChannel | "All",
   eventLogFilterSeverity: "All" as EventLogSeverity | "All",
   activeTab: "timeline" as const,
+  sortField: "time" as IntuneSortField,
+  sortDirection: "asc" as SortDirection,
+  downloadSortField: "timestamp" as DownloadSortField,
+  downloadSortDirection: "asc" as SortDirection,
 };
 
 export const useIntuneStore = create<IntuneState>((set) => ({
@@ -430,6 +445,12 @@ export const useIntuneStore = create<IntuneState>((set) => ({
   setEventLogFilterSeverity: (severity) => set({ eventLogFilterSeverity: severity }),
   selectEventLogEntry: (id) => set({ selectedEventLogEntryId: id }),
   setActiveTab: (tab) => set({ activeTab: tab }),
+  setSortField: (field) => set({ sortField: field }),
+  toggleSortDirection: () =>
+    set((state) => ({ sortDirection: state.sortDirection === "asc" ? "desc" : "asc" })),
+  setDownloadSortField: (field) => set({ downloadSortField: field }),
+  toggleDownloadSortDirection: () =>
+    set((state) => ({ downloadSortDirection: state.downloadSortDirection === "asc" ? "desc" : "asc" })),
 
   clear: () =>
     set({

--- a/src/types/intune.ts
+++ b/src/types/intune.ts
@@ -33,6 +33,8 @@ export interface IntuneEvent {
   detail: string;
   sourceFile: string;
   lineNumber: number;
+  startTimeEpoch: number | null;
+  endTimeEpoch: number | null;
 }
 
 export interface DownloadStat {
@@ -44,6 +46,7 @@ export interface DownloadStat {
   durationSecs: number;
   success: boolean;
   timestamp: string | null;
+  timestampEpoch: number | null;
 }
 
 export interface IntuneTimestampBounds {

--- a/src/types/intune.ts
+++ b/src/types/intune.ts
@@ -49,6 +49,16 @@ export interface DownloadStat {
   timestampEpoch: number | null;
 }
 
+/** Canonical ordering of Intune status values (lower = more severe). */
+export const STATUS_RANK: Record<string, number> = {
+  Failed: 0,
+  Timeout: 1,
+  InProgress: 2,
+  Pending: 3,
+  Success: 4,
+  Unknown: 5,
+};
+
 export interface IntuneTimestampBounds {
   firstTimestamp: string | null;
   lastTimestamp: string | null;


### PR DESCRIPTION
## Summary

Closes #70

- Adds column sorting to the **Event Timeline** (Sort by: Time, Name, Type, Status, Duration) via a dropdown + asc/desc toggle in the navbar
- Adds clickable column header sorting to the **Download Stats** table (Content, Size, Speed, DO %, Duration, Timestamp)
- Backend pre-computes epoch millisecond timestamps on `IntuneEvent` and `DownloadStat` for instant frontend sorting with no IPC round-trip
- Null values always sort last regardless of sort direction
- Sort state resets on new analysis

## Test plan

- [ ] Load IME logs into Intune Diagnostics workspace
- [ ] Verify "Sort by" dropdown appears in timeline navbar alongside existing filters
- [ ] Sort by each field (Time, Name, Type, Status, Duration) and toggle asc/desc
- [ ] Verify nulls (events with no timestamp/duration) always appear at the end
- [ ] Switch to Downloads tab and click column headers to sort
- [ ] Verify clicking same header toggles direction, clicking different header switches sort field
- [ ] Load new analysis and verify sort resets to Time ascending
- [ ] `cargo test` — all pass
- [ ] `cargo clippy -- -D warnings` — zero warnings
- [ ] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)