### PR TITLE
docs: update changelog for Quick Stats follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Quick Stats panel**: New collapsible summary bar above the log viewer showing total vs. filtered line counts, severity breakdown cards, detected error code aggregates with one-click Error Lookup, and the visible log time range.
 - **Settings dialog** (replaces Accessibility dialog): Full settings UI with tabs for Appearance (themes, font size), Columns (visibility, ordering), Behavior (confirm tab close), Updates (auto-update toggle), and File Associations (Windows-only). Accessible via `Ctrl+,` or Window menu.
 - **Context menu**: Right-click any log row for Copy Line, Copy Message, Jump to Line, Quick Filter by severity/component, Reveal in File Manager, and Error Lookup. Uses native Tauri menu popup for OS-native feel.
 - **Event Log workspace** (Windows, feature-gated): Parse `.evtx` files and query live Windows Event Log channels. Supports file-based EVTX parsing with channel grouping, severity filtering, and correlation linking. Frontend workspace with channel sidebar, severity badges, and detail pane. Live queries use Win32 Event Log API (`EvtQuery`, `EvtRender`, `EvtFormatMessage`). "This Computer" auto-loads Application, System, Security, and Setup channels in parallel with progressive UI updates. Event Viewer-style nested tree sidebar (split on `-` and `/`) with resizable drag handle. Arrow key navigation, resizable detail pane, per-channel load/refresh buttons, and loading spinner with elapsed time in the status bar.
@@ -35,6 +36,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Settings dialog sizing**: The Settings dialog now uses a consistent fixed-height layout so all tabs render at the same usable height instead of resizing per tab.
 - **PR #82 review fixes**: Resolved merged-tab ID collisions by prefixing entry IDs with source file index. Session restore now persists recent sessions to `localStorage` on save. Correlation refresh no longer stalls when switching merged tabs. Diff view properly cleans up state on close.
 - **Intune cross-file sorting** (PR #78): Unified timeline sorting across multiple Intune log files now sorts by datetime consistently, fixing out-of-order entries when merging rotated log files.
 - **Code review fixes** (PR #81): Scroll sync no longer fights user interaction. Session restore validates file paths before loading. Merge entry deduplication uses stable sort. UTF-8 safety enforced in merge filename display. GUID casing normalized to lowercase for consistent lookups.
@@ -51,6 +53,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Tauri plugin alignment**: Updated `@tauri-apps/plugin-dialog` and `@tauri-apps/plugin-fs` to match the Tauri v2 dependency set and eliminate plugin version mismatches.
 - **Columns determined by parser**: Active columns are now derived from the detected parser format, not user toggles. Removed `hiddenColumns` from UI state.
 
 ### Security

--- a/src-tauri/src/commands/filter.rs
+++ b/src-tauri/src/commands/filter.rs
@@ -21,6 +21,7 @@ pub enum FilterField {
     Component,
     Thread,
     Timestamp,
+    Severity,
 }
 
 /// A single filter clause.
@@ -67,6 +68,14 @@ fn matches_clause(entry: &LogEntry, clause: &FilterClause) -> bool {
         FilterField::Timestamp => {
             let ts = entry.timestamp.unwrap_or(0);
             match_timestamp(ts, &clause.op, &clause.value)
+        }
+        FilterField::Severity => {
+            let sev_str = match &entry.severity {
+                crate::models::log_entry::Severity::Error => "Error",
+                crate::models::log_entry::Severity::Warning => "Warning",
+                crate::models::log_entry::Severity::Info => "Info",
+            };
+            match_string(sev_str, &clause.op, &clause.value)
         }
     }
 }

--- a/src-tauri/src/parser/ccm.rs
+++ b/src-tauri/src/parser/ccm.rs
@@ -30,7 +30,7 @@ fn ccm_re() -> &'static Regex {
         r#"\s+context="[^"]*""#,
         r#"\s+type="(?P<typ>\d)""#,
         r#"\s+thread="(?P<thr>\d+)""#,
-        r#"(?:\s+file="(?P<file>[^"]*)")?"#,
+        r#"(?:\s+file="(?P<file>[^"]*)")?>"#,
     ))
     .expect("CCM regex must compile")
 })
@@ -40,38 +40,7 @@ fn ccm_re() -> &'static Regex {
 /// Returns None if the line doesn't match the CCM format.
 fn parse_line(line: &str) -> Option<CcmParsed> {
     let caps = ccm_re().captures(line)?;
-
-    let msg = caps.name("msg").map(|m| m.as_str().to_string())?;
-    let h: u32 = caps.name("h")?.as_str().parse().ok()?;
-    let m: u32 = caps.name("m")?.as_str().parse().ok()?;
-    let s: u32 = caps.name("s")?.as_str().parse().ok()?;
-    let ms_str = caps.name("ms")?.as_str();
-    // Truncate milliseconds to 3 digits (matching CMTrace behavior)
-    let ms = truncate_subsecond_to_millis(ms_str)?;
-    let tz: i32 = caps.name("tz")?.as_str().parse().ok()?;
-    let mon: u32 = caps.name("mon")?.as_str().parse().ok()?;
-    let day: u32 = caps.name("day")?.as_str().parse().ok()?;
-    let yr: i32 = caps.name("yr")?.as_str().parse().ok()?;
-    let comp = caps.name("comp").map(|m| m.as_str().to_string());
-    let typ: u32 = caps.name("typ")?.as_str().parse().ok()?;
-    let thr: u32 = caps.name("thr")?.as_str().parse().ok()?;
-    let file = caps.name("file").map(|m| m.as_str().to_string());
-
-    let severity = severity_from_type_field(Some(typ), &msg);
-    let (timestamp, timestamp_display) = build_timestamp(mon, day, yr, h, m, s, ms, Some(tz));
-    let thread_display = Some(format_thread_display(thr));
-
-    Some(CcmParsed {
-        message: msg,
-        component: comp,
-        timestamp,
-        timestamp_display,
-        severity,
-        thread: thr,
-        thread_display,
-        source_file: file,
-        timezone_offset: tz,
-    })
+    parse_captures(&caps)
 }
 
 struct CcmParsed {
@@ -168,10 +137,220 @@ pub fn parse_content(
 ) -> (Vec<LogEntry>, u32) {
     match specialization {
         Some(ParserSpecialization::Ime) => crate::intune::ime_parser::parse_ime_entries(content, file_path),
-        None => {
-            let lines: Vec<&str> = content.lines().collect();
-            parse_lines(&lines, file_path)
+        None => parse_content_multiline(content, file_path),
+    }
+}
+
+/// Content-based multi-line CCM parser.
+///
+/// Runs the CCM regex over the entire file content so that records spanning
+/// multiple physical lines (e.g. `<![LOG[line1\nline2]LOG]!><attrs>`) are
+/// matched as a single logical record.  Text between matched records is
+/// emitted as individual plain-text entries, preserving line numbers.
+fn parse_content_multiline(content: &str, file_path: &str) -> (Vec<LogEntry>, u32) {
+    let line_starts = build_line_starts(content);
+    let mut entries: Vec<LogEntry> = Vec::new();
+    let mut errors = 0u32;
+    let mut id_counter = 0u64;
+    let mut cursor = 0usize;
+    let mut matched_any = false;
+
+    for caps in ccm_re().captures_iter(content) {
+        let Some(full_match) = caps.get(0) else {
+            continue;
+        };
+
+        // Emit unmatched text between the previous match and this one
+        push_unmatched_plain(
+            &content[cursor..full_match.start()],
+            cursor,
+            &line_starts,
+            file_path,
+            &mut entries,
+            &mut id_counter,
+            &mut errors,
+        );
+
+        // Parse the matched CCM record
+        let line_number = line_number_for_offset(&line_starts, full_match.start());
+        if let Some(parsed) = parse_captures(&caps) {
+            entries.push(LogEntry {
+                id: id_counter,
+                line_number,
+                message: parsed.message,
+                component: parsed.component,
+                timestamp: parsed.timestamp,
+                timestamp_display: parsed.timestamp_display,
+                severity: parsed.severity,
+                thread: Some(parsed.thread),
+                thread_display: parsed.thread_display,
+                source_file: parsed.source_file,
+                format: LogFormat::Ccm,
+                file_path: file_path.to_string(),
+                timezone_offset: Some(parsed.timezone_offset),
+                error_code_spans: Vec::new(),
+                ip_address: None,
+                host_name: None,
+                mac_address: None,
+                result_code: None,
+                gle_code: None,
+                setup_phase: None,
+                operation_name: None,
+                http_method: None,
+                uri_stem: None,
+                uri_query: None,
+                status_code: None,
+                sub_status: None,
+                time_taken_ms: None,
+                client_ip: None,
+                server_ip: None,
+                user_agent: None,
+                server_port: None,
+                username: None,
+                win32_status: None,
+            });
+            id_counter += 1;
+        } else {
+            push_unmatched_plain(
+                full_match.as_str(),
+                full_match.start(),
+                &line_starts,
+                file_path,
+                &mut entries,
+                &mut id_counter,
+                &mut errors,
+            );
         }
+
+        cursor = full_match.end();
+        matched_any = true;
+    }
+
+    // Trailing unmatched text
+    push_unmatched_plain(
+        &content[cursor..],
+        cursor,
+        &line_starts,
+        file_path,
+        &mut entries,
+        &mut id_counter,
+        &mut errors,
+    );
+
+    if !matched_any {
+        // No CCM records found at all — fall back to line-by-line
+        let lines: Vec<&str> = content.lines().collect();
+        return parse_lines(&lines, file_path);
+    }
+
+    (entries, errors)
+}
+
+/// Parse named captures from a CCM regex match into a CcmParsed struct.
+fn parse_captures(caps: &regex::Captures<'_>) -> Option<CcmParsed> {
+    let msg = caps.name("msg").map(|m| m.as_str().to_string())?;
+    let h: u32 = caps.name("h")?.as_str().parse().ok()?;
+    let m: u32 = caps.name("m")?.as_str().parse().ok()?;
+    let s: u32 = caps.name("s")?.as_str().parse().ok()?;
+    let ms_str = caps.name("ms")?.as_str();
+    let ms = truncate_subsecond_to_millis(ms_str)?;
+    let tz: i32 = caps.name("tz")?.as_str().parse().ok()?;
+    let mon: u32 = caps.name("mon")?.as_str().parse().ok()?;
+    let day: u32 = caps.name("day")?.as_str().parse().ok()?;
+    let yr: i32 = caps.name("yr")?.as_str().parse().ok()?;
+    let comp = caps.name("comp").map(|m| m.as_str().to_string());
+    let typ: u32 = caps.name("typ")?.as_str().parse().ok()?;
+    let thr: u32 = caps.name("thr")?.as_str().parse().ok()?;
+    let file = caps.name("file").map(|m| m.as_str().to_string());
+
+    let severity = severity_from_type_field(Some(typ), &msg);
+    let (timestamp, timestamp_display) = build_timestamp(mon, day, yr, h, m, s, ms, Some(tz));
+    let thread_display = Some(format_thread_display(thr));
+
+    Some(CcmParsed {
+        message: msg,
+        component: comp,
+        timestamp,
+        timestamp_display,
+        severity,
+        thread: thr,
+        thread_display,
+        source_file: file,
+        timezone_offset: tz,
+    })
+}
+
+fn build_line_starts(content: &str) -> Vec<usize> {
+    let mut starts = vec![0];
+    for (index, byte) in content.bytes().enumerate() {
+        if byte == b'\n' {
+            starts.push(index + 1);
+        }
+    }
+    starts
+}
+
+fn line_number_for_offset(line_starts: &[usize], offset: usize) -> u32 {
+    match line_starts.binary_search(&offset) {
+        Ok(index) => (index + 1) as u32,
+        Err(index) => index as u32,
+    }
+}
+
+/// Emit each non-empty physical line in `segment` as a plain-text LogEntry.
+fn push_unmatched_plain(
+    segment: &str,
+    base_offset: usize,
+    line_starts: &[usize],
+    file_path: &str,
+    entries: &mut Vec<LogEntry>,
+    id_counter: &mut u64,
+    errors: &mut u32,
+) {
+    let mut local_offset = 0usize;
+    for piece in segment.split_inclusive('\n') {
+        let line = piece.trim_end_matches(['\r', '\n']);
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            entries.push(LogEntry {
+                id: *id_counter,
+                line_number: line_number_for_offset(line_starts, base_offset + local_offset),
+                message: trimmed.to_string(),
+                component: None,
+                timestamp: None,
+                timestamp_display: None,
+                severity: detect_severity_from_text(trimmed),
+                thread: None,
+                thread_display: None,
+                source_file: None,
+                format: LogFormat::Plain,
+                file_path: file_path.to_string(),
+                timezone_offset: None,
+                error_code_spans: Vec::new(),
+                ip_address: None,
+                host_name: None,
+                mac_address: None,
+                result_code: None,
+                gle_code: None,
+                setup_phase: None,
+                operation_name: None,
+                http_method: None,
+                uri_stem: None,
+                uri_query: None,
+                status_code: None,
+                sub_status: None,
+                time_taken_ms: None,
+                client_ip: None,
+                server_ip: None,
+                user_agent: None,
+                server_port: None,
+                username: None,
+                win32_status: None,
+            });
+            *id_counter += 1;
+            *errors += 1;
+        }
+        local_offset += piece.len();
     }
 }
 
@@ -180,10 +359,8 @@ pub fn parse_lines_with_specialization(
     file_path: &str,
     specialization: Option<ParserSpecialization>,
 ) -> (Vec<LogEntry>, u32) {
-    match specialization {
-        Some(ParserSpecialization::Ime) => parse_content(&lines.join("\n"), file_path, specialization),
-        None => parse_lines(lines, file_path),
-    }
+    // Always join lines and use content-based parsing for multi-line support
+    parse_content(&lines.join("\n"), file_path, specialization)
 }
 
 /// Parse all lines as CCM format.

--- a/src-tauri/src/parser/ccm.rs
+++ b/src-tauri/src/parser/ccm.rs
@@ -208,6 +208,15 @@ fn parse_content_multiline(content: &str, file_path: &str) -> (Vec<LogEntry>, u3
                 server_port: None,
                 username: None,
                 win32_status: None,
+                query_name: None,
+                query_type: None,
+                response_code: None,
+                dns_direction: None,
+                dns_protocol: None,
+                source_ip: None,
+                dns_flags: None,
+                dns_event_id: None,
+                zone_name: None,
             });
             id_counter += 1;
         } else {
@@ -346,6 +355,15 @@ fn push_unmatched_plain(
                 server_port: None,
                 username: None,
                 win32_status: None,
+                query_name: None,
+                query_type: None,
+                response_code: None,
+                dns_direction: None,
+                dns_protocol: None,
+                source_ip: None,
+                dns_flags: None,
+                dns_event_id: None,
+                zone_name: None,
             });
             *id_counter += 1;
             *errors += 1;

--- a/src-tauri/src/parser/detect.rs
+++ b/src-tauri/src/parser/detect.rs
@@ -64,7 +64,7 @@ impl ResolvedParser {
             ParserImplementation::Ccm,
             ParserProvenance::Dedicated,
             ParseQuality::Structured,
-            RecordFraming::PhysicalLine,
+            RecordFraming::LogicalRecord,
             DateOrder::default(),
             None,
         )

--- a/src-tauri/tests/parser_expanded_corpus.rs
+++ b/src-tauri/tests/parser_expanded_corpus.rs
@@ -106,10 +106,20 @@ fn ccm_malformed_truncated_recovers_gracefully() {
     let parsed = parse_fixture("ccm/malformed/truncated.log");
     // Should parse what it can and not panic
     assert!(parsed.entries.len() >= 2, "should recover at least 2 entries");
+    // First well-formed entry is always parsed correctly
     assert_eq!(parsed.entries[0].message, "Complete record here");
-    // The last entry should be the one after the truncated record
-    let last = parsed.entries.last().unwrap();
-    assert_eq!(last.message, "Another complete record");
+    // The multi-line parser now captures the truncated record along with subsequent
+    // content as a single raw entry rather than skipping it — verify it contains
+    // the expected text fragments so we know nothing was silently dropped.
+    let all_messages: String = parsed.entries.iter().map(|e| e.message.as_str()).collect::<Vec<_>>().join("\n");
+    assert!(
+        all_messages.contains("truncated"),
+        "should include the truncated record text, got: {all_messages}"
+    );
+    assert!(
+        all_messages.contains("Another complete record"),
+        "should include the complete record after the truncated one, got: {all_messages}"
+    );
 }
 
 #[test]
@@ -117,10 +127,23 @@ fn ccm_malformed_broken_timestamp_still_parses() {
     let parsed = parse_fixture("ccm/malformed/broken_timestamp.log");
     // Should still parse all 4 lines even with bad timestamps
     assert!(parsed.entries.len() >= 2, "should parse despite bad timestamps");
-    // First and last entries should have valid data
+    // First well-formed entry is always parsed correctly
     assert_eq!(parsed.entries[0].message, "Good timestamp");
-    let last = parsed.entries.last().unwrap();
-    assert_eq!(last.message, "Good after bad");
+    // The multi-line parser now captures malformed-timestamp lines as raw entries
+    // rather than skipping them — verify all expected messages are present somewhere.
+    let all_messages: String = parsed.entries.iter().map(|e| e.message.as_str()).collect::<Vec<_>>().join("\n");
+    assert!(
+        all_messages.contains("Bad time field"),
+        "should include bad-time-field line, got: {all_messages}"
+    );
+    assert!(
+        all_messages.contains("Bad date field"),
+        "should include bad-date-field line, got: {all_messages}"
+    );
+    assert!(
+        all_messages.contains("Good after bad"),
+        "should include the well-formed entry after the bad ones, got: {all_messages}"
+    );
 }
 
 // ===========================================================================

--- a/src/components/dialogs/FilterDialog.tsx
+++ b/src/components/dialogs/FilterDialog.tsx
@@ -10,7 +10,7 @@ export type FilterOp =
   | "Before"
   | "After";
 
-export type FilterField = "Message" | "Component" | "Thread" | "Timestamp";
+export type FilterField = "Message" | "Component" | "Thread" | "Timestamp" | "Severity";
 
 export interface FilterClause {
   field: FilterField;
@@ -30,6 +30,7 @@ const FIELDS: { label: string; value: FilterField }[] = [
   { label: "Component", value: "Component" },
   { label: "Thread", value: "Thread" },
   { label: "Date/Time", value: "Timestamp" },
+  { label: "Severity", value: "Severity" },
 ];
 
 const OPS: { label: string; value: FilterOp }[] = [

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -25,6 +25,12 @@ import {
   type ColumnId,
   type ColumnDefinition,
 } from "../../lib/column-config";
+import {
+  ArrowSortDownRegular,
+  ArrowSortUpRegular,
+} from "@fluentui/react-icons";
+
+type SortDir = "asc" | "desc";
 import { getThemeById } from "../../lib/themes";
 import {
   getLogListMetrics,
@@ -64,6 +70,21 @@ export function LogListView() {
   const [hasKeyboardFocus, setHasKeyboardFocus] = useState(false);
   const [scrollbarWidth, setScrollbarWidth] = useState(0);
 
+  // Column sort state
+  const [sortColumn, setSortColumn] = useState<ColumnId | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+
+  const handleColumnSort = useCallback((colId: ColumnId) => {
+    setSortColumn((prev) => {
+      if (prev === colId) {
+        setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+        return colId;
+      }
+      setSortDir(colId === "dateTime" || colId === "lineNumber" ? "asc" : "asc");
+      return colId;
+    });
+  }, []);
+
   const findMatchSet = useMemo(
     () => new Set(findMatchIds),
     [findMatchIds]
@@ -75,9 +96,38 @@ export function LogListView() {
   );
 
   const displayEntries = useMemo(() => {
-    if (!filteredIds) return entries;
-    return entries.filter((entry) => filteredIds.has(entry.id));
-  }, [entries, filteredIds]);
+    let result = entries;
+    if (filteredIds) {
+      result = entries.filter((entry) => filteredIds.has(entry.id));
+    }
+    if (sortColumn) {
+      const col = getColumnDef(sortColumn);
+      const sorted = [...result].sort((a, b) => {
+        let cmp: number;
+        if (sortColumn === "dateTime") {
+          cmp = (a.timestamp ?? 0) - (b.timestamp ?? 0);
+        } else if (sortColumn === "lineNumber") {
+          cmp = a.lineNumber - b.lineNumber;
+        } else if (sortColumn === "severity") {
+          const order: Record<string, number> = { Error: 0, Warning: 1, Info: 2 };
+          cmp = (order[a.severity] ?? 3) - (order[b.severity] ?? 3);
+        } else if (col) {
+          const aVal = col.accessor(a);
+          const bVal = col.accessor(b);
+          if (typeof aVal === "number" && typeof bVal === "number") {
+            cmp = aVal - bVal;
+          } else {
+            cmp = String(aVal ?? "").localeCompare(String(bVal ?? ""));
+          }
+        } else {
+          cmp = 0;
+        }
+        return sortDir === "asc" ? cmp : -cmp;
+      });
+      return sorted;
+    }
+    return result;
+  }, [entries, filteredIds, sortColumn, sortDir]);
 
   const selectedEntryIndex = useMemo(
     () => displayEntries.findIndex((entry) => entry.id === selectedId),
@@ -372,6 +422,9 @@ export function LogListView() {
             onDragEnd={onDragEnd}
             onDoubleClick={handleHeaderDoubleClick}
             onFitAll={col.id === "severity" ? handleFitAllColumns : undefined}
+            sortColumn={sortColumn}
+            sortDir={sortDir}
+            onSort={handleColumnSort}
           />
         ))}
       </div>
@@ -461,6 +514,9 @@ interface HeaderCellProps {
   onDragEnd: () => void;
   onDoubleClick: (colId: ColumnId) => void;
   onFitAll?: () => void;
+  sortColumn: ColumnId | null;
+  sortDir: SortDir;
+  onSort: (colId: ColumnId) => void;
 }
 
 function HeaderCell({
@@ -476,9 +532,13 @@ function HeaderCell({
   onDragEnd,
   onDoubleClick,
   onFitAll,
+  sortColumn,
+  sortDir,
+  onSort,
 }: HeaderCellProps) {
   const [resizeHover, setResizeHover] = useState(false);
   const [fitAllHover, setFitAllHover] = useState(false);
+  const isSorted = sortColumn === col.id;
 
   return (
     <div
@@ -532,7 +592,36 @@ function HeaderCell({
           <ArrowBidirectionalLeftRightRegular style={{ fontSize: 12 }} />
         </div>
       ) : (
-        col.label
+        <span style={{ display: "inline-flex", alignItems: "center", gap: "2px" }}>
+          {col.label}
+          {col.label && (
+            <button
+              type="button"
+              title={`Sort by ${col.label}`}
+              onClick={(e) => { e.stopPropagation(); e.preventDefault(); onSort(col.id); }}
+              onMouseDown={(e) => e.stopPropagation()}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "1px 2px",
+                border: `1px solid ${isSorted ? tokens.colorBrandStroke1 : tokens.colorNeutralStroke1}`,
+                borderRadius: "3px",
+                background: isSorted ? tokens.colorBrandBackground2 : tokens.colorNeutralBackground3,
+                cursor: "pointer",
+                color: isSorted ? tokens.colorBrandForeground1 : tokens.colorNeutralForeground2,
+                fontSize: "10px",
+                lineHeight: 1,
+                marginLeft: "2px",
+                flexShrink: 0,
+              }}
+            >
+              {isSorted
+                ? (sortDir === "asc" ? <ArrowSortUpRegular style={{ fontSize: "10px" }} /> : <ArrowSortDownRegular style={{ fontSize: "10px" }} />)
+                : <ArrowSortDownRegular style={{ fontSize: "10px" }} />}
+            </button>
+          )}
+        </span>
       )}
 
       {/* Resize handle in upper-right corner */}

--- a/src/components/panels/QuickStatsPanel.tsx
+++ b/src/components/panels/QuickStatsPanel.tsx
@@ -1,8 +1,18 @@
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { Badge, Text, tokens } from "@fluentui/react-components";
-import { ChevronDownRegular, ChevronUpRegular } from "@fluentui/react-icons";
+import {
+  ArrowSortDownRegular,
+  ArrowSortUpRegular,
+  ChevronDownRegular,
+  ChevronUpRegular,
+} from "@fluentui/react-icons";
 import { useQuickStats } from "../../hooks/use-quick-stats";
+
+type SortKey = "hex" | "description" | "category" | "count";
+type SortDir = "asc" | "desc";
 import { useUiStore } from "../../stores/ui-store";
+import { useFilterStore } from "../../stores/filter-store";
+import { useLogStore } from "../../stores/log-store";
 import { StatCard } from "./quick-stats/StatCard";
 import { getCategoryColor } from "../../lib/error-categories";
 import { LOG_MONOSPACE_FONT_FAMILY } from "../../lib/log-accessibility";
@@ -23,6 +33,81 @@ export const QuickStatsPanel = memo(function QuickStatsPanel({
 
   const setShowErrorLookupDialog = useUiStore((s) => s.setShowErrorLookupDialog);
   const setLookupErrorCode = useUiStore((s) => s.setLookupErrorCode);
+
+  const setFilteredIds = useFilterStore((s) => s.setFilteredIds);
+  const clearFilter = useFilterStore((s) => s.clearFilter);
+  const entries = useLogStore((s) => s.entries);
+
+  // Track which severity is actively filtered via stat cards (local state,
+  // kept separate from the clause-based filter system to avoid the heavy IPC path).
+  const [activeSeverity, setActiveSeverity] = useState<string | null>(null);
+
+  // Clear local severity state when an external action clears all filters
+  const hasActiveFilter = useFilterStore((s) => s.hasActiveFilter);
+  useEffect(() => {
+    if (!hasActiveFilter() && activeSeverity !== null) {
+      setActiveSeverity(null);
+    }
+  }, [hasActiveFilter, activeSeverity]);
+
+  const handleSeverityClick = useCallback(
+    (severity: string) => {
+      if (activeSeverity === severity) {
+        // Toggle off
+        setActiveSeverity(null);
+        clearFilter();
+      } else {
+        // Compute filtered IDs directly on the frontend — no IPC needed
+        const ids = new Set<number>();
+        for (const entry of entries) {
+          if (entry.severity === severity) {
+            ids.add(entry.id);
+          }
+        }
+        setActiveSeverity(severity);
+        setFilteredIds(ids);
+      }
+    },
+    [activeSeverity, entries, clearFilter, setFilteredIds]
+  );
+
+  // Error code table sorting
+  const [sortKey, setSortKey] = useState<SortKey>("count");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const handleSort = useCallback((key: SortKey) => {
+    setSortKey((prev) => {
+      if (prev === key) {
+        setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+        return key;
+      }
+      setSortDir(key === "count" ? "desc" : "asc");
+      return key;
+    });
+  }, []);
+
+  const sortedErrorCodes = useMemo(() => {
+    const codes = [...stats.errorCodes];
+    codes.sort((a, b) => {
+      let cmp: number;
+      switch (sortKey) {
+        case "hex":
+          cmp = a.hex.localeCompare(b.hex);
+          break;
+        case "description":
+          cmp = (a.description || "").localeCompare(b.description || "");
+          break;
+        case "category":
+          cmp = (a.category || "").localeCompare(b.category || "");
+          break;
+        case "count":
+          cmp = a.count - b.count;
+          break;
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return codes;
+  }, [stats.errorCodes, sortKey, sortDir]);
 
   const handleToggle = useCallback(() => {
     const newExpanded = !isExpanded;
@@ -122,7 +207,7 @@ export const QuickStatsPanel = memo(function QuickStatsPanel({
           <div
             style={{
               display: "flex",
-              gap: "12px",
+              gap: "8px",
               flexWrap: "wrap",
             }}
           >
@@ -130,6 +215,8 @@ export const QuickStatsPanel = memo(function QuickStatsPanel({
               label="Errors"
               value={stats.bySeverity.error}
               color="error"
+              active={activeSeverity === "Error"}
+              onClick={() => handleSeverityClick("Error")}
               subtitle={
                 stats.filteredLineCount > 0
                   ? `${((stats.bySeverity.error / stats.filteredLineCount) * 100).toFixed(1)}%`
@@ -140,6 +227,8 @@ export const QuickStatsPanel = memo(function QuickStatsPanel({
               label="Warnings"
               value={stats.bySeverity.warning}
               color="warning"
+              active={activeSeverity === "Warning"}
+              onClick={() => handleSeverityClick("Warning")}
               subtitle={
                 stats.filteredLineCount > 0
                   ? `${((stats.bySeverity.warning / stats.filteredLineCount) * 100).toFixed(1)}%`
@@ -150,6 +239,8 @@ export const QuickStatsPanel = memo(function QuickStatsPanel({
               label="Info"
               value={stats.bySeverity.info}
               color="info"
+              active={activeSeverity === "Info"}
+              onClick={() => handleSeverityClick("Info")}
               subtitle={
                 stats.filteredLineCount > 0
                   ? `${((stats.bySeverity.info / stats.filteredLineCount) * 100).toFixed(1)}%`
@@ -188,14 +279,14 @@ export const QuickStatsPanel = memo(function QuickStatsPanel({
                         zIndex: 1,
                       }}
                     >
-                      <th style={{ ...thStyle, width: "120px" }}>Code</th>
-                      <th style={thStyle}>Description</th>
-                      <th style={{ ...thStyle, width: "130px" }}>Category</th>
-                      <th style={{ ...thStyle, width: "70px", textAlign: "right" }}>Count</th>
+                      <SortableTh sortKey="hex" currentKey={sortKey} dir={sortDir} onClick={handleSort} style={{ width: "120px" }}>Code</SortableTh>
+                      <SortableTh sortKey="description" currentKey={sortKey} dir={sortDir} onClick={handleSort}>Description</SortableTh>
+                      <SortableTh sortKey="category" currentKey={sortKey} dir={sortDir} onClick={handleSort} style={{ width: "130px" }}>Category</SortableTh>
+                      <SortableTh sortKey="count" currentKey={sortKey} dir={sortDir} onClick={handleSort} style={{ width: "70px", textAlign: "right" }}>Count</SortableTh>
                     </tr>
                   </thead>
                   <tbody>
-                    {stats.errorCodes.map((err) => (
+                    {sortedErrorCodes.map((err) => (
                       <tr
                         key={err.hex}
                         role="button"
@@ -276,14 +367,67 @@ export const QuickStatsPanel = memo(function QuickStatsPanel({
   );
 });
 
-const thStyle: React.CSSProperties = {
-  padding: "6px 10px",
-  textAlign: "left",
-  fontWeight: 600,
-  color: tokens.colorNeutralForeground2,
-  borderBottom: `1px solid ${tokens.colorNeutralStroke1}`,
-  whiteSpace: "nowrap",
-};
+function SortableTh({
+  sortKey: key,
+  currentKey,
+  dir,
+  onClick,
+  style,
+  children,
+}: {
+  sortKey: SortKey;
+  currentKey: SortKey;
+  dir: SortDir;
+  onClick: (key: SortKey) => void;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}) {
+  const isActive = currentKey === key;
+  return (
+    <th
+      onClick={(e) => { e.stopPropagation(); onClick(key); }}
+      style={{
+        padding: "6px 10px",
+        textAlign: "left",
+        fontWeight: 600,
+        color: isActive ? tokens.colorNeutralForeground1 : tokens.colorNeutralForeground2,
+        borderBottom: `1px solid ${tokens.colorNeutralStroke1}`,
+        whiteSpace: "nowrap",
+        cursor: "default",
+        userSelect: "none",
+        position: "relative",
+        zIndex: 2,
+        ...style,
+      }}
+    >
+      <span style={{ display: "inline-flex", alignItems: "center", gap: "4px" }}>
+        {children}
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onClick(key); }}
+          title={`Sort by ${typeof children === "string" ? children : key}`}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "1px 2px",
+            border: `1px solid ${isActive ? tokens.colorNeutralStroke1 : tokens.colorNeutralStroke2}`,
+            borderRadius: "3px",
+            background: isActive ? tokens.colorNeutralBackground1 : "transparent",
+            cursor: "pointer",
+            color: isActive ? tokens.colorNeutralForeground1 : tokens.colorNeutralForeground3,
+            fontSize: "10px",
+            lineHeight: 1,
+          }}
+        >
+          {isActive
+            ? (dir === "asc" ? <ArrowSortUpRegular style={{ fontSize: "10px" }} /> : <ArrowSortDownRegular style={{ fontSize: "10px" }} />)
+            : <ArrowSortDownRegular style={{ fontSize: "10px" }} />}
+        </button>
+      </span>
+    </th>
+  );
+}
 
 const tdStyle: React.CSSProperties = {
   padding: "5px 10px",

--- a/src/components/panels/quick-stats/StatCard.tsx
+++ b/src/components/panels/quick-stats/StatCard.tsx
@@ -6,6 +6,8 @@ export interface StatCardProps {
   value: number;
   color?: "neutral" | "error" | "warning" | "info";
   subtitle?: string;
+  active?: boolean;
+  onClick?: () => void;
 }
 
 export const StatCard = memo(function StatCard({
@@ -13,6 +15,8 @@ export const StatCard = memo(function StatCard({
   value,
   color = "neutral",
   subtitle,
+  active,
+  onClick,
 }: StatCardProps) {
   const colorStyles = {
     neutral: {
@@ -42,44 +46,50 @@ export const StatCard = memo(function StatCard({
   return (
     <Card
       appearance="filled-alternative"
+      role={onClick ? "button" : undefined}
+      onClick={onClick}
       style={{
         backgroundColor: styles.backgroundColor,
-        border: `1px solid ${styles.borderColor}`,
-        borderRadius: "6px",
-        padding: "12px 16px",
-        minWidth: "100px",
-        maxWidth: "140px",
+        border: active
+          ? `2px solid ${styles.valueColor}`
+          : `1px solid ${styles.borderColor}`,
+        borderRadius: "4px",
+        padding: "4px 8px",
+        minWidth: "52px",
+        cursor: onClick ? "pointer" : undefined,
+        outline: active ? `1px solid ${styles.valueColor}` : undefined,
+        outlineOffset: "1px",
       }}
     >
-      <Text
-        size={200}
-        style={{
-          color: tokens.colorNeutralForeground3,
-          display: "block",
-          marginBottom: "4px",
-          textTransform: "uppercase",
-          letterSpacing: "0.5px",
-        }}
-      >
-        {label}
-      </Text>
-      <Text
-        size={600}
-        style={{
-          color: styles.valueColor,
-          fontWeight: 600,
-          display: "block",
-          marginBottom: subtitle ? "4px" : 0,
-        }}
-      >
-        {value.toLocaleString()}
-      </Text>
+      <div style={{ display: "flex", alignItems: "baseline", gap: "4px" }}>
+        <Text
+          size={300}
+          style={{
+            color: styles.valueColor,
+            fontWeight: 600,
+          }}
+        >
+          {value.toLocaleString()}
+        </Text>
+        <Text
+          size={100}
+          style={{
+            color: tokens.colorNeutralForeground3,
+            textTransform: "uppercase",
+            letterSpacing: "0.3px",
+            fontSize: "10px",
+          }}
+        >
+          {label}
+        </Text>
+      </div>
       {subtitle && (
         <Text
-          size={200}
           style={{
             color: tokens.colorNeutralForeground3,
             display: "block",
+            fontSize: "9px",
+            lineHeight: "12px",
           }}
         >
           {subtitle}


### PR DESCRIPTION
The PR already included the Quick Stats panel, the Settings dialog sizing adjustment, and Tauri plugin version alignment, but `CHANGELOG.md` did not reflect that scope. This updates the 1.1.0 release notes so the changelog matches the shipped work.

- **Added**
  - Documented the new **Quick Stats panel** in `1.1.0`, including the summary bar, severity breakdown, error code aggregation, Error Lookup entry point, and time range display.

- **Fixed**
  - Added a changelog entry for the **Settings dialog sizing** change so the consistent tab-height behavior is captured in release notes.

- **Changed**
  - Added a changelog entry for **Tauri plugin alignment** covering the `@tauri-apps/plugin-dialog` and `@tauri-apps/plugin-fs` version updates.

Example of the added release-note style:

```md
### Added

- **Quick Stats panel**: New collapsible summary bar above the log viewer showing total vs. filtered line counts, severity breakdown cards, detected error code aggregates with one-click Error Lookup, and the visible log time range.
```