### PR TITLE
security: harden GitHub Actions and repo for Patch My PC distribution

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner — all PRs request review from repo owner
+* @adamgell

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      production-dependencies:
+        dependency-type: "production"
+    open-pull-requests-limit: 10
+
+  # Rust crate dependencies
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions — proposes SHA pin updates when new versions release
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5

--- a/.github/workflows/cmtrace-ci.yml
+++ b/.github/workflows/cmtrace-ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: Check & Test (Rust)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install system dependencies
         run: |
@@ -30,10 +30,10 @@ jobs:
             patchelf
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/bin/
@@ -68,23 +68,27 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy -- -D warnings
 
-      - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
+      - name: Install cargo-deny and cargo-audit
+        uses: taiki-e/install-action@94cb46f8d6e437890146ffbd78a778b78e623fb2 # v2.74.0
         with:
-          tool: cargo-deny
+          tool: cargo-deny,cargo-audit
 
-      - name: Supply chain audit
+      - name: Supply chain audit (licenses & bans)
         working-directory: src-tauri
         run: cargo deny check
+
+      - name: Security vulnerability audit
+        working-directory: src-tauri
+        run: cargo audit
 
   frontend:
     name: TypeScript Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -98,6 +102,10 @@ jobs:
 
       - name: Frontend tests
         run: npm run test
+
+      - name: npm security audit
+        run: npm audit --audit-level=high
+        continue-on-error: true
 
   build:
     name: Build (${{ matrix.label }})
@@ -117,7 +125,7 @@ jobs:
             label: Linux-x64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -131,19 +139,19 @@ jobs:
             patchelf
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: package-lock.json
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/bin/
@@ -167,7 +175,7 @@ jobs:
           "
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -175,7 +183,7 @@ jobs:
           args: --target ${{ matrix.target }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cmtrace-open-${{ matrix.label }}
           path: |

--- a/.github/workflows/cmtrace-release.yml
+++ b/.github/workflows/cmtrace-release.yml
@@ -7,12 +7,15 @@ on:
       - "[0-9]*.[0-9]*.[0-9]*"
       - "!*.*.*.*"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   release:
     name: Release (${{ matrix.label }})
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     environment: codesigning
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Import Apple Developer Certificate
         if: runner.os == 'macOS'
@@ -67,22 +70,32 @@ jobs:
             patchelf
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: package-lock.json
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Install cargo-cyclonedx
+        run: cargo install cargo-cyclonedx --locked
+
+      - name: Generate Rust SBOM
+        working-directory: src-tauri
+        run: cargo cyclonedx --format json --output-file ../sbom-rust.cdx.json
+
+      - name: Generate npm SBOM
+        run: npm sbom --sbom-format cyclonedx > sbom-npm.cdx.json
+
       - name: Build and create release
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -111,3 +124,20 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: --target ${{ matrix.target }}
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/**/*.dmg
+            src-tauri/target/${{ matrix.target }}/release/bundle/**/*.deb
+            src-tauri/target/${{ matrix.target }}/release/bundle/**/*.AppImage
+
+      - name: Upload SBOMs to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            sbom-rust.cdx.json \
+            sbom-npm.cdx.json \
+            --clobber

--- a/.github/workflows/cmtrace-release.yml
+++ b/.github/workflows/cmtrace-release.yml
@@ -85,7 +85,7 @@ jobs:
         run: npm ci
 
       - name: Install cargo-cyclonedx
-        run: cargo install cargo-cyclonedx --locked
+        run: cargo install cargo-cyclonedx --version 0.5.9 --locked
 
       - name: Generate Rust SBOM
         working-directory: src-tauri

--- a/.github/workflows/codesign.yml
+++ b/.github/workflows/codesign.yml
@@ -13,24 +13,25 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   prepare-windows-release:
     name: Prepare Windows Release
     runs-on: windows-latest
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.resolve_version.outputs.version }}
       tag_name: ${{ steps.resolve_version.outputs.tag_name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: npm
@@ -160,6 +161,10 @@ jobs:
     name: Signed Windows Release (${{ matrix.label }})
     needs: prepare-windows-release
     runs-on: windows-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     environment: codesigning
     strategy:
       fail-fast: false
@@ -177,19 +182,19 @@ jobs:
       TAG_NAME: ${{ needs.prepare-windows-release.outputs.tag_name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: npm
           cache-dependency-path: package-lock.json
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.rust_target }}
 
@@ -253,7 +258,7 @@ jobs:
       # The signed standalone EXEs are also used by mpdev to build the MSI,
       # so the binaries inside the MSI will carry valid signatures.
       - name: Sign release EXEs
-        uses: azure/trusted-signing-action@v0
+        uses: azure/trusted-signing-action@1d365fec12862c4aa68fcac418143d73f0cea293 # v0.5.11
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -266,6 +271,12 @@ jobs:
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
+
+      - name: Attest signed EXEs
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: |
+            release-artifacts/*.exe
 
       # ── Build MSI via Master Packager Dev (bundles signed full + lite EXEs) ──
       - name: Install Master Packager Dev
@@ -305,6 +316,12 @@ jobs:
           }
           "msi_path=$msiPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
+      - name: Attest MSI
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: |
+            ${{ steps.verify_msi.outputs.msi_path }}
+
       # ── Generate updater signature for NSIS installer ──
       - name: Generate updater signature for NSIS installer
         shell: pwsh
@@ -322,7 +339,7 @@ jobs:
 
       # ── Upload artifacts ──
       - name: Upload signed workflow artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cmtrace-open-windows-signed-${{ matrix.artifact_suffix }}-${{ env.VERSION }}
           path: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | Yes — full support |
+| Previous minor release | Security fixes only |
+| Older releases | Not supported — please upgrade |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities via
+[GitHub's private vulnerability reporting](https://github.com/adamgell/cmtraceopen/security/advisories/new):
+
+1. Go to the **Security** tab of this repository
+2. Click **"Report a vulnerability"**
+3. Provide details of the issue
+
+**Do NOT open a public issue for security vulnerabilities.**
+
+## Response Timeline
+
+- Acknowledgment within 48 hours
+- Assessment and fix target within 7 days for critical issues
+- Coordinated disclosure after fix is released
+
+## Scope
+
+This policy covers the CMTrace Open application, its build pipeline,
+and release artifacts distributed through GitHub Releases and Patch My PC.


### PR DESCRIPTION
## Summary

- **Pin all third-party GitHub Actions to commit SHAs** across CI, release, and codesign workflows (9 actions total) — prevents tag-based supply chain attacks
- **Scope workflow permissions to least-privilege** — release workflows now default to `permissions: {}` with explicit per-job grants (`contents: write`, `id-token: write`, `attestations: write`)
- **Add SLSA build provenance attestations** to all release artifacts (macOS `.dmg`, Linux `.deb`/`.AppImage`, Windows signed `.exe`/`.msi`) via `actions/attest-build-provenance`
- **Generate CycloneDX SBOMs** for both Rust and npm dependencies, uploaded to each GitHub Release
- **Add security audit steps** — `cargo audit` (blocking) and `npm audit --audit-level=high` (non-blocking) in CI
- **Enable Dependabot** for npm, Cargo, and GitHub Actions version updates (weekly on Monday)
- **Add SECURITY.md** with vulnerability disclosure policy via GitHub's private reporting
- **Add CODEOWNERS** — all PRs auto-request review from @adamgell
- **Enable branch protection ruleset** on `main` — require PR reviews, signed commits, status checks (5 jobs), linear history, no force push

Prompted by CMTrace Open being listed in the Patch My PC Publishing Catalog — raises the bar on supply chain security for enterprise consumers.

## Test plan

- [ ] CI workflow runs successfully on this PR (SHA-pinned actions resolve, audit steps execute)
- [ ] Verify `cargo audit` and `npm audit` steps appear in CI logs
- [ ] Confirm Dependabot begins proposing PRs after merge (check Settings > Dependabot)
- [ ] On next tag push, verify attestation + SBOM steps run in release workflows
- [ ] Verify signed commits show as "Verified" on GitHub
- [ ] Test `gh attestation verify` on release artifacts after next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)