### PR TITLE
Auto-fit Column Width

### DIFF
--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -15,17 +15,20 @@ import { LogRow } from "./LogRow";
 import { MergeLegendBar } from "./MergeLegendBar";
 import type { ErrorCodeSpan } from "../../types/log";
 import { useContextMenu } from "../../hooks/use-context-menu";
+import { ArrowBidirectionalLeftRightRegular } from "@fluentui/react-icons";
 import {
   applyColumnOrder,
   getVisibleColumns,
   buildGridTemplateColumns,
   getColumnDef,
+  calcAutoFitWidth,
   type ColumnId,
   type ColumnDefinition,
 } from "../../lib/column-config";
 import { getThemeById } from "../../lib/themes";
 import {
   getLogListMetrics,
+  getCanvasFont,
   LOG_UI_FONT_FAMILY,
 } from "../../lib/log-accessibility";
 
@@ -291,6 +294,29 @@ export function LogListView() {
 
   const onDragEnd = useCallback(() => setDragState(null), []);
 
+  // ── Auto-fit column width ────────────────────────────────────────────────
+  const handleHeaderDoubleClick = useCallback(
+    (colId: ColumnId) => {
+      const def = getColumnDef(colId);
+      if (!def) return;
+      // Use a rendered row element so the font-family is fully resolved (no CSS variables)
+      const rowEl = parentRef.current?.querySelector<HTMLElement>(".log-row") ?? null;
+      const contentFont = getCanvasFont(logListFontSize, false, rowEl);
+      const headerFont = getCanvasFont(listMetrics.headerFontSize, true, rowEl);
+      setColumnWidth(colId, calcAutoFitWidth(def, displayEntries, contentFont, headerFont));
+    },
+    [displayEntries, logListFontSize, listMetrics, setColumnWidth]
+  );
+
+  const handleFitAllColumns = useCallback(() => {
+    const rowEl = parentRef.current?.querySelector<HTMLElement>(".log-row") ?? null;
+    const contentFont = getCanvasFont(logListFontSize, false, rowEl);
+    const headerFont = getCanvasFont(listMetrics.headerFontSize, true, rowEl);
+    for (const col of visibleColumns) {
+      setColumnWidth(col.id, calcAutoFitWidth(col, displayEntries, contentFont, headerFont));
+    }
+  }, [visibleColumns, displayEntries, logListFontSize, listMetrics, setColumnWidth]);
+
   const activeRowDomId =
     selectedEntryIndex >= 0
       ? `log-list-row-${displayEntries[selectedEntryIndex].id}`
@@ -339,6 +365,8 @@ export function LogListView() {
             onDragOver={onDragOver}
             onDrop={onDrop}
             onDragEnd={onDragEnd}
+            onDoubleClick={handleHeaderDoubleClick}
+            onFitAll={col.id === "severity" ? handleFitAllColumns : undefined}
           />
         ))}
       </div>
@@ -426,6 +454,8 @@ interface HeaderCellProps {
   onDragOver: (index: number, e: React.DragEvent) => void;
   onDrop: (e: React.DragEvent) => void;
   onDragEnd: () => void;
+  onDoubleClick: (colId: ColumnId) => void;
+  onFitAll?: () => void;
 }
 
 function HeaderCell({
@@ -439,8 +469,11 @@ function HeaderCell({
   onDragOver,
   onDrop,
   onDragEnd,
+  onDoubleClick,
+  onFitAll,
 }: HeaderCellProps) {
   const [resizeHover, setResizeHover] = useState(false);
+  const [fitAllHover, setFitAllHover] = useState(false);
 
   return (
     <div
@@ -449,6 +482,7 @@ function HeaderCell({
       onDragOver={(e) => onDragOver(index, e)}
       onDrop={onDrop}
       onDragEnd={onDragEnd}
+      onDoubleClick={(e) => { e.preventDefault(); onDoubleClick(col.id); }}
       style={{
         position: "relative",
         ...(col.isFlex ? { minWidth: 0 } : {}),
@@ -468,7 +502,28 @@ function HeaderCell({
             : {}),
       }}
     >
-      {col.label}
+      {onFitAll ? (
+        /* Fit-all-columns button lives in the severity column header (no label, always first) */
+        <div
+          title="Auto-fit all columns to content width"
+          onClick={(e) => { e.stopPropagation(); onFitAll(); }}
+          onMouseEnter={() => setFitAllHover(true)}
+          onMouseLeave={() => setFitAllHover(false)}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "100%",
+            height: "100%",
+            cursor: "pointer",
+            color: fitAllHover ? tokens.colorBrandForeground1 : tokens.colorNeutralForeground2,
+          }}
+        >
+          <ArrowBidirectionalLeftRightRegular style={{ fontSize: 12 }} />
+        </div>
+      ) : (
+        col.label
+      )}
 
       {/* Resize handle in upper-right corner */}
       {(

--- a/src/lib/column-config.ts
+++ b/src/lib/column-config.ts
@@ -315,6 +315,80 @@ export function getColumnsForAggregate(parsers: ParserKind[]): ColumnId[] {
  * Filters the user order to only include columns that are active (parser-relevant).
  * Any active columns not in the user order are appended at the end.
  */
+// ── Auto-fit measurement ─────────────────────────────────────────────────────
+
+/** Singleton canvas context for measuring text width without DOM layout. */
+let _measureCtx: CanvasRenderingContext2D | null = null;
+function getMeasureCtx(): CanvasRenderingContext2D | null {
+  if (!_measureCtx) {
+    const canvas = document.createElement("canvas");
+    _measureCtx = canvas.getContext("2d");
+  }
+  return _measureCtx;
+}
+
+export function measureTextWidth(text: string, font: string): number {
+  const ctx = getMeasureCtx();
+  if (!ctx) return text.length * 8;
+  ctx.font = font;
+  return ctx.measureText(text).width;
+}
+
+const CELL_PAD = 10;   // 4px left + 4px right cell padding + 2px buffer
+const HEADER_PAD = 24; // extra room for the resize grip
+
+/**
+ * Calculate the auto-fit width for a column given the current display entries.
+ * - severity: returns defaultWidth (renders a colored dot, not text)
+ * - dateTime: uses a fixed representative timestamp string (view layer formats it)
+ * - all others: two-pass approach —
+ *     Pass 1 (O(n), no canvas): find the max string length across ALL entries
+ *     Pass 2 (O(k), canvas): measure only strings within 90% of the max length
+ *   This ensures the widest entry is always found regardless of how large the log is,
+ *   while keeping canvas calls to a minimum.
+ */
+export function calcAutoFitWidth(
+  col: ColumnDefinition,
+  entries: readonly LogEntry[],
+  contentFont: string,
+  headerFont: string
+): number {
+  if (col.id === "severity") return col.defaultWidth;
+
+  if (col.id === "dateTime") {
+    const sample = "2024-01-01 00:00:00.000";
+    return Math.ceil(Math.max(measureTextWidth(sample, contentFont) + CELL_PAD, col.minWidth));
+  }
+
+  const headerW = measureTextWidth(col.label, headerFont) + HEADER_PAD;
+
+  // Pass 1: find the longest string length (cheap — no canvas)
+  let maxLen = 0;
+  for (const entry of entries) {
+    const val = col.accessor(entry);
+    if (val == null) continue;
+    const len = String(val).length;
+    if (len > maxLen) maxLen = len;
+  }
+
+  // No data found — use defaultWidth so we never shrink an empty column below its designed size
+  if (maxLen === 0) return Math.ceil(Math.max(headerW, col.defaultWidth));
+
+  // Pass 2: canvas-measure only strings ≥ 90% of max length
+  const threshold = maxLen * 0.9;
+  let maxContent = 0;
+  for (const entry of entries) {
+    const val = col.accessor(entry);
+    if (val == null) continue;
+    const text = String(val);
+    if (text.length < threshold) continue;
+    const w = measureTextWidth(text, contentFont);
+    if (w > maxContent) maxContent = w;
+  }
+
+  return Math.ceil(Math.max(headerW, maxContent + CELL_PAD, col.minWidth));
+}
+
 export function applyColumnOrder(
   activeColumns: ColumnId[],
   userOrder: ColumnId[] | null

--- a/src/lib/log-accessibility.ts
+++ b/src/lib/log-accessibility.ts
@@ -45,6 +45,29 @@ export function getLogListMetrics(fontSize: number): LogListMetrics {
   };
 }
 
+/**
+ * Returns a canvas-compatible font string.
+ * Prefers reading the resolved font-family from a real DOM element (most accurate),
+ * falling back to resolving the CSS custom property, then a hardcoded fallback.
+ * canvas.measureText() cannot handle var(--...) syntax.
+ */
+export function getCanvasFont(
+  size: number,
+  bold = false,
+  sourceElement?: Element | null
+): string {
+  let family: string;
+  if (sourceElement) {
+    family = getComputedStyle(sourceElement).fontFamily;
+  } else {
+    family =
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--cmtrace-font-family-ui")
+        .trim() || "'Segoe UI', Tahoma, sans-serif";
+  }
+  return `${bold ? "bold " : ""}${size}px ${family}`;
+}
+
 export function getLogDetailsLineHeight(fontSize: number): number {
   const clampedFontSize = clampLogDetailsFontSize(fontSize);
   return Math.max(20, Math.round(clampedFontSize * 1.6));


### PR DESCRIPTION
**added only changed files as Adam requested**

What this adds

    Double-click any column header → auto-fits that column to the widest content in the loaded log
    ↔ button in the severity column header → auto-fits all visible columns at once
    Both changes are permanent and saved to preferences (same as a manual drag-resize)

Files changed

src/lib/log-accessibility.ts

Added getCanvasFont(size, bold?, sourceElement?) — returns a canvas-compatible font string. Prefers reading fontFamily from a real rendered
DOM element, falls back to resolving the --cmtrace-font-family-ui CSS custom property. This is needed because canvas.measureText() cannot
handle var(--...) syntax.

src/lib/column-config.ts

Added three exports:

    measureTextWidth(text, font) — measures pixel width of a string using a singleton canvas context (avoids repeated DOM creation).
    calcAutoFitWidth(col, entries, contentFont, headerFont) — computes the optimal column width:
        severity → returns its fixed defaultWidth (renders a dot, not text)
        dateTime → uses a representative timestamp string ("2024-01-01 00:00:00.000") since the view layer formats it separately
        All other columns → two-pass approach:
            Pass 1 (O(n), no canvas): scans every entry by String.length to find the maximum string length across the entire dataset — no
            MAX_SAMPLE cap, so entries at line 50,000+ are always included
            Pass 2 (O(k), canvas): runs measureText() only on strings within 90% of the maximum length, keeping canvas calls minimal
        If no data is found for a column, returns defaultWidth (never shrinks an empty column below its designed size)
        Result is Math.ceil'd to prevent sub-pixel under-sizing

src/components/log-view/LogListView.tsx

    Added imports: ArrowBidirectionalLeftRightRegular from @fluentui/react-icons, calcAutoFitWidth from column-config, getCanvasFont from
    log-accessibility
    handleHeaderDoubleClick(colId) — resolves font from a rendered .log-row DOM element via parentRef (guarantees the same font the browser is
    actually using), calls calcAutoFitWidth, then setColumnWidth
    handleFitAllColumns() — same font resolution, iterates all visibleColumns and sets each
    HeaderCellProps / HeaderCell — added onDoubleClick: (colId) => void and optional onFitAll?: () => void props
    HeaderCell renders the ArrowBidirectionalLeftRightRegular icon button when onFitAll is provided (passed only to the severity column, which
    has no label and is always first), otherwise renders the normal column label
    onDoubleClick is attached to the header cell div; e.preventDefault() prevents any drag/selection conflict
    Header strip structure reverted to original (no extra wrapper div, no absolute overlay) — the button lives naturally inside the severity
    cell
