### PR TITLE
feat: auto-fit column width on double-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Auto-fit column widths** (PR #114, original PR #108 by @gepardjaro): Double-click a column resize handle to auto-fit that column to its widest content. Click the ↔ icon in the severity column header to auto-fit all visible columns at once. Uses a two-pass measurement algorithm (string length scan then canvas measurement of top candidates) for efficient sizing on large logs. Message column is excluded from auto-fit to prevent long content from pushing everything off-screen. Results are capped at 1200px and persist to preferences.
+
 ## [1.1.0] - 2026-04-05
 
 ### Added

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -15,17 +15,20 @@ import { LogRow } from "./LogRow";
 import { MergeLegendBar } from "./MergeLegendBar";
 import type { ErrorCodeSpan } from "../../types/log";
 import { useContextMenu } from "../../hooks/use-context-menu";
+import { ArrowBidirectionalLeftRightRegular } from "@fluentui/react-icons";
 import {
   applyColumnOrder,
   getVisibleColumns,
   buildGridTemplateColumns,
   getColumnDef,
+  calcAutoFitWidth,
   type ColumnId,
   type ColumnDefinition,
 } from "../../lib/column-config";
 import { getThemeById } from "../../lib/themes";
 import {
   getLogListMetrics,
+  getCanvasFont,
   LOG_UI_FONT_FAMILY,
 } from "../../lib/log-accessibility";
 
@@ -291,6 +294,29 @@ export function LogListView() {
 
   const onDragEnd = useCallback(() => setDragState(null), []);
 
+  // ── Auto-fit column width ────────────────────────────────────────────────
+  const handleHeaderDoubleClick = useCallback(
+    (colId: ColumnId) => {
+      const def = getColumnDef(colId);
+      if (!def) return;
+      // Use a rendered row element so the font-family is fully resolved (no CSS variables)
+      const rowEl = parentRef.current?.querySelector<HTMLElement>(".log-row") ?? null;
+      const contentFont = getCanvasFont(logListFontSize, false, rowEl);
+      const headerFont = getCanvasFont(listMetrics.headerFontSize, true, rowEl);
+      setColumnWidth(colId, calcAutoFitWidth(def, displayEntries, contentFont, headerFont));
+    },
+    [displayEntries, logListFontSize, listMetrics, setColumnWidth]
+  );
+
+  const handleFitAllColumns = useCallback(() => {
+    const rowEl = parentRef.current?.querySelector<HTMLElement>(".log-row") ?? null;
+    const contentFont = getCanvasFont(logListFontSize, false, rowEl);
+    const headerFont = getCanvasFont(listMetrics.headerFontSize, true, rowEl);
+    for (const col of visibleColumns) {
+      setColumnWidth(col.id, calcAutoFitWidth(col, displayEntries, contentFont, headerFont));
+    }
+  }, [visibleColumns, displayEntries, logListFontSize, listMetrics, setColumnWidth]);
+
   const activeRowDomId =
     selectedEntryIndex >= 0
       ? `log-list-row-${displayEntries[selectedEntryIndex].id}`
@@ -339,6 +365,8 @@ export function LogListView() {
             onDragOver={onDragOver}
             onDrop={onDrop}
             onDragEnd={onDragEnd}
+            onDoubleClick={handleHeaderDoubleClick}
+            onFitAll={col.id === "severity" ? handleFitAllColumns : undefined}
           />
         ))}
       </div>
@@ -426,6 +454,8 @@ interface HeaderCellProps {
   onDragOver: (index: number, e: React.DragEvent) => void;
   onDrop: (e: React.DragEvent) => void;
   onDragEnd: () => void;
+  onDoubleClick: (colId: ColumnId) => void;
+  onFitAll?: () => void;
 }
 
 function HeaderCell({
@@ -439,8 +469,11 @@ function HeaderCell({
   onDragOver,
   onDrop,
   onDragEnd,
+  onDoubleClick,
+  onFitAll,
 }: HeaderCellProps) {
   const [resizeHover, setResizeHover] = useState(false);
+  const [fitAllHover, setFitAllHover] = useState(false);
 
   return (
     <div
@@ -449,6 +482,7 @@ function HeaderCell({
       onDragOver={(e) => onDragOver(index, e)}
       onDrop={onDrop}
       onDragEnd={onDragEnd}
+      onDoubleClick={(e) => { e.preventDefault(); onDoubleClick(col.id); }}
       style={{
         position: "relative",
         ...(col.isFlex ? { minWidth: 0 } : {}),
@@ -468,7 +502,28 @@ function HeaderCell({
             : {}),
       }}
     >
-      {col.label}
+      {onFitAll ? (
+        /* Fit-all-columns button lives in the severity column header (no label, always first) */
+        <div
+          title="Auto-fit all columns to content width"
+          onClick={(e) => { e.stopPropagation(); onFitAll(); }}
+          onMouseEnter={() => setFitAllHover(true)}
+          onMouseLeave={() => setFitAllHover(false)}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "100%",
+            height: "100%",
+            cursor: "pointer",
+            color: fitAllHover ? tokens.colorBrandForeground1 : tokens.colorNeutralForeground2,
+          }}
+        >
+          <ArrowBidirectionalLeftRightRegular style={{ fontSize: 12 }} />
+        </div>
+      ) : (
+        col.label
+      )}
 
       {/* Resize handle in upper-right corner */}
       {(

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -298,6 +298,7 @@ export function LogListView() {
   // ── Auto-fit column width ────────────────────────────────────────────────
   const handleHeaderDoubleClick = useCallback(
     (colId: ColumnId) => {
+      if (colId === "message") return;
       const def = getColumnDef(colId);
       if (!def) return;
       // Use a rendered row element so the font-family is fully resolved (no CSS variables)
@@ -315,6 +316,7 @@ export function LogListView() {
     const headerFont = getCanvasFont(listMetrics.headerFontSize, true, rowEl);
     const updates: Record<string, number> = {};
     for (const col of visibleColumns) {
+      if (col.id === "message") continue;
       updates[col.id] = calcAutoFitWidth(col, displayEntries, contentFont, headerFont);
     }
     setColumnWidths(updates);
@@ -510,6 +512,8 @@ function HeaderCell({
           role="button"
           aria-label="Auto-fit all columns to content width"
           title="Auto-fit all columns to content width"
+          draggable={false}
+          onDragStart={(e) => { e.preventDefault(); e.stopPropagation(); }}
           onClick={(e) => { e.stopPropagation(); onFitAll(); }}
           onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onFitAll(); } }}
           tabIndex={0}

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -58,6 +58,7 @@ export function LogListView() {
   const columnWidths = useUiStore((s) => s.columnWidths);
   const columnOrder = useUiStore((s) => s.columnOrder);
   const setColumnWidth = useUiStore((s) => s.setColumnWidth);
+  const setColumnWidths = useUiStore((s) => s.setColumnWidths);
   const setColumnOrder = useUiStore((s) => s.setColumnOrder);
 
   const [hasKeyboardFocus, setHasKeyboardFocus] = useState(false);
@@ -312,10 +313,12 @@ export function LogListView() {
     const rowEl = parentRef.current?.querySelector<HTMLElement>(".log-row") ?? null;
     const contentFont = getCanvasFont(logListFontSize, false, rowEl);
     const headerFont = getCanvasFont(listMetrics.headerFontSize, true, rowEl);
+    const updates: Record<string, number> = {};
     for (const col of visibleColumns) {
-      setColumnWidth(col.id, calcAutoFitWidth(col, displayEntries, contentFont, headerFont));
+      updates[col.id] = calcAutoFitWidth(col, displayEntries, contentFont, headerFont);
     }
-  }, [visibleColumns, displayEntries, logListFontSize, listMetrics, setColumnWidth]);
+    setColumnWidths(updates);
+  }, [visibleColumns, displayEntries, logListFontSize, listMetrics, setColumnWidths]);
 
   const activeRowDomId =
     selectedEntryIndex >= 0
@@ -482,7 +485,6 @@ function HeaderCell({
       onDragOver={(e) => onDragOver(index, e)}
       onDrop={onDrop}
       onDragEnd={onDragEnd}
-      onDoubleClick={(e) => { e.preventDefault(); onDoubleClick(col.id); }}
       style={{
         position: "relative",
         ...(col.isFlex ? { minWidth: 0 } : {}),
@@ -505,8 +507,12 @@ function HeaderCell({
       {onFitAll ? (
         /* Fit-all-columns button lives in the severity column header (no label, always first) */
         <div
+          role="button"
+          aria-label="Auto-fit all columns to content width"
           title="Auto-fit all columns to content width"
           onClick={(e) => { e.stopPropagation(); onFitAll(); }}
+          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onFitAll(); } }}
+          tabIndex={0}
           onMouseEnter={() => setFitAllHover(true)}
           onMouseLeave={() => setFitAllHover(false)}
           style={{
@@ -529,6 +535,7 @@ function HeaderCell({
       {(
         <div
           onMouseDown={(e) => onResizeStart(col.id, e)}
+          onDoubleClick={(e) => { e.preventDefault(); e.stopPropagation(); onDoubleClick(col.id); }}
           onMouseEnter={() => setResizeHover(true)}
           onMouseLeave={() => setResizeHover(false)}
           style={{

--- a/src/lib/column-config.ts
+++ b/src/lib/column-config.ts
@@ -316,6 +316,80 @@ export function getColumnsForAggregate(parsers: ParserKind[]): ColumnId[] {
  * Filters the user order to only include columns that are active (parser-relevant).
  * Any active columns not in the user order are appended at the end.
  */
+// ── Auto-fit measurement ─────────────────────────────────────────────────────
+
+/** Singleton canvas context for measuring text width without DOM layout. */
+let _measureCtx: CanvasRenderingContext2D | null = null;
+function getMeasureCtx(): CanvasRenderingContext2D | null {
+  if (!_measureCtx) {
+    const canvas = document.createElement("canvas");
+    _measureCtx = canvas.getContext("2d");
+  }
+  return _measureCtx;
+}
+
+export function measureTextWidth(text: string, font: string): number {
+  const ctx = getMeasureCtx();
+  if (!ctx) return text.length * 8;
+  ctx.font = font;
+  return ctx.measureText(text).width;
+}
+
+const CELL_PAD = 10;   // 4px left + 4px right cell padding + 2px buffer
+const HEADER_PAD = 24; // extra room for the resize grip
+
+/**
+ * Calculate the auto-fit width for a column given the current display entries.
+ * - severity: returns defaultWidth (renders a colored dot, not text)
+ * - dateTime: uses a fixed representative timestamp string (view layer formats it)
+ * - all others: two-pass approach —
+ *     Pass 1 (O(n), no canvas): find the max string length across ALL entries
+ *     Pass 2 (O(k), canvas): measure only strings within 90% of the max length
+ *   This ensures the widest entry is always found regardless of how large the log is,
+ *   while keeping canvas calls to a minimum.
+ */
+export function calcAutoFitWidth(
+  col: ColumnDefinition,
+  entries: readonly LogEntry[],
+  contentFont: string,
+  headerFont: string
+): number {
+  if (col.id === "severity") return col.defaultWidth;
+
+  if (col.id === "dateTime") {
+    const sample = "2024-01-01 00:00:00.000";
+    return Math.ceil(Math.max(measureTextWidth(sample, contentFont) + CELL_PAD, col.minWidth));
+  }
+
+  const headerW = measureTextWidth(col.label, headerFont) + HEADER_PAD;
+
+  // Pass 1: find the longest string length (cheap — no canvas)
+  let maxLen = 0;
+  for (const entry of entries) {
+    const val = col.accessor(entry);
+    if (val == null) continue;
+    const len = String(val).length;
+    if (len > maxLen) maxLen = len;
+  }
+
+  // No data found — use defaultWidth so we never shrink an empty column below its designed size
+  if (maxLen === 0) return Math.ceil(Math.max(headerW, col.defaultWidth));
+
+  // Pass 2: canvas-measure only strings ≥ 90% of max length
+  const threshold = maxLen * 0.9;
+  let maxContent = 0;
+  for (const entry of entries) {
+    const val = col.accessor(entry);
+    if (val == null) continue;
+    const text = String(val);
+    if (text.length < threshold) continue;
+    const w = measureTextWidth(text, contentFont);
+    if (w > maxContent) maxContent = w;
+  }
+
+  return Math.ceil(Math.max(headerW, maxContent + CELL_PAD, col.minWidth));
+}
+
 export function applyColumnOrder(
   activeColumns: ColumnId[],
   userOrder: ColumnId[] | null

--- a/src/lib/column-config.ts
+++ b/src/lib/column-config.ts
@@ -358,6 +358,10 @@ export function calcAutoFitWidth(
 ): number {
   if (col.id === "severity") return col.defaultWidth;
 
+  // The message column contains arbitrarily long content (JSON blobs, stack traces, etc.).
+  // Auto-fitting it just pushes everything off-screen — keep its current/default width.
+  if (col.id === "message") return col.defaultWidth;
+
   if (col.id === "dateTime") {
     // Representative sample matching the widest output of formatLogEntryTimestamp().
     // Update this if the display format changes (see src/lib/date-time-format.ts).

--- a/src/lib/column-config.ts
+++ b/src/lib/column-config.ts
@@ -337,6 +337,8 @@ export function measureTextWidth(text: string, font: string): number {
 
 const CELL_PAD = 10;   // 4px left + 4px right cell padding + 2px buffer
 const HEADER_PAD = 24; // extra room for the resize grip
+/** Hard cap to prevent absurdly wide columns (e.g., 2000-char log messages). */
+const MAX_AUTOFIT_WIDTH = 1200;
 
 /**
  * Calculate the auto-fit width for a column given the current display entries.
@@ -357,6 +359,8 @@ export function calcAutoFitWidth(
   if (col.id === "severity") return col.defaultWidth;
 
   if (col.id === "dateTime") {
+    // Representative sample matching the widest output of formatLogEntryTimestamp().
+    // Update this if the display format changes (see src/lib/date-time-format.ts).
     const sample = "2024-01-01 00:00:00.000";
     return Math.ceil(Math.max(measureTextWidth(sample, contentFont) + CELL_PAD, col.minWidth));
   }
@@ -387,7 +391,10 @@ export function calcAutoFitWidth(
     if (w > maxContent) maxContent = w;
   }
 
-  return Math.ceil(Math.max(headerW, maxContent + CELL_PAD, col.minWidth));
+  return Math.min(
+    MAX_AUTOFIT_WIDTH,
+    Math.ceil(Math.max(headerW, maxContent + CELL_PAD, col.minWidth)),
+  );
 }
 
 export function applyColumnOrder(

--- a/src/lib/log-accessibility.ts
+++ b/src/lib/log-accessibility.ts
@@ -45,6 +45,29 @@ export function getLogListMetrics(fontSize: number): LogListMetrics {
   };
 }
 
+/**
+ * Returns a canvas-compatible font string.
+ * Prefers reading the resolved font-family from a real DOM element (most accurate),
+ * falling back to resolving the CSS custom property, then a hardcoded fallback.
+ * canvas.measureText() cannot handle var(--...) syntax.
+ */
+export function getCanvasFont(
+  size: number,
+  bold = false,
+  sourceElement?: Element | null
+): string {
+  let family: string;
+  if (sourceElement) {
+    family = getComputedStyle(sourceElement).fontFamily;
+  } else {
+    family =
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--cmtrace-font-family-ui")
+        .trim() || "'Segoe UI', Tahoma, sans-serif";
+  }
+  return `${bold ? "bold " : ""}${size}px ${family}`;
+}
+
 export function getLogDetailsLineHeight(fontSize: number): number {
   const clampedFontSize = clampLogDetailsFontSize(fontSize);
   return Math.max(20, Math.round(clampedFontSize * 1.6));

--- a/src/lib/log-source.ts
+++ b/src/lib/log-source.ts
@@ -179,6 +179,7 @@ async function applyParseResultToStore(
   state.setByteOffset(result.byteOffset);
   const columns = getColumnsForParser(result.parserSelection.parser);
   state.setActiveColumns(columns);
+  useUiStore.getState().resetColumnWidths();
   state.selectEntry(null);
   state.setSourceStatus({
     kind: "loaded",
@@ -350,6 +351,7 @@ async function loadFolderProgressive(
     allResults.map((r) => r.parserSelection.parser)
   );
   state.setActiveColumns(aggregateColumns);
+  useUiStore.getState().resetColumnWidths();
   state.selectEntry(null);
   state.setFolderLoadProgress(null);
   state.setSourceStatus({
@@ -664,6 +666,7 @@ export async function switchToTab(
     logState.setTotalLines(cached.totalLines);
     logState.setByteOffset(cached.byteOffset);
     logState.setActiveColumns(cached.activeColumns);
+    useUiStore.getState().resetColumnWidths();
     logState.setAggregateFiles([]);
     logState.selectEntry(null);
     logState.setSourceStatus({
@@ -824,6 +827,7 @@ export async function loadFilesAsLogSource(paths: string[]): Promise<void> {
       results.map((r) => r.parserSelection.parser)
     );
     state.setActiveColumns(aggregateColumns);
+    useUiStore.getState().resetColumnWidths();
     state.selectEntry(null);
     state.setFolderLoadProgress(null);
 

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -196,6 +196,7 @@ interface UiState {
   setDefaultShowInfoPane: (show: boolean) => void;
   setConfirmTabClose: (confirm: boolean) => void;
   setColumnWidth: (columnId: string, width: number) => void;
+  setColumnWidths: (updates: Record<string, number>) => void;
   resetColumnWidths: () => void;
   setColumnOrder: (order: ColumnId[]) => void;
   resetColumnOrder: () => void;
@@ -469,6 +470,10 @@ export const useUiStore = create<UiState>()(
       setColumnWidth: (columnId, width) =>
         set((state) => ({
           columnWidths: { ...state.columnWidths, [columnId]: width },
+        })),
+      setColumnWidths: (updates) =>
+        set((state) => ({
+          columnWidths: { ...state.columnWidths, ...updates },
         })),
       resetColumnWidths: () => set({ columnWidths: {} }),
       setColumnOrder: (order) => set({ columnOrder: order }),


### PR DESCRIPTION
## Summary
Supersedes #108 (original by @gepardjaro) with review fixes applied.

- **Double-click a column resize handle** to auto-fit that column to its widest content
- **↔ button in severity header** to auto-fit all visible columns at once
- Changes persist to preferences (same as manual drag-resize)

### Review fixes applied:
- Batch `setColumnWidths()` for fit-all to avoid N re-renders
- Move double-click target to resize handle (matches Excel/VS Code UX, fixes drag-to-reorder conflict)
- Exclude message column from auto-fit (long content pushes everything off-screen)
- Add max-width cap (1200px) for remaining columns
- Add accessibility (`role="button"`, `aria-label`, keyboard support) to fit-all button
- Document dateTime sample string dependency on format function

## Test plan
- [ ] Open a log file with multiple columns visible
- [ ] Double-click a column resize handle — column should auto-fit to content
- [ ] Click the ↔ icon in the severity header — all columns except message should auto-fit
- [ ] Verify message column stays at default width (not stretched to longest entry)
- [ ] Verify column widths persist after closing and reopening

🤖 Generated with [Claude Code](https://claude.com/claude-code)