### PR TITLE
feat: .cmtlog format, markers, and PowerShell module

### DIFF
--- a/docs/superpowers/plans/2026-04-13-cmtlog-format-markers.md
+++ b/docs/superpowers/plans/2026-04-13-cmtlog-format-markers.md
@@ -1,0 +1,2012 @@
+# `.cmtlog` Format, Markers, and PowerShell Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a custom `.cmtlog` log format with sections/WhatIf/tags, color-coded user markers persisted to AppData, section divider rendering, multi-select copy, and a PowerShell authoring module.
+
+**Architecture:** The `.cmtlog` format extends CCM's `<![LOG[...]LOG]!>` line structure with reserved component names (`__HEADER__`, `__SECTION__`, `__ITERATION__`) and optional extended attributes (`section`, `tag`, `whatif`, `iteration`, `color`). A new Rust parser module extracts these. Markers are independent — persisted as JSON in AppData keyed by file path hash. Frontend gains a marker store, gutter UI, section band rendering, WhatIf styling, and multi-select copy.
+
+**Tech Stack:** Rust (parser, marker persistence), React + TypeScript (UI), Zustand (marker store), PowerShell (authoring module), Tauri IPC (marker commands)
+
+**Spec:** `docs/superpowers/specs/2026-04-13-cmtlog-format-markers-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `src-tauri/src/parser/cmtlog.rs` | CmtLog parser — detects reserved components, extracts extended attributes |
+| `src-tauri/src/commands/markers.rs` | Tauri IPC commands for marker load/save/delete |
+| `src-tauri/tests/cmtlog_parser.rs` | Parser regression tests for `.cmtlog` format |
+| `src-tauri/tests/fixtures/cmtlog/` | Test fixture `.cmtlog` files |
+| `src/stores/marker-store.ts` | Zustand store for marker state per tab |
+| `src/types/markers.ts` | TypeScript types for markers and categories |
+| `scripts/powershell/CmtLog/CmtLog.psm1` | PowerShell module for writing `.cmtlog` files |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `src-tauri/src/models/log_entry.rs` | Add `EntryKind` enum, `CmtLog` to `ParserKind`/`ParserImplementation`/`LogFormat`, new optional fields on `LogEntry` |
+| `src-tauri/src/parser/mod.rs` | Add `pub mod cmtlog;`, dispatch arm in `parse_lines_with_selection` |
+| `src-tauri/src/parser/detect.rs` | Add `.cmtlog` extension detection and content fallback |
+| `src-tauri/src/lib.rs` | Register marker commands in `invoke_handler` |
+| `src-tauri/src/commands/mod.rs` | Add `pub mod markers;` |
+| `src-tauri/tauri.conf.json` | Add `.cmtlog` file association |
+| `src/types/log.ts` | Add `CmtLog` to `LogFormat`, new optional fields on `LogEntry` interface |
+| `src/components/log-view/LogRow.tsx` | Marker gutter, section bands, WhatIf styling, multi-select highlight |
+| `src/components/log-view/LogListView.tsx` | Section divider rows, multi-select state, gutter column, copy handler |
+| `src/stores/filter-store.ts` | Add WhatIf filter toggle |
+
+---
+
+## Task 1: Extend LogEntry Model with CmtLog Fields
+
+**Files:**
+- Modify: `src-tauri/src/models/log_entry.rs`
+
+- [ ] **Step 1: Add `EntryKind` enum**
+
+Add after the `Severity` enum (around line 10):
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum EntryKind {
+    Log,
+    Section,
+    Iteration,
+    Header,
+}
+
+impl Default for EntryKind {
+    fn default() -> Self {
+        EntryKind::Log
+    }
+}
+```
+
+- [ ] **Step 2: Add `CmtLog` variant to `ParserKind` enum**
+
+Add `CmtLog` to the `ParserKind` enum (around line 32-50):
+
+```rust
+CmtLog,
+```
+
+- [ ] **Step 3: Add `CmtLog` variant to `ParserImplementation` enum**
+
+Add `CmtLog` to the `ParserImplementation` enum (around line 55-70):
+
+```rust
+CmtLog,
+```
+
+- [ ] **Step 4: Add `CmtLog` variant to `LogFormat` enum**
+
+Add `CmtLog` to the `LogFormat` enum (around line 14-27):
+
+```rust
+CmtLog,
+```
+
+- [ ] **Step 5: Add optional CmtLog fields to `LogEntry` struct**
+
+Add these fields to the `LogEntry` struct (after the existing DNS fields, before the closing brace):
+
+```rust
+    // CmtLog extended fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry_kind: Option<EntryKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub whatif: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section_color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iteration: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+```
+
+- [ ] **Step 6: Run cargo check**
+
+Run: `cargo check` from `src-tauri/`
+Expected: Compiles with no errors. Warnings about unused variants are OK at this stage.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/models/log_entry.rs
+git commit -m "feat(models): add EntryKind enum and CmtLog fields to LogEntry"
+```
+
+---
+
+## Task 2: Create CmtLog Parser Module
+
+**Files:**
+- Create: `src-tauri/src/parser/cmtlog.rs`
+- Modify: `src-tauri/src/parser/mod.rs`
+
+- [ ] **Step 1: Write the test fixture file**
+
+Create `src-tauri/tests/fixtures/cmtlog/basic.cmtlog`:
+
+```
+<![LOG[Script started: Detect-WDAC.ps1 v2.1.0]LOG]!><time="10:30:00.000+000" date="04-13-2026" component="__HEADER__" context="" type="1" thread="0" file="" script="Detect-WDAC.ps1" version="2.1.0" runid="a3f8c9e1" mode="Normal" ps_version="7.4.2">
+<![LOG[Detection Phase]LOG]!><time="10:32:01.000+000" date="04-13-2026" component="__SECTION__" context="" type="1" thread="0" file="" color="#5b9aff">
+<![LOG[Scanning policy files]LOG]!><time="10:32:01.123+000" date="04-13-2026" component="Detect-WDAC" context="CONTOSO\admin" type="1" thread="1234" file="" section="detection" tag="phase:scan">
+<![LOG[Policy validation failed]LOG]!><time="10:32:01.456+000" date="04-13-2026" component="Detect-WDAC" context="CONTOSO\admin" type="3" thread="1234" file="" section="detection">
+<![LOG[Loop Iteration 1/3 - WDAC policies]LOG]!><time="10:32:02.000+000" date="04-13-2026" component="__ITERATION__" context="" type="1" thread="0" file="" iteration="1/3" color="#a78bfa">
+<![LOG[Processing policy contoso.xml]LOG]!><time="10:32:02.100+000" date="04-13-2026" component="Detect-WDAC" context="CONTOSO\admin" type="1" thread="1234" file="" section="detection" iteration="1/3">
+<![LOG[Would apply policy contoso.xml]LOG]!><time="10:32:02.200+000" date="04-13-2026" component="Detect-WDAC" context="CONTOSO\admin" type="1" thread="1234" file="" section="detection" whatif="1">
+```
+
+- [ ] **Step 2: Write the failing parser test**
+
+Create `src-tauri/tests/cmtlog_parser.rs`:
+
+```rust
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempLogFixture {
+    dir: PathBuf,
+    path: PathBuf,
+}
+
+impl TempLogFixture {
+    fn new(file_name: &str, content: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("cmtrace-open-cmtlog-test-{unique}"));
+        fs::create_dir_all(&dir).expect("create temp fixture dir");
+        let path = dir.join(file_name);
+        fs::write(&path, content).expect("write temp fixture");
+        Self { dir, path }
+    }
+
+    fn parse(&self) -> app_lib::parser::ParseResult {
+        let path_str = self.path.to_string_lossy().to_string();
+        let (result, _selection) =
+            app_lib::parser::parse_file(&path_str).expect("fixture should parse successfully");
+        result
+    }
+
+    fn detect(&self) -> app_lib::parser::detect::ResolvedParser {
+        let content =
+            fs::read_to_string(&self.path).expect("fixture should be readable as UTF-8");
+        app_lib::parser::detect::detect_parser(&self.path.to_string_lossy(), &content)
+    }
+}
+
+impl Drop for TempLogFixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn cmtlog_extension_triggers_cmtlog_parser() {
+    let content = include_str!("fixtures/cmtlog/basic.cmtlog");
+    let fixture = TempLogFixture::new("test.cmtlog", content);
+    let selection = fixture.detect();
+    assert_eq!(
+        format!("{:?}", selection.parser),
+        "CmtLog",
+        "should detect CmtLog parser for .cmtlog extension"
+    );
+}
+
+#[test]
+fn cmtlog_parses_header_entry() {
+    let content = include_str!("fixtures/cmtlog/basic.cmtlog");
+    let fixture = TempLogFixture::new("test.cmtlog", content);
+    let result = fixture.parse();
+    let header = &result.entries[0];
+    assert_eq!(header.component.as_deref(), Some("__HEADER__"));
+    assert_eq!(
+        header.entry_kind,
+        Some(app_lib::models::log_entry::EntryKind::Header)
+    );
+    assert_eq!(header.message, "Script started: Detect-WDAC.ps1 v2.1.0");
+}
+
+#[test]
+fn cmtlog_parses_section_entry() {
+    let content = include_str!("fixtures/cmtlog/basic.cmtlog");
+    let fixture = TempLogFixture::new("test.cmtlog", content);
+    let result = fixture.parse();
+    let section = &result.entries[1];
+    assert_eq!(
+        section.entry_kind,
+        Some(app_lib::models::log_entry::EntryKind::Section)
+    );
+    assert_eq!(section.message, "Detection Phase");
+    assert_eq!(section.section_color.as_deref(), Some("#5b9aff"));
+}
+
+#[test]
+fn cmtlog_parses_iteration_entry() {
+    let content = include_str!("fixtures/cmtlog/basic.cmtlog");
+    let fixture = TempLogFixture::new("test.cmtlog", content);
+    let result = fixture.parse();
+    let iteration = &result.entries[4];
+    assert_eq!(
+        iteration.entry_kind,
+        Some(app_lib::models::log_entry::EntryKind::Iteration)
+    );
+    assert_eq!(iteration.iteration.as_deref(), Some("1/3"));
+    assert_eq!(iteration.section_color.as_deref(), Some("#a78bfa"));
+}
+
+#[test]
+fn cmtlog_parses_regular_entries_with_section_name() {
+    let content = include_str!("fixtures/cmtlog/basic.cmtlog");
+    let fixture = TempLogFixture::new("test.cmtlog", content);
+    let result = fixture.parse();
+    let entry = &result.entries[2];
+    assert_eq!(
+        entry.entry_kind,
+        Some(app_lib::models::log_entry::EntryKind::Log)
+    );
+    assert_eq!(entry.section_name.as_deref(), Some("detection"));
+    assert_eq!(entry.message, "Scanning policy files");
+    assert!(entry.tags.as_ref().unwrap().contains(&"phase:scan".to_string()));
+}
+
+#[test]
+fn cmtlog_parses_whatif_flag() {
+    let content = include_str!("fixtures/cmtlog/basic.cmtlog");
+    let fixture = TempLogFixture::new("test.cmtlog", content);
+    let result = fixture.parse();
+    let whatif_entry = &result.entries[6];
+    assert_eq!(whatif_entry.whatif, Some(true));
+    assert_eq!(whatif_entry.message, "Would apply policy contoso.xml");
+}
+
+#[test]
+fn cmtlog_regular_entries_have_correct_severity() {
+    let content = include_str!("fixtures/cmtlog/basic.cmtlog");
+    let fixture = TempLogFixture::new("test.cmtlog", content);
+    let result = fixture.parse();
+    // Entry at index 3 has type="3" → Error
+    let error_entry = &result.entries[3];
+    assert_eq!(
+        error_entry.severity,
+        app_lib::models::log_entry::Severity::Error
+    );
+}
+
+#[test]
+fn cmtlog_total_entries_count() {
+    let content = include_str!("fixtures/cmtlog/basic.cmtlog");
+    let fixture = TempLogFixture::new("test.cmtlog", content);
+    let result = fixture.parse();
+    assert_eq!(result.entries.len(), 7);
+}
+
+#[test]
+fn cmtlog_content_fallback_detection() {
+    // A .log file with __SECTION__ component should still detect as CmtLog
+    let content = r#"<![LOG[Detection Phase]LOG]!><time="10:32:01.000+000" date="04-13-2026" component="__SECTION__" context="" type="1" thread="0" file="" color="#5b9aff">
+<![LOG[Scanning policy files]LOG]!><time="10:32:01.123+000" date="04-13-2026" component="Detect-WDAC" context="CONTOSO\admin" type="1" thread="1234" file="" section="detection">"#;
+    let fixture = TempLogFixture::new("test.log", content);
+    let selection = fixture.detect();
+    assert_eq!(
+        format!("{:?}", selection.parser),
+        "CmtLog",
+        "should detect CmtLog parser via content fallback for .log with reserved components"
+    );
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test --test cmtlog_parser` from `src-tauri/`
+Expected: Compilation errors — `cmtlog` module doesn't exist yet, `EntryKind` variants may not be wired up.
+
+- [ ] **Step 4: Create the cmtlog parser module**
+
+Create `src-tauri/src/parser/cmtlog.rs`:
+
+```rust
+use lazy_static::lazy_static;
+use regex::Regex;
+
+use crate::models::log_entry::{EntryKind, LogEntry, LogFormat, Severity};
+use crate::parser::ccm;
+
+lazy_static! {
+    /// Regex to extract extended attributes from the metadata portion of a CCM line.
+    /// Matches key="value" pairs after the standard CCM attributes.
+    static ref EXTENDED_ATTR_RE: Regex =
+        Regex::new(r#"(\w+)="([^"]*)""#).expect("extended attribute regex should compile");
+}
+
+/// Reserved component names that signal structural entries.
+const HEADER_COMPONENT: &str = "__HEADER__";
+const SECTION_COMPONENT: &str = "__SECTION__";
+const ITERATION_COMPONENT: &str = "__ITERATION__";
+
+/// Returns true if a CCM-format line contains a reserved CmtLog component.
+pub fn matches_cmtlog_record(line: &str) -> bool {
+    line.contains(HEADER_COMPONENT)
+        || line.contains(SECTION_COMPONENT)
+        || line.contains(ITERATION_COMPONENT)
+}
+
+/// Classify a component string into an EntryKind.
+fn classify_component(component: &str) -> EntryKind {
+    match component {
+        HEADER_COMPONENT => EntryKind::Header,
+        SECTION_COMPONENT => EntryKind::Section,
+        ITERATION_COMPONENT => EntryKind::Iteration,
+        _ => EntryKind::Log,
+    }
+}
+
+/// Extract extended attributes from the raw metadata portion of a line.
+/// Returns a map of key-value pairs for known extended attributes.
+struct ExtendedAttrs {
+    section: Option<String>,
+    color: Option<String>,
+    tag: Option<String>,
+    whatif: Option<bool>,
+    iteration: Option<String>,
+}
+
+fn extract_extended_attrs(line: &str) -> ExtendedAttrs {
+    let mut attrs = ExtendedAttrs {
+        section: None,
+        color: None,
+        tag: None,
+        whatif: None,
+        iteration: None,
+    };
+
+    for cap in EXTENDED_ATTR_RE.captures_iter(line) {
+        let key = &cap[1];
+        let value = &cap[2];
+        match key {
+            "section" => attrs.section = Some(value.to_string()),
+            "color" => attrs.color = Some(value.to_string()),
+            "tag" => attrs.tag = Some(value.to_string()),
+            "whatif" if value == "1" => attrs.whatif = Some(true),
+            "whatif" if value == "0" => attrs.whatif = Some(false),
+            "iteration" => attrs.iteration = Some(value.to_string()),
+            _ => {} // standard CCM attrs and unknown attrs are ignored
+        }
+    }
+
+    attrs
+}
+
+/// Parse lines as CmtLog format.
+///
+/// Delegates core CCM parsing to `ccm::parse_lines`, then post-processes
+/// each entry to extract extended attributes and classify entry kinds.
+pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
+    let (mut entries, error_count) = ccm::parse_lines(lines, file_path);
+
+    // Track the current section name and color for propagation to child entries.
+    let mut current_section_name: Option<String> = None;
+    let mut current_section_color: Option<String> = None;
+
+    for (i, entry) in entries.iter_mut().enumerate() {
+        // Override format to CmtLog
+        entry.format = LogFormat::CmtLog;
+
+        let line = if i < lines.len() { lines[i] } else { "" };
+        let attrs = extract_extended_attrs(line);
+        let component = entry.component.as_deref().unwrap_or("");
+        let kind = classify_component(component);
+
+        match &kind {
+            EntryKind::Section => {
+                current_section_name = Some(entry.message.clone());
+                current_section_color = attrs.color.clone();
+                entry.section_name = current_section_name.clone();
+                entry.section_color = attrs.color;
+            }
+            EntryKind::Iteration => {
+                entry.iteration = attrs.iteration;
+                entry.section_color = attrs.color.or(current_section_color.clone());
+                entry.section_name = current_section_name.clone();
+            }
+            EntryKind::Header => {
+                // Header is a metadata line — no section propagation
+            }
+            EntryKind::Log => {
+                // Propagate current section context to regular log entries
+                if entry.section_name.is_none() {
+                    entry.section_name = attrs.section.or(current_section_name.clone());
+                } else {
+                    entry.section_name = attrs.section;
+                }
+                entry.section_color = current_section_color.clone();
+                entry.whatif = attrs.whatif;
+                entry.iteration = attrs.iteration;
+                if let Some(tag_str) = attrs.tag {
+                    entry.tags = Some(
+                        tag_str
+                            .split(',')
+                            .map(|t| t.trim().to_string())
+                            .filter(|t| !t.is_empty())
+                            .collect(),
+                    );
+                }
+            }
+        }
+
+        entry.entry_kind = Some(kind);
+    }
+
+    (entries, error_count)
+}
+```
+
+- [ ] **Step 5: Register the module in parser/mod.rs**
+
+Add to the module declarations at the top of `src-tauri/src/parser/mod.rs`:
+
+```rust
+pub mod cmtlog;
+```
+
+Add a dispatch arm in `parse_lines_with_selection` (inside the `match selection.implementation` block):
+
+```rust
+ParserImplementation::CmtLog => cmtlog::parse_lines(lines, file_path),
+```
+
+- [ ] **Step 6: Run cargo check**
+
+Run: `cargo check` from `src-tauri/`
+Expected: Compiles successfully.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/parser/cmtlog.rs src-tauri/src/parser/mod.rs
+git commit -m "feat(parser): add cmtlog parser module with extended attribute extraction"
+```
+
+---
+
+## Task 3: Wire CmtLog Detection
+
+**Files:**
+- Modify: `src-tauri/src/parser/detect.rs`
+- Create: `src-tauri/tests/fixtures/cmtlog/basic.cmtlog`
+- Create: `src-tauri/tests/cmtlog_parser.rs`
+
+- [ ] **Step 1: Add `.cmtlog` extension detection in `detect_parser`**
+
+In `src-tauri/src/parser/detect.rs`, inside `detect_parser()`, add an early extension check before the existing path hint extraction. Add after the DHCP/IIS checks but before the sample-lines loop (around line 350):
+
+```rust
+    // ── CmtLog: extension-based detection ──
+    let path_lower = path.to_lowercase();
+    if path_lower.ends_with(".cmtlog") {
+        return ResolvedParser {
+            parser: ParserKind::CmtLog,
+            implementation: ParserImplementation::CmtLog,
+            provenance: ParserProvenance::Dedicated,
+            parse_quality: ParseQuality::Structured,
+            record_framing: RecordFraming::PhysicalLine,
+            date_order: DateFieldOrder::MonthFirst,
+            specialization: None,
+        };
+    }
+```
+
+Note: Check the existing code to see if `path_lower` is already defined. If so, reuse it. If the variable name differs, match the existing convention.
+
+- [ ] **Step 2: Add content-based fallback detection**
+
+In the sample-lines counting loop in `detect_parser()` (around lines 422-467), add a counter for CmtLog reserved components:
+
+```rust
+    let mut cmtlog_count = 0;
+```
+
+Inside the line-matching loop, add:
+
+```rust
+    if crate::parser::cmtlog::matches_cmtlog_record(line) {
+        cmtlog_count += 1;
+    }
+```
+
+In the decision tree (around lines 469-515), add a check before the CCM check — if we detected any reserved components and the file also has CCM lines, prefer CmtLog:
+
+```rust
+    if cmtlog_count > 0 && ccm_count > 0 {
+        return ResolvedParser {
+            parser: ParserKind::CmtLog,
+            implementation: ParserImplementation::CmtLog,
+            provenance: ParserProvenance::Heuristic,
+            parse_quality: ParseQuality::Structured,
+            record_framing: RecordFraming::PhysicalLine,
+            date_order: DateFieldOrder::MonthFirst,
+            specialization: None,
+        };
+    }
+```
+
+- [ ] **Step 3: Create the test fixtures directory and fixture file**
+
+Run: `mkdir -p src-tauri/tests/fixtures/cmtlog` from project root.
+
+The fixture file was already specified in Task 2, Step 1. Create it now if not already done.
+
+- [ ] **Step 4: Create the test file**
+
+The test file was already specified in Task 2, Step 2. Create it now if not already done.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --test cmtlog_parser` from `src-tauri/`
+Expected: All 9 tests pass.
+
+- [ ] **Step 6: Run full cargo check and clippy**
+
+Run: `cargo check && cargo clippy -- -D warnings` from `src-tauri/`
+Expected: No errors, no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/parser/detect.rs src-tauri/tests/cmtlog_parser.rs src-tauri/tests/fixtures/cmtlog/basic.cmtlog
+git commit -m "feat(parser): wire cmtlog detection by extension and content fallback"
+```
+
+---
+
+## Task 4: Update Frontend TypeScript Types
+
+**Files:**
+- Modify: `src/types/log.ts`
+- Create: `src/types/markers.ts`
+
+- [ ] **Step 1: Add CmtLog to LogFormat type**
+
+In `src/types/log.ts`, find the `LogFormat` type union and add `"CmtLog"`:
+
+```typescript
+export type LogFormat = "Ccm" | "Simple" | "Plain" | "Timestamped" | "DnsDebug" | "DnsAudit" | "CmtLog";
+```
+
+Note: Match the exact existing variants — read the file first to confirm the current list.
+
+- [ ] **Step 2: Add EntryKind type**
+
+In `src/types/log.ts`, add:
+
+```typescript
+export type EntryKind = "Log" | "Section" | "Iteration" | "Header";
+```
+
+- [ ] **Step 3: Add CmtLog fields to LogEntry interface**
+
+In `src/types/log.ts`, add these optional fields to the `LogEntry` interface:
+
+```typescript
+  entryKind?: EntryKind;
+  whatif?: boolean;
+  sectionName?: string;
+  sectionColor?: string;
+  iteration?: string;
+  tags?: string[];
+```
+
+- [ ] **Step 4: Create marker types**
+
+Create `src/types/markers.ts`:
+
+```typescript
+export interface MarkerCategory {
+  id: string;
+  label: string;
+  color: string;
+}
+
+export interface Marker {
+  lineId: number;
+  category: string;
+  color: string;
+  added: string; // ISO 8601
+}
+
+export interface MarkerFile {
+  version: number;
+  sourcePath: string;
+  sourceSize: number;
+  created: string;
+  modified: string;
+  markers: Marker[];
+  categories: MarkerCategory[];
+}
+
+export const DEFAULT_CATEGORIES: MarkerCategory[] = [
+  { id: "bug", label: "Bug", color: "#ef4444" },
+  { id: "investigate", label: "Investigate", color: "#60a5fa" },
+  { id: "confirmed", label: "Confirmed", color: "#4ade80" },
+];
+```
+
+- [ ] **Step 5: Run TypeScript check**
+
+Run: `npx tsc --noEmit` from project root.
+Expected: No type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/log.ts src/types/markers.ts
+git commit -m "feat(types): add CmtLog format types, EntryKind, and marker type definitions"
+```
+
+---
+
+## Task 5: Marker Persistence Backend
+
+**Files:**
+- Create: `src-tauri/src/commands/markers.rs`
+- Modify: `src-tauri/src/commands/mod.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test for marker round-trip**
+
+Add to the bottom of `src-tauri/tests/cmtlog_parser.rs` (or create a separate `src-tauri/tests/markers.rs`):
+
+```rust
+#[test]
+fn marker_file_path_hash_is_deterministic() {
+    use sha2::{Digest, Sha256};
+    let path = r"C:\ProgramData\Microsoft\IntuneManagementExtension\Logs\test.cmtlog";
+    let hash1 = format!("{:x}", Sha256::digest(path.as_bytes()));
+    let hash2 = format!("{:x}", Sha256::digest(path.as_bytes()));
+    assert_eq!(hash1, hash2);
+    assert_eq!(hash1.len(), 64);
+}
+```
+
+- [ ] **Step 2: Add sha2 dependency**
+
+Run: `cargo add sha2` from `src-tauri/`
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `cargo test marker_file_path_hash_is_deterministic` from `src-tauri/`
+Expected: PASS
+
+- [ ] **Step 4: Create the markers command module**
+
+Create `src-tauri/src/commands/markers.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::PathBuf;
+use tauri::AppHandle;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkerCategory {
+    pub id: String,
+    pub label: String,
+    pub color: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Marker {
+    pub line_id: u64,
+    pub category: String,
+    pub color: String,
+    pub added: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkerFile {
+    pub version: u32,
+    pub source_path: String,
+    pub source_size: u64,
+    pub created: String,
+    pub modified: String,
+    pub markers: Vec<Marker>,
+    pub categories: Vec<MarkerCategory>,
+}
+
+fn markers_dir(app: &AppHandle) -> Result<PathBuf, crate::error::AppError> {
+    let app_data = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| crate::error::AppError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())))?;
+    let dir = app_data.join("markers");
+    if !dir.exists() {
+        fs::create_dir_all(&dir)
+            .map_err(crate::error::AppError::Io)?;
+    }
+    Ok(dir)
+}
+
+fn path_to_hash(file_path: &str) -> String {
+    format!("{:x}", Sha256::digest(file_path.as_bytes()))
+}
+
+#[tauri::command]
+pub fn load_markers(file_path: String, app: AppHandle) -> Result<Option<MarkerFile>, crate::error::AppError> {
+    let dir = markers_dir(&app)?;
+    let hash = path_to_hash(&file_path);
+    let marker_path = dir.join(format!("{hash}.json"));
+
+    if !marker_path.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&marker_path)
+        .map_err(crate::error::AppError::Io)?;
+    let marker_file: MarkerFile = serde_json::from_str(&content)
+        .map_err(|e| crate::error::AppError::Parse(e.to_string()))?;
+
+    Ok(Some(marker_file))
+}
+
+#[tauri::command]
+pub fn save_markers(file_path: String, marker_file: MarkerFile, app: AppHandle) -> Result<(), crate::error::AppError> {
+    let dir = markers_dir(&app)?;
+    let hash = path_to_hash(&file_path);
+    let marker_path = dir.join(format!("{hash}.json"));
+
+    let content = serde_json::to_string_pretty(&marker_file)
+        .map_err(|e| crate::error::AppError::Parse(e.to_string()))?;
+
+    fs::write(&marker_path, content)
+        .map_err(crate::error::AppError::Io)?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn delete_markers(file_path: String, app: AppHandle) -> Result<(), crate::error::AppError> {
+    let dir = markers_dir(&app)?;
+    let hash = path_to_hash(&file_path);
+    let marker_path = dir.join(format!("{hash}.json"));
+
+    if marker_path.exists() {
+        fs::remove_file(&marker_path)
+            .map_err(crate::error::AppError::Io)?;
+    }
+
+    Ok(())
+}
+```
+
+Note: Check the actual `AppError` enum variants in `src-tauri/src/error.rs` to make sure `Io` and `Parse` variants exist. If different names are used, match the existing pattern.
+
+- [ ] **Step 5: Register the module**
+
+In `src-tauri/src/commands/mod.rs`, add:
+
+```rust
+pub mod markers;
+```
+
+In `src-tauri/src/lib.rs`, add the three commands to `tauri::generate_handler!`:
+
+```rust
+commands::markers::load_markers,
+commands::markers::save_markers,
+commands::markers::delete_markers,
+```
+
+- [ ] **Step 6: Check that `tauri::path()` API matches**
+
+Read `src-tauri/src/lib.rs` to verify how Tauri's `AppHandle` path resolver is used. The `app.path().app_data_dir()` call may need adjustment based on the Tauri v2 API. If the codebase uses a different pattern (e.g., `app.path_resolver().app_data_dir()`), match it.
+
+- [ ] **Step 7: Run cargo check and clippy**
+
+Run: `cargo check && cargo clippy -- -D warnings` from `src-tauri/`
+Expected: No errors, no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src-tauri/src/commands/markers.rs src-tauri/src/commands/mod.rs src-tauri/src/lib.rs src-tauri/Cargo.toml src-tauri/Cargo.lock
+git commit -m "feat(commands): add marker persistence commands (load/save/delete)"
+```
+
+---
+
+## Task 6: Marker Store (Frontend)
+
+**Files:**
+- Create: `src/stores/marker-store.ts`
+
+- [ ] **Step 1: Create the marker store**
+
+Create `src/stores/marker-store.ts`:
+
+```typescript
+import { create } from "zustand";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  Marker,
+  MarkerCategory,
+  MarkerFile,
+  DEFAULT_CATEGORIES,
+} from "../types/markers";
+
+interface MarkerState {
+  /** Markers keyed by file path, then by line ID */
+  markersByFile: Map<string, Map<number, Marker>>;
+  /** Categories (shared across all files) */
+  categories: MarkerCategory[];
+  /** Currently active marker category for placement */
+  activeCategory: string;
+  /** Loading state per file */
+  loadingFiles: Set<string>;
+
+  // Actions
+  loadMarkers: (filePath: string) => Promise<void>;
+  saveMarkers: (filePath: string) => Promise<void>;
+  toggleMarker: (filePath: string, lineId: number) => void;
+  setMarkerCategory: (
+    filePath: string,
+    lineId: number,
+    category: string
+  ) => void;
+  removeMarker: (filePath: string, lineId: number) => void;
+  setActiveCategory: (category: string) => void;
+  addCategory: (category: MarkerCategory) => void;
+  getMarkersForFile: (filePath: string) => Map<number, Marker>;
+  getMarkedLineIds: (filePath: string, category?: string) => number[];
+  clearMarkersForFile: (filePath: string) => void;
+}
+
+export const useMarkerStore = create<MarkerState>((set, get) => ({
+  markersByFile: new Map(),
+  categories: [...DEFAULT_CATEGORIES],
+  activeCategory: "bug",
+  loadingFiles: new Set(),
+
+  loadMarkers: async (filePath: string) => {
+    const { loadingFiles } = get();
+    if (loadingFiles.has(filePath)) return;
+
+    set((state) => ({
+      loadingFiles: new Set(state.loadingFiles).add(filePath),
+    }));
+
+    try {
+      const result = await invoke<MarkerFile | null>("load_markers", {
+        filePath,
+      });
+
+      if (result) {
+        const markerMap = new Map<number, Marker>();
+        for (const m of result.markers) {
+          markerMap.set(m.lineId, m);
+        }
+
+        set((state) => {
+          const updated = new Map(state.markersByFile);
+          updated.set(filePath, markerMap);
+          return {
+            markersByFile: updated,
+            categories:
+              result.categories.length > 0
+                ? result.categories
+                : state.categories,
+          };
+        });
+      }
+    } finally {
+      set((state) => {
+        const updated = new Set(state.loadingFiles);
+        updated.delete(filePath);
+        return { loadingFiles: updated };
+      });
+    }
+  },
+
+  saveMarkers: async (filePath: string) => {
+    const { markersByFile, categories } = get();
+    const fileMarkers = markersByFile.get(filePath);
+    if (!fileMarkers || fileMarkers.size === 0) {
+      // No markers — delete the file if it exists
+      await invoke("delete_markers", { filePath });
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const markerFile: MarkerFile = {
+      version: 1,
+      sourcePath: filePath,
+      sourceSize: 0, // Frontend doesn't know file size — backend could populate
+      created: now,
+      modified: now,
+      markers: Array.from(fileMarkers.values()),
+      categories,
+    };
+
+    await invoke("save_markers", { filePath, markerFile });
+  },
+
+  toggleMarker: (filePath: string, lineId: number) => {
+    const { markersByFile, activeCategory, categories } = get();
+    const fileMarkers = new Map(markersByFile.get(filePath) || new Map());
+    const existing = fileMarkers.get(lineId);
+
+    if (existing) {
+      fileMarkers.delete(lineId);
+    } else {
+      const cat = categories.find((c) => c.id === activeCategory);
+      fileMarkers.set(lineId, {
+        lineId,
+        category: activeCategory,
+        color: cat?.color ?? "#ef4444",
+        added: new Date().toISOString(),
+      });
+    }
+
+    set((state) => {
+      const updated = new Map(state.markersByFile);
+      updated.set(filePath, fileMarkers);
+      return { markersByFile: updated };
+    });
+  },
+
+  setMarkerCategory: (filePath: string, lineId: number, category: string) => {
+    const { markersByFile, categories } = get();
+    const fileMarkers = new Map(markersByFile.get(filePath) || new Map());
+    const existing = fileMarkers.get(lineId);
+    if (!existing) return;
+
+    const cat = categories.find((c) => c.id === category);
+    fileMarkers.set(lineId, {
+      ...existing,
+      category,
+      color: cat?.color ?? existing.color,
+    });
+
+    set((state) => {
+      const updated = new Map(state.markersByFile);
+      updated.set(filePath, fileMarkers);
+      return { markersByFile: updated };
+    });
+  },
+
+  removeMarker: (filePath: string, lineId: number) => {
+    const { markersByFile } = get();
+    const fileMarkers = new Map(markersByFile.get(filePath) || new Map());
+    fileMarkers.delete(lineId);
+
+    set((state) => {
+      const updated = new Map(state.markersByFile);
+      updated.set(filePath, fileMarkers);
+      return { markersByFile: updated };
+    });
+  },
+
+  setActiveCategory: (category: string) => {
+    set({ activeCategory: category });
+  },
+
+  addCategory: (category: MarkerCategory) => {
+    set((state) => ({
+      categories: [...state.categories, category],
+    }));
+  },
+
+  getMarkersForFile: (filePath: string) => {
+    return get().markersByFile.get(filePath) || new Map();
+  },
+
+  getMarkedLineIds: (filePath: string, category?: string) => {
+    const fileMarkers = get().markersByFile.get(filePath);
+    if (!fileMarkers) return [];
+    const entries = Array.from(fileMarkers.values());
+    if (category) {
+      return entries.filter((m) => m.category === category).map((m) => m.lineId);
+    }
+    return entries.map((m) => m.lineId);
+  },
+
+  clearMarkersForFile: (filePath: string) => {
+    set((state) => {
+      const updated = new Map(state.markersByFile);
+      updated.delete(filePath);
+      return { markersByFile: updated };
+    });
+  },
+}));
+```
+
+- [ ] **Step 2: Run TypeScript check**
+
+Run: `npx tsc --noEmit` from project root.
+Expected: No type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/stores/marker-store.ts
+git commit -m "feat(stores): add marker-store with Zustand for marker persistence and management"
+```
+
+---
+
+## Task 7: Section Divider Rendering
+
+**Files:**
+- Modify: `src/components/log-view/LogListView.tsx`
+- Modify: `src/components/log-view/LogRow.tsx`
+
+- [ ] **Step 1: Read both files before editing**
+
+Read `src/components/log-view/LogListView.tsx` and `src/components/log-view/LogRow.tsx` to understand the current rendering code, virtualizer setup, and row component props.
+
+- [ ] **Step 2: Add section divider row rendering in LogListView**
+
+In `LogListView.tsx`, modify the row rendering logic (where `LogRow` is mapped from virtual items). Before rendering a `LogRow`, check if the entry has `entryKind === "Section"` or `entryKind === "Iteration"`. If so, render a section divider instead:
+
+```tsx
+// Inside the virtualizer row map
+const entry = displayEntries[virtualRow.index];
+
+if (entry.entryKind === "Section" || entry.entryKind === "Iteration") {
+  return (
+    <div
+      key={virtualRow.key}
+      data-index={virtualRow.index}
+      ref={virtualizer.measureElement}
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        transform: `translateY(${virtualRow.start}px)`,
+      }}
+    >
+      <SectionDividerRow entry={entry} />
+    </div>
+  );
+}
+```
+
+Create a `SectionDividerRow` component inline or in a separate file:
+
+```tsx
+function SectionDividerRow({ entry }: { entry: LogEntry }) {
+  const bgColor = entry.sectionColor ?? "#3b82f6";
+  const isIteration = entry.entryKind === "Iteration";
+
+  return (
+    <div
+      style={{
+        padding: "4px 12px",
+        background: bgColor + "22", // 13% opacity tint
+        borderLeft: `4px solid ${bgColor}`,
+        color: bgColor,
+        fontWeight: 600,
+        fontSize: "12px",
+        letterSpacing: "0.3px",
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+      }}
+    >
+      <span>{isIteration ? "\u25B6" : "\u25CF"}</span>
+      <span>{entry.message}</span>
+      {entry.iteration && (
+        <span style={{ opacity: 0.7, fontWeight: 400 }}>
+          {entry.iteration}
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add left-edge band to regular LogRow entries**
+
+In `LogRow.tsx`, add a conditional left border based on `sectionColor`:
+
+Find the outermost `<div>` of the row that applies the row styles. Add to its style:
+
+```tsx
+borderLeft: entry.sectionColor ? `4px solid ${entry.sectionColor}` : undefined,
+```
+
+Note: This interacts with the marker border — per the spec, marker color takes priority. This will be handled in Task 8 when marker gutter is added. For now, section band is the only left border.
+
+- [ ] **Step 3a: Add auto-color palette for sections without explicit color**
+
+When a section has no `color` attribute, the frontend should auto-assign from a palette. In `LogListView.tsx`, add a palette and assignment:
+
+```tsx
+const SECTION_PALETTE = [
+  "#3b82f6", "#a78bfa", "#f59e0b", "#10b981",
+  "#ef4444", "#ec4899", "#06b6d4", "#84cc16",
+];
+
+// Track section→color mapping for sections without explicit colors
+const sectionColorMap = useMemo(() => {
+  const map = new Map<string, string>();
+  let paletteIdx = 0;
+  for (const entry of displayEntries) {
+    if (
+      (entry.entryKind === "Section" || entry.entryKind === "Iteration") &&
+      !entry.sectionColor &&
+      entry.message
+    ) {
+      if (!map.has(entry.message)) {
+        map.set(entry.message, SECTION_PALETTE[paletteIdx % SECTION_PALETTE.length]);
+        paletteIdx++;
+      }
+    }
+  }
+  return map;
+}, [displayEntries]);
+```
+
+Apply the auto-assigned color when rendering `SectionDividerRow` and when computing left-edge band color:
+
+```tsx
+const effectiveColor = entry.sectionColor ?? sectionColorMap.get(entry.sectionName ?? entry.message) ?? undefined;
+```
+
+- [ ] **Step 4: Run TypeScript check**
+
+Run: `npx tsc --noEmit` from project root.
+Expected: No type errors.
+
+- [ ] **Step 5: Test visually**
+
+Run: `npm run app:dev` and open the `basic.cmtlog` fixture file in CMTrace Open.
+Expected: Section divider banner rows appear with colored left bands. Regular entries within a section show the left-edge color band. Sections without explicit colors get auto-assigned palette colors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/log-view/LogListView.tsx src/components/log-view/LogRow.tsx
+git commit -m "feat(ui): add section divider rows, left-edge bands, and auto-color palette for cmtlog"
+```
+
+---
+
+## Task 8: Marker Gutter UI
+
+**Files:**
+- Modify: `src/components/log-view/LogRow.tsx`
+- Modify: `src/components/log-view/LogListView.tsx`
+
+- [ ] **Step 1: Read both files before editing**
+
+Re-read `LogRow.tsx` and `LogListView.tsx` to see current state after Task 7 changes.
+
+- [ ] **Step 2: Add marker gutter to LogRow**
+
+In `LogRow.tsx`, add a new prop for marker data:
+
+```tsx
+// Add to LogRowProps interface
+marker?: Marker | null;
+onToggleMarker?: (lineId: number) => void;
+onMarkerContextMenu?: (lineId: number, event: React.MouseEvent) => void;
+```
+
+Add a gutter element as the first child of the row:
+
+```tsx
+<div
+  style={{
+    width: "20px",
+    minWidth: "20px",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    cursor: "pointer",
+  }}
+  onClick={(e) => {
+    e.stopPropagation();
+    onToggleMarker?.(entry.id);
+  }}
+  onContextMenu={(e) => {
+    e.stopPropagation();
+    onMarkerContextMenu?.(entry.id, e);
+  }}
+>
+  <div
+    style={{
+      width: 8,
+      height: 8,
+      borderRadius: "50%",
+      background: marker ? marker.color : "transparent",
+      border: marker ? "none" : "1px solid transparent",
+      transition: "background 0.15s",
+    }}
+  />
+</div>
+```
+
+Add marker row tint — if a marker exists, overlay a subtle background:
+
+```tsx
+// On the row container style
+background: marker
+  ? `${marker.color}18` // ~9% opacity
+  : existingBackground,
+borderLeft: marker
+  ? `3px solid ${marker.color}`
+  : entry.sectionColor
+    ? `4px solid ${entry.sectionColor}`
+    : undefined,
+```
+
+This implements the visual precedence rule: marker border wins over section band.
+
+- [ ] **Step 3: Wire marker store into LogListView**
+
+In `LogListView.tsx`, import and use the marker store:
+
+```tsx
+import { useMarkerStore } from "../../stores/marker-store";
+
+// Inside the component
+const activeTab = useUiStore((s) => s.openTabs[s.activeTabIndex]);
+const filePath = activeTab?.filePath ?? "";
+const markersForFile = useMarkerStore((s) => s.getMarkersForFile(filePath));
+const toggleMarker = useMarkerStore((s) => s.toggleMarker);
+const saveMarkers = useMarkerStore((s) => s.saveMarkers);
+const loadMarkers = useMarkerStore((s) => s.loadMarkers);
+
+// Load markers when tab changes
+useEffect(() => {
+  if (filePath) {
+    loadMarkers(filePath);
+  }
+}, [filePath, loadMarkers]);
+
+// Auto-save markers on changes (debounced)
+useEffect(() => {
+  if (!filePath) return;
+  const timeout = setTimeout(() => {
+    saveMarkers(filePath);
+  }, 1000);
+  return () => clearTimeout(timeout);
+}, [markersForFile, filePath, saveMarkers]);
+```
+
+Pass marker data to each `LogRow`:
+
+```tsx
+<LogRow
+  // ...existing props
+  marker={markersForFile.get(entry.id) ?? null}
+  onToggleMarker={(lineId) => toggleMarker(filePath, lineId)}
+/>
+```
+
+- [ ] **Step 4: Add Ctrl+M keyboard shortcut**
+
+In `LogListView.tsx`, add a keyboard handler for `Ctrl+M`:
+
+```tsx
+useEffect(() => {
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.ctrlKey && e.key === "m") {
+      e.preventDefault();
+      const selectedId = activeTab?.selectedLineId;
+      if (selectedId != null && filePath) {
+        toggleMarker(filePath, selectedId);
+      }
+    }
+  };
+  window.addEventListener("keydown", handleKeyDown);
+  return () => window.removeEventListener("keydown", handleKeyDown);
+}, [activeTab?.selectedLineId, filePath, toggleMarker]);
+```
+
+- [ ] **Step 5: Add right-click context menu for marker categories**
+
+In `LogListView.tsx`, add a context menu state and handler for the marker gutter. When the user right-clicks the gutter, show a menu with marker categories:
+
+```tsx
+const [markerMenuAnchor, setMarkerMenuAnchor] = useState<{
+  x: number;
+  y: number;
+  lineId: number;
+} | null>(null);
+
+const categories = useMarkerStore((s) => s.categories);
+const setMarkerCategory = useMarkerStore((s) => s.setMarkerCategory);
+const setActiveCategory = useMarkerStore((s) => s.setActiveCategory);
+```
+
+Render the context menu (use Fluent UI `MenuList` + `MenuPopover` or a simple positioned `<div>`):
+
+```tsx
+{markerMenuAnchor && (
+  <div
+    style={{
+      position: "fixed",
+      top: markerMenuAnchor.y,
+      left: markerMenuAnchor.x,
+      background: "var(--colorNeutralBackground1)",
+      border: "1px solid var(--colorNeutralStroke1)",
+      borderRadius: 4,
+      padding: "4px 0",
+      zIndex: 1000,
+      boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+    }}
+    onMouseLeave={() => setMarkerMenuAnchor(null)}
+  >
+    {categories.map((cat) => (
+      <div
+        key={cat.id}
+        style={{
+          padding: "6px 16px",
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          fontSize: 13,
+        }}
+        onClick={() => {
+          toggleMarker(filePath, markerMenuAnchor.lineId);
+          // If toggling on, set to this category
+          setActiveCategory(cat.id);
+          setMarkerCategory(filePath, markerMenuAnchor.lineId, cat.id);
+          setMarkerMenuAnchor(null);
+        }}
+      >
+        <div
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: "50%",
+            background: cat.color,
+          }}
+        />
+        {cat.label}
+      </div>
+    ))}
+  </div>
+)}
+```
+
+Pass the context menu handler to `LogRow`:
+
+```tsx
+<LogRow
+  // ...existing props
+  onMarkerContextMenu={(lineId, event) => {
+    event.preventDefault();
+    setMarkerMenuAnchor({ x: event.clientX, y: event.clientY, lineId });
+  }}
+/>
+```
+
+- [ ] **Step 6: Run TypeScript check**
+
+Run: `npx tsc --noEmit` from project root.
+Expected: No type errors.
+
+- [ ] **Step 7: Test visually**
+
+Run: `npm run app:dev`, open any log file, click the gutter area or press Ctrl+M to toggle markers. Right-click the gutter for category selection. Close and reopen the file — markers should persist.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/log-view/LogRow.tsx src/components/log-view/LogListView.tsx
+git commit -m "feat(ui): add marker gutter, category context menu, and Ctrl+M shortcut"
+```
+
+---
+
+## Task 9: WhatIf Rendering
+
+**Files:**
+- Modify: `src/components/log-view/LogRow.tsx`
+- Modify: `src/stores/filter-store.ts`
+
+- [ ] **Step 1: Read both files before editing**
+
+Re-read `LogRow.tsx` and `filter-store.ts` to see current state.
+
+- [ ] **Step 2: Add WhatIf styling to LogRow**
+
+In `LogRow.tsx`, add conditional styling for WhatIf entries. On the row container:
+
+```tsx
+const isWhatIf = entry.whatif === true;
+
+// Apply to the row's style
+opacity: isWhatIf ? 0.6 : 1,
+fontStyle: isWhatIf ? "italic" : "normal",
+```
+
+Add a WhatIf badge next to the severity indicator. Find where the severity dot is rendered and add after it:
+
+```tsx
+{isWhatIf && (
+  <span
+    style={{
+      fontSize: "9px",
+      fontWeight: 600,
+      color: "#a78bfa",
+      background: "#a78bfa22",
+      borderRadius: "3px",
+      padding: "1px 4px",
+      marginLeft: "4px",
+      fontStyle: "normal",
+      letterSpacing: "0.3px",
+    }}
+  >
+    WhatIf
+  </span>
+)}
+```
+
+- [ ] **Step 3: Add WhatIf filter to filter store**
+
+In `src/stores/filter-store.ts`, add a `whatIfFilter` field to the state:
+
+```typescript
+// Add to FilterState interface
+whatIfFilter: "all" | "whatif-only" | "real-only";
+setWhatIfFilter: (filter: "all" | "whatif-only" | "real-only") => void;
+```
+
+Add to the store creation:
+
+```typescript
+whatIfFilter: "all",
+setWhatIfFilter: (filter) => set({ whatIfFilter: filter }),
+```
+
+- [ ] **Step 4: Apply WhatIf filter in the filtering logic**
+
+Find where `filteredIds` is computed in the filtering pipeline. Add WhatIf filtering:
+
+```typescript
+// After existing filter logic
+const whatIfFilter = get().whatIfFilter;
+if (whatIfFilter !== "all") {
+  // Apply to the filtered entries
+  filteredEntries = filteredEntries.filter((entry) => {
+    if (whatIfFilter === "whatif-only") return entry.whatif === true;
+    if (whatIfFilter === "real-only") return entry.whatif !== true;
+    return true;
+  });
+}
+```
+
+Note: The exact integration point depends on how the filter pipeline is structured. Read the current code and wire it into the appropriate place.
+
+- [ ] **Step 5: Run TypeScript check**
+
+Run: `npx tsc --noEmit` from project root.
+Expected: No type errors.
+
+- [ ] **Step 6: Test visually**
+
+Run: `npm run app:dev`, open the `basic.cmtlog` fixture. The "Would apply policy contoso.xml" entry should appear dimmed, italic, with a purple "WhatIf" badge.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/log-view/LogRow.tsx src/stores/filter-store.ts
+git commit -m "feat(ui): add WhatIf visual treatment (dimmed, italic, badge) and filter toggle"
+```
+
+---
+
+## Task 10: Multi-Select and Copy
+
+**Files:**
+- Modify: `src/components/log-view/LogListView.tsx`
+- Modify: `src/components/log-view/LogRow.tsx`
+
+- [ ] **Step 1: Read both files before editing**
+
+Re-read `LogListView.tsx` and `LogRow.tsx` to see current state.
+
+- [ ] **Step 2: Add multi-select state to LogListView**
+
+Add state for tracking selected IDs:
+
+```tsx
+const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+const lastClickedId = useRef<number | null>(null);
+```
+
+Create a click handler with multi-select logic:
+
+```tsx
+const handleRowClick = useCallback(
+  (id: number, event: React.MouseEvent) => {
+    if (event.ctrlKey || event.metaKey) {
+      // Toggle individual line
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        return next;
+      });
+      lastClickedId.current = id;
+    } else if (event.shiftKey && lastClickedId.current != null) {
+      // Range select
+      const allIds = displayEntries.map((e) => e.id);
+      const startIdx = allIds.indexOf(lastClickedId.current);
+      const endIdx = allIds.indexOf(id);
+      if (startIdx !== -1 && endIdx !== -1) {
+        const [lo, hi] = startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx];
+        const rangeIds = allIds.slice(lo, hi + 1);
+        setSelectedIds((prev) => {
+          const next = new Set(prev);
+          for (const rid of rangeIds) {
+            next.add(rid);
+          }
+          return next;
+        });
+      }
+      lastClickedId.current = id;
+    } else {
+      // Single select — clear others
+      setSelectedIds(new Set([id]));
+      lastClickedId.current = id;
+    }
+
+    // Also update the existing single-selection for details pane etc.
+    // Keep existing onClick behavior for the primary selection
+  },
+  [displayEntries]
+);
+```
+
+- [ ] **Step 3: Add Ctrl+A handler**
+
+Add to the existing keyboard handler:
+
+```tsx
+if ((e.ctrlKey || e.metaKey) && e.key === "a") {
+  e.preventDefault();
+  const allIds = new Set(displayEntries.map((entry) => entry.id));
+  setSelectedIds(allIds);
+}
+```
+
+- [ ] **Step 4: Add Ctrl+C copy handler**
+
+```tsx
+if ((e.ctrlKey || e.metaKey) && e.key === "c" && selectedIds.size > 0) {
+  e.preventDefault();
+  // Get messages in display order
+  const selectedMessages = displayEntries
+    .filter((entry) => selectedIds.has(entry.id))
+    .map((entry) => entry.message);
+  const text = selectedMessages.join("\n");
+  navigator.clipboard.writeText(text);
+}
+```
+
+- [ ] **Step 5: Pass multi-select state to LogRow**
+
+Add prop to LogRow:
+
+```tsx
+// Add to LogRowProps
+isMultiSelected?: boolean;
+```
+
+In the row container styling, add a multi-select highlight that doesn't conflict with marker tinting:
+
+```tsx
+// Multi-select gets a distinct outline/background
+outline: isMultiSelected ? "1px solid rgba(59, 130, 246, 0.5)" : undefined,
+background: isMultiSelected && !marker
+  ? "rgba(59, 130, 246, 0.08)"
+  : existingBackground,
+```
+
+Pass from `LogListView`:
+
+```tsx
+<LogRow
+  // ...existing props
+  isMultiSelected={selectedIds.has(entry.id)}
+  onClick={(id) => handleRowClick(id, event)}
+/>
+```
+
+Note: The click event needs to be passed through. Read how the existing `onClick` prop works on `LogRow` and adapt `handleRowClick` to receive the event. This may require changing the `onClick` signature from `(id: number) => void` to `(id: number, event: React.MouseEvent) => void`.
+
+- [ ] **Step 6: Add "Copy marked lines" context menu option**
+
+In the existing right-click context menu for the log view (find where `onContextMenu` is handled in `LogListView.tsx`), add options for each marker category:
+
+```tsx
+// Inside the context menu rendering
+const getMarkedLineIds = useMarkerStore((s) => s.getMarkedLineIds);
+
+// Add menu items for each category
+{categories.map((cat) => {
+  const markedIds = getMarkedLineIds(filePath, cat.id);
+  if (markedIds.length === 0) return null;
+  return (
+    <div
+      key={`copy-${cat.id}`}
+      style={{ padding: "6px 16px", cursor: "pointer", fontSize: 13 }}
+      onClick={() => {
+        const markedIdSet = new Set(markedIds);
+        const messages = displayEntries
+          .filter((e) => markedIdSet.has(e.id))
+          .map((e) => e.message);
+        navigator.clipboard.writeText(messages.join("\n"));
+        // Close menu
+      }}
+    >
+      Copy all "{cat.label}" lines ({markedIds.length})
+    </div>
+  );
+})}
+```
+
+- [ ] **Step 7: Run TypeScript check**
+
+Run: `npx tsc --noEmit` from project root.
+Expected: No type errors.
+
+- [ ] **Step 8: Test visually**
+
+Run: `npm run app:dev`, open a log file:
+- Click a row -> single select
+- Ctrl+Click -> toggle additional rows
+- Shift+Click -> range select
+- Ctrl+A -> select all visible
+- Ctrl+C -> copies messages to clipboard
+- Right-click -> "Copy all Bug lines" copies only marked lines
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/components/log-view/LogListView.tsx src/components/log-view/LogRow.tsx
+git commit -m "feat(ui): add multi-select copy and copy-by-marker-category context menu"
+```
+
+---
+
+## Task 11: File Association Registration
+
+**Files:**
+- Modify: `src-tauri/tauri.conf.json`
+
+- [ ] **Step 1: Read the current config**
+
+Read `src-tauri/tauri.conf.json` to find the `fileAssociations` array.
+
+- [ ] **Step 2: Add `.cmtlog` extension**
+
+Add to the `fileAssociations` array:
+
+```json
+{
+  "ext": ["cmtlog"],
+  "mimeType": "text/plain",
+  "description": "CMTrace Open Log File"
+}
+```
+
+- [ ] **Step 3: Update workspace file filters**
+
+Find the Log workspace definition in `src/workspaces/log/index.ts` (or wherever `fileFilters` is defined for the log workspace). Add `"cmtlog"` to the extensions list:
+
+```typescript
+fileFilters: [
+  { name: "Log Files", extensions: ["log", "cmtlog"] },
+  // ...existing filters
+],
+```
+
+Note: Read the exact file first to confirm the location and structure.
+
+- [ ] **Step 4: Run cargo check**
+
+Run: `cargo check` from `src-tauri/`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/tauri.conf.json src/workspaces/log/index.ts
+git commit -m "feat(config): register .cmtlog file association and add to file picker filters"
+```
+
+---
+
+## Task 12: PowerShell Module
+
+**Files:**
+- Create: `scripts/powershell/CmtLog/CmtLog.psm1`
+
+- [ ] **Step 1: Create directory structure**
+
+Run: `mkdir -p scripts/powershell/CmtLog` from project root.
+
+- [ ] **Step 2: Create the module**
+
+Create `scripts/powershell/CmtLog/CmtLog.psm1`:
+
+```powershell
+<#
+.SYNOPSIS
+    CmtLog PowerShell module for writing .cmtlog format files compatible with CMTrace Open.
+
+.DESCRIPTION
+    Provides functions for structured log output in the .cmtlog format:
+    - Start-CmtLog: Initialize a new log file with header
+    - Write-LogEntry: Write a log line with optional extended attributes
+    - Write-LogSection: Write a section divider
+    - Write-LogIteration: Write a loop iteration marker
+    - Write-LogHeader: Write a file header (called by Start-CmtLog)
+#>
+
+# Module-level state
+$script:CmtLogFilePath = $null
+
+function Get-CmtLogTimestamp {
+    [CmdletBinding()]
+    param()
+    $Bias = (Get-CimInstance -ClassName Win32_TimeZone | Select-Object -ExpandProperty Bias)
+    $Time = (Get-Date -Format "HH:mm:ss.fff") + "{0:+0;-0;+0}" -f $Bias
+    $Date = (Get-Date -Format "MM-dd-yyyy")
+    return @{ Time = $Time; Date = $Date }
+}
+
+function Write-LogHeader {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ScriptName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Version = "1.0.0",
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("Normal", "WhatIf", "Verbose")]
+        [string]$Mode,
+
+        [Parameter(Mandatory = $false)]
+        [string]$FileName = $script:CmtLogFilePath
+    )
+
+    if (-not $Mode) {
+        if ($WhatIfPreference) { $Mode = "WhatIf" }
+        elseif ($VerbosePreference -ne "SilentlyContinue") { $Mode = "Verbose" }
+        else { $Mode = "Normal" }
+    }
+
+    $ts = Get-CmtLogTimestamp
+    $RunId = [guid]::NewGuid().ToString("N").Substring(0, 8)
+    $PsVer = $PSVersionTable.PSVersion.ToString()
+
+    $LogText = "<![LOG[Script started: $ScriptName v$Version]LOG]!>" +
+        "<time=""$($ts.Time)"" date=""$($ts.Date)"" component=""__HEADER__"" " +
+        "context="""" type=""1"" thread=""0"" file="""" " +
+        "script=""$ScriptName"" version=""$Version"" runid=""$RunId"" " +
+        "mode=""$Mode"" ps_version=""$PsVer"">"
+
+    Out-File -InputObject $LogText -Append -NoClobber -Encoding Default -FilePath $FileName -ErrorAction Stop
+}
+
+function Start-CmtLog {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ScriptName,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Version = "1.0.0",
+
+        [Parameter(Mandatory = $false)]
+        [string]$OutputPath,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("Normal", "WhatIf", "Verbose")]
+        [string]$Mode
+    )
+
+    if (-not $OutputPath) {
+        $OutputPath = Join-Path -Path $env:ProgramData -ChildPath "CMTraceOpen\Logs"
+    }
+
+    if (-not (Test-Path $OutputPath)) {
+        New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+    }
+
+    $SafeName = $ScriptName -replace '[^\w\-\.]', '_'
+    $Timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $FileName = "${SafeName}_${Timestamp}.cmtlog"
+    $FullPath = Join-Path -Path $OutputPath -ChildPath $FileName
+
+    $script:CmtLogFilePath = $FullPath
+
+    Write-LogHeader -ScriptName $ScriptName -Version $Version -Mode $Mode -FileName $FullPath
+
+    return $FullPath
+}
+
+function Write-LogEntry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Value,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("1", "2", "3")]
+        [string]$Severity,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Component = "Script",
+
+        [Parameter(Mandatory = $false)]
+        [string]$FileName = $script:CmtLogFilePath,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Section,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$Tag,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$WhatIfEntry,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Iteration
+    )
+
+    $ts = Get-CmtLogTimestamp
+    $Context = $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)
+
+    $ExtAttrs = ""
+    if ($Section) { $ExtAttrs += " section=""$Section""" }
+    if ($Tag) { $ExtAttrs += " tag=""$($Tag -join ',')""" }
+    if ($WhatIfEntry) { $ExtAttrs += ' whatif="1"' }
+    if ($Iteration) { $ExtAttrs += " iteration=""$Iteration""" }
+
+    $LogText = "<![LOG[$Value]LOG]!>" +
+        "<time=""$($ts.Time)"" date=""$($ts.Date)"" component=""$Component"" " +
+        "context=""$Context"" type=""$Severity"" thread=""$PID"" file=""""$ExtAttrs>"
+
+    try {
+        Out-File -InputObject $LogText -Append -NoClobber -Encoding Default -FilePath $FileName -ErrorAction Stop
+        if ($Severity -eq "1") { Write-Verbose -Message $Value }
+        elseif ($Severity -eq "3") { Write-Warning -Message $Value }
+    }
+    catch [System.Exception] {
+        Write-Warning -Message "Unable to append log entry to $FileName. Error: $($_.Exception.Message)"
+    }
+}
+
+function Write-LogSection {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Color,
+
+        [Parameter(Mandatory = $false)]
+        [string]$FileName = $script:CmtLogFilePath
+    )
+
+    $ts = Get-CmtLogTimestamp
+    $ColorAttr = if ($Color) { " color=""$Color""" } else { "" }
+
+    $LogText = "<![LOG[$Name]LOG]!>" +
+        "<time=""$($ts.Time)"" date=""$($ts.Date)"" component=""__SECTION__"" " +
+        "context="""" type=""1"" thread=""0"" file=""""$ColorAttr>"
+
+    Out-File -InputObject $LogText -Append -NoClobber -Encoding Default -FilePath $FileName -ErrorAction Stop
+}
+
+function Write-LogIteration {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [int]$Current,
+
+        [Parameter(Mandatory = $true)]
+        [int]$Total,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Color,
+
+        [Parameter(Mandatory = $false)]
+        [string]$FileName = $script:CmtLogFilePath
+    )
+
+    $ts = Get-CmtLogTimestamp
+    $IterStr = "$Current/$Total"
+    $ColorAttr = if ($Color) { " color=""$Color""" } else { "" }
+
+    $LogText = "<![LOG[Loop Iteration $IterStr - $Name]LOG]!>" +
+        "<time=""$($ts.Time)"" date=""$($ts.Date)"" component=""__ITERATION__"" " +
+        "context="""" type=""1"" thread=""0"" file="""" " +
+        "iteration=""$IterStr""$ColorAttr>"
+
+    Out-File -InputObject $LogText -Append -NoClobber -Encoding Default -FilePath $FileName -ErrorAction Stop
+}
+
+Export-ModuleMember -Function Start-CmtLog, Write-LogEntry, Write-LogSection, Write-LogIteration, Write-LogHeader
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/powershell/CmtLog/CmtLog.psm1
+git commit -m "feat(powershell): add CmtLog module with Start-CmtLog, Write-LogEntry, Write-LogSection, Write-LogIteration"
+```
+
+---
+
+## Task 13: Final Integration Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full Rust checks**
+
+Run from `src-tauri/`:
+```bash
+cargo check && cargo test && cargo clippy -- -D warnings
+```
+Expected: All checks pass, all tests pass, no warnings.
+
+- [ ] **Step 2: Run TypeScript check**
+
+Run from project root:
+```bash
+npx tsc --noEmit
+```
+Expected: No type errors.
+
+- [ ] **Step 3: Run the full app**
+
+Run: `npm run app:dev`
+
+Test the following:
+1. Open `src-tauri/tests/fixtures/cmtlog/basic.cmtlog` — should detect CmtLog parser
+2. Section dividers render as banner rows with left-edge color bands
+3. WhatIf entry appears dimmed, italic, with badge
+4. Click gutter to toggle markers — colored dots and row tinting appear
+5. Close and reopen the file — markers persist
+6. Ctrl+Click to multi-select, Ctrl+C to copy, paste into notepad to verify plain text
+7. Ctrl+M to toggle marker on selected row
+
+- [ ] **Step 4: Final commit if any fixes needed**
+
+Fix any issues found during integration testing and commit them individually.

--- a/docs/superpowers/specs/2026-04-13-cmtlog-format-markers-design.md
+++ b/docs/superpowers/specs/2026-04-13-cmtlog-format-markers-design.md
@@ -98,6 +98,8 @@ Color-coded categories with:
 - **Row tint** — subtle background highlight in the category color
 - **Left border** — 3px colored left border on marked rows
 
+**Visual precedence:** When a marked line is also inside a section (both marker left-border and section left-edge band apply), the marker color takes priority on the left border since it represents user intent. The section band shifts to a secondary indicator (e.g., a thin 2px band outside the marker border, or the row tint carries the section color while the border carries the marker color).
+
 ### Default Categories
 
 | ID | Label | Color |

--- a/docs/superpowers/specs/2026-04-13-cmtlog-format-markers-design.md
+++ b/docs/superpowers/specs/2026-04-13-cmtlog-format-markers-design.md
@@ -1,0 +1,317 @@
+# CMTrace Open: `.cmtlog` Format, Markers, and PowerShell Integration
+
+**Issue:** #117
+**Date:** 2026-04-13
+**Approach:** Format-First — design the file format, then parser, then UI features
+
+---
+
+## Overview
+
+Five features that form a cohesive system for PowerShell-driven log authoring and interactive log analysis:
+
+1. **`.cmtlog` file format** — extends CCM's `<![LOG[...]LOG]!>` structure with metadata for sections, loops, WhatIf, and custom tags
+2. **User markers** — color-coded annotations (Bug, Investigate, Confirmed) placed on log entries, persisted to AppData by file path
+3. **Section dividers** — full-width banner rows + colored left-edge bands for visual grouping of phases and loop iterations
+4. **Multi-select copy** — Ctrl+Click / Shift+Click line selection, Ctrl+C copies raw message text
+5. **WhatIf rendering** — dimmed italic lines with a badge for simulated actions
+
+---
+
+## 1. `.cmtlog` File Format
+
+### Design Principles
+
+- Every line uses `<![LOG[...]LOG]!>` — fully backward-compatible with CMTrace.exe
+- Structural markers use reserved component names — CMTrace.exe shows them as normal log lines
+- Extended attributes on standard CCM lines are ignored by legacy parsers
+- File extension `.cmtlog` triggers the enhanced parser in CMTrace Open
+
+### File Header
+
+A single `<![LOG[` line with reserved component `__HEADER__`, written once at script start:
+
+```
+<![LOG[Script started: Detect-WDAC.ps1 v2.1.0]LOG]!><time="10:30:00.000+000" date="04-13-2026" component="__HEADER__" context="" type="1" thread="0" file="" script="Detect-WDAC.ps1" version="2.1.0" runid="a3f8c9e1" mode="WhatIf" ps_version="7.4.2">
+```
+
+Header attributes:
+- `script` — script filename
+- `version` — script version
+- `runid` — unique execution ID (for correlating runs)
+- `mode` — execution mode (`"WhatIf"`, `"Verbose"`, `"Normal"`)
+- `ps_version` — PowerShell version
+
+If absent, the file is still valid `.cmtlog` — headerless.
+
+### Log Entries
+
+Standard CCM log lines with optional extended attributes:
+
+```
+<![LOG[Checking WDAC policy for contoso.xml]LOG]!><time="10:32:01.123+000" date="04-13-2026" component="Detect-WDAC" context="CONTOSO\admin" type="1" thread="1234" file="" section="detection" tag="phase:scan" whatif="0">
+```
+
+Extended attributes (all optional, ignored by CMTrace.exe):
+- `section` — names the current section/phase (drives left-edge band coloring)
+- `tag` — freeform key:value metadata for custom categories
+- `whatif` — `"1"` for simulated actions, `"0"` or absent for real
+- `iteration` — loop counter string, e.g., `"2/5"`
+
+### Section Control Lines
+
+Section and iteration boundaries use reserved component names:
+
+```
+<![LOG[Detection Phase]LOG]!><time="10:32:01.000+000" date="04-13-2026" component="__SECTION__" context="" type="1" thread="0" file="" color="#5b9aff">
+<![LOG[Loop Iteration 2/5 - WDAC policies]LOG]!><time="10:32:02.000+000" date="04-13-2026" component="__ITERATION__" context="" type="1" thread="0" file="" iteration="2/5" color="#a78bfa">
+```
+
+Reserved components:
+- `__HEADER__` — file-level metadata (parsed once, shown in file info panel)
+- `__SECTION__` — phase/section divider (rendered as full-width banner row, starts left-edge band on subsequent lines)
+- `__ITERATION__` — loop iteration boundary (rendered as banner row, inherits parent section color)
+
+Optional `color` attribute allows scripts to specify section band colors as hex values. If absent, CMTrace Open auto-assigns from a default palette.
+
+### Backward Compatibility
+
+- CMTrace.exe reads all lines normally (ignores unknown attributes and shows reserved components as regular entries)
+- CMTrace Open auto-detects `.cmtlog` extension and uses the enhanced parser
+- Notepad/plain text editors can read the file — it's still text with the familiar CCM structure
+
+---
+
+## 2. User Markers
+
+### Interaction
+
+Three ways to place a marker on a log entry:
+- **Gutter click** — click the left gutter area of a row (like IDE breakpoints)
+- **Right-click context menu** — "Toggle Marker" with category submenu
+- **Keyboard shortcut** — `Ctrl+M` while a row is selected
+
+### Visual Rendering
+
+Color-coded categories with:
+- **Gutter dot** — colored circle in the left gutter matching the category
+- **Row tint** — subtle background highlight in the category color
+- **Left border** — 3px colored left border on marked rows
+
+### Default Categories
+
+| ID | Label | Color |
+|----|-------|-------|
+| `bug` | Bug | `#ef4444` (red) |
+| `investigate` | Investigate | `#60a5fa` (blue) |
+| `confirmed` | Confirmed | `#4ade80` (green) |
+
+Users can add custom categories via UI or right-click submenu.
+
+### Persistence
+
+Markers are stored in the OS app data directory, keyed by SHA-256 hash of the **file path**:
+
+- **Windows:** `%APPDATA%\cmtrace-open\markers\<hash>.json`
+- **macOS:** `~/Library/Application Support/cmtrace-open/markers/<hash>.json`
+- **Linux:** `~/.local/share/cmtrace-open/markers/<hash>.json`
+
+Tauri provides the base directory via `app_data_dir()`.
+
+### Marker File Schema
+
+```json
+{
+  "version": 1,
+  "source_path": "C:\\ProgramData\\...\\Detect-WDAC.log",
+  "source_size": 48230,
+  "created": "2026-04-13T10:45:00Z",
+  "modified": "2026-04-13T11:02:00Z",
+  "markers": [
+    {
+      "line_id": 42,
+      "category": "bug",
+      "color": "#ef4444",
+      "added": "2026-04-13T10:45:12Z"
+    }
+  ],
+  "categories": [
+    { "id": "bug", "label": "Bug", "color": "#ef4444" },
+    { "id": "investigate", "label": "Investigate", "color": "#60a5fa" },
+    { "id": "confirmed", "label": "Confirmed", "color": "#4ade80" }
+  ]
+}
+```
+
+### Tailing Behavior
+
+- Markers are held in memory during active tailing sessions
+- Flushed to disk when tailing stops or the tab closes
+- File path hash is stable during tailing, so markers survive appends
+- `source_size` field tracks last-known file size — if current size is smaller on next open, show a warning: "File appears to have been truncated since markers were added"
+
+---
+
+## 3. Section Dividers and Left-Edge Bands
+
+### Divider Rows
+
+When the parser encounters a `__SECTION__` or `__ITERATION__` component:
+- Render a **full-width banner row** spanning all columns
+- Banner uses the section's color as background with contrasting text
+- Shows the section name and iteration info (e.g., "Loop Iteration 2/5 — WDAC policies")
+
+### Left-Edge Bands
+
+All log entries following a section marker get a **4px colored left border** in the section's color, until the next section marker or end of file. This provides persistent visual grouping — you can scan the left edge and see phase boundaries at a glance.
+
+### Color Assignment
+
+- Scripts can specify colors via the `color` attribute on section lines
+- If no color specified, CMTrace Open assigns from a built-in palette that cycles through distinct, accessible colors
+- Nested sections (iteration within a section) use the iteration's color if specified, otherwise inherit the parent section's color
+
+---
+
+## 4. Multi-Select and Copy
+
+### Selection
+
+- **Click** — selects a single line, clears previous selection
+- **Ctrl+Click** — toggles a line in/out of selection (additive)
+- **Shift+Click** — selects a range from last selected line to clicked line
+- **Ctrl+A** — selects all visible lines (respects active filters)
+
+Selected lines get a distinct highlight (border or background shade) that doesn't conflict with marker tinting.
+
+### Copy
+
+- **Ctrl+C** with multi-selection — copies selected lines as plain text, one per line, in log order
+- Copies the `message` field only (raw log text), not timestamps or column data
+- Lines joined with `\n`
+
+### Convenience: Copy by Marker Category
+
+Right-click context menu or command palette: "Copy all lines marked as [Bug/Investigate/Confirmed]" — selects and copies all lines in a specific marker category without manual multi-selection.
+
+---
+
+## 5. WhatIf Rendering
+
+### Visual Treatment
+
+Log entries with `whatif="1"` are rendered with:
+- **Dimmed opacity** (~60%) — communicates "this didn't really happen"
+- **Italic text** on the message
+- **"WhatIf" badge** — small label near the severity column
+
+### Filtering
+
+The filter system gains a WhatIf toggle:
+- **Show all** (default) — WhatIf and real lines together, visually differentiated
+- **WhatIf only** — isolate simulated actions
+- **Real only** — hide WhatIf lines
+
+---
+
+## 6. Parser and Format Detection
+
+### New Module: `src-tauri/src/parser/cmtlog.rs`
+
+- Reuses CCM parser's line-level `<![LOG[...]LOG]!>` parsing logic
+- Extracts extended attributes: `section`, `tag`, `whatif`, `iteration`, `color`, `script`, `version`, `runid`, `mode`
+- Recognizes reserved components: `__HEADER__`, `__SECTION__`, `__ITERATION__`
+- Maps reserved components into `EntryKind` enum values
+
+### Detection (in `detect.rs`)
+
+Two-tier:
+1. **Extension match** — `.cmtlog` → immediately select CmtLog parser
+2. **Content fallback** — if a `.log` file contains `__SECTION__`, `__HEADER__`, or `__ITERATION__` components in the first 50 lines, upgrade to CmtLog parser
+
+### ResolvedParser Configuration
+
+| Field | Value |
+|-------|-------|
+| `ParserKind` | `CmtLog` |
+| `ParserImplementation` | `CmtLog` |
+| `ParseQuality` | `Structured` |
+| `RecordFraming` | `PhysicalLine` |
+| `ParserSpecialization` | `None` |
+
+### LogEntry Extensions
+
+New optional fields on `LogEntry` (skip-serialized when `None`):
+
+- `entry_kind: Option<EntryKind>` — `Log` (default), `Section`, `Iteration`, `Header`
+- `whatif: Option<bool>`
+- `section_name: Option<String>` — current section name (for left-edge band)
+- `section_color: Option<String>` — hex color for the band
+- `iteration: Option<String>` — e.g., `"2/5"`
+- `tags: Option<Vec<String>>` — freeform tags from `tag` attribute
+
+All optional — existing parsers are unaffected.
+
+---
+
+## 7. PowerShell Module
+
+### Location
+
+`scripts/powershell/CmtLog/CmtLog.psm1` in the CMTrace Open repository.
+
+### Functions
+
+**`Start-CmtLog`** — creates the log file, writes the `__HEADER__` line, returns the file path.
+- Parameters: `-ScriptName`, `-Version`, `-OutputPath` (optional), `-Mode` (auto-detects `$WhatIfPreference`)
+
+**`Write-LogEntry`** — upgraded from existing function, emits a standard log line with optional extended attributes.
+- Existing parameters: `-Value`, `-Severity`, `-Component`, `-FileName`
+- New parameters: `-Section`, `-Tag`, `-WhatIfEntry`, `-Iteration`
+
+**`Write-LogSection`** — emits a `__SECTION__` line.
+- Parameters: `-Name`, `-Color` (optional)
+
+**`Write-LogIteration`** — emits an `__ITERATION__` line.
+- Parameters: `-Name`, `-Current`, `-Total`, `-Color` (optional)
+
+**`Write-LogHeader`** — emits a `__HEADER__` line (called by `Start-CmtLog`, also available standalone).
+- Parameters: `-ScriptName`, `-Version`, `-Mode`
+
+### Example Usage
+
+```powershell
+$LogFile = Start-CmtLog -ScriptName "Detect-WDAC" -Version "2.1.0"
+
+Write-LogSection -Name "Detection Phase" -Color "#5b9aff"
+
+Write-LogEntry -Value "Scanning policy files" -Severity 1 -Section "Detection" -Tag "phase:scan"
+
+foreach ($i in 1..5) {
+    Write-LogIteration -Name "WDAC Policy" -Current $i -Total 5
+
+    Write-LogEntry -Value "Processing policy $i" -Severity 1 -Iteration "$i/5"
+
+    if ($WhatIfPreference) {
+        Write-LogEntry -Value "Would apply policy $i" -Severity 1 -WhatIfEntry
+    }
+}
+
+Write-LogSection -Name "Remediation Phase" -Color "#4ade80"
+```
+
+### Distribution
+
+Standalone `.psm1` file. Users `Import-Module ./CmtLog.psm1` or copy functions into their scripts. PSGallery publication is out of scope for the initial release.
+
+---
+
+## Implementation Order (Format-First)
+
+1. **`.cmtlog` format spec + parser** — `cmtlog.rs`, detection in `detect.rs`, `LogEntry` extensions
+2. **PowerShell module** — `CmtLog.psm1` with all helper functions
+3. **Marker system** — backend persistence (Rust commands for load/save), frontend store, gutter UI
+4. **Section rendering** — divider banner rows + left-edge bands in the log view
+5. **WhatIf rendering** — dimmed/italic/badge styling + filter toggle
+6. **Multi-select copy** — selection model + Ctrl+C handler
+7. **`.cmtlog` extension registration** — OS file association (Windows/macOS) so double-click opens in CMTrace Open

--- a/scripts/Install-CMTraceOpenBuildPrereqs.ps1
+++ b/scripts/Install-CMTraceOpenBuildPrereqs.ps1
@@ -290,9 +290,24 @@ function Install-VisualStudioTools {
     $workload = 'Microsoft.VisualStudio.Workload.VCTools'
     $vcComponent = 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
     $sdk = 'Microsoft.VisualStudio.Component.Windows11SDK.26100'
-    $override = "--passive --add $workload --add $vcComponent --add $sdk --includeRecommended"
 
-    $compliantInstallPath = Get-VisualStudioInstallationPath -ProductRequirement $productRequirement -Requires @($vcComponent)
+    # On ARM64 hosts, also install ARM64 build tools so native compilation works.
+    $isArm64 = $env:PROCESSOR_ARCHITECTURE -eq 'ARM64'
+    $vcArm64Component = 'Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+
+    $components = @($workload, $vcComponent, $sdk)
+    if ($isArm64) {
+        $components += $vcArm64Component
+        Write-Step 'ARM64 host detected — will include ARM64 C++ build tools.'
+    }
+
+    $overrideParts = @('--passive') + ($components | ForEach-Object { "--add $_" }) + @('--includeRecommended')
+    $override = $overrideParts -join ' '
+
+    $requiredComponents = @($vcComponent)
+    if ($isArm64) { $requiredComponents += $vcArm64Component }
+
+    $compliantInstallPath = Get-VisualStudioInstallationPath -ProductRequirement $productRequirement -Requires $requiredComponents
     if ($compliantInstallPath) {
         Write-Step "Skipping $packageId because the required C++ build tools are already installed at '$compliantInstallPath'."
         return
@@ -302,16 +317,15 @@ function Install-VisualStudioTools {
     if ($existingInstallPath) {
         $installerPath = Resolve-VisualStudioInstallerPath
         Write-Step "Updating Visual Studio at '$existingInstallPath' to add the C++ workload and Windows SDK."
-        Invoke-CheckedProcess -FilePath $installerPath -ArgumentList @(
+        $modifyArgs = @(
             'modify',
-            '--installPath', $existingInstallPath,
-            '--add', $workload,
-            '--add', $vcComponent,
-            '--add', $sdk,
-            '--includeRecommended',
-            '--passive',
-            '--norestart'
+            '--installPath', $existingInstallPath
         )
+        foreach ($c in $components) {
+            $modifyArgs += @('--add', $c)
+        }
+        $modifyArgs += @('--includeRecommended', '--passive', '--norestart')
+        Invoke-CheckedProcess -FilePath $installerPath -ArgumentList $modifyArgs
         return
     }
 
@@ -322,20 +336,19 @@ function Install-VisualStudioTools {
     # the installation to add the required components if they are still missing.
     $postInstallPath = Get-VisualStudioInstallationPath -ProductRequirement $productRequirement
     if ($postInstallPath) {
-        $postCompliantPath = Get-VisualStudioInstallationPath -ProductRequirement $productRequirement -Requires @($vcComponent)
+        $postCompliantPath = Get-VisualStudioInstallationPath -ProductRequirement $productRequirement -Requires $requiredComponents
         if (-not $postCompliantPath) {
             $installerPath = Resolve-VisualStudioInstallerPath
             Write-Step "Adding the C++ workload and Windows SDK to the installation at '$postInstallPath'."
-            Invoke-CheckedProcess -FilePath $installerPath -ArgumentList @(
+            $modifyArgs = @(
                 'modify',
-                '--installPath', $postInstallPath,
-                '--add', $workload,
-                '--add', $vcComponent,
-                '--add', $sdk,
-                '--includeRecommended',
-                '--passive',
-                '--norestart'
+                '--installPath', $postInstallPath
             )
+            foreach ($c in $components) {
+                $modifyArgs += @('--add', $c)
+            }
+            $modifyArgs += @('--includeRecommended', '--passive', '--norestart')
+            Invoke-CheckedProcess -FilePath $installerPath -ArgumentList $modifyArgs
         }
     }
 }
@@ -386,10 +399,17 @@ function Enable-VsDeveloperPowerShell {
     }
 
     Import-Module $devShellModule -Force
-    # Use amd64 tools explicitly — works on both x64 (native) and ARM64
-    # (via emulation). The default without -Arch is x86 which causes
-    # linker architecture mismatches with Rust's target.
-    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation -Arch amd64 -HostArch amd64 | Out-Null
+    # Default -Arch is x86 which causes linker mismatches with Rust targets.
+    # On ARM64 hosts with ARM64 tools installed, use native arm64 compilation.
+    # Otherwise use amd64 which works on x64 (native) and ARM64 (emulated).
+    $arch = 'amd64'
+    if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
+        $arm64Libs = Join-Path $vsInstallPath 'VC\Tools\MSVC\*\lib\arm64'
+        if (Test-Path $arm64Libs) {
+            $arch = 'arm64'
+        }
+    }
+    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation -Arch $arch -HostArch amd64 | Out-Null
 
     return $vsInstallPath
 }

--- a/scripts/Install-CMTraceOpenBuildPrereqs.ps1
+++ b/scripts/Install-CMTraceOpenBuildPrereqs.ps1
@@ -386,7 +386,10 @@ function Enable-VsDeveloperPowerShell {
     }
 
     Import-Module $devShellModule -Force
-    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation | Out-Null
+    # Use amd64 tools explicitly — works on both x64 (native) and ARM64
+    # (via emulation). The default without -Arch is x86 which causes
+    # linker architecture mismatches with Rust's target.
+    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation -Arch amd64 -HostArch amd64 | Out-Null
 
     return $vsInstallPath
 }

--- a/scripts/Install-CMTraceOpenBuildPrereqs.ps1
+++ b/scripts/Install-CMTraceOpenBuildPrereqs.ps1
@@ -485,6 +485,11 @@ Install-VisualStudioTools -Sku $VisualStudioSku
 Install-WingetPackage -PackageId 'Microsoft.EdgeWebView2Runtime'
 Install-WingetPackage -PackageId 'Rustlang.Rustup'
 
+# The ring crate requires clang for ARM64 assembly compilation.
+if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
+    Install-WingetPackage -PackageId 'LLVM.LLVM'
+}
+
 if ($EnableVbScript) {
     Enable-VbScriptFeature
 }

--- a/scripts/Install-CMTraceOpenBuildPrereqs.ps1
+++ b/scripts/Install-CMTraceOpenBuildPrereqs.ps1
@@ -197,7 +197,7 @@ function Install-WingetPackage {
         }
 
         if ($ec -eq -1978335189 -or $ec -eq -1978335135) {
-            Write-Step "Skipping $PackageId — already installed (detected by winget installer)."
+            Write-Step "Skipping $PackageId - already installed (detected by winget installer)."
         }
 
         # Invalidate the cache so subsequent checks see the newly installed package.
@@ -298,7 +298,7 @@ function Install-VisualStudioTools {
     $components = @($workload, $vcComponent, $sdk)
     if ($isArm64) {
         $components += $vcArm64Component
-        Write-Step 'ARM64 host detected — will include ARM64 C++ build tools.'
+        Write-Step 'ARM64 host detected - will include ARM64 C++ build tools.'
     }
 
     $overrideParts = @('--passive') + ($components | ForEach-Object { "--add $_" }) + @('--includeRecommended')

--- a/scripts/Launch-CMTraceOpen.ps1
+++ b/scripts/Launch-CMTraceOpen.ps1
@@ -87,10 +87,17 @@ function Enable-VsDeveloperPowerShell {
     }
 
     Import-Module $devShellModule
-    # Use amd64 tools explicitly — works on both x64 (native) and ARM64
-    # (via emulation). The default without -Arch is x86 which causes
-    # linker architecture mismatches with Rust's target.
-    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation -Arch amd64 -HostArch amd64 | Out-Null
+    # Default -Arch is x86 which causes linker mismatches with Rust targets.
+    # On ARM64 hosts with ARM64 tools installed, use native arm64 compilation.
+    # Otherwise use amd64 which works on x64 (native) and ARM64 (emulated).
+    $arch = 'amd64'
+    if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
+        $arm64Libs = Join-Path $vsInstallPath 'VC\Tools\MSVC\*\lib\arm64'
+        if (Test-Path $arm64Libs) {
+            $arch = 'arm64'
+        }
+    }
+    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation -Arch $arch -HostArch amd64 | Out-Null
 
     return $vsInstallPath
 }

--- a/scripts/Launch-CMTraceOpen.ps1
+++ b/scripts/Launch-CMTraceOpen.ps1
@@ -96,11 +96,13 @@ function Enable-VsDeveloperPowerShell {
         throw "Could not find Microsoft.VisualStudio.DevShell.dll at '$devShellModule'."
     }
 
-    $hostArch = Get-HostArchitecture
-    Write-Step "Detected host architecture: $hostArch"
+    $targetArch = Get-HostArchitecture
+    # -HostArch only accepts x86, amd64, or Default — use amd64 for ARM64 hosts
+    $hostToolArch = if ($targetArch -eq 'arm64') { 'amd64' } else { $targetArch }
+    Write-Step "Target architecture: $targetArch (host tools: $hostToolArch)"
 
     Import-Module $devShellModule
-    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation -Arch $hostArch -HostArch $hostArch | Out-Null
+    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation -Arch $targetArch -HostArch $hostToolArch | Out-Null
 
     return $vsInstallPath
 }

--- a/scripts/Launch-CMTraceOpen.ps1
+++ b/scripts/Launch-CMTraceOpen.ps1
@@ -182,6 +182,9 @@ $nodeModulesPath = Join-Path $appRoot 'node_modules'
 Write-Step 'Ensuring Rust toolchain is available on PATH'
 Add-RustToolchainToPath
 
+# ring crate needs clang on ARM64 - add LLVM to PATH if installed
+Add-PathEntryIfExists -PathEntry 'C:\Program Files\LLVM\bin'
+
 Write-Step 'Entering Visual Studio Developer PowerShell'
 $vsInstallPath = Enable-VsDeveloperPowerShell
 Write-Host "Using Visual Studio at $vsInstallPath" -ForegroundColor DarkGray

--- a/scripts/Launch-CMTraceOpen.ps1
+++ b/scripts/Launch-CMTraceOpen.ps1
@@ -74,11 +74,11 @@ function Resolve-VsWherePath {
 }
 
 function Get-HostArchitecture {
-    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    $arch = $env:PROCESSOR_ARCHITECTURE
     switch ($arch) {
-        'Arm64' { return 'arm64' }
-        'X64'   { return 'amd64' }
-        'X86'   { return 'x86' }
+        'ARM64' { return 'arm64' }
+        'AMD64' { return 'amd64' }
+        'x86'   { return 'x86' }
         default { return 'amd64' }
     }
 }

--- a/scripts/Launch-CMTraceOpen.ps1
+++ b/scripts/Launch-CMTraceOpen.ps1
@@ -73,16 +73,6 @@ function Resolve-VsWherePath {
     throw 'Could not find vswhere.exe. Install Visual Studio Installer or add vswhere.exe to PATH.'
 }
 
-function Get-HostArchitecture {
-    $arch = $env:PROCESSOR_ARCHITECTURE
-    switch ($arch) {
-        'ARM64' { return 'arm64' }
-        'AMD64' { return 'amd64' }
-        'x86'   { return 'x86' }
-        default { return 'amd64' }
-    }
-}
-
 function Enable-VsDeveloperPowerShell {
     $vsWherePath = Resolve-VsWherePath
     $vsInstallPath = & $vsWherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
@@ -96,13 +86,11 @@ function Enable-VsDeveloperPowerShell {
         throw "Could not find Microsoft.VisualStudio.DevShell.dll at '$devShellModule'."
     }
 
-    $targetArch = Get-HostArchitecture
-    # -HostArch only accepts x86, amd64, or Default — use amd64 for ARM64 hosts
-    $hostToolArch = if ($targetArch -eq 'arm64') { 'amd64' } else { $targetArch }
-    Write-Step "Target architecture: $targetArch (host tools: $hostToolArch)"
-
     Import-Module $devShellModule
-    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation -Arch $targetArch -HostArch $hostToolArch | Out-Null
+    # Use amd64 tools explicitly — works on both x64 (native) and ARM64
+    # (via emulation). The default without -Arch is x86 which causes
+    # linker architecture mismatches with Rust's target.
+    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation -Arch amd64 -HostArch amd64 | Out-Null
 
     return $vsInstallPath
 }

--- a/scripts/Launch-CMTraceOpen.ps1
+++ b/scripts/Launch-CMTraceOpen.ps1
@@ -73,6 +73,16 @@ function Resolve-VsWherePath {
     throw 'Could not find vswhere.exe. Install Visual Studio Installer or add vswhere.exe to PATH.'
 }
 
+function Get-HostArchitecture {
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    switch ($arch) {
+        'Arm64' { return 'arm64' }
+        'X64'   { return 'amd64' }
+        'X86'   { return 'x86' }
+        default { return 'amd64' }
+    }
+}
+
 function Enable-VsDeveloperPowerShell {
     $vsWherePath = Resolve-VsWherePath
     $vsInstallPath = & $vsWherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
@@ -86,8 +96,11 @@ function Enable-VsDeveloperPowerShell {
         throw "Could not find Microsoft.VisualStudio.DevShell.dll at '$devShellModule'."
     }
 
+    $hostArch = Get-HostArchitecture
+    Write-Step "Detected host architecture: $hostArch"
+
     Import-Module $devShellModule
-    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation | Out-Null
+    Enter-VsDevShell -VsInstallPath $vsInstallPath -SkipAutomaticLocation -Arch $hostArch -HostArch $hostArch | Out-Null
 
     return $vsInstallPath
 }

--- a/scripts/powershell/CmtLog/CmtLog.psm1
+++ b/scripts/powershell/CmtLog/CmtLog.psm1
@@ -1,0 +1,519 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    CmtLog PowerShell module — write .cmtlog files from scripts.
+
+.DESCRIPTION
+    Provides functions to create and write files in the CMTrace Open .cmtlog
+    format, which extends the standard CCM <![LOG[...]LOG]!> line format with
+    reserved component names (__HEADER__, __SECTION__, __ITERATION__) and
+    optional extended attributes (section, tag, whatif, iteration, color).
+
+.NOTES
+    Format reference: https://github.com/adamgell/cmtraceopen
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Module-scoped default file path set by Start-CmtLog
+$script:CmtLogFilePath = $null
+
+#region Private helpers
+
+function Get-CmtLogTimestamp {
+    <#
+    .SYNOPSIS
+        Returns a hashtable with Time and Date keys formatted for .cmtlog lines.
+
+    .OUTPUTS
+        Hashtable with keys: Time (HH:mm:ss.fff+bias), Date (MM-dd-yyyy)
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+
+    $now = [datetime]::Now
+
+    # Resolve UTC offset from Win32_TimeZone (avoids the deprecated Get-WmiObject)
+    $bias = 0
+    try {
+        $tz = Get-CimInstance -ClassName Win32_TimeZone -ErrorAction SilentlyContinue
+        if ($null -ne $tz) {
+            $bias = [int]$tz.Bias
+        }
+    }
+    catch {
+        # Fall back to zero bias — non-critical
+        $bias = 0
+    }
+
+    # CMTrace time format: HH:mm:ss.fff+bias  (bias is positive = west of UTC,
+    # matching the historical CMTrace convention)
+    $timeStr = '{0:HH:mm:ss.fff}+{1:000}' -f $now, $bias
+    $dateStr = '{0:MM-dd-yyyy}' -f $now
+
+    return @{
+        Time = $timeStr
+        Date = $dateStr
+    }
+}
+
+function New-CmtLogRunId {
+    <#
+    .SYNOPSIS
+        Generates a random 8-character hex run identifier.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    $bytes = [byte[]]::new(4)
+    [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes)
+    return ([System.BitConverter]::ToString($bytes) -replace '-', '').ToLower()
+}
+
+function Get-CmtLogContext {
+    <#
+    .SYNOPSIS
+        Returns the current Windows identity as a string, or empty string on
+        platforms where it is unavailable.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    try {
+        return [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    }
+    catch {
+        return ''
+    }
+}
+
+function Get-CmtLogMode {
+    <#
+    .SYNOPSIS
+        Returns "WhatIf" when $WhatIfPreference is active, otherwise "Normal".
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    # $WhatIfPreference is a preference variable in the caller's scope.
+    # We reach it via the call stack.
+    $callerWhatIf = $false
+    try {
+        $callerWhatIf = (Get-Variable -Name WhatIfPreference -Scope 1 -ValueOnly -ErrorAction SilentlyContinue) -eq $true
+    }
+    catch {
+        $callerWhatIf = $false
+    }
+
+    return ($callerWhatIf ? 'WhatIf' : 'Normal')
+}
+
+function Get-PsVersionString {
+    <#
+    .SYNOPSIS
+        Returns a string representation of the current PowerShell version.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    $v = $PSVersionTable.PSVersion
+    return '{0}.{1}.{2}' -f $v.Major, $v.Minor, $v.Build
+}
+
+function Resolve-CmtLogFile {
+    <#
+    .SYNOPSIS
+        Resolves the target file path: returns $FileName if non-null/empty,
+        otherwise returns $script:CmtLogFilePath.
+
+    .OUTPUTS
+        String file path.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [string]$FileName
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($FileName)) {
+        return $FileName
+    }
+
+    if ([string]::IsNullOrWhiteSpace($script:CmtLogFilePath)) {
+        throw 'No log file path specified and Start-CmtLog has not been called. Provide -FileName or call Start-CmtLog first.'
+    }
+
+    return $script:CmtLogFilePath
+}
+
+#endregion
+
+#region Public functions
+
+function Start-CmtLog {
+    <#
+    .SYNOPSIS
+        Creates a new .cmtlog file with a header entry and returns the file path.
+
+    .DESCRIPTION
+        Generates a safe filename based on ScriptName and the current timestamp,
+        creates the output directory if needed, writes the __HEADER__ line via
+        Write-LogHeader, stores the path in $script:CmtLogFilePath, and returns
+        the full path.
+
+    .PARAMETER ScriptName
+        Name of the script being logged (mandatory).
+
+    .PARAMETER Version
+        Script version string (default: "1.0.0").
+
+    .PARAMETER OutputPath
+        Directory in which to create the log file.
+        Defaults to $env:ProgramData\CMTraceOpen\Logs.
+
+    .PARAMETER Mode
+        Execution mode to embed in the header ("Normal" or "WhatIf").
+        Auto-detected from $WhatIfPreference when omitted.
+
+    .OUTPUTS
+        String — full path to the created .cmtlog file.
+
+    .EXAMPLE
+        $log = Start-CmtLog -ScriptName 'Detect-WDAC.ps1' -Version '2.1.0'
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ScriptName,
+
+        [Parameter()]
+        [string]$Version = '1.0.0',
+
+        [Parameter()]
+        [string]$OutputPath = '',
+
+        [Parameter()]
+        [ValidateSet('Normal', 'WhatIf')]
+        [string]$Mode = ''
+    )
+
+    # Resolve output directory
+    if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+        $OutputPath = Join-Path $env:ProgramData 'CMTraceOpen\Logs'
+    }
+
+    # Create directory if it does not exist
+    if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+        $null = New-Item -ItemType Directory -Path $OutputPath -Force
+    }
+
+    # Build safe file name: {ScriptName}_{yyyyMMdd-HHmmss}.cmtlog
+    # Strip any path separators or characters unsafe for file names
+    $safeName = [System.IO.Path]::GetFileNameWithoutExtension($ScriptName) -replace '[\\/:*?"<>|]', '_'
+    $timestamp = [datetime]::Now.ToString('yyyyMMdd-HHmmss')
+    $fileName  = '{0}_{1}.cmtlog' -f $safeName, $timestamp
+    $filePath  = Join-Path $OutputPath $fileName
+
+    # Resolve mode
+    if ([string]::IsNullOrWhiteSpace($Mode)) {
+        $Mode = if ($WhatIfPreference) { 'WhatIf' } else { 'Normal' }
+    }
+
+    # Store for module-wide use
+    $script:CmtLogFilePath = $filePath
+
+    # Create the file and write the header
+    $null = New-Item -ItemType File -Path $filePath -Force
+    Write-LogHeader -ScriptName $ScriptName -Version $Version -Mode $Mode -FileName $filePath
+
+    return $filePath
+}
+
+function Write-LogHeader {
+    <#
+    .SYNOPSIS
+        Emits a __HEADER__ line to the log file.
+
+    .DESCRIPTION
+        Writes the first structured line of a .cmtlog file recording the script
+        name, version, execution mode, PS version, and a random run identifier.
+
+    .PARAMETER ScriptName
+        Name of the script being logged (mandatory).
+
+    .PARAMETER Version
+        Script version string.
+
+    .PARAMETER Mode
+        Execution mode ("Normal" or "WhatIf"). Auto-detected from
+        $WhatIfPreference when omitted.
+
+    .PARAMETER FileName
+        Path to the log file. Falls back to $script:CmtLogFilePath.
+
+    .EXAMPLE
+        Write-LogHeader -ScriptName 'Deploy-App.ps1' -Version '3.0.0'
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ScriptName,
+
+        [Parameter()]
+        [string]$Version = '1.0.0',
+
+        [Parameter()]
+        [ValidateSet('Normal', 'WhatIf')]
+        [string]$Mode = '',
+
+        [Parameter()]
+        [string]$FileName = ''
+    )
+
+    $resolvedFile = Resolve-CmtLogFile -FileName $FileName
+
+    # Resolve mode
+    if ([string]::IsNullOrWhiteSpace($Mode)) {
+        $Mode = if ($WhatIfPreference) { 'WhatIf' } else { 'Normal' }
+    }
+
+    $ts     = Get-CmtLogTimestamp
+    $runId  = New-CmtLogRunId
+    $psVer  = Get-PsVersionString
+
+    $line = '<![LOG[Script started: {0} v{1}]LOG]!><time="{2}" date="{3}" component="__HEADER__" context="" type="1" thread="0" file="" script="{0}" version="{1}" runid="{4}" mode="{5}" ps_version="{6}">' -f `
+        $ScriptName, $Version, $ts.Time, $ts.Date, $runId, $Mode, $psVer
+
+    Add-Content -LiteralPath $resolvedFile -Value $line -Encoding UTF8
+}
+
+function Write-LogEntry {
+    <#
+    .SYNOPSIS
+        Emits a standard log line to the .cmtlog file.
+
+    .DESCRIPTION
+        Writes a CCM-format log line with optional CmtLog extended attributes
+        (section, tag, whatif, iteration) appended before the closing >.
+
+    .PARAMETER Value
+        Log message text (mandatory).
+
+    .PARAMETER Severity
+        Log severity: "1" (Information), "2" (Warning), or "3" (Error) (mandatory).
+
+    .PARAMETER Component
+        Component name. Defaults to "Script".
+
+    .PARAMETER Section
+        Section label to associate with this entry.
+
+    .PARAMETER Tag
+        One or more tags. Multiple values are joined with commas.
+
+    .PARAMETER WhatIfEntry
+        When present, sets whatif="1" on the entry.
+
+    .PARAMETER Iteration
+        Iteration identifier (e.g. "1/3") to associate with this entry.
+
+    .PARAMETER FileName
+        Path to the log file. Falls back to $script:CmtLogFilePath.
+
+    .EXAMPLE
+        Write-LogEntry -Value 'Policy file found' -Severity '1' -Section 'detection' -Tag 'phase:scan','result:ok'
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Value,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('1', '2', '3')]
+        [string]$Severity,
+
+        [Parameter()]
+        [string]$Component = 'Script',
+
+        [Parameter()]
+        [string]$Section = '',
+
+        [Parameter()]
+        [string[]]$Tag = @(),
+
+        [Parameter()]
+        [switch]$WhatIfEntry,
+
+        [Parameter()]
+        [string]$Iteration = '',
+
+        [Parameter()]
+        [string]$FileName = ''
+    )
+
+    $resolvedFile = Resolve-CmtLogFile -FileName $FileName
+    $ts           = Get-CmtLogTimestamp
+    $context      = Get-CmtLogContext
+    $thread       = $PID
+
+    # Build base line (no closing > yet)
+    $base = '<![LOG[{0}]LOG]!><time="{1}" date="{2}" component="{3}" context="{4}" type="{5}" thread="{6}" file=""' -f `
+        $Value, $ts.Time, $ts.Date, $Component, $context, $Severity, $thread
+
+    # Append optional extended attributes
+    $extended = [System.Text.StringBuilder]::new($base)
+
+    if (-not [string]::IsNullOrWhiteSpace($Section)) {
+        $null = $extended.Append(' section="{0}"' -f $Section)
+    }
+
+    if ($Tag.Count -gt 0) {
+        $tagValue = ($Tag | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join ','
+        if (-not [string]::IsNullOrWhiteSpace($tagValue)) {
+            $null = $extended.Append(' tag="{0}"' -f $tagValue)
+        }
+    }
+
+    if ($WhatIfEntry.IsPresent) {
+        $null = $extended.Append(' whatif="1"')
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($Iteration)) {
+        $null = $extended.Append(' iteration="{0}"' -f $Iteration)
+    }
+
+    $null = $extended.Append('>')
+    $line = $extended.ToString()
+
+    Add-Content -LiteralPath $resolvedFile -Value $line -Encoding UTF8
+}
+
+function Write-LogSection {
+    <#
+    .SYNOPSIS
+        Emits a __SECTION__ marker line to the .cmtlog file.
+
+    .DESCRIPTION
+        Writes a section boundary that CMTrace Open renders as a visual divider.
+        The color attribute is only included when -Color is provided.
+
+    .PARAMETER Name
+        Section name to display (mandatory).
+
+    .PARAMETER Color
+        Optional hex color string (e.g. "#5b9aff"). Omitted from output when
+        not specified.
+
+    .PARAMETER FileName
+        Path to the log file. Falls back to $script:CmtLogFilePath.
+
+    .EXAMPLE
+        Write-LogSection -Name 'Detection Phase' -Color '#5b9aff'
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter()]
+        [string]$Color = '',
+
+        [Parameter()]
+        [string]$FileName = ''
+    )
+
+    $resolvedFile = Resolve-CmtLogFile -FileName $FileName
+    $ts           = Get-CmtLogTimestamp
+
+    $base = '<![LOG[{0}]LOG]!><time="{1}" date="{2}" component="__SECTION__" context="" type="1" thread="0" file=""' -f `
+        $Name, $ts.Time, $ts.Date
+
+    if (-not [string]::IsNullOrWhiteSpace($Color)) {
+        $line = '{0} color="{1}">' -f $base, $Color
+    }
+    else {
+        $line = '{0}>' -f $base
+    }
+
+    Add-Content -LiteralPath $resolvedFile -Value $line -Encoding UTF8
+}
+
+function Write-LogIteration {
+    <#
+    .SYNOPSIS
+        Emits an __ITERATION__ marker line to the .cmtlog file.
+
+    .DESCRIPTION
+        Writes a loop iteration boundary. CMTrace Open renders this as a
+        progress indicator within the current section.
+
+    .PARAMETER Name
+        Descriptive name for the iteration target (mandatory).
+
+    .PARAMETER Current
+        Current iteration index, 1-based (mandatory).
+
+    .PARAMETER Total
+        Total number of iterations (mandatory).
+
+    .PARAMETER Color
+        Optional hex color string. Omitted from output when not specified.
+
+    .PARAMETER FileName
+        Path to the log file. Falls back to $script:CmtLogFilePath.
+
+    .EXAMPLE
+        Write-LogIteration -Name 'WDAC policies' -Current 1 -Total 3 -Color '#a78bfa'
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]$Current,
+
+        [Parameter(Mandatory)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$Total,
+
+        [Parameter()]
+        [string]$Color = '',
+
+        [Parameter()]
+        [string]$FileName = ''
+    )
+
+    $resolvedFile  = Resolve-CmtLogFile -FileName $FileName
+    $ts            = Get-CmtLogTimestamp
+    $iterationFrac = '{0}/{1}' -f $Current, $Total
+
+    $base = '<![LOG[Loop Iteration {0} - {1}]LOG]!><time="{2}" date="{3}" component="__ITERATION__" context="" type="1" thread="0" file="" iteration="{0}"' -f `
+        $iterationFrac, $Name, $ts.Time, $ts.Date
+
+    if (-not [string]::IsNullOrWhiteSpace($Color)) {
+        $line = '{0} color="{1}">' -f $base, $Color
+    }
+    else {
+        $line = '{0}>' -f $base
+    }
+
+    Add-Content -LiteralPath $resolvedFile -Value $line -Encoding UTF8
+}
+
+#endregion
+
+Export-ModuleMember -Function Start-CmtLog, Write-LogEntry, Write-LogSection, Write-LogIteration, Write-LogHeader

--- a/scripts/powershell/CmtLog/CmtLog.psm1
+++ b/scripts/powershell/CmtLog/CmtLog.psm1
@@ -20,13 +20,13 @@ $ErrorActionPreference = 'Stop'
 $script:CmtLogFilePath = $null
 
 # UTF-8 without BOM encoder - PS 5.1's -Encoding UTF8 adds a BOM on every
-# Add-Content/Out-File call, corrupting log lines for parsers that don't
-# expect embedded BOMs. Use this for all file writes.
+# Add-Content call, corrupting log lines for parsers that don't expect
+# embedded BOMs.
 $script:Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
 
 #region Private helpers
 
-function Append-CmtLogLine {
+function Add-CmtLogLine {
     <#
     .SYNOPSIS
         Appends a line to a file using UTF-8 without BOM.
@@ -70,7 +70,8 @@ function Get-CmtLogTimestamp {
 
     # CMTrace time format: HH:mm:ss.fff+bias  (bias is positive = west of UTC,
     # matching the historical CMTrace convention)
-    $timeStr = '{0:HH:mm:ss.fff}+{1:000}' -f $now, $bias
+    # Use positive/negative/zero format sections so the sign is always correct
+    $timeStr = '{0:HH:mm:ss.fff}{1:+000;-000;+000}' -f $now, $bias
     $dateStr = '{0:MM-dd-yyyy}' -f $now
 
     return @{
@@ -130,7 +131,7 @@ function Get-CmtLogMode {
         $callerWhatIf = $false
     }
 
-    return ($callerWhatIf ? 'WhatIf' : 'Normal')
+    if ($callerWhatIf) { return 'WhatIf' } else { return 'Normal' }
 }
 
 function Get-PsVersionString {
@@ -197,6 +198,10 @@ function Start-CmtLog {
         Directory in which to create the log file.
         Defaults to $env:ProgramData\CMTraceOpen\Logs.
 
+    .PARAMETER FileName
+        Exact file name (not path) for the log file, e.g. 'MyScript.cmtlog'.
+        When provided, the timestamp suffix is omitted.
+
     .PARAMETER Mode
         Execution mode to embed in the header ("Normal" or "WhatIf").
         Auto-detected from $WhatIfPreference when omitted.
@@ -221,6 +226,9 @@ function Start-CmtLog {
         [string]$OutputPath = '',
 
         [Parameter()]
+        [string]$FileName = '',
+
+        [Parameter()]
         [ValidateSet('Normal', 'WhatIf')]
         [string]$Mode = ''
     )
@@ -235,12 +243,17 @@ function Start-CmtLog {
         $null = New-Item -ItemType Directory -Path $OutputPath -Force
     }
 
-    # Build safe file name: {ScriptName}_{yyyyMMdd-HHmmss}.cmtlog
-    # Strip any path separators or characters unsafe for file names
-    $safeName = [System.IO.Path]::GetFileNameWithoutExtension($ScriptName) -replace '[\\/:*?"<>|]', '_'
-    $timestamp = [datetime]::Now.ToString('yyyyMMdd-HHmmss')
-    $fileName  = '{0}_{1}.cmtlog' -f $safeName, $timestamp
-    $filePath  = Join-Path $OutputPath $fileName
+    # Build safe file name: {ScriptName}_{yyyyMMdd-HHmmss}.cmtlog or use -FileName
+    if (-not [string]::IsNullOrWhiteSpace($FileName)) {
+        $fileName = $FileName
+    }
+    else {
+        # Strip any path separators or characters unsafe for file names
+        $safeName = [System.IO.Path]::GetFileNameWithoutExtension($ScriptName) -replace '[\\/:*?"<>|]', '_'
+        $timestamp = [datetime]::Now.ToString('yyyyMMdd-HHmmss')
+        $fileName = '{0}_{1}.cmtlog' -f $safeName, $timestamp
+    }
+    $filePath = Join-Path $OutputPath $fileName
 
     # Resolve mode
     if ([string]::IsNullOrWhiteSpace($Mode)) {
@@ -282,7 +295,7 @@ function Write-LogHeader {
     .EXAMPLE
         Write-LogHeader -ScriptName 'Deploy-App.ps1' -Version '3.0.0'
     #>
-    [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -306,14 +319,14 @@ function Write-LogHeader {
         $Mode = if ($WhatIfPreference) { 'WhatIf' } else { 'Normal' }
     }
 
-    $ts     = Get-CmtLogTimestamp
-    $runId  = New-CmtLogRunId
-    $psVer  = Get-PsVersionString
+    $ts = Get-CmtLogTimestamp
+    $runId = New-CmtLogRunId
+    $psVer = Get-PsVersionString
 
     $line = '<![LOG[Script started: {0} v{1}]LOG]!><time="{2}" date="{3}" component="__HEADER__" context="" type="1" thread="0" file="" script="{0}" version="{1}" runid="{4}" mode="{5}" ps_version="{6}">' -f `
         $ScriptName, $Version, $ts.Time, $ts.Date, $runId, $Mode, $psVer
 
-    Append-CmtLogLine -Path $resolvedFile -Line $line
+    Add-CmtLogLine -Path $resolvedFile -Line $line
 }
 
 function Write-LogEntry {
@@ -352,7 +365,7 @@ function Write-LogEntry {
     .EXAMPLE
         Write-LogEntry -Value 'Policy file found' -Severity '1' -Section 'detection' -Tag 'phase:scan','result:ok'
     #>
-    [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -382,9 +395,9 @@ function Write-LogEntry {
     )
 
     $resolvedFile = Resolve-CmtLogFile -FileName $FileName
-    $ts           = Get-CmtLogTimestamp
-    $context      = Get-CmtLogContext
-    $thread       = $PID
+    $ts = Get-CmtLogTimestamp
+    $context = Get-CmtLogContext
+    $thread = $PID
 
     # Build base line (no closing > yet)
     $base = '<![LOG[{0}]LOG]!><time="{1}" date="{2}" component="{3}" context="{4}" type="{5}" thread="{6}" file=""' -f `
@@ -415,7 +428,7 @@ function Write-LogEntry {
     $null = $extended.Append('>')
     $line = $extended.ToString()
 
-    Append-CmtLogLine -Path $resolvedFile -Line $line
+    Add-CmtLogLine -Path $resolvedFile -Line $line
 }
 
 function Write-LogSection {
@@ -440,7 +453,7 @@ function Write-LogSection {
     .EXAMPLE
         Write-LogSection -Name 'Detection Phase' -Color '#5b9aff'
     #>
-    [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -454,7 +467,7 @@ function Write-LogSection {
     )
 
     $resolvedFile = Resolve-CmtLogFile -FileName $FileName
-    $ts           = Get-CmtLogTimestamp
+    $ts = Get-CmtLogTimestamp
 
     $base = '<![LOG[{0}]LOG]!><time="{1}" date="{2}" component="__SECTION__" context="" type="1" thread="0" file=""' -f `
         $Name, $ts.Time, $ts.Date
@@ -466,7 +479,7 @@ function Write-LogSection {
         $line = '{0}>' -f $base
     }
 
-    Append-CmtLogLine -Path $resolvedFile -Line $line
+    Add-CmtLogLine -Path $resolvedFile -Line $line
 }
 
 function Write-LogIteration {
@@ -496,7 +509,7 @@ function Write-LogIteration {
     .EXAMPLE
         Write-LogIteration -Name 'WDAC policies' -Current 1 -Total 3 -Color '#a78bfa'
     #>
-    [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -517,8 +530,8 @@ function Write-LogIteration {
         [string]$FileName = ''
     )
 
-    $resolvedFile  = Resolve-CmtLogFile -FileName $FileName
-    $ts            = Get-CmtLogTimestamp
+    $resolvedFile = Resolve-CmtLogFile -FileName $FileName
+    $ts = Get-CmtLogTimestamp
     $iterationFrac = '{0}/{1}' -f $Current, $Total
 
     $base = '<![LOG[Loop Iteration {0} - {1}]LOG]!><time="{2}" date="{3}" component="__ITERATION__" context="" type="1" thread="0" file="" iteration="{0}"' -f `
@@ -531,7 +544,7 @@ function Write-LogIteration {
         $line = '{0}>' -f $base
     }
 
-    Append-CmtLogLine -Path $resolvedFile -Line $line
+    Add-CmtLogLine -Path $resolvedFile -Line $line
 }
 
 #endregion

--- a/scripts/powershell/CmtLog/CmtLog.psm1
+++ b/scripts/powershell/CmtLog/CmtLog.psm1
@@ -1,7 +1,7 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-    CmtLog PowerShell module — write .cmtlog files from scripts.
+    CmtLog PowerShell module - write .cmtlog files from scripts.
 
 .DESCRIPTION
     Provides functions to create and write files in the CMTrace Open .cmtlog
@@ -19,7 +19,27 @@ $ErrorActionPreference = 'Stop'
 # Module-scoped default file path set by Start-CmtLog
 $script:CmtLogFilePath = $null
 
+# UTF-8 without BOM encoder - PS 5.1's -Encoding UTF8 adds a BOM on every
+# Add-Content/Out-File call, corrupting log lines for parsers that don't
+# expect embedded BOMs. Use this for all file writes.
+$script:Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+
 #region Private helpers
+
+function Append-CmtLogLine {
+    <#
+    .SYNOPSIS
+        Appends a line to a file using UTF-8 without BOM.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$Line
+    )
+    [System.IO.File]::AppendAllText($Path, $Line + [Environment]::NewLine, $script:Utf8NoBom)
+}
 
 function Get-CmtLogTimestamp {
     <#
@@ -44,7 +64,7 @@ function Get-CmtLogTimestamp {
         }
     }
     catch {
-        # Fall back to zero bias — non-critical
+        # Fall back to zero bias - non-critical
         $bias = 0
     }
 
@@ -182,7 +202,7 @@ function Start-CmtLog {
         Auto-detected from $WhatIfPreference when omitted.
 
     .OUTPUTS
-        String — full path to the created .cmtlog file.
+        String - full path to the created .cmtlog file.
 
     .EXAMPLE
         $log = Start-CmtLog -ScriptName 'Detect-WDAC.ps1' -Version '2.1.0'
@@ -293,7 +313,7 @@ function Write-LogHeader {
     $line = '<![LOG[Script started: {0} v{1}]LOG]!><time="{2}" date="{3}" component="__HEADER__" context="" type="1" thread="0" file="" script="{0}" version="{1}" runid="{4}" mode="{5}" ps_version="{6}">' -f `
         $ScriptName, $Version, $ts.Time, $ts.Date, $runId, $Mode, $psVer
 
-    Add-Content -LiteralPath $resolvedFile -Value $line -Encoding UTF8
+    Append-CmtLogLine -Path $resolvedFile -Line $line
 }
 
 function Write-LogEntry {
@@ -395,7 +415,7 @@ function Write-LogEntry {
     $null = $extended.Append('>')
     $line = $extended.ToString()
 
-    Add-Content -LiteralPath $resolvedFile -Value $line -Encoding UTF8
+    Append-CmtLogLine -Path $resolvedFile -Line $line
 }
 
 function Write-LogSection {
@@ -446,7 +466,7 @@ function Write-LogSection {
         $line = '{0}>' -f $base
     }
 
-    Add-Content -LiteralPath $resolvedFile -Value $line -Encoding UTF8
+    Append-CmtLogLine -Path $resolvedFile -Line $line
 }
 
 function Write-LogIteration {
@@ -511,7 +531,7 @@ function Write-LogIteration {
         $line = '{0}>' -f $base
     }
 
-    Add-Content -LiteralPath $resolvedFile -Value $line -Encoding UTF8
+    Append-CmtLogLine -Path $resolvedFile -Line $line
 }
 
 #endregion

--- a/src-tauri/src/commands/bundle_ops.rs
+++ b/src-tauri/src/commands/bundle_ops.rs
@@ -787,6 +787,7 @@ fn describe_parser_selection(parser_selection: &ParserSelectionInfo) -> String {
             ParserKind::SecureBootLog => "Secure Boot certificate update log".to_string(),
             ParserKind::DnsDebug => "Windows DNS Server debug log".to_string(),
             ParserKind::DnsAudit => "Windows DNS Server audit log".to_string(),
+            ParserKind::CmtLog => "CMTrace Open structured log".to_string(),
         },
     }
 }

--- a/src-tauri/src/commands/deployment.rs
+++ b/src-tauri/src/commands/deployment.rs
@@ -756,6 +756,12 @@ mod tests {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+            entry_kind: None,
+            whatif: None,
+            section_name: None,
+            section_color: None,
+            iteration: None,
+            tags: None,
         }
     }
 

--- a/src-tauri/src/commands/markers.rs
+++ b/src-tauri/src/commands/markers.rs
@@ -1,0 +1,116 @@
+use std::fs;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Manager};
+
+use crate::error::AppError;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkerCategory {
+    pub id: String,
+    pub label: String,
+    pub color: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Marker {
+    pub line_id: u64,
+    pub category: String,
+    pub color: String,
+    pub added: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkerFile {
+    pub version: u32,
+    pub source_path: String,
+    pub source_size: u64,
+    pub created: String,
+    pub modified: String,
+    pub markers: Vec<Marker>,
+    pub categories: Vec<MarkerCategory>,
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Compute a lowercase hex SHA-256 hash of a file path string.
+fn hash_file_path(file_path: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(file_path.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Resolve the path `markers/<hash>.json` inside the app data directory.
+fn marker_file_path(app: &AppHandle, file_path: &str) -> Result<std::path::PathBuf, AppError> {
+    let hash = hash_file_path(file_path);
+    let mut path = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    path.push("markers");
+    path.push(format!("{hash}.json"));
+    Ok(path)
+}
+
+// ── Commands ─────────────────────────────────────────────────────────────────
+
+/// Load persisted markers for a file. Returns `None` if no marker file exists.
+#[tauri::command]
+pub fn load_markers(
+    file_path: String,
+    app: AppHandle,
+) -> Result<Option<MarkerFile>, AppError> {
+    let path = marker_file_path(&app, &file_path)?;
+
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&path)?;
+    let marker_file: MarkerFile = serde_json::from_str(&content).map_err(|e| AppError::Parse {
+        file: path.to_string_lossy().into_owned(),
+        reason: e.to_string(),
+    })?;
+
+    Ok(Some(marker_file))
+}
+
+/// Persist markers for a file, creating the markers directory if needed.
+#[tauri::command]
+pub fn save_markers(
+    file_path: String,
+    marker_file: MarkerFile,
+    app: AppHandle,
+) -> Result<(), AppError> {
+    let path = marker_file_path(&app, &file_path)?;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let content = serde_json::to_string_pretty(&marker_file).map_err(|e| AppError::Parse {
+        file: path.to_string_lossy().into_owned(),
+        reason: e.to_string(),
+    })?;
+
+    fs::write(&path, content)?;
+    Ok(())
+}
+
+/// Delete the persisted marker file for a given source file, if it exists.
+#[tauri::command]
+pub fn delete_markers(file_path: String, app: AppHandle) -> Result<(), AppError> {
+    let path = marker_file_path(&app, &file_path)?;
+
+    if path.exists() {
+        fs::remove_file(&path)?;
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod app_config;
 #[cfg(target_os = "windows")]
 pub mod graph_api;
 pub mod known_sources;
+pub mod markers;
 #[cfg(feature = "macos-diag")]
 pub mod macos_diag;
 pub mod parsing;

--- a/src-tauri/src/intune/ime_parser.rs
+++ b/src-tauri/src/intune/ime_parser.rs
@@ -113,6 +113,12 @@ pub fn parse_ime_entries(content: &str, file_path: &str) -> (Vec<LogEntry>, u32)
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
         })
         .collect();
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -109,6 +109,9 @@ pub fn run() {
             #[cfg(feature = "deployment")]
             commands::deployment::analyze_deployment_folder,
             commands::fonts::list_system_fonts,
+            commands::markers::load_markers,
+            commands::markers::save_markers,
+            commands::markers::delete_markers,
             commands::reveal::reveal_in_file_manager,
             #[cfg(feature = "dsregcmd")]
             commands::dsregcmd::analyze_dsregcmd,

--- a/src-tauri/src/models/log_entry.rs
+++ b/src-tauri/src/models/log_entry.rs
@@ -9,6 +9,22 @@ pub enum Severity {
     Error,
 }
 
+/// Distinguishes the role of a CmtLog entry: regular log line, section divider, loop
+/// iteration marker, or file header.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum EntryKind {
+    Log,
+    Section,
+    Iteration,
+    Header,
+}
+
+impl Default for EntryKind {
+    fn default() -> Self {
+        EntryKind::Log
+    }
+}
+
 /// Which log format was detected/used to parse this entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LogFormat {
@@ -24,6 +40,8 @@ pub enum LogFormat {
     DnsDebug,
     /// Windows DNS Server analytical/audit EVTX log
     DnsAudit,
+    /// CmtLog structured JSON log format (.cmtlog)
+    CmtLog,
 }
 
 /// High-level parser selection resolved by the backend.
@@ -49,6 +67,7 @@ pub enum ParserKind {
     SecureBootLog,
     DnsDebug,
     DnsAudit,
+    CmtLog,
 }
 
 /// Concrete parser implementation currently used by the backend.
@@ -71,6 +90,7 @@ pub enum ParserImplementation {
     SecureBootLog,
     DnsDebug,
     DnsAudit,
+    CmtLog,
 }
 
 /// How the backend arrived at the parser selection.
@@ -248,6 +268,25 @@ pub struct LogEntry {
     /// DNS zone name (DNS audit)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub zone_name: Option<String>,
+    // CmtLog extended fields
+    /// Entry role — distinguishes sections, iterations, and headers from normal log lines
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry_kind: Option<EntryKind>,
+    /// WhatIf/simulation flag (CmtLog)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub whatif: Option<bool>,
+    /// Section label for Section entries (CmtLog)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section_name: Option<String>,
+    /// Optional color hint associated with a section (CmtLog)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section_color: Option<String>,
+    /// Iteration identifier for Iteration entries (CmtLog)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iteration: Option<String>,
+    /// Arbitrary tag list attached to a log entry (CmtLog)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
 }
 
 /// Result of parsing a complete log file.

--- a/src-tauri/src/models/log_entry.rs
+++ b/src-tauri/src/models/log_entry.rs
@@ -35,7 +35,7 @@ pub enum LogFormat {
     DnsDebug,
     /// Windows DNS Server analytical/audit EVTX log
     DnsAudit,
-    /// CmtLog structured JSON log format (.cmtlog)
+    /// CCM-style text lines with extended attributes (.cmtlog)
     CmtLog,
 }
 

--- a/src-tauri/src/models/log_entry.rs
+++ b/src-tauri/src/models/log_entry.rs
@@ -11,18 +11,13 @@ pub enum Severity {
 
 /// Distinguishes the role of a CmtLog entry: regular log line, section divider, loop
 /// iteration marker, or file header.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub enum EntryKind {
+    #[default]
     Log,
     Section,
     Iteration,
     Header,
-}
-
-impl Default for EntryKind {
-    fn default() -> Self {
-        EntryKind::Log
-    }
 }
 
 /// Which log format was detected/used to parse this entry.

--- a/src-tauri/src/parser/burn.rs
+++ b/src-tauri/src/parser/burn.rs
@@ -122,6 +122,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                entry_kind: None,
+                whatif: None,
+                section_name: None,
+                section_color: None,
+                iteration: None,
+                tags: None,
             });
         } else {
             // Non-matching line — plain text fallback
@@ -168,6 +174,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                entry_kind: None,
+                whatif: None,
+                section_name: None,
+                section_color: None,
+                iteration: None,
+                tags: None,
             });
             parse_errors += 1;
         }

--- a/src-tauri/src/parser/cbs.rs
+++ b/src-tauri/src/parser/cbs.rs
@@ -185,6 +185,12 @@ fn build_entry_from_caps(caps: &regex::Captures<'_>, file_path: &str) -> Option<
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
     })
 }
 
@@ -254,6 +260,12 @@ fn fallback_entry(id: u64, line_number: u32, line: &str, file_path: &str) -> Log
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
     }
 }
 

--- a/src-tauri/src/parser/ccm.rs
+++ b/src-tauri/src/parser/ccm.rs
@@ -217,6 +217,12 @@ fn parse_content_multiline(content: &str, file_path: &str) -> (Vec<LogEntry>, u3
                 dns_flags: None,
                 dns_event_id: None,
                 zone_name: None,
+                entry_kind: None,
+                whatif: None,
+                section_name: None,
+                section_color: None,
+                iteration: None,
+                tags: None,
             });
             id_counter += 1;
         } else {
@@ -364,6 +370,12 @@ fn push_unmatched_plain(
                 dns_flags: None,
                 dns_event_id: None,
                 zone_name: None,
+                entry_kind: None,
+                whatif: None,
+                section_name: None,
+                section_color: None,
+                iteration: None,
+                tags: None,
             });
             *id_counter += 1;
             *errors += 1;

--- a/src-tauri/src/parser/ccm.rs
+++ b/src-tauri/src/parser/ccm.rs
@@ -438,6 +438,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
                 });
                 id_counter += 1;
             }
@@ -487,6 +493,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
                 });
                 id_counter += 1;
                 errors += 1;

--- a/src-tauri/src/parser/ccm.rs
+++ b/src-tauri/src/parser/ccm.rs
@@ -24,7 +24,7 @@ fn ccm_re() -> &'static Regex {
     CELL.get_or_init(|| {
     Regex::new(concat!(
         r#"<!\[LOG\[(?P<msg>[\s\S]*?)\]LOG\]!>"#,
-        r#"<time="(?P<h>\d{1,2}):(?P<m>\d{1,2}):(?P<s>\d{1,2})\.(?P<ms>\d+)(?P<tz>[+-]?\d+)""#,
+        r#"<time="(?P<h>\d{1,2}):(?P<m>\d{1,2}):(?P<s>\d{1,2})\.(?P<ms>\d+)(?P<tz>[+-]*\d+)""#,
         r#"\s+date="(?P<mon>\d{1,2})-(?P<day>\d{1,2})-(?P<yr>\d{4})""#,
         r#"\s+component="(?P<comp>[^"]*)""#,
         r#"\s+context="[^"]*""#,

--- a/src-tauri/src/parser/cmtlog.rs
+++ b/src-tauri/src/parser/cmtlog.rs
@@ -4,14 +4,16 @@
 //! (`__HEADER__`, `__SECTION__`, `__ITERATION__`) and optional extended attributes
 //! (`section`, `tag`, `whatif`, `iteration`, `color`).
 //!
-//! Delegates core CCM line parsing to `ccm::parse_lines`, then post-processes
-//! entries to extract extended attributes and classify by component name.
+//! Uses a relaxed CCM regex that allows trailing key="value" attributes after the
+//! standard `file=""` field, then post-processes entries to extract extended
+//! attributes and classify by component name.
 
 use regex::Regex;
 use std::sync::OnceLock;
 
 use super::ccm;
-use crate::models::log_entry::{EntryKind, LogEntry, LogFormat};
+use super::severity::detect_severity_from_text;
+use crate::models::log_entry::{EntryKind, LogEntry, LogFormat, Severity};
 
 /// Reserved component names that signal CmtLog structured entries.
 const HEADER_COMPONENT: &str = "__HEADER__";
@@ -24,12 +26,38 @@ fn attr_re() -> &'static Regex {
     CELL.get_or_init(|| Regex::new(r#"(\w+)="([^"]*)""#).expect("attr regex must compile"))
 }
 
-/// Returns true if the line contains any CmtLog reserved component name,
+/// Relaxed CCM regex that allows arbitrary trailing attributes after `file=""`.
+///
+/// Standard CCM regex requires `>` immediately after the optional `file` field.
+/// CmtLog lines contain additional key="value" pairs (script, version, color,
+/// section, etc.) between `file=""` and `>`.  This regex uses `[^>]*>` to
+/// tolerate those extra attributes.
+fn cmtlog_re() -> &'static Regex {
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    CELL.get_or_init(|| {
+        Regex::new(concat!(
+            r#"<!\[LOG\[(?P<msg>[\s\S]*?)\]LOG\]!>"#,
+            r#"<time="(?P<h>\d{1,2}):(?P<m>\d{1,2}):(?P<s>\d{1,2})\.(?P<ms>\d+)(?P<tz>[+-]*\d+)""#,
+            r#"\s+date="(?P<mon>\d{1,2})-(?P<day>\d{1,2})-(?P<yr>\d{4})""#,
+            r#"\s+component="(?P<comp>[^"]*)""#,
+            r#"\s+context="[^"]*""#,
+            r#"\s+type="(?P<typ>\d)""#,
+            r#"\s+thread="(?P<thr>\d+)""#,
+            r#"[^>]*>"#,
+        ))
+        .expect("CmtLog regex must compile")
+    })
+}
+
+/// Returns true if the line contains a CmtLog reserved `component="..."` attribute,
 /// indicating the file uses the CmtLog format rather than plain CCM.
+///
+/// Checks for exact attribute syntax to avoid false positives when reserved
+/// names appear in log message text.
 pub fn matches_cmtlog_record(line: &str) -> bool {
-    line.contains(HEADER_COMPONENT)
-        || line.contains(SECTION_COMPONENT)
-        || line.contains(ITERATION_COMPONENT)
+    line.contains(&format!("component=\"{}\"", HEADER_COMPONENT))
+        || line.contains(&format!("component=\"{}\"", SECTION_COMPONENT))
+        || line.contains(&format!("component=\"{}\"", ITERATION_COMPONENT))
 }
 
 /// Extract extended attributes from a raw CmtLog line.
@@ -62,33 +90,202 @@ struct ExtractedAttrs {
     iteration: Option<String>,
 }
 
+/// Parse a single CmtLog line using the relaxed regex.
+fn parse_cmtlog_line(line: &str) -> Option<CmtLogParsed> {
+    let caps = cmtlog_re().captures(line)?;
+
+    let message = caps.name("msg").map(|m| m.as_str().to_string())?;
+    let component_str = caps.name("comp").map(|m| m.as_str().to_string());
+    let severity_type = caps
+        .name("typ")
+        .and_then(|m| m.as_str().parse::<u32>().ok());
+    let severity = ccm::severity_from_type_field(severity_type, &message);
+
+    let thread = caps
+        .name("thr")
+        .and_then(|m| m.as_str().parse::<u32>().ok())
+        .unwrap_or(0);
+    let thread_display = Some(ccm::format_thread_display(thread));
+
+    let h: u32 = caps.name("h").and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    let min: u32 = caps.name("m").and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    let s: u32 = caps.name("s").and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    let ms: u32 = caps.name("ms").and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+    let tz_str = caps.name("tz").map(|m| m.as_str()).unwrap_or("0");
+    let tz_offset: i32 = tz_str.replace("+-", "-").parse().unwrap_or(0);
+    let mon: u32 = caps.name("mon").and_then(|m| m.as_str().parse().ok()).unwrap_or(1);
+    let day: u32 = caps.name("day").and_then(|m| m.as_str().parse().ok()).unwrap_or(1);
+    let yr: i32 = caps.name("yr").and_then(|m| m.as_str().parse().ok()).unwrap_or(2000);
+
+    let (timestamp, timestamp_display) =
+        ccm::build_timestamp(mon, day, yr, h, min, s, ms, Some(tz_offset));
+
+    Some(CmtLogParsed {
+        message,
+        component: component_str,
+        timestamp,
+        timestamp_display,
+        severity,
+        thread,
+        thread_display,
+        timezone_offset: tz_offset,
+    })
+}
+
+struct CmtLogParsed {
+    message: String,
+    component: Option<String>,
+    timestamp: Option<i64>,
+    timestamp_display: Option<String>,
+    severity: Severity,
+    thread: u32,
+    thread_display: Option<String>,
+    timezone_offset: i32,
+}
+
 /// Parse all lines as CmtLog format.
 ///
-/// Delegates to `ccm::parse_lines` for base parsing, then post-processes each
-/// entry to extract CmtLog-specific attributes and classify by component name.
+/// Uses a relaxed CCM regex that tolerates extra key="value" attributes, then
+/// post-processes entries to extract CmtLog-specific attributes and classify
+/// by component name.
 ///
 /// Returns `(entries, parse_error_count)`.
 pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
-    let (mut entries, parse_errors) = ccm::parse_lines(lines, file_path);
+    let mut entries = Vec::with_capacity(lines.len());
+    let mut errors = 0u32;
+    let mut id_counter = 0u64;
 
     // Track current section context for propagation to child entries.
     let mut current_section_name: Option<String> = None;
     let mut current_section_color: Option<String> = None;
 
-    for (entry, raw_line) in entries.iter_mut().zip(lines.iter()) {
-        // Override format to CmtLog for all entries.
-        entry.format = LogFormat::CmtLog;
+    for (i, line) in lines.iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
 
-        let attrs = extract_attrs(raw_line);
-        let component = entry.component.as_deref().unwrap_or("");
+        let attrs = extract_attrs(line);
 
-        match component {
+        let (base_entry, component_str) = match parse_cmtlog_line(line) {
+            Some(parsed) => {
+                let comp = parsed.component.clone();
+                let entry = LogEntry {
+                    id: id_counter,
+                    line_number: (i + 1) as u32,
+                    message: parsed.message,
+                    component: parsed.component,
+                    timestamp: parsed.timestamp,
+                    timestamp_display: parsed.timestamp_display,
+                    severity: parsed.severity,
+                    thread: Some(parsed.thread),
+                    thread_display: parsed.thread_display,
+                    source_file: None,
+                    format: LogFormat::CmtLog,
+                    file_path: file_path.to_string(),
+                    timezone_offset: Some(parsed.timezone_offset),
+                    error_code_spans: Vec::new(),
+                    ip_address: None,
+                    host_name: None,
+                    mac_address: None,
+                    result_code: None,
+                    gle_code: None,
+                    setup_phase: None,
+                    operation_name: None,
+                    http_method: None,
+                    uri_stem: None,
+                    uri_query: None,
+                    status_code: None,
+                    sub_status: None,
+                    time_taken_ms: None,
+                    client_ip: None,
+                    server_ip: None,
+                    user_agent: None,
+                    server_port: None,
+                    username: None,
+                    win32_status: None,
+                    query_name: None,
+                    query_type: None,
+                    response_code: None,
+                    dns_direction: None,
+                    dns_protocol: None,
+                    source_ip: None,
+                    dns_flags: None,
+                    dns_event_id: None,
+                    zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
+                };
+                (entry, comp.unwrap_or_default())
+            }
+            None => {
+                errors += 1;
+                let entry = LogEntry {
+                    id: id_counter,
+                    line_number: (i + 1) as u32,
+                    message: line.to_string(),
+                    component: None,
+                    timestamp: None,
+                    timestamp_display: None,
+                    severity: detect_severity_from_text(line),
+                    thread: None,
+                    thread_display: None,
+                    source_file: None,
+                    format: LogFormat::CmtLog,
+                    file_path: file_path.to_string(),
+                    timezone_offset: None,
+                    error_code_spans: Vec::new(),
+                    ip_address: None,
+                    host_name: None,
+                    mac_address: None,
+                    result_code: None,
+                    gle_code: None,
+                    setup_phase: None,
+                    operation_name: None,
+                    http_method: None,
+                    uri_stem: None,
+                    uri_query: None,
+                    status_code: None,
+                    sub_status: None,
+                    time_taken_ms: None,
+                    client_ip: None,
+                    server_ip: None,
+                    user_agent: None,
+                    server_port: None,
+                    username: None,
+                    win32_status: None,
+                    query_name: None,
+                    query_type: None,
+                    response_code: None,
+                    dns_direction: None,
+                    dns_protocol: None,
+                    source_ip: None,
+                    dns_flags: None,
+                    dns_event_id: None,
+                    zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
+                };
+                (entry, String::new())
+            }
+        };
+
+        let mut entry = base_entry;
+
+        // Classify by component name and extract CmtLog-specific attributes
+        match component_str.as_str() {
             HEADER_COMPONENT => {
                 entry.entry_kind = Some(EntryKind::Header);
             }
             SECTION_COMPONENT => {
                 entry.entry_kind = Some(EntryKind::Section);
-                // The message IS the section name.
                 current_section_name = Some(entry.message.clone());
                 current_section_color = attrs.color.clone();
                 entry.section_name = Some(entry.message.clone());
@@ -97,12 +294,10 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
             ITERATION_COMPONENT => {
                 entry.entry_kind = Some(EntryKind::Iteration);
                 entry.iteration = attrs.iteration;
-                // Inherit parent section color if no explicit color.
                 entry.section_color = attrs.color.or_else(|| current_section_color.clone());
                 entry.section_name = current_section_name.clone();
             }
             _ => {
-                // Regular log entry — propagate section context.
                 entry.entry_kind = Some(EntryKind::Log);
                 entry.section_name = attrs
                     .section
@@ -118,9 +313,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                 });
             }
         }
+
+        entries.push(entry);
+        id_counter += 1;
     }
 
-    (entries, parse_errors)
+    (entries, errors)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/parser/cmtlog.rs
+++ b/src-tauri/src/parser/cmtlog.rs
@@ -1,0 +1,199 @@
+//! CmtLog format parser.
+//!
+//! Extends CCM's `<![LOG[...]LOG]!>` line format with reserved component names
+//! (`__HEADER__`, `__SECTION__`, `__ITERATION__`) and optional extended attributes
+//! (`section`, `tag`, `whatif`, `iteration`, `color`).
+//!
+//! Delegates core CCM line parsing to `ccm::parse_lines`, then post-processes
+//! entries to extract extended attributes and classify by component name.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+use super::ccm;
+use crate::models::log_entry::{EntryKind, LogEntry, LogFormat};
+
+/// Reserved component names that signal CmtLog structured entries.
+const HEADER_COMPONENT: &str = "__HEADER__";
+const SECTION_COMPONENT: &str = "__SECTION__";
+const ITERATION_COMPONENT: &str = "__ITERATION__";
+
+/// Compiled regex for extracting key="value" pairs from raw log lines.
+fn attr_re() -> &'static Regex {
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    CELL.get_or_init(|| Regex::new(r#"(\w+)="([^"]*)""#).expect("attr regex must compile"))
+}
+
+/// Returns true if the line contains any CmtLog reserved component name,
+/// indicating the file uses the CmtLog format rather than plain CCM.
+pub fn matches_cmtlog_record(line: &str) -> bool {
+    line.contains(HEADER_COMPONENT)
+        || line.contains(SECTION_COMPONENT)
+        || line.contains(ITERATION_COMPONENT)
+}
+
+/// Extract extended attributes from a raw CmtLog line.
+///
+/// Scans for `key="value"` pairs and returns the ones relevant to CmtLog:
+/// `section`, `color`, `tag`, `whatif`, `iteration`.
+fn extract_attrs(line: &str) -> ExtractedAttrs {
+    let mut attrs = ExtractedAttrs::default();
+    for caps in attr_re().captures_iter(line) {
+        let key = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+        let value = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+        match key {
+            "section" => attrs.section = Some(value.to_string()),
+            "color" => attrs.color = Some(value.to_string()),
+            "tag" => attrs.tag = Some(value.to_string()),
+            "whatif" => attrs.whatif = Some(value.to_string()),
+            "iteration" => attrs.iteration = Some(value.to_string()),
+            _ => {}
+        }
+    }
+    attrs
+}
+
+#[derive(Default)]
+struct ExtractedAttrs {
+    section: Option<String>,
+    color: Option<String>,
+    tag: Option<String>,
+    whatif: Option<String>,
+    iteration: Option<String>,
+}
+
+/// Parse all lines as CmtLog format.
+///
+/// Delegates to `ccm::parse_lines` for base parsing, then post-processes each
+/// entry to extract CmtLog-specific attributes and classify by component name.
+///
+/// Returns `(entries, parse_error_count)`.
+pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
+    let (mut entries, parse_errors) = ccm::parse_lines(lines, file_path);
+
+    // Track current section context for propagation to child entries.
+    let mut current_section_name: Option<String> = None;
+    let mut current_section_color: Option<String> = None;
+
+    for (entry, raw_line) in entries.iter_mut().zip(lines.iter()) {
+        // Override format to CmtLog for all entries.
+        entry.format = LogFormat::CmtLog;
+
+        let attrs = extract_attrs(raw_line);
+        let component = entry.component.as_deref().unwrap_or("");
+
+        match component {
+            HEADER_COMPONENT => {
+                entry.entry_kind = Some(EntryKind::Header);
+            }
+            SECTION_COMPONENT => {
+                entry.entry_kind = Some(EntryKind::Section);
+                // The message IS the section name.
+                current_section_name = Some(entry.message.clone());
+                current_section_color = attrs.color.clone();
+                entry.section_name = Some(entry.message.clone());
+                entry.section_color = attrs.color;
+            }
+            ITERATION_COMPONENT => {
+                entry.entry_kind = Some(EntryKind::Iteration);
+                entry.iteration = attrs.iteration;
+                // Inherit parent section color if no explicit color.
+                entry.section_color = attrs.color.or_else(|| current_section_color.clone());
+                entry.section_name = current_section_name.clone();
+            }
+            _ => {
+                // Regular log entry — propagate section context.
+                entry.entry_kind = Some(EntryKind::Log);
+                entry.section_name = attrs
+                    .section
+                    .or_else(|| current_section_name.clone());
+                entry.section_color = current_section_color.clone();
+                entry.whatif = attrs.whatif.map(|v| v == "1");
+                entry.iteration = attrs.iteration;
+                entry.tags = attrs.tag.map(|t| {
+                    t.split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                });
+            }
+        }
+    }
+
+    (entries, parse_errors)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::log_entry::Severity;
+
+    fn sample_lines() -> Vec<String> {
+        vec![
+            r##"<![LOG[Script started: Detect-WDAC.ps1 v2.1.0]LOG]!><time="10:30:00.000+000" date="04-13-2026" component="__HEADER__" context="" type="1" thread="0" file="" script="Detect-WDAC.ps1" version="2.1.0">"##.to_string(),
+            r##"<![LOG[Detection Phase]LOG]!><time="10:32:01.000+000" date="04-13-2026" component="__SECTION__" context="" type="1" thread="0" file="" color="#5b9aff">"##.to_string(),
+            r##"<![LOG[Scanning policy files]LOG]!><time="10:32:01.123+000" date="04-13-2026" component="Detect-WDAC" context="CONTOSO\admin" type="1" thread="1234" file="" section="detection" tag="phase:scan">"##.to_string(),
+        ]
+    }
+
+    #[test]
+    fn test_matches_cmtlog_record() {
+        assert!(matches_cmtlog_record(
+            r#"component="__HEADER__" context="" type="1""#
+        ));
+        assert!(matches_cmtlog_record(
+            r#"component="__SECTION__" context="" type="1""#
+        ));
+        assert!(matches_cmtlog_record(
+            r#"component="__ITERATION__" context="" type="1""#
+        ));
+        assert!(!matches_cmtlog_record(
+            r#"component="TestComp" context="" type="1""#
+        ));
+    }
+
+    #[test]
+    fn test_header_classification() {
+        let lines = sample_lines();
+        let line_refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        let (entries, _) = parse_lines(&line_refs, "test.cmtlog");
+        assert_eq!(entries[0].entry_kind, Some(EntryKind::Header));
+        assert_eq!(entries[0].format, LogFormat::CmtLog);
+    }
+
+    #[test]
+    fn test_section_classification() {
+        let lines = sample_lines();
+        let line_refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        let (entries, _) = parse_lines(&line_refs, "test.cmtlog");
+        assert_eq!(entries[1].entry_kind, Some(EntryKind::Section));
+        assert_eq!(entries[1].section_name.as_deref(), Some("Detection Phase"));
+        assert_eq!(entries[1].section_color.as_deref(), Some("#5b9aff"));
+    }
+
+    #[test]
+    fn test_log_inherits_section_context() {
+        let lines = sample_lines();
+        let line_refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        let (entries, _) = parse_lines(&line_refs, "test.cmtlog");
+        assert_eq!(entries[2].entry_kind, Some(EntryKind::Log));
+        // Explicit section attr overrides inherited section name
+        assert_eq!(entries[2].section_name.as_deref(), Some("detection"));
+        // Color is inherited from the current section
+        assert_eq!(entries[2].section_color.as_deref(), Some("#5b9aff"));
+        assert_eq!(
+            entries[2].tags,
+            Some(vec!["phase:scan".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_severity_mapping() {
+        let lines = vec![
+            r#"<![LOG[Policy validation failed]LOG]!><time="10:32:01.456+000" date="04-13-2026" component="Detect-WDAC" context="" type="3" thread="1234" file="">"#.to_string(),
+        ];
+        let line_refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        let (entries, _) = parse_lines(&line_refs, "test.cmtlog");
+        assert_eq!(entries[0].severity, Severity::Error);
+    }
+}

--- a/src-tauri/src/parser/detect.rs
+++ b/src-tauri/src/parser/detect.rs
@@ -16,7 +16,7 @@
 //! - Otherwise → Plain text
 
 use super::{
-    burn, cbs, dhcp, dism, dns_debug, iis_w3c, intune_macos, msi, panther,
+    burn, cbs, cmtlog, dhcp, dism, dns_debug, iis_w3c, intune_macos, msi, panther,
     patchmypc_detection, psadt, reporting_events, secureboot_log,
     timestamped::{self, DateOrder},
 };
@@ -262,6 +262,30 @@ impl ResolvedParser {
         )
     }
 
+    pub fn cmtlog() -> Self {
+        Self::new(
+            ParserKind::CmtLog,
+            ParserImplementation::CmtLog,
+            ParserProvenance::Dedicated,
+            ParseQuality::Structured,
+            RecordFraming::PhysicalLine,
+            DateOrder::MonthFirst,
+            None,
+        )
+    }
+
+    pub fn cmtlog_heuristic() -> Self {
+        Self::new(
+            ParserKind::CmtLog,
+            ParserImplementation::CmtLog,
+            ParserProvenance::Heuristic,
+            ParseQuality::Structured,
+            RecordFraming::PhysicalLine,
+            DateOrder::MonthFirst,
+            None,
+        )
+    }
+
     pub fn psadt_legacy() -> Self {
         Self::new(
             ParserKind::PsadtLegacy,
@@ -383,6 +407,11 @@ pub fn detect_parser(path: &str, content: &str) -> ResolvedParser {
     // Path hints must be computed before sample_lines so the sample limit can depend on them.
     let path_lower = path.to_ascii_lowercase();
 
+    // .cmtlog extension — unambiguous dedicated format, return immediately.
+    if path_lower.ends_with(".cmtlog") {
+        return ResolvedParser::cmtlog();
+    }
+
     let dns_debug_path_hint = path_lower.contains("dns")
         || path_lower.ends_with("dns.log")
         || path_lower.contains("\\dns\\")
@@ -451,15 +480,22 @@ pub fn detect_parser(path: &str, content: &str) -> ResolvedParser {
     let mut patchmypc_detection_count = 0u32;
     let mut secureboot_log_count = 0u32;
     let mut dns_debug_count = 0u32;
+    let mut cmtlog_count = 0u32;
     let mut timestamp_count = 0;
     let mut has_day_first = false;
 
     for line in &sample_lines {
         if line.contains("<![LOG[") && line.contains("]LOG]!>") {
             ccm_count += 1;
+            if cmtlog::matches_cmtlog_record(line) {
+                cmtlog_count += 1;
+            }
         } else if line.contains(" type=\"") && line.contains("component=\"") {
             // Fallback CCM detection from the binary's ` type="` check
             ccm_count += 1;
+            if cmtlog::matches_cmtlog_record(line) {
+                cmtlog_count += 1;
+            }
         } else if line.contains("$$<") {
             simple_count += 1;
         } else if reporting_events::matches_reporting_events_record(line.trim()) {
@@ -507,7 +543,10 @@ pub fn detect_parser(path: &str, content: &str) -> ResolvedParser {
         }
     }
 
-    if (secureboot_log_path_hint && secureboot_log_count >= 1) || secureboot_log_count >= 2 {
+    if cmtlog_count >= 1 && ccm_count > 0 {
+        // CmtLog markers found alongside CCM lines — prefer CmtLog with Heuristic provenance.
+        ResolvedParser::cmtlog_heuristic()
+    } else if (secureboot_log_path_hint && secureboot_log_count >= 1) || secureboot_log_count >= 2 {
         ResolvedParser::secureboot_log()
     } else if ime_path_hint && ccm_count > 0 {
         ResolvedParser::ime()

--- a/src-tauri/src/parser/detect.rs
+++ b/src-tauri/src/parser/detect.rs
@@ -316,6 +316,8 @@ impl ResolvedParser {
             ParserImplementation::SecureBootLog => LogFormat::Timestamped,
             ParserImplementation::DnsDebug => LogFormat::DnsDebug,
             ParserImplementation::DnsAudit => LogFormat::DnsAudit,
+            ParserImplementation::SecureBootLog => LogFormat::Plain,
+            ParserImplementation::CmtLog => LogFormat::CmtLog,
         }
     }
 

--- a/src-tauri/src/parser/detect.rs
+++ b/src-tauri/src/parser/detect.rs
@@ -340,7 +340,6 @@ impl ResolvedParser {
             ParserImplementation::SecureBootLog => LogFormat::Timestamped,
             ParserImplementation::DnsDebug => LogFormat::DnsDebug,
             ParserImplementation::DnsAudit => LogFormat::DnsAudit,
-            ParserImplementation::SecureBootLog => LogFormat::Plain,
             ParserImplementation::CmtLog => LogFormat::CmtLog,
         }
     }

--- a/src-tauri/src/parser/dhcp.rs
+++ b/src-tauri/src/parser/dhcp.rs
@@ -121,6 +121,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                entry_kind: None,
+                whatif: None,
+                section_name: None,
+                section_color: None,
+                iteration: None,
+                tags: None,
             });
             id += 1;
             continue;
@@ -184,6 +190,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+            entry_kind: None,
+            whatif: None,
+            section_name: None,
+            section_color: None,
+            iteration: None,
+            tags: None,
         });
         id += 1;
     }

--- a/src-tauri/src/parser/dism.rs
+++ b/src-tauri/src/parser/dism.rs
@@ -176,6 +176,12 @@ fn build_entry_from_caps(caps: &regex::Captures<'_>, file_path: &str) -> Option<
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
     })
 }
 
@@ -245,6 +251,12 @@ fn fallback_entry(id: u64, line_number: u32, line: &str, file_path: &str) -> Log
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
     }
 }
 

--- a/src-tauri/src/parser/dns_audit.rs
+++ b/src-tauri/src/parser/dns_audit.rs
@@ -147,6 +147,12 @@ pub fn parse_evtx(path: &str) -> Result<ParseResult, String> {
             dns_flags: None,
             dns_event_id: Some(event_id),
             zone_name,
+            entry_kind: None,
+            whatif: None,
+            section_name: None,
+            section_color: None,
+            iteration: None,
+            tags: None,
         });
 
         id += 1;

--- a/src-tauri/src/parser/dns_debug.rs
+++ b/src-tauri/src/parser/dns_debug.rs
@@ -234,6 +234,12 @@ fn parse_packet_line(line: &str, file_path: &str, date_order: DateOrder) -> Opti
         dns_flags: Some(format!("0x{}", flags_hex)),
         dns_event_id: None,
         zone_name: None,
+        entry_kind: None,
+        whatif: None,
+        section_name: None,
+        section_color: None,
+        iteration: None,
+        tags: None,
     })
 }
 

--- a/src-tauri/src/parser/iis_w3c.rs
+++ b/src-tauri/src/parser/iis_w3c.rs
@@ -131,6 +131,12 @@ fn malformed_entry(id: u64, line_number: u32, line: &str, file_path: &str) -> Lo
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+        entry_kind: None,
+        whatif: None,
+        section_name: None,
+        section_color: None,
+        iteration: None,
+        tags: None,
     }
 }
 
@@ -258,6 +264,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
             dns_flags: None,
             dns_event_id: None,
             zone_name: None,
+            entry_kind: None,
+            whatif: None,
+            section_name: None,
+            section_color: None,
+            iteration: None,
+            tags: None,
         });
         id += 1;
     }

--- a/src-tauri/src/parser/intune_macos.rs
+++ b/src-tauri/src/parser/intune_macos.rs
@@ -127,6 +127,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
             });
         } else {
             // Non-matching line (e.g., continuation/JSON dump) — plain text
@@ -173,6 +179,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
             });
             parse_errors += 1;
         }

--- a/src-tauri/src/parser/mod.rs
+++ b/src-tauri/src/parser/mod.rs
@@ -166,6 +166,11 @@ pub fn parse_lines_with_selection(
         }
         crate::models::log_entry::ParserImplementation::DnsAudit => {
             // EVTX files are parsed via the binary path in parse_file(), not the line-based pipeline.
+            // SecureBootLog has its own dedicated IPC command; not routed through this pipeline.
+            (vec![], 0)
+        }
+        crate::models::log_entry::ParserImplementation::CmtLog => {
+            // CmtLog parser is not yet implemented; placeholder for Task 2.
             (vec![], 0)
         }
         crate::models::log_entry::ParserImplementation::GenericTimestamped => match selection.parser {

--- a/src-tauri/src/parser/mod.rs
+++ b/src-tauri/src/parser/mod.rs
@@ -1,5 +1,6 @@
 pub mod burn;
 pub mod cbs;
+pub mod cmtlog;
 pub mod panther;
 pub mod ccm;
 pub mod detect;
@@ -170,8 +171,7 @@ pub fn parse_lines_with_selection(
             (vec![], 0)
         }
         crate::models::log_entry::ParserImplementation::CmtLog => {
-            // CmtLog parser is not yet implemented; placeholder for Task 2.
-            (vec![], 0)
+            cmtlog::parse_lines(lines, file_path)
         }
         crate::models::log_entry::ParserImplementation::GenericTimestamped => match selection.parser {
             crate::models::log_entry::ParserKind::Cbs => cbs::parse_lines(lines, file_path),

--- a/src-tauri/src/parser/msi.rs
+++ b/src-tauri/src/parser/msi.rs
@@ -727,6 +727,12 @@ fn make_entry(
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
     }
 }
 

--- a/src-tauri/src/parser/panther.rs
+++ b/src-tauri/src/parser/panther.rs
@@ -224,6 +224,12 @@ fn build_entry_from_caps(caps: &regex::Captures<'_>, file_path: &str) -> Option<
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+        entry_kind: None,
+        whatif: None,
+        section_name: None,
+        section_color: None,
+        iteration: None,
+        tags: None,
     };
 
     post_process_entry(&mut entry);
@@ -345,6 +351,12 @@ fn fallback_entry(id: u64, line_number: u32, line: &str, file_path: &str) -> Log
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+        entry_kind: None,
+        whatif: None,
+        section_name: None,
+        section_color: None,
+        iteration: None,
+        tags: None,
     }
 }
 

--- a/src-tauri/src/parser/patchmypc_detection.rs
+++ b/src-tauri/src/parser/patchmypc_detection.rs
@@ -126,6 +126,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                 dns_flags: None,
                 dns_event_id: None,
                 zone_name: None,
+                entry_kind: None,
+                whatif: None,
+                section_name: None,
+                section_color: None,
+                iteration: None,
+                tags: None,
             });
         } else {
             entries.push(LogEntry {
@@ -171,6 +177,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                 dns_flags: None,
                 dns_event_id: None,
                 zone_name: None,
+                entry_kind: None,
+                whatif: None,
+                section_name: None,
+                section_color: None,
+                iteration: None,
+                tags: None,
             });
             parse_errors += 1;
         }

--- a/src-tauri/src/parser/plain.rs
+++ b/src-tauri/src/parser/plain.rs
@@ -60,6 +60,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
         });
     }
 

--- a/src-tauri/src/parser/psadt.rs
+++ b/src-tauri/src/parser/psadt.rs
@@ -168,6 +168,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
                 });
                 id_counter += 1;
             }
@@ -216,6 +222,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
                 });
                 id_counter += 1;
                 errors += 1;

--- a/src-tauri/src/parser/reporting_events.rs
+++ b/src-tauri/src/parser/reporting_events.rs
@@ -139,6 +139,12 @@ fn parse_line(line: &str, file_path: &str) -> Option<LogEntry> {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
     })
 }
 
@@ -330,6 +336,12 @@ fn fallback_entry(id: u64, line_number: u32, line: &str, file_path: &str) -> Log
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
     }
 }
 

--- a/src-tauri/src/parser/secureboot_log.rs
+++ b/src-tauri/src/parser/secureboot_log.rs
@@ -113,6 +113,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                 dns_flags: None,
                 dns_event_id: None,
                 zone_name: None,
+                entry_kind: None,
+                whatif: None,
+                section_name: None,
+                section_color: None,
+                iteration: None,
+                tags: None,
             });
         } else {
             // Non-matching line — plain text fallback
@@ -159,6 +165,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                 dns_flags: None,
                 dns_event_id: None,
                 zone_name: None,
+                entry_kind: None,
+                whatif: None,
+                section_name: None,
+                section_color: None,
+                iteration: None,
+                tags: None,
             });
             parse_errors += 1;
         }

--- a/src-tauri/src/parser/simple.rs
+++ b/src-tauri/src/parser/simple.rs
@@ -148,6 +148,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
                 });
                 id_counter += 1;
             }
@@ -196,6 +202,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
                 });
                 id_counter += 1;
                 errors += 1;

--- a/src-tauri/src/parser/timestamped.rs
+++ b/src-tauri/src/parser/timestamped.rs
@@ -170,6 +170,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str, date_order: DateOrder) -> (V
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
             });
             parse_errors += 1;
         }
@@ -278,6 +284,12 @@ fn try_iso(line: &str) -> Option<LogEntry> {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
     })
 }
 
@@ -368,6 +380,12 @@ fn try_slash_date(line: &str, date_order: DateOrder) -> Option<LogEntry> {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
     })
 }
 
@@ -445,6 +463,12 @@ fn try_syslog(line: &str) -> Option<LogEntry> {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
     })
 }
 
@@ -512,6 +536,12 @@ fn try_time_only(line: &str) -> Option<LogEntry> {
                     dns_flags: None,
                     dns_event_id: None,
                     zone_name: None,
+                    entry_kind: None,
+                    whatif: None,
+                    section_name: None,
+                    section_color: None,
+                    iteration: None,
+                    tags: None,
     })
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -62,6 +62,13 @@
         ],
         "mimeType": "text/plain",
         "description": "Old Log File"
+      },
+      {
+        "ext": [
+          "cmtlog"
+        ],
+        "mimeType": "text/plain",
+        "description": "CMTrace Open Log File"
       }
     ],
     "windows": {

--- a/src-tauri/tests/cmtlog_parser.rs
+++ b/src-tauri/tests/cmtlog_parser.rs
@@ -1,0 +1,241 @@
+mod common;
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempLogFixture {
+    dir: PathBuf,
+    path: PathBuf,
+}
+
+impl TempLogFixture {
+    fn new(file_name: &str, content: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("cmtrace-open-cmtlog-test-{unique}"));
+        fs::create_dir_all(&dir).expect("create temp fixture dir");
+
+        let path = dir.join(file_name);
+        fs::write(&path, content).expect("write temp fixture");
+
+        Self { dir, path }
+    }
+
+    fn detect(&self) -> app_lib::parser::ResolvedParser {
+        let content = fs::read_to_string(&self.path).expect("fixture should be readable as UTF-8");
+        app_lib::parser::detect::detect_parser(&self.path.to_string_lossy(), &content)
+    }
+}
+
+impl Drop for TempLogFixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn fixture_content() -> &'static str {
+    concat!(
+        "<![LOG[Script started: Detect-WDAC.ps1 v2.1.0]LOG]!><time=\"10:30:00.000+000\" date=\"04-13-2026\" component=\"__HEADER__\" context=\"\" type=\"1\" thread=\"0\" file=\"\" script=\"Detect-WDAC.ps1\" version=\"2.1.0\" runid=\"a3f8c9e1\" mode=\"Normal\" ps_version=\"7.4.2\">\n",
+        "<![LOG[Detection Phase]LOG]!><time=\"10:32:01.000+000\" date=\"04-13-2026\" component=\"__SECTION__\" context=\"\" type=\"1\" thread=\"0\" file=\"\" color=\"#5b9aff\">\n",
+        "<![LOG[Scanning policy files]LOG]!><time=\"10:32:01.123+000\" date=\"04-13-2026\" component=\"Detect-WDAC\" context=\"CONTOSO\\admin\" type=\"1\" thread=\"1234\" file=\"\" section=\"detection\" tag=\"phase:scan\">\n",
+        "<![LOG[Policy validation failed]LOG]!><time=\"10:32:01.456+000\" date=\"04-13-2026\" component=\"Detect-WDAC\" context=\"CONTOSO\\admin\" type=\"3\" thread=\"1234\" file=\"\" section=\"detection\">\n",
+        "<![LOG[Loop Iteration 1/3 - WDAC policies]LOG]!><time=\"10:32:02.000+000\" date=\"04-13-2026\" component=\"__ITERATION__\" context=\"\" type=\"1\" thread=\"0\" file=\"\" iteration=\"1/3\" color=\"#a78bfa\">\n",
+        "<![LOG[Processing policy contoso.xml]LOG]!><time=\"10:32:02.100+000\" date=\"04-13-2026\" component=\"Detect-WDAC\" context=\"CONTOSO\\admin\" type=\"1\" thread=\"1234\" file=\"\" section=\"detection\" iteration=\"1/3\">\n",
+        "<![LOG[Would apply policy contoso.xml]LOG]!><time=\"10:32:02.200+000\" date=\"04-13-2026\" component=\"Detect-WDAC\" context=\"CONTOSO\\admin\" type=\"1\" thread=\"1234\" file=\"\" section=\"detection\" whatif=\"1\">\n",
+    )
+}
+
+/// Helper: parse the fixture and return entries + parse_errors via `parse_file`.
+fn parse_fixture(file_name: &str, content: &str) -> TempLogFixtureResult {
+    let fixture = TempLogFixture::new(file_name, content);
+    let path_str = fixture.path.to_string_lossy().to_string();
+    let (result, selection) =
+        app_lib::parser::parse_file(&path_str).expect("fixture should parse successfully");
+
+    // Snapshot entries into owned structs so we don't depend on private type names.
+    let entries: Vec<EntrySnapshot> = result
+        .entries
+        .iter()
+        .map(|e| EntrySnapshot {
+            message: e.message.clone(),
+            component: e.component.clone(),
+            entry_kind: format!("{:?}", e.entry_kind),
+            format: format!("{:?}", e.format),
+            severity: format!("{:?}", e.severity),
+            section_name: e.section_name.clone(),
+            section_color: e.section_color.clone(),
+            iteration: e.iteration.clone(),
+            whatif: e.whatif,
+            tags: e.tags.clone(),
+        })
+        .collect();
+
+    TempLogFixtureResult {
+        entry_count: result.entries.len(),
+        parse_errors: result.parse_errors,
+        entries,
+        selection_parser: format!("{:?}", selection.parser),
+        selection_implementation: format!("{:?}", selection.implementation),
+        selection_provenance: format!("{:?}", selection.provenance),
+        selection_parse_quality: format!("{:?}", selection.parse_quality),
+        selection_record_framing: format!("{:?}", selection.record_framing),
+        _fixture: fixture,
+    }
+}
+
+#[allow(dead_code)]
+struct EntrySnapshot {
+    message: String,
+    component: Option<String>,
+    entry_kind: String,
+    format: String,
+    severity: String,
+    section_name: Option<String>,
+    section_color: Option<String>,
+    iteration: Option<String>,
+    whatif: Option<bool>,
+    tags: Option<Vec<String>>,
+}
+
+#[allow(dead_code)]
+struct TempLogFixtureResult {
+    entry_count: usize,
+    parse_errors: u32,
+    entries: Vec<EntrySnapshot>,
+    selection_parser: String,
+    selection_implementation: String,
+    selection_provenance: String,
+    selection_parse_quality: String,
+    selection_record_framing: String,
+    // Hold fixture alive so temp files aren't cleaned up before assertions.
+    _fixture: TempLogFixture,
+}
+
+// Test 1: .cmtlog extension triggers CmtLog parser detection
+#[test]
+fn cmtlog_extension_triggers_cmtlog_parser() {
+    let fixture = TempLogFixture::new("test.cmtlog", fixture_content());
+    let selection = fixture.detect();
+
+    assert_eq!(format!("{:?}", selection.parser), "CmtLog");
+    assert_eq!(format!("{:?}", selection.implementation), "CmtLog");
+    assert_eq!(format!("{:?}", selection.provenance), "Dedicated");
+    assert_eq!(format!("{:?}", selection.parse_quality), "Structured");
+    assert_eq!(format!("{:?}", selection.record_framing), "PhysicalLine");
+}
+
+// Test 2: Header entry parsed with EntryKind::Header
+#[test]
+fn header_entry_parsed_correctly() {
+    let result = parse_fixture("test.cmtlog", fixture_content());
+
+    assert_eq!(result.entries[0].entry_kind, "Some(Header)");
+    assert_eq!(result.entries[0].format, "CmtLog");
+    assert_eq!(
+        result.entries[0].message,
+        "Script started: Detect-WDAC.ps1 v2.1.0"
+    );
+    assert_eq!(result.entries[0].component.as_deref(), Some("__HEADER__"));
+}
+
+// Test 3: Section entry parsed with EntryKind::Section and correct color
+#[test]
+fn section_entry_parsed_with_color() {
+    let result = parse_fixture("test.cmtlog", fixture_content());
+
+    assert_eq!(result.entries[1].entry_kind, "Some(Section)");
+    assert_eq!(
+        result.entries[1].section_name.as_deref(),
+        Some("Detection Phase")
+    );
+    assert_eq!(
+        result.entries[1].section_color.as_deref(),
+        Some("#5b9aff")
+    );
+}
+
+// Test 4: Iteration entry parsed with EntryKind::Iteration and iteration string
+#[test]
+fn iteration_entry_parsed_correctly() {
+    let result = parse_fixture("test.cmtlog", fixture_content());
+
+    assert_eq!(result.entries[4].entry_kind, "Some(Iteration)");
+    assert_eq!(result.entries[4].iteration.as_deref(), Some("1/3"));
+    // Iteration has its own explicit color
+    assert_eq!(
+        result.entries[4].section_color.as_deref(),
+        Some("#a78bfa")
+    );
+}
+
+// Test 5: Regular entries have EntryKind::Log with section_name propagated
+#[test]
+fn regular_entries_have_section_propagated() {
+    let result = parse_fixture("test.cmtlog", fixture_content());
+
+    // Entry 2 (index 2): "Scanning policy files" — has explicit section="detection"
+    assert_eq!(result.entries[2].entry_kind, "Some(Log)");
+    assert_eq!(
+        result.entries[2].section_name.as_deref(),
+        Some("detection")
+    );
+    // Section color is inherited from the current section
+    assert_eq!(
+        result.entries[2].section_color.as_deref(),
+        Some("#5b9aff")
+    );
+
+    // Entry 5 (index 5): "Processing policy contoso.xml" — has explicit section="detection"
+    assert_eq!(result.entries[5].entry_kind, "Some(Log)");
+    assert_eq!(
+        result.entries[5].section_name.as_deref(),
+        Some("detection")
+    );
+    assert_eq!(result.entries[5].iteration.as_deref(), Some("1/3"));
+}
+
+// Test 6: WhatIf flag parsed correctly
+#[test]
+fn whatif_flag_parsed() {
+    let result = parse_fixture("test.cmtlog", fixture_content());
+
+    // Entry 6 (index 6): "Would apply policy contoso.xml" — whatif="1"
+    assert_eq!(result.entries[6].whatif, Some(true));
+    // Entry 2 (index 2): "Scanning policy files" — no whatif attr
+    assert_eq!(result.entries[2].whatif, None);
+}
+
+// Test 7: Severity mapped correctly (type="3" -> Error)
+#[test]
+fn severity_mapped_correctly() {
+    let result = parse_fixture("test.cmtlog", fixture_content());
+
+    // Entry 3 (index 3): "Policy validation failed" — type="3"
+    assert_eq!(result.entries[3].severity, "Error");
+    // Entry 0 (index 0): Header — type="1"
+    assert_eq!(result.entries[0].severity, "Info");
+}
+
+// Test 8: Total entry count = 7
+#[test]
+fn total_entry_count() {
+    let result = parse_fixture("test.cmtlog", fixture_content());
+
+    assert_eq!(result.entry_count, 7);
+    assert_eq!(result.parse_errors, 0);
+}
+
+// Test 9: Content fallback detection (.log file with __SECTION__ component -> CmtLog)
+#[test]
+fn content_fallback_detection() {
+    let fixture = TempLogFixture::new("script-output.log", fixture_content());
+    let selection = fixture.detect();
+
+    assert_eq!(format!("{:?}", selection.parser), "CmtLog");
+    assert_eq!(format!("{:?}", selection.implementation), "CmtLog");
+    assert_eq!(format!("{:?}", selection.provenance), "Heuristic");
+    assert_eq!(format!("{:?}", selection.parse_quality), "Structured");
+}

--- a/src-tauri/tests/fixtures/cmtlog/basic.cmtlog
+++ b/src-tauri/tests/fixtures/cmtlog/basic.cmtlog
@@ -1,0 +1,7 @@
+<![LOG[Script started: Detect-WDAC.ps1 v2.1.0]LOG]!><time="10:30:00.000+000" date="04-13-2026" component="__HEADER__" context="" type="1" thread="0" file="" script="Detect-WDAC.ps1" version="2.1.0" runid="a3f8c9e1" mode="Normal" ps_version="7.4.2">
+<![LOG[Detection Phase]LOG]!><time="10:32:01.000+000" date="04-13-2026" component="__SECTION__" context="" type="1" thread="0" file="" color="#5b9aff">
+<![LOG[Scanning policy files]LOG]!><time="10:32:01.123+000" date="04-13-2026" component="Detect-WDAC" context="CONTOSO\admin" type="1" thread="1234" file="" section="detection" tag="phase:scan">
+<![LOG[Policy validation failed]LOG]!><time="10:32:01.456+000" date="04-13-2026" component="Detect-WDAC" context="CONTOSO\admin" type="3" thread="1234" file="" section="detection">
+<![LOG[Loop Iteration 1/3 - WDAC policies]LOG]!><time="10:32:02.000+000" date="04-13-2026" component="__ITERATION__" context="" type="1" thread="0" file="" iteration="1/3" color="#a78bfa">
+<![LOG[Processing policy contoso.xml]LOG]!><time="10:32:02.100+000" date="04-13-2026" component="Detect-WDAC" context="CONTOSO\admin" type="1" thread="1234" file="" section="detection" iteration="1/3">
+<![LOG[Would apply policy contoso.xml]LOG]!><time="10:32:02.200+000" date="04-13-2026" component="Detect-WDAC" context="CONTOSO\admin" type="1" thread="1234" file="" section="detection" whatif="1">

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -197,7 +197,8 @@ export function LogListView() {
   const setMarkerCategory = useMarkerStore((s) => s.setMarkerCategory);
   const markerCategories = useMarkerStore((s) => s.categories);
 
-  const activeFilePath = openFilePath ?? "";
+  // Use openFilePath if set, otherwise derive from the first entry's filePath
+  const activeFilePath = openFilePath ?? (entries.length > 0 ? entries[0].filePath : "");
   const fileMarkers: Map<number, Marker> = useMemo(
     () => markersByFile.get(activeFilePath) ?? new Map(),
     [markersByFile, activeFilePath]

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -12,6 +12,7 @@ import { useLogStore } from "../../stores/log-store";
 import { useUiStore } from "../../stores/ui-store";
 import { useFilterStore } from "../../stores/filter-store";
 import { LogRow } from "./LogRow";
+import { SectionDividerRow } from "./SectionDividerRow";
 import { MergeLegendBar } from "./MergeLegendBar";
 import type { ErrorCodeSpan } from "../../types/log";
 import { useContextMenu } from "../../hooks/use-context-menu";
@@ -159,6 +160,29 @@ export function LogListView() {
     () => getLogListMetrics(logListFontSize),
     [logListFontSize]
   );
+
+  // ── Section color auto-assignment ────────────────────────────────────
+  const SECTION_PALETTE = useMemo(() => [
+    "#3b82f6", "#a78bfa", "#f59e0b", "#10b981",
+    "#ef4444", "#ec4899", "#06b6d4", "#84cc16",
+  ], []);
+
+  const sectionColorMap = useMemo(() => {
+    const map = new Map<string, string>();
+    let paletteIndex = 0;
+    for (const entry of displayEntries) {
+      if (
+        (entry.entryKind === "Section" || entry.entryKind === "Iteration") &&
+        entry.sectionName &&
+        !map.has(entry.sectionName)
+      ) {
+        const color = entry.sectionColor ?? SECTION_PALETTE[paletteIndex % SECTION_PALETTE.length];
+        map.set(entry.sectionName, color);
+        if (!entry.sectionColor) paletteIndex++;
+      }
+    }
+    return map;
+  }, [displayEntries, SECTION_PALETTE]);
 
   const { showContextMenu } = useContextMenu();
 
@@ -459,6 +483,14 @@ export function LogListView() {
         >
           {virtualizer.getVirtualItems().map((virtualRow) => {
             const entry = displayEntries[virtualRow.index];
+            const isSectionDivider =
+              entry.entryKind === "Section" || entry.entryKind === "Iteration";
+
+            // Resolve section band color for regular rows
+            const sectionBandColor = !isSectionDivider && entry.sectionName
+              ? (entry.sectionColor ?? sectionColorMap.get(entry.sectionName) ?? null)
+              : null;
+
             return (
               <div
                 key={entry.id}
@@ -471,25 +503,40 @@ export function LogListView() {
                   transform: `translateY(${virtualRow.start}px)`,
                 }}
               >
-                <LogRow
-                  entry={entry}
-                  rowDomId={`log-list-row-${entry.id}`}
-                  isSelected={entry.id === selectedId}
-                  isFindMatch={findMatchSet.has(entry.id)}
-                  visibleColumns={visibleColumns}
-                  gridTemplateColumns={gridTemplateColumns}
-                  listFontSize={listMetrics.fontSize}
-                  rowLineHeight={listMetrics.rowLineHeight}
-                  severityPalette={severityPalette}
-                  highlightText={highlightText}
-                  highlightCaseSensitive={highlightCaseSensitive}
-                  onClick={(id) => { if (id !== selectedId) { suppressScrollRef.current = true; } selectEntry(id); }}
-                  onContextMenu={showContextMenu}
-                  onErrorCodeClick={handleErrorCodeClick}
-                  mergeFileColor={sourceOpenMode === "merged" ? mergedTabState?.colorAssignments[entry.filePath] ?? null : null}
-                  isCorrelated={sourceOpenMode === "merged" && correlatedIdSet.has(entry.id)}
-                  correlationColor={sourceOpenMode === "merged" ? mergedTabState?.colorAssignments[entry.filePath] ?? null : null}
-                />
+                {isSectionDivider ? (
+                  <SectionDividerRow
+                    entry={entry}
+                    resolvedColor={
+                      entry.sectionColor ??
+                      sectionColorMap.get(entry.sectionName ?? entry.message) ??
+                      "#3b82f6"
+                    }
+                    listFontSize={listMetrics.fontSize}
+                    rowLineHeight={listMetrics.rowLineHeight}
+                    onClick={(id) => { if (id !== selectedId) { suppressScrollRef.current = true; } selectEntry(id); }}
+                  />
+                ) : (
+                  <LogRow
+                    entry={entry}
+                    rowDomId={`log-list-row-${entry.id}`}
+                    isSelected={entry.id === selectedId}
+                    isFindMatch={findMatchSet.has(entry.id)}
+                    visibleColumns={visibleColumns}
+                    gridTemplateColumns={gridTemplateColumns}
+                    listFontSize={listMetrics.fontSize}
+                    rowLineHeight={listMetrics.rowLineHeight}
+                    severityPalette={severityPalette}
+                    highlightText={highlightText}
+                    highlightCaseSensitive={highlightCaseSensitive}
+                    onClick={(id) => { if (id !== selectedId) { suppressScrollRef.current = true; } selectEntry(id); }}
+                    onContextMenu={showContextMenu}
+                    onErrorCodeClick={handleErrorCodeClick}
+                    mergeFileColor={sourceOpenMode === "merged" ? mergedTabState?.colorAssignments[entry.filePath] ?? null : null}
+                    isCorrelated={sourceOpenMode === "merged" && correlatedIdSet.has(entry.id)}
+                    correlationColor={sourceOpenMode === "merged" ? mergedTabState?.colorAssignments[entry.filePath] ?? null : null}
+                    sectionBandColor={sectionBandColor}
+                  />
+                )}
               </div>
             );
           })}

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -18,6 +18,7 @@ import type { ErrorCodeSpan } from "../../types/log";
 import type { Marker } from "../../types/markers";
 import { useMarkerStore } from "../../stores/marker-store";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { formatLogEntryTimestamp } from "../../lib/date-time-format";
 import { useContextMenu } from "../../hooks/use-context-menu";
 import { ArrowBidirectionalLeftRightRegular } from "@fluentui/react-icons";
 import {
@@ -289,11 +290,24 @@ export function LogListView() {
 
   const handleCopySelected = useCallback(() => {
     if (selectedIds.size === 0) return;
-    // Preserve display order
-    const messages = displayEntries
-      .filter((e) => selectedIds.has(e.id))
-      .map((e) => e.message);
-    writeText(messages.join("\n")).catch(console.error);
+    const selected = displayEntries.filter((e) => selectedIds.has(e.id));
+    if (selected.length === 0) return;
+
+    let text: string;
+    if (selected.length === 1) {
+      // Single entry: tab-separated format matching legacy Ctrl+C behavior
+      const entry = selected[0];
+      text = [
+        entry.message,
+        entry.component ?? "",
+        formatLogEntryTimestamp(entry) ?? "",
+        entry.threadDisplay ?? "",
+      ].join("\t");
+    } else {
+      // Multi-select: plain messages, one per line
+      text = selected.map((e) => e.message).join("\n");
+    }
+    writeText(text).catch(console.error);
   }, [selectedIds, displayEntries]);
 
   const handleCopyByCategory = useCallback(

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -15,6 +15,8 @@ import { LogRow } from "./LogRow";
 import { SectionDividerRow } from "./SectionDividerRow";
 import { MergeLegendBar } from "./MergeLegendBar";
 import type { ErrorCodeSpan } from "../../types/log";
+import type { Marker } from "../../types/markers";
+import { useMarkerStore } from "../../stores/marker-store";
 import { useContextMenu } from "../../hooks/use-context-menu";
 import { ArrowBidirectionalLeftRightRegular } from "@fluentui/react-icons";
 import {
@@ -52,6 +54,7 @@ export function LogListView() {
   const sourceOpenMode = useLogStore((s) => s.sourceOpenMode);
   const mergedTabState = useLogStore((s) => s.mergedTabState);
   const correlatedEntries = useLogStore((s) => s.correlatedEntries);
+  const openFilePath = useLogStore((s) => s.openFilePath);
 
   const logListFontSize = useUiStore((s) => s.logListFontSize);
   const themeId = useUiStore((s) => s.themeId);
@@ -184,6 +187,54 @@ export function LogListView() {
     return map;
   }, [displayEntries, SECTION_PALETTE]);
 
+  // ── Marker store wiring ───────────────────────────────────────────────
+  const markersByFile = useMarkerStore((s) => s.markersByFile);
+  const loadMarkers = useMarkerStore((s) => s.loadMarkers);
+  const saveMarkers = useMarkerStore((s) => s.saveMarkers);
+  const toggleMarker = useMarkerStore((s) => s.toggleMarker);
+  const setMarkerCategory = useMarkerStore((s) => s.setMarkerCategory);
+  const markerCategories = useMarkerStore((s) => s.categories);
+
+  const activeFilePath = openFilePath ?? "";
+  const fileMarkers: Map<number, Marker> = useMemo(
+    () => markersByFile.get(activeFilePath) ?? new Map(),
+    [markersByFile, activeFilePath]
+  );
+
+  // Load markers when tab changes
+  useEffect(() => {
+    if (activeFilePath) {
+      loadMarkers(activeFilePath);
+    }
+  }, [activeFilePath, loadMarkers]);
+
+  // Auto-save markers on changes with 1-second debounce
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!activeFilePath) return;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      saveMarkers(activeFilePath);
+    }, 1000);
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, [fileMarkers, activeFilePath, saveMarkers]);
+
+  const handleToggleMarker = useCallback(
+    (lineId: number) => {
+      if (activeFilePath) toggleMarker(activeFilePath, lineId);
+    },
+    [activeFilePath, toggleMarker]
+  );
+
+  const handleSetMarkerCategory = useCallback(
+    (lineId: number, category: string) => {
+      if (activeFilePath) setMarkerCategory(activeFilePath, lineId, category);
+    },
+    [activeFilePath, setMarkerCategory]
+  );
+
   const { showContextMenu } = useContextMenu();
 
   const handleErrorCodeClick = useCallback((span: ErrorCodeSpan) => {
@@ -247,7 +298,6 @@ export function LogListView() {
 
   // ── Consume pending scroll target from deployment workspace ────────
   const pendingScrollTarget = useLogStore((s) => s.pendingScrollTarget);
-  const openFilePath = useLogStore((s) => s.openFilePath);
 
   useEffect(() => {
     if (!pendingScrollTarget) return;
@@ -414,7 +464,7 @@ export function LogListView() {
       <div
         style={{
           display: "grid",
-          gridTemplateColumns,
+          gridTemplateColumns: `20px ${gridTemplateColumns}`,
           backgroundColor: tokens.colorNeutralBackground4,
           borderBottom: `2px solid ${tokens.colorNeutralStroke2}`,
           fontSize: `${listMetrics.headerFontSize}px`,
@@ -427,6 +477,8 @@ export function LogListView() {
           paddingRight: `${scrollbarWidth}px`,
         }}
       >
+        {/* Gutter header spacer */}
+        <div style={{ width: 20 }} />
         {visibleColumns.map((col, i) => (
           <HeaderCell
             key={col.id}
@@ -466,6 +518,15 @@ export function LogListView() {
         onFocus={() => setHasKeyboardFocus(true)}
         onBlur={() => setHasKeyboardFocus(false)}
         onMouseDown={() => parentRef.current?.focus()}
+        onKeyDown={(e) => {
+          // Ctrl+M / Cmd+M: toggle marker on selected row
+          if ((e.ctrlKey || e.metaKey) && e.key === "m") {
+            e.preventDefault();
+            if (selectedId !== null) {
+              handleToggleMarker(selectedId);
+            }
+          }
+        }}
         style={{
           flex: 1,
           overflow: "auto",
@@ -535,6 +596,10 @@ export function LogListView() {
                     isCorrelated={sourceOpenMode === "merged" && correlatedIdSet.has(entry.id)}
                     correlationColor={sourceOpenMode === "merged" ? mergedTabState?.colorAssignments[entry.filePath] ?? null : null}
                     sectionBandColor={sectionBandColor}
+                    marker={fileMarkers.get(entry.id) ?? null}
+                    onToggleMarker={handleToggleMarker}
+                    onSetMarkerCategory={handleSetMarkerCategory}
+                    markerCategories={markerCategories}
                   />
                 )}
               </div>

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -190,6 +190,7 @@ export function LogListView() {
   }, [displayEntries, SECTION_PALETTE]);
 
   // ── Marker store wiring ───────────────────────────────────────────────
+  const isMerged = sourceOpenMode === "merged";
   const markersByFile = useMarkerStore((s) => s.markersByFile);
   const loadMarkers = useMarkerStore((s) => s.loadMarkers);
   const saveMarkers = useMarkerStore((s) => s.saveMarkers);
@@ -200,47 +201,74 @@ export function LogListView() {
   // Use openFilePath if set, otherwise derive from the first entry's filePath
   const activeFilePath = openFilePath ?? (entries.length > 0 ? entries[0].filePath : "");
   const fileMarkers: Map<number, Marker> = useMemo(
-    () => markersByFile.get(activeFilePath) ?? new Map(),
-    [markersByFile, activeFilePath]
+    () => isMerged ? new Map() : (markersByFile.get(activeFilePath) ?? new Map()),
+    [markersByFile, activeFilePath, isMerged]
   );
 
-  // Load markers when tab changes
+  // Load markers when tab changes (skip in merged mode)
   useEffect(() => {
+    if (isMerged) return;
     if (activeFilePath) {
       loadMarkers(activeFilePath);
     }
-  }, [activeFilePath, loadMarkers]);
+  }, [activeFilePath, loadMarkers, isMerged]);
 
-  // Auto-save markers on changes with 1-second debounce
+  // Auto-save markers on changes with 1-second debounce.
+  // markersDirtyRef prevents save from firing after loadMarkers hydrates state.
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const markersDirtyRef = useRef(false);
   useEffect(() => {
+    if (isMerged) return;
     if (!activeFilePath) return;
+    if (!markersDirtyRef.current) return;
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
       saveMarkers(activeFilePath);
+      markersDirtyRef.current = false;
     }, 1000);
     return () => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     };
-  }, [fileMarkers, activeFilePath, saveMarkers]);
+  }, [fileMarkers, activeFilePath, saveMarkers, isMerged]);
 
   const handleToggleMarker = useCallback(
     (lineId: number) => {
-      if (activeFilePath) toggleMarker(activeFilePath, lineId);
+      if (isMerged) return;
+      if (activeFilePath) {
+        markersDirtyRef.current = true;
+        toggleMarker(activeFilePath, lineId);
+      }
     },
-    [activeFilePath, toggleMarker]
+    [activeFilePath, toggleMarker, isMerged]
   );
 
   const handleSetMarkerCategory = useCallback(
     (lineId: number, category: string) => {
-      if (activeFilePath) setMarkerCategory(activeFilePath, lineId, category);
+      if (isMerged) return;
+      if (activeFilePath) {
+        markersDirtyRef.current = true;
+        setMarkerCategory(activeFilePath, lineId, category);
+      }
     },
-    [activeFilePath, setMarkerCategory]
+    [activeFilePath, setMarkerCategory, isMerged]
   );
 
   // ── Multi-select state ─────────────────────────────────────────────
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const lastClickedIdRef = useRef<number | null>(null);
+  /** Tracks whether the last selection change came from a mouse interaction. */
+  const mouseSelectRef = useRef(false);
+
+  // Sync selectedIds when selectedId changes from keyboard navigation
+  useEffect(() => {
+    if (mouseSelectRef.current) {
+      mouseSelectRef.current = false;
+      return;
+    }
+    if (selectedId !== null) {
+      setSelectedIds(new Set([selectedId]));
+    }
+  }, [selectedId]);
 
   const handleRowClick = useCallback(
     (id: number, event: React.MouseEvent) => {
@@ -280,6 +308,9 @@ export function LogListView() {
         lastClickedIdRef.current = id;
       }
 
+      // Mark as mouse-driven so the selectedId sync effect skips
+      mouseSelectRef.current = true;
+
       // Always update the details pane via the store's single-selection
       if (id !== selectedId) {
         suppressScrollRef.current = true;
@@ -310,25 +341,6 @@ export function LogListView() {
     }
     writeText(text).catch(console.error);
   }, [selectedIds, displayEntries]);
-
-  const handleCopyByCategory = useCallback(
-    (categoryId: string) => {
-      const markerMap = fileMarkers;
-      const messages = displayEntries
-        .filter((e) => {
-          const m = markerMap.get(e.id);
-          return m && m.category === categoryId;
-        })
-        .map((e) => e.message);
-      if (messages.length > 0) {
-        writeText(messages.join("\n")).catch(console.error);
-      }
-    },
-    [displayEntries, fileMarkers]
-  );
-
-  // Keep selectedIds unused variable from being stale; suppress ESLint warning
-  void handleCopyByCategory;
 
   const { showContextMenu } = useContextMenu();
 
@@ -703,10 +715,10 @@ export function LogListView() {
                     isCorrelated={sourceOpenMode === "merged" && correlatedIdSet.has(entry.id)}
                     correlationColor={sourceOpenMode === "merged" ? mergedTabState?.colorAssignments[entry.filePath] ?? null : null}
                     sectionBandColor={sectionBandColor}
-                    marker={fileMarkers.get(entry.id) ?? null}
+                    marker={isMerged ? null : (fileMarkers.get(entry.id) ?? null)}
                     onToggleMarker={handleToggleMarker}
                     onSetMarkerCategory={handleSetMarkerCategory}
-                    markerCategories={markerCategories}
+                    markerCategories={isMerged ? [] : markerCategories}
                   />
                 )}
               </div>

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -17,6 +17,7 @@ import { MergeLegendBar } from "./MergeLegendBar";
 import type { ErrorCodeSpan } from "../../types/log";
 import type { Marker } from "../../types/markers";
 import { useMarkerStore } from "../../stores/marker-store";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { useContextMenu } from "../../hooks/use-context-menu";
 import { ArrowBidirectionalLeftRightRegular } from "@fluentui/react-icons";
 import {
@@ -234,6 +235,85 @@ export function LogListView() {
     },
     [activeFilePath, setMarkerCategory]
   );
+
+  // ── Multi-select state ─────────────────────────────────────────────
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const lastClickedIdRef = useRef<number | null>(null);
+
+  const handleRowClick = useCallback(
+    (id: number, event: React.MouseEvent) => {
+      const isMeta = event.metaKey || event.ctrlKey;
+      const isShift = event.shiftKey;
+
+      if (isMeta) {
+        // Ctrl/Cmd+Click: toggle additive
+        setSelectedIds((prev) => {
+          const next = new Set(prev);
+          if (next.has(id)) {
+            next.delete(id);
+          } else {
+            next.add(id);
+          }
+          return next;
+        });
+        lastClickedIdRef.current = id;
+      } else if (isShift && lastClickedIdRef.current !== null) {
+        // Shift+Click: range select
+        const lastIdx = displayEntries.findIndex(
+          (e) => e.id === lastClickedIdRef.current
+        );
+        const currentIdx = displayEntries.findIndex((e) => e.id === id);
+        if (lastIdx >= 0 && currentIdx >= 0) {
+          const start = Math.min(lastIdx, currentIdx);
+          const end = Math.max(lastIdx, currentIdx);
+          const rangeIds = new Set<number>();
+          for (let i = start; i <= end; i++) {
+            rangeIds.add(displayEntries[i].id);
+          }
+          setSelectedIds(rangeIds);
+        }
+      } else {
+        // Plain click: single select (clear others)
+        setSelectedIds(new Set([id]));
+        lastClickedIdRef.current = id;
+      }
+
+      // Always update the details pane via the store's single-selection
+      if (id !== selectedId) {
+        suppressScrollRef.current = true;
+      }
+      selectEntry(id);
+    },
+    [displayEntries, selectedId, selectEntry]
+  );
+
+  const handleCopySelected = useCallback(() => {
+    if (selectedIds.size === 0) return;
+    // Preserve display order
+    const messages = displayEntries
+      .filter((e) => selectedIds.has(e.id))
+      .map((e) => e.message);
+    writeText(messages.join("\n")).catch(console.error);
+  }, [selectedIds, displayEntries]);
+
+  const handleCopyByCategory = useCallback(
+    (categoryId: string) => {
+      const markerMap = fileMarkers;
+      const messages = displayEntries
+        .filter((e) => {
+          const m = markerMap.get(e.id);
+          return m && m.category === categoryId;
+        })
+        .map((e) => e.message);
+      if (messages.length > 0) {
+        writeText(messages.join("\n")).catch(console.error);
+      }
+    },
+    [displayEntries, fileMarkers]
+  );
+
+  // Keep selectedIds unused variable from being stale; suppress ESLint warning
+  void handleCopyByCategory;
 
   const { showContextMenu } = useContextMenu();
 
@@ -519,12 +599,23 @@ export function LogListView() {
         onBlur={() => setHasKeyboardFocus(false)}
         onMouseDown={() => parentRef.current?.focus()}
         onKeyDown={(e) => {
+          const mod = e.ctrlKey || e.metaKey;
           // Ctrl+M / Cmd+M: toggle marker on selected row
-          if ((e.ctrlKey || e.metaKey) && e.key === "m") {
+          if (mod && e.key === "m") {
             e.preventDefault();
             if (selectedId !== null) {
               handleToggleMarker(selectedId);
             }
+          }
+          // Ctrl+A / Cmd+A: select all visible entries
+          if (mod && e.key === "a") {
+            e.preventDefault();
+            setSelectedIds(new Set(displayEntries.map((entry) => entry.id)));
+          }
+          // Ctrl+C / Cmd+C: copy selected entries
+          if (mod && e.key === "c") {
+            e.preventDefault();
+            handleCopySelected();
           }
         }}
         style={{
@@ -581,6 +672,7 @@ export function LogListView() {
                     entry={entry}
                     rowDomId={`log-list-row-${entry.id}`}
                     isSelected={entry.id === selectedId}
+                    isMultiSelected={selectedIds.has(entry.id)}
                     isFindMatch={findMatchSet.has(entry.id)}
                     visibleColumns={visibleColumns}
                     gridTemplateColumns={gridTemplateColumns}
@@ -589,7 +681,7 @@ export function LogListView() {
                     severityPalette={severityPalette}
                     highlightText={highlightText}
                     highlightCaseSensitive={highlightCaseSensitive}
-                    onClick={(id) => { if (id !== selectedId) { suppressScrollRef.current = true; } selectEntry(id); }}
+                    onClick={handleRowClick}
                     onContextMenu={showContextMenu}
                     onErrorCodeClick={handleErrorCodeClick}
                     mergeFileColor={sourceOpenMode === "merged" ? mergedTabState?.colorAssignments[entry.filePath] ?? null : null}

--- a/src/components/log-view/LogRow.tsx
+++ b/src/components/log-view/LogRow.tsx
@@ -315,6 +315,7 @@ export const LogRow = memo(function LogRow({
         ...(backgroundOverlays.length > 0
           ? { backgroundImage: backgroundOverlays.join(", ") }
           : {}),
+        ...(entry.whatif ? { opacity: 0.6 } : {}),
       }}
       onClick={() => onClick(entry.id)}
       onContextMenu={(e) => onContextMenu(entry, e)}
@@ -444,7 +445,7 @@ export const LogRow = memo(function LogRow({
       )}
 
       {visibleColumns.map((col) => {
-        // Severity column: colored dot indicator
+        // Severity column: colored dot indicator + WhatIf badge
         if (col.id === "severity") {
           return (
             <div
@@ -454,6 +455,7 @@ export const LogRow = memo(function LogRow({
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
+                gap: 2,
                 overflow: "hidden",
                 padding: "1px 2px",
               }}
@@ -471,6 +473,23 @@ export const LogRow = memo(function LogRow({
                   flexShrink: 0,
                 }}
               />
+              {entry.whatif && (
+                <span
+                  style={{
+                    fontSize: 9,
+                    fontWeight: 600,
+                    lineHeight: "12px",
+                    padding: "0 3px",
+                    borderRadius: 3,
+                    backgroundColor: "#9333ea33",
+                    color: "#9333ea",
+                    whiteSpace: "nowrap",
+                    flexShrink: 0,
+                  }}
+                >
+                  WhatIf
+                </span>
+              )}
             </div>
           );
         }
@@ -486,6 +505,7 @@ export const LogRow = memo(function LogRow({
                 overflow: "hidden",
                 textOverflow: "ellipsis",
                 padding: "1px 4px",
+                ...(entry.whatif ? { fontStyle: "italic" } : {}),
               }}
             >
               {renderMessageWithSpans(

--- a/src/components/log-view/LogRow.tsx
+++ b/src/components/log-view/LogRow.tsx
@@ -23,6 +23,7 @@ interface LogRowProps {
   mergeFileColor?: string | null;
   isCorrelated?: boolean;
   correlationColor?: string | null;
+  sectionBandColor?: string | null;
 }
 
 /** Subtle tint for find-match rows (not the active selection). */
@@ -240,8 +241,18 @@ export const LogRow = memo(function LogRow({
   mergeFileColor,
   isCorrelated,
   correlationColor,
+  sectionBandColor,
 }: LogRowProps) {
   const style = getRowStyle(entry, isSelected, isFindMatch, severityPalette);
+
+  // Determine left-edge indicator: mergeFileColor > sectionBandColor > default
+  const leftBorderColor = mergeFileColor
+    ? mergeFileColor
+    : sectionBandColor
+      ? sectionBandColor
+      : isSelected
+        ? tokens.colorNeutralForegroundOnBrand
+        : "transparent";
 
   return (
     <div
@@ -261,9 +272,7 @@ export const LogRow = memo(function LogRow({
         lineHeight: `${rowLineHeight}px`,
         whiteSpace: "nowrap",
         transition: "filter 80ms linear",
-        boxShadow: mergeFileColor
-          ? `inset 3px 0 0 ${mergeFileColor}`
-          : `inset 3px 0 0 ${isSelected ? tokens.colorNeutralForegroundOnBrand : "transparent"}`,
+        boxShadow: `inset 4px 0 0 ${leftBorderColor}`,
         ...(isCorrelated && correlationColor && !isSelected ? {
           backgroundImage: `linear-gradient(${correlationColor}30, ${correlationColor}30)`,
         } : {}),

--- a/src/components/log-view/LogRow.tsx
+++ b/src/components/log-view/LogRow.tsx
@@ -1,5 +1,6 @@
 import { tokens } from "@fluentui/react-components";
 import type { LogEntry, ErrorCodeSpan, Severity } from "../../types/log";
+import type { Marker, MarkerCategory } from "../../types/markers";
 import type { LogSeverityPalette } from "../../lib/constants";
 import type { ColumnDefinition } from "../../lib/column-config";
 import { formatLogEntryTimestamp } from "../../lib/date-time-format";
@@ -24,6 +25,10 @@ interface LogRowProps {
   isCorrelated?: boolean;
   correlationColor?: string | null;
   sectionBandColor?: string | null;
+  marker?: Marker | null;
+  onToggleMarker?: (lineId: number) => void;
+  onSetMarkerCategory?: (lineId: number, category: string) => void;
+  markerCategories?: MarkerCategory[];
 }
 
 /** Subtle tint for find-match rows (not the active selection). */
@@ -221,7 +226,7 @@ const detailCellStyle: React.CSSProperties = {
   borderLeft: `1px solid ${tokens.colorNeutralStroke1}`,
 };
 
-import { memo } from "react";
+import { memo, useState, useCallback } from "react";
 
 export const LogRow = memo(function LogRow({
   entry,
@@ -242,17 +247,49 @@ export const LogRow = memo(function LogRow({
   isCorrelated,
   correlationColor,
   sectionBandColor,
+  marker,
+  onToggleMarker,
+  onSetMarkerCategory,
+  markerCategories,
 }: LogRowProps) {
   const style = getRowStyle(entry, isSelected, isFindMatch, severityPalette);
 
-  // Determine left-edge indicator: mergeFileColor > sectionBandColor > default
-  const leftBorderColor = mergeFileColor
-    ? mergeFileColor
-    : sectionBandColor
-      ? sectionBandColor
-      : isSelected
-        ? tokens.colorNeutralForegroundOnBrand
-        : "transparent";
+  // ── Marker gutter context menu ────────────────────────────────────
+  const [gutterMenu, setGutterMenu] = useState<{ x: number; y: number } | null>(null);
+
+  const handleGutterContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setGutterMenu({ x: e.clientX, y: e.clientY });
+    },
+    []
+  );
+
+  const closeGutterMenu = useCallback(() => setGutterMenu(null), []);
+
+  // Determine left-edge indicator: marker > mergeFileColor > sectionBandColor > default
+  const leftBorderColor = marker
+    ? marker.color
+    : mergeFileColor
+      ? mergeFileColor
+      : sectionBandColor
+        ? sectionBandColor
+        : isSelected
+          ? tokens.colorNeutralForegroundOnBrand
+          : "transparent";
+
+  // Marker tint: subtle background in marker color (~9% opacity)
+  const markerTint = marker && !isSelected
+    ? `linear-gradient(${marker.color}17, ${marker.color}17)`
+    : undefined;
+
+  // Combine background overlays
+  const backgroundOverlays: string[] = [];
+  if (markerTint) backgroundOverlays.push(markerTint);
+  if (isCorrelated && correlationColor && !isSelected) {
+    backgroundOverlays.push(`linear-gradient(${correlationColor}30, ${correlationColor}30)`);
+  }
 
   return (
     <div
@@ -264,7 +301,7 @@ export const LogRow = memo(function LogRow({
       style={{
         ...style,
         display: "grid",
-        gridTemplateColumns,
+        gridTemplateColumns: `20px ${gridTemplateColumns}`,
         cursor: "pointer",
         borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
         fontSize: `${listFontSize}px`,
@@ -272,14 +309,140 @@ export const LogRow = memo(function LogRow({
         lineHeight: `${rowLineHeight}px`,
         whiteSpace: "nowrap",
         transition: "filter 80ms linear",
-        boxShadow: `inset 4px 0 0 ${leftBorderColor}`,
-        ...(isCorrelated && correlationColor && !isSelected ? {
-          backgroundImage: `linear-gradient(${correlationColor}30, ${correlationColor}30)`,
-        } : {}),
+        boxShadow: marker
+          ? `inset 3px 0 0 ${leftBorderColor}`
+          : `inset 4px 0 0 ${leftBorderColor}`,
+        ...(backgroundOverlays.length > 0
+          ? { backgroundImage: backgroundOverlays.join(", ") }
+          : {}),
       }}
       onClick={() => onClick(entry.id)}
       onContextMenu={(e) => onContextMenu(entry, e)}
     >
+      {/* Marker gutter */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 20,
+          cursor: "pointer",
+          flexShrink: 0,
+        }}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleMarker?.(entry.id);
+        }}
+        onContextMenu={handleGutterContextMenu}
+      >
+        <span
+          style={{
+            display: "inline-block",
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            backgroundColor: marker ? marker.color : "transparent",
+            border: marker ? "none" : `1px solid ${tokens.colorNeutralStroke2}`,
+            flexShrink: 0,
+          }}
+        />
+      </div>
+
+      {/* Gutter context menu (positioned overlay) */}
+      {gutterMenu && markerCategories && (
+        <div
+          style={{
+            position: "fixed",
+            top: gutterMenu.y,
+            left: gutterMenu.x,
+            zIndex: 9999,
+            backgroundColor: tokens.colorNeutralBackground1,
+            border: `1px solid ${tokens.colorNeutralStroke1}`,
+            borderRadius: 4,
+            boxShadow: "0 4px 12px rgba(0,0,0,0.2)",
+            padding: "4px 0",
+            minWidth: 140,
+          }}
+          onMouseLeave={closeGutterMenu}
+        >
+          {markerCategories.map((cat) => (
+            <div
+              key={cat.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "4px 12px",
+                cursor: "pointer",
+                fontSize: `${listFontSize}px`,
+                lineHeight: `${rowLineHeight}px`,
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLElement).style.backgroundColor =
+                  tokens.colorNeutralBackground1Hover;
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLElement).style.backgroundColor = "transparent";
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!marker) {
+                  // First toggle it on, then set category
+                  onToggleMarker?.(entry.id);
+                }
+                onSetMarkerCategory?.(entry.id, cat.id);
+                closeGutterMenu();
+              }}
+            >
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  backgroundColor: cat.color,
+                  flexShrink: 0,
+                }}
+              />
+              <span>{cat.label}</span>
+            </div>
+          ))}
+          {marker && (
+            <>
+              <div
+                style={{
+                  borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
+                  margin: "4px 0",
+                }}
+              />
+              <div
+                style={{
+                  padding: "4px 12px",
+                  cursor: "pointer",
+                  fontSize: `${listFontSize}px`,
+                  lineHeight: `${rowLineHeight}px`,
+                  color: tokens.colorPaletteRedForeground1,
+                }}
+                onMouseEnter={(e) => {
+                  (e.currentTarget as HTMLElement).style.backgroundColor =
+                    tokens.colorNeutralBackground1Hover;
+                }}
+                onMouseLeave={(e) => {
+                  (e.currentTarget as HTMLElement).style.backgroundColor = "transparent";
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleMarker?.(entry.id);
+                  closeGutterMenu();
+                }}
+              >
+                Remove Marker
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
       {visibleColumns.map((col) => {
         // Severity column: colored dot indicator
         if (col.id === "severity") {

--- a/src/components/log-view/LogRow.tsx
+++ b/src/components/log-view/LogRow.tsx
@@ -10,6 +10,7 @@ interface LogRowProps {
   entry: LogEntry;
   rowDomId: string;
   isSelected: boolean;
+  isMultiSelected?: boolean;
   isFindMatch: boolean;
   visibleColumns: ColumnDefinition[];
   gridTemplateColumns: string;
@@ -18,7 +19,7 @@ interface LogRowProps {
   severityPalette: LogSeverityPalette;
   highlightText: string;
   highlightCaseSensitive: boolean;
-  onClick: (id: number) => void;
+  onClick: (id: number, event: React.MouseEvent) => void;
   onContextMenu: (entry: LogEntry, event: React.MouseEvent) => void;
   onErrorCodeClick?: (span: ErrorCodeSpan) => void;
   mergeFileColor?: string | null;
@@ -232,6 +233,7 @@ export const LogRow = memo(function LogRow({
   entry,
   rowDomId,
   isSelected,
+  isMultiSelected,
   isFindMatch,
   visibleColumns,
   gridTemplateColumns,
@@ -291,6 +293,9 @@ export const LogRow = memo(function LogRow({
     backgroundOverlays.push(`linear-gradient(${correlationColor}30, ${correlationColor}30)`);
   }
 
+  // Multi-select visual: subtle blue background when no marker tint is present
+  const showMultiSelectHighlight = isMultiSelected && !isSelected && !marker;
+
   return (
     <div
       id={rowDomId}
@@ -316,8 +321,24 @@ export const LogRow = memo(function LogRow({
           ? { backgroundImage: backgroundOverlays.join(", ") }
           : {}),
         ...(entry.whatif ? { opacity: 0.6 } : {}),
+        ...(showMultiSelectHighlight
+          ? {
+              outline: "1px solid rgba(59, 130, 246, 0.5)",
+              outlineOffset: -1,
+              backgroundImage: [
+                ...backgroundOverlays,
+                "linear-gradient(rgba(59, 130, 246, 0.08), rgba(59, 130, 246, 0.08))",
+              ].join(", "),
+            }
+          : {}),
+        ...(isMultiSelected && !isSelected && marker
+          ? {
+              outline: "1px solid rgba(59, 130, 246, 0.5)",
+              outlineOffset: -1,
+            }
+          : {}),
       }}
-      onClick={() => onClick(entry.id)}
+      onClick={(e) => onClick(entry.id, e)}
       onContextMenu={(e) => onContextMenu(entry, e)}
     >
       {/* Marker gutter */}

--- a/src/components/log-view/SectionDividerRow.tsx
+++ b/src/components/log-view/SectionDividerRow.tsx
@@ -1,0 +1,84 @@
+import { memo } from "react";
+import { tokens } from "@fluentui/react-components";
+import type { LogEntry } from "../../types/log";
+import { LOG_UI_FONT_FAMILY } from "../../lib/log-accessibility";
+
+interface SectionDividerRowProps {
+  entry: LogEntry;
+  resolvedColor: string;
+  listFontSize: number;
+  rowLineHeight: number;
+  onClick: (id: number) => void;
+}
+
+/**
+ * Full-width banner row for Section and Iteration entry kinds.
+ * Rendered in place of a LogRow inside the virtualizer.
+ */
+export const SectionDividerRow = memo(function SectionDividerRow({
+  entry,
+  resolvedColor,
+  listFontSize,
+  rowLineHeight,
+  onClick,
+}: SectionDividerRowProps) {
+  // ~13% opacity tint of the section color
+  const bgTint = `${resolvedColor}21`;
+
+  return (
+    <div
+      role="option"
+      aria-selected={false}
+      className="section-divider-row"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        height: "100%",
+        padding: "0 8px",
+        backgroundColor: bgTint,
+        borderLeft: `4px solid ${resolvedColor}`,
+        borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+        fontFamily: LOG_UI_FONT_FAMILY,
+        fontSize: `${listFontSize}px`,
+        lineHeight: `${rowLineHeight}px`,
+        fontWeight: 600,
+        color: tokens.colorNeutralForeground1,
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        boxSizing: "border-box",
+      }}
+      onClick={() => onClick(entry.id)}
+    >
+      {/* Section/Iteration icon */}
+      <span
+        style={{
+          display: "inline-block",
+          width: 10,
+          height: 10,
+          borderRadius: entry.entryKind === "Iteration" ? 2 : "50%",
+          backgroundColor: resolvedColor,
+          flexShrink: 0,
+        }}
+      />
+
+      <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+        {entry.message}
+      </span>
+
+      {entry.entryKind === "Iteration" && entry.iteration && (
+        <span
+          style={{
+            fontSize: `${Math.max(listFontSize - 1, 9)}px`,
+            opacity: 0.7,
+            fontWeight: 400,
+          }}
+        >
+          {entry.iteration}
+        </span>
+      )}
+    </div>
+  );
+});

--- a/src/components/log-view/SectionDividerRow.tsx
+++ b/src/components/log-view/SectionDividerRow.tsx
@@ -27,6 +27,7 @@ export const SectionDividerRow = memo(function SectionDividerRow({
 
   return (
     <div
+      id={`log-list-row-${entry.id}`}
       role="option"
       aria-selected={false}
       className="section-divider-row"

--- a/src/hooks/use-context-menu.ts
+++ b/src/hooks/use-context-menu.ts
@@ -43,10 +43,10 @@ export function useContextMenu() {
       const errorCode = findErrorCode(entry);
       const messagePreview = truncate(entry.message, 40);
 
-      // Marker state — check if entry is already marked
+      // Marker state — use entry.filePath as the canonical key
       const markerState = useMarkerStore.getState();
-      const currentFilePath = useLogStore.getState().openFilePath || "";
-      const fileMarkers = markerState.markersByFile.get(currentFilePath);
+      const entryFilePath = entry.filePath;
+      const fileMarkers = markerState.markersByFile.get(entryFilePath);
       const existingMarker = fileMarkers?.get(entry.id);
 
       const items: (MenuItem | PredefinedMenuItem)[] = [
@@ -133,7 +133,7 @@ export function useContextMenu() {
               id: "marker-remove",
               text: `Remove Marker (${currentCat?.label ?? existingMarker.category})`,
               action: () => {
-                const fp = useLogStore.getState().openFilePath || "";
+                const fp = entry.filePath;
                 if (!fp) return;
                 useMarkerStore.getState().toggleMarker(fp, entry.id);
                 useMarkerStore.getState().saveMarkers(fp);

--- a/src/hooks/use-context-menu.ts
+++ b/src/hooks/use-context-menu.ts
@@ -9,6 +9,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useFilterStore } from "../stores/filter-store";
 import { useLogStore } from "../stores/log-store";
 import { useUiStore } from "../stores/ui-store";
+import { useMarkerStore } from "../stores/marker-store";
 import type { LogEntry } from "../types/log";
 
 function truncate(text: string, max: number): string {
@@ -41,6 +42,14 @@ export function useContextMenu() {
 
       const errorCode = findErrorCode(entry);
       const messagePreview = truncate(entry.message, 40);
+
+      // Marker state — read directly from store to get current state
+      const markerState = useMarkerStore.getState();
+      const uiState = useUiStore.getState();
+      const activeTab = uiState.openTabs[uiState.activeTabIndex];
+      const filePath = activeTab?.filePath ?? "";
+      const fileMarkers = markerState.markersByFile.get(filePath);
+      const existingMarker = fileMarkers?.get(entry.id);
 
       const items: (MenuItem | PredefinedMenuItem)[] = [
         await MenuItem.new({
@@ -113,6 +122,57 @@ export function useContextMenu() {
       );
 
       items.push(await PredefinedMenuItem.new({ item: "Separator" }));
+
+      // ── Marker actions ──
+      if (filePath) {
+        const categories = markerState.categories;
+        if (existingMarker) {
+          // Show current category and option to remove
+          const currentCat = categories.find((c) => c.id === existingMarker.category);
+          items.push(
+            await MenuItem.new({
+              id: "marker-remove",
+              text: `Remove Marker (${currentCat?.label ?? existingMarker.category})`,
+              action: () => {
+                useMarkerStore.getState().toggleMarker(filePath, entry.id);
+                useMarkerStore.getState().saveMarkers(filePath);
+              },
+            })
+          );
+          // Show category options to change
+          for (const cat of categories) {
+            if (cat.id === existingMarker.category) continue;
+            items.push(
+              await MenuItem.new({
+                id: `marker-set-${cat.id}`,
+                text: `Change to ${cat.label}`,
+                action: () => {
+                  useMarkerStore.getState().setMarkerCategory(filePath, entry.id, cat.id);
+                  useMarkerStore.getState().saveMarkers(filePath);
+                },
+              })
+            );
+          }
+        } else {
+          // Show options to mark with each category
+          for (const cat of categories) {
+            items.push(
+              await MenuItem.new({
+                id: `marker-add-${cat.id}`,
+                text: `Mark as ${cat.label}`,
+                action: () => {
+                  const store = useMarkerStore.getState();
+                  store.setActiveCategory(cat.id);
+                  store.toggleMarker(filePath, entry.id);
+                  store.saveMarkers(filePath);
+                },
+              })
+            );
+          }
+        }
+
+        items.push(await PredefinedMenuItem.new({ item: "Separator" }));
+      }
 
       if (errorCode) {
         items.push(

--- a/src/hooks/use-context-menu.ts
+++ b/src/hooks/use-context-menu.ts
@@ -122,7 +122,7 @@ export function useContextMenu() {
       items.push(await PredefinedMenuItem.new({ item: "Separator" }));
 
       // ── Marker actions ──
-      // Always show marker items — actions read filePath at click time.
+      // Always show marker items — actions use entry.filePath directly.
       {
         const categories = markerState.categories;
         if (existingMarker) {
@@ -149,7 +149,7 @@ export function useContextMenu() {
                 id: `marker-set-${catId}`,
                 text: `Change to ${cat.label}`,
                 action: () => {
-                  const fp = useLogStore.getState().openFilePath || "";
+                  const fp = entry.filePath;
                   if (!fp) return;
                   useMarkerStore.getState().setMarkerCategory(fp, entry.id, catId);
                   useMarkerStore.getState().saveMarkers(fp);
@@ -167,8 +167,7 @@ export function useContextMenu() {
                 id: `marker-add-${catId}`,
                 text: `Mark as ${cat.label}`,
                 action: () => {
-                  // Read fresh state at action time — not from the closure
-                  const fp = useLogStore.getState().openFilePath || "";
+                  const fp = entry.filePath;
                   if (!fp) return;
                   const store = useMarkerStore.getState();
                   store.setActiveCategory(catId);

--- a/src/hooks/use-context-menu.ts
+++ b/src/hooks/use-context-menu.ts
@@ -43,11 +43,10 @@ export function useContextMenu() {
       const errorCode = findErrorCode(entry);
       const messagePreview = truncate(entry.message, 40);
 
-      // Marker state — use openFilePath from log-store as the canonical key,
-      // matching what LogListView uses for marker lookups.
+      // Marker state — check if entry is already marked
       const markerState = useMarkerStore.getState();
-      const filePath = useLogStore.getState().openFilePath || "";
-      const fileMarkers = markerState.markersByFile.get(filePath);
+      const currentFilePath = useLogStore.getState().openFilePath || "";
+      const fileMarkers = markerState.markersByFile.get(currentFilePath);
       const existingMarker = fileMarkers?.get(entry.id);
 
       const items: (MenuItem | PredefinedMenuItem)[] = [
@@ -123,7 +122,8 @@ export function useContextMenu() {
       items.push(await PredefinedMenuItem.new({ item: "Separator" }));
 
       // ── Marker actions ──
-      if (filePath) {
+      // Always show marker items — actions read filePath at click time.
+      {
         const categories = markerState.categories;
         if (existingMarker) {
           // Show current category and option to remove

--- a/src/hooks/use-context-menu.ts
+++ b/src/hooks/use-context-menu.ts
@@ -43,11 +43,10 @@ export function useContextMenu() {
       const errorCode = findErrorCode(entry);
       const messagePreview = truncate(entry.message, 40);
 
-      // Marker state — read directly from store to get current state
+      // Marker state — use openFilePath from log-store as the canonical key,
+      // matching what LogListView uses for marker lookups.
       const markerState = useMarkerStore.getState();
-      const uiState = useUiStore.getState();
-      const activeTab = uiState.openTabs[uiState.activeTabIndex];
-      const filePath = activeTab?.filePath ?? "";
+      const filePath = useLogStore.getState().openFilePath || "";
       const fileMarkers = markerState.markersByFile.get(filePath);
       const existingMarker = fileMarkers?.get(entry.id);
 
@@ -134,21 +133,26 @@ export function useContextMenu() {
               id: "marker-remove",
               text: `Remove Marker (${currentCat?.label ?? existingMarker.category})`,
               action: () => {
-                useMarkerStore.getState().toggleMarker(filePath, entry.id);
-                useMarkerStore.getState().saveMarkers(filePath);
+                const fp = useLogStore.getState().openFilePath || "";
+                if (!fp) return;
+                useMarkerStore.getState().toggleMarker(fp, entry.id);
+                useMarkerStore.getState().saveMarkers(fp);
               },
             })
           );
           // Show category options to change
           for (const cat of categories) {
             if (cat.id === existingMarker.category) continue;
+            const catId = cat.id;
             items.push(
               await MenuItem.new({
-                id: `marker-set-${cat.id}`,
+                id: `marker-set-${catId}`,
                 text: `Change to ${cat.label}`,
                 action: () => {
-                  useMarkerStore.getState().setMarkerCategory(filePath, entry.id, cat.id);
-                  useMarkerStore.getState().saveMarkers(filePath);
+                  const fp = useLogStore.getState().openFilePath || "";
+                  if (!fp) return;
+                  useMarkerStore.getState().setMarkerCategory(fp, entry.id, catId);
+                  useMarkerStore.getState().saveMarkers(fp);
                 },
               })
             );
@@ -156,15 +160,20 @@ export function useContextMenu() {
         } else {
           // Show options to mark with each category
           for (const cat of categories) {
+            // Capture cat.id in a local const so the closure gets the right value
+            const catId = cat.id;
             items.push(
               await MenuItem.new({
-                id: `marker-add-${cat.id}`,
+                id: `marker-add-${catId}`,
                 text: `Mark as ${cat.label}`,
                 action: () => {
+                  // Read fresh state at action time — not from the closure
+                  const fp = useLogStore.getState().openFilePath || "";
+                  if (!fp) return;
                   const store = useMarkerStore.getState();
-                  store.setActiveCategory(cat.id);
-                  store.toggleMarker(filePath, entry.id);
-                  store.saveMarkers(filePath);
+                  store.setActiveCategory(catId);
+                  store.toggleMarker(fp, entry.id);
+                  store.saveMarkers(fp);
                 },
               })
             );

--- a/src/hooks/use-keyboard.ts
+++ b/src/hooks/use-keyboard.ts
@@ -244,6 +244,13 @@ export function useKeyboard() {
       }
 
       if (ctrl && event.key.toLowerCase() === "c" && !isInput) {
+        // When the log list is focused, let LogListView's onKeyDown handle
+        // Ctrl+C so multi-select copy works. This global handler only fires
+        // as a fallback when the log list is NOT focused.
+        if (isLogListFocused()) {
+          return;
+        }
+
         event.preventDefault();
         const state = useLogStore.getState();
 

--- a/src/lib/column-config.ts
+++ b/src/lib/column-config.ts
@@ -376,6 +376,7 @@ const PARSER_COLUMN_MAP: Record<ParserKind, ColumnId[]> = {
   secureBootLog: ["severity", "dateTime", "message", "component"],
   dnsDebug: ["severity", "dateTime", "dnsDirection", "dnsProtocol", "queryName", "queryType", "responseCode", "sourceIp", "dnsFlags", "message"],
   dnsAudit: ["severity", "dateTime", "dnsEventId", "queryName", "queryType", "responseCode", "zoneName", "sourceIp", "message"],
+  cmtLog: ["severity", "dateTime", "message", "component"],
 };
 
 /** Default columns used before any file is loaded. */

--- a/src/stores/filter-store.ts
+++ b/src/stores/filter-store.ts
@@ -75,6 +75,8 @@ function reconcileSelectionWithFilter(ids: Set<number> | null): void {
   logState.selectEntry(null);
 }
 
+export type WhatIfFilter = "all" | "whatif-only" | "real-only";
+
 interface FilterState {
   /** Active filter clauses */
   clauses: FilterClause[];
@@ -84,6 +86,8 @@ interface FilterState {
   isFiltering: boolean;
   /** Most recent filter application error */
   filterError: string | null;
+  /** WhatIf display filter */
+  whatIfFilter: WhatIfFilter;
 
   hasActiveFilter: () => boolean;
   addQuickFilter: (field: FilterField, value: string, op: FilterOp) => void;
@@ -91,6 +95,7 @@ interface FilterState {
   setFilteredIds: (ids: Set<number> | null) => void;
   setIsFiltering: (filtering: boolean) => void;
   setFilterError: (error: string | null) => void;
+  setWhatIfFilter: (filter: WhatIfFilter) => void;
   clearFilter: () => void;
 }
 
@@ -99,6 +104,7 @@ export const useFilterStore = create<FilterState>((set, get) => ({
   filteredIds: null,
   isFiltering: false,
   filterError: null,
+  whatIfFilter: "all",
 
   hasActiveFilter: () => get().clauses.length > 0,
   addQuickFilter: (field, value, op) =>
@@ -110,11 +116,13 @@ export const useFilterStore = create<FilterState>((set, get) => ({
   },
   setIsFiltering: (filtering) => set({ isFiltering: filtering }),
   setFilterError: (error) => set({ filterError: error }),
+  setWhatIfFilter: (filter) => set({ whatIfFilter: filter }),
   clearFilter: () =>
     set({
       clauses: [],
       filteredIds: null,
       isFiltering: false,
       filterError: null,
+      whatIfFilter: "all",
     }),
 }));

--- a/src/stores/log-store.ts
+++ b/src/stores/log-store.ts
@@ -305,6 +305,8 @@ function getParserLabel(parser: ParserSelectionInfo["parser"]): string {
       return "DNS Debug Log";
     case "dnsAudit":
       return "DNS Audit (EVTX)";
+    case "cmtLog":
+      return "CmtLog";
   }
 }
 
@@ -344,6 +346,8 @@ function getImplementationLabel(
       return "DNS debug log parser";
     case "dnsAudit":
       return "DNS audit EVTX parser";
+    case "cmtLog":
+      return "CmtLog parser";
   }
 }
 

--- a/src/stores/marker-store.ts
+++ b/src/stores/marker-store.ts
@@ -18,6 +18,8 @@ interface MarkerState {
   activeCategory: string;
   /** File paths currently being loaded from the backend. */
   loadingFiles: Set<string>;
+  /** Preserved `created` timestamps per file path (from loaded marker files). */
+  createdTimestamps: Map<string, string>;
 
   // ── Async backend actions ─────────────────────────────────────────────────
   loadMarkers: (filePath: string) => Promise<void>;
@@ -45,6 +47,7 @@ export const useMarkerStore = create<MarkerState>((set, get) => ({
   categories: [...DEFAULT_CATEGORIES],
   activeCategory: "bug",
   loadingFiles: new Set(),
+  createdTimestamps: new Map(),
 
   // ── loadMarkers ─────────────────────────────────────────────────────────
 
@@ -72,7 +75,24 @@ export const useMarkerStore = create<MarkerState>((set, get) => ({
         set((state) => {
           const next = new Map(state.markersByFile);
           next.set(filePath, fileMap);
-          return { markersByFile: next };
+
+          // Preserve the original created timestamp for later saves
+          const nextCreated = new Map(state.createdTimestamps);
+          if (result.created) {
+            nextCreated.set(filePath, result.created);
+          }
+
+          // Restore saved categories if the file provided them
+          const nextCategories =
+            result.categories && result.categories.length > 0
+              ? result.categories
+              : state.categories;
+
+          return {
+            markersByFile: next,
+            createdTimestamps: nextCreated,
+            categories: nextCategories,
+          };
         });
       } else {
         // Ensure the file has an empty map so callers can safely query it.
@@ -98,7 +118,7 @@ export const useMarkerStore = create<MarkerState>((set, get) => ({
   // ── saveMarkers ─────────────────────────────────────────────────────────
 
   saveMarkers: async (filePath) => {
-    const { markersByFile, categories } = get();
+    const { markersByFile, categories, createdTimestamps } = get();
     const fileMap = markersByFile.get(filePath);
 
     if (!fileMap || fileMap.size === 0) {
@@ -112,11 +132,12 @@ export const useMarkerStore = create<MarkerState>((set, get) => ({
     }
 
     const now = new Date().toISOString();
+    const created = createdTimestamps.get(filePath) ?? now;
     const markerFile: MarkerFile = {
       version: 1,
       sourcePath: filePath,
       sourceSize: 0,
-      created: now,
+      created,
       modified: now,
       markers: Array.from(fileMap.values()),
       categories,

--- a/src/stores/marker-store.ts
+++ b/src/stores/marker-store.ts
@@ -1,0 +1,237 @@
+import { create } from "zustand";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  type Marker,
+  type MarkerCategory,
+  type MarkerFile,
+  DEFAULT_CATEGORIES,
+} from "../types/markers";
+
+// ── State shape ───────────────────────────────────────────────────────────────
+
+interface MarkerState {
+  /** Markers keyed by file path, then by line ID. */
+  markersByFile: Map<string, Map<number, Marker>>;
+  /** Shared categories across all files. */
+  categories: MarkerCategory[];
+  /** Category ID used when toggling a new marker on. */
+  activeCategory: string;
+  /** File paths currently being loaded from the backend. */
+  loadingFiles: Set<string>;
+
+  // ── Async backend actions ─────────────────────────────────────────────────
+  loadMarkers: (filePath: string) => Promise<void>;
+  saveMarkers: (filePath: string) => Promise<void>;
+
+  // ── Marker mutation actions ───────────────────────────────────────────────
+  toggleMarker: (filePath: string, lineId: number) => void;
+  setMarkerCategory: (filePath: string, lineId: number, category: string) => void;
+  removeMarker: (filePath: string, lineId: number) => void;
+  clearMarkersForFile: (filePath: string) => void;
+
+  // ── Category actions ──────────────────────────────────────────────────────
+  setActiveCategory: (category: string) => void;
+  addCategory: (category: MarkerCategory) => void;
+
+  // ── Selectors ─────────────────────────────────────────────────────────────
+  getMarkersForFile: (filePath: string) => Map<number, Marker>;
+  getMarkedLineIds: (filePath: string, category?: string) => number[];
+}
+
+// ── Store implementation ──────────────────────────────────────────────────────
+
+export const useMarkerStore = create<MarkerState>((set, get) => ({
+  markersByFile: new Map(),
+  categories: [...DEFAULT_CATEGORIES],
+  activeCategory: "bug",
+  loadingFiles: new Set(),
+
+  // ── loadMarkers ─────────────────────────────────────────────────────────
+
+  loadMarkers: async (filePath) => {
+    const { loadingFiles, markersByFile } = get();
+
+    // Guard against duplicate in-flight loads.
+    if (loadingFiles.has(filePath)) {
+      return;
+    }
+
+    set((state) => ({
+      loadingFiles: new Set([...state.loadingFiles, filePath]),
+    }));
+
+    try {
+      const result = await invoke<MarkerFile | null>("load_markers", { filePath });
+
+      if (result) {
+        const fileMap = new Map<number, Marker>();
+        for (const marker of result.markers) {
+          fileMap.set(marker.lineId, marker);
+        }
+
+        set((state) => {
+          const next = new Map(state.markersByFile);
+          next.set(filePath, fileMap);
+          return { markersByFile: next };
+        });
+      } else {
+        // Ensure the file has an empty map so callers can safely query it.
+        if (!markersByFile.has(filePath)) {
+          set((state) => {
+            const next = new Map(state.markersByFile);
+            next.set(filePath, new Map());
+            return { markersByFile: next };
+          });
+        }
+      }
+    } catch (err) {
+      console.error("[marker-store] loadMarkers failed", { filePath, err });
+    } finally {
+      set((state) => {
+        const next = new Set(state.loadingFiles);
+        next.delete(filePath);
+        return { loadingFiles: next };
+      });
+    }
+  },
+
+  // ── saveMarkers ─────────────────────────────────────────────────────────
+
+  saveMarkers: async (filePath) => {
+    const { markersByFile, categories } = get();
+    const fileMap = markersByFile.get(filePath);
+
+    if (!fileMap || fileMap.size === 0) {
+      // No markers remaining — delete any persisted file.
+      try {
+        await invoke<void>("delete_markers", { filePath });
+      } catch (err) {
+        console.error("[marker-store] delete_markers failed", { filePath, err });
+      }
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const markerFile: MarkerFile = {
+      version: 1,
+      sourcePath: filePath,
+      sourceSize: 0,
+      created: now,
+      modified: now,
+      markers: Array.from(fileMap.values()),
+      categories,
+    };
+
+    try {
+      await invoke<void>("save_markers", { filePath, markerFile });
+    } catch (err) {
+      console.error("[marker-store] save_markers failed", { filePath, err });
+    }
+  },
+
+  // ── toggleMarker ────────────────────────────────────────────────────────
+
+  toggleMarker: (filePath, lineId) => {
+    const { activeCategory, categories } = get();
+
+    set((state) => {
+      const next = new Map(state.markersByFile);
+      const fileMap = new Map(next.get(filePath) ?? []);
+
+      if (fileMap.has(lineId)) {
+        // Toggle off — remove the marker.
+        fileMap.delete(lineId);
+      } else {
+        // Toggle on — add a new marker using the active category.
+        const categoryDef = categories.find((c) => c.id === activeCategory);
+        const color = categoryDef?.color ?? "#60a5fa";
+        const marker: Marker = {
+          lineId,
+          category: activeCategory,
+          color,
+          added: new Date().toISOString(),
+        };
+        fileMap.set(lineId, marker);
+      }
+
+      next.set(filePath, fileMap);
+      return { markersByFile: next };
+    });
+  },
+
+  // ── setMarkerCategory ───────────────────────────────────────────────────
+
+  setMarkerCategory: (filePath, lineId, category) => {
+    set((state) => {
+      const next = new Map(state.markersByFile);
+      const fileMap = new Map(next.get(filePath) ?? []);
+      const existing = fileMap.get(lineId);
+
+      if (!existing) {
+        return {};
+      }
+
+      const categoryDef = state.categories.find((c) => c.id === category);
+      const color = categoryDef?.color ?? existing.color;
+
+      fileMap.set(lineId, { ...existing, category, color });
+      next.set(filePath, fileMap);
+      return { markersByFile: next };
+    });
+  },
+
+  // ── removeMarker ────────────────────────────────────────────────────────
+
+  removeMarker: (filePath, lineId) => {
+    set((state) => {
+      const next = new Map(state.markersByFile);
+      const fileMap = new Map(next.get(filePath) ?? []);
+      fileMap.delete(lineId);
+      next.set(filePath, fileMap);
+      return { markersByFile: next };
+    });
+  },
+
+  // ── clearMarkersForFile ─────────────────────────────────────────────────
+
+  clearMarkersForFile: (filePath) => {
+    set((state) => {
+      const next = new Map(state.markersByFile);
+      next.delete(filePath);
+      return { markersByFile: next };
+    });
+  },
+
+  // ── setActiveCategory ───────────────────────────────────────────────────
+
+  setActiveCategory: (category) => set({ activeCategory: category }),
+
+  // ── addCategory ─────────────────────────────────────────────────────────
+
+  addCategory: (category) => {
+    set((state) => ({
+      categories: [...state.categories, category],
+    }));
+  },
+
+  // ── getMarkersForFile (selector) ────────────────────────────────────────
+
+  getMarkersForFile: (filePath) => {
+    return get().markersByFile.get(filePath) ?? new Map<number, Marker>();
+  },
+
+  // ── getMarkedLineIds (selector) ─────────────────────────────────────────
+
+  getMarkedLineIds: (filePath, category) => {
+    const fileMap = get().markersByFile.get(filePath);
+    if (!fileMap) return [];
+
+    const ids: number[] = [];
+    for (const [lineId, marker] of fileMap) {
+      if (category === undefined || marker.category === category) {
+        ids.push(lineId);
+      }
+    }
+    return ids;
+  },
+}));

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -1,7 +1,8 @@
 import type { EvidenceBundleMetadata } from "./evidence";
 
 export type Severity = "Info" | "Warning" | "Error";
-export type LogFormat = "Ccm" | "Simple" | "Plain" | "Timestamped" | "DnsDebug" | "DnsAudit";
+export type LogFormat = "Ccm" | "Simple" | "Plain" | "Timestamped" | "DnsDebug" | "DnsAudit" | "CmtLog";
+export type EntryKind = "Log" | "Section" | "Iteration" | "Header";
 export type ParserKind =
   | "ccm"
   | "simple"
@@ -21,7 +22,8 @@ export type ParserKind =
   | "registry"
   | "secureBootLog"
   | "dnsDebug"
-  | "dnsAudit";
+  | "dnsAudit"
+  | "cmtLog";
 export type ParserImplementation =
   | "ccm"
   | "simple"
@@ -38,7 +40,8 @@ export type ParserImplementation =
   | "registry"
   | "secureBootLog"
   | "dnsDebug"
-  | "dnsAudit";
+  | "dnsAudit"
+  | "cmtLog";
 export type ParserProvenance = "dedicated" | "heuristic" | "fallback";
 export type ParseQuality = "structured" | "semiStructured" | "textFallback";
 export type RecordFraming = "physicalLine" | "logicalRecord";
@@ -189,6 +192,12 @@ export interface LogEntry {
   dnsFlags?: string | null;
   dnsEventId?: number | null;
   zoneName?: string | null;
+  entryKind?: EntryKind;
+  whatif?: boolean;
+  sectionName?: string;
+  sectionColor?: string;
+  iteration?: string;
+  tags?: string[];
 }
 
 export interface ParserSelectionInfo {

--- a/src/types/markers.ts
+++ b/src/types/markers.ts
@@ -1,0 +1,28 @@
+export interface MarkerCategory {
+  id: string;
+  label: string;
+  color: string;
+}
+
+export interface Marker {
+  lineId: number;
+  category: string;
+  color: string;
+  added: string; // ISO 8601
+}
+
+export interface MarkerFile {
+  version: number;
+  sourcePath: string;
+  sourceSize: number;
+  created: string;
+  modified: string;
+  markers: Marker[];
+  categories: MarkerCategory[];
+}
+
+export const DEFAULT_CATEGORIES: MarkerCategory[] = [
+  { id: "bug", label: "Bug", color: "#ef4444" },
+  { id: "investigate", label: "Investigate", color: "#60a5fa" },
+  { id: "confirmed", label: "Confirmed", color: "#4ade80" },
+];

--- a/src/workspaces/log/index.ts
+++ b/src/workspaces/log/index.ts
@@ -29,7 +29,7 @@ export const logWorkspace: WorkspaceDefinition = {
     knownSources: true,
   },
   fileFilters: [
-    { name: "Log Files", extensions: ["log"] },
+    { name: "Log Files", extensions: ["log", "cmtlog"] },
     { name: "Old Log Files", extensions: ["lo_"] },
     { name: "Registry Files", extensions: ["reg"] },
     { name: "All Files", extensions: ["*"] },


### PR DESCRIPTION
## Summary

- **`.cmtlog` file format** — extends CCM's `<![LOG[...]LOG]!>` with reserved components (`__HEADER__`, `__SECTION__`, `__ITERATION__`) and extended attributes (`section`, `tag`, `whatif`, `iteration`, `color`). Fully backward-compatible with CMTrace.exe.
- **Color-coded user markers** — Bug (red), Investigate (blue), Confirmed (green) via right-click context menu, gutter click, or Ctrl+M. Persisted to AppData keyed by file path.
- **Section divider rendering** — full-width banner rows + colored left-edge bands for visual phase/loop grouping
- **WhatIf rendering** — dimmed/italic lines with purple badge for simulated actions
- **Multi-select copy** — Ctrl+Click, Shift+Click range, Ctrl+A, Ctrl+C copies plain text messages
- **PowerShell module** — `CmtLog.psm1` with `Start-CmtLog`, `Write-LogEntry`, `Write-LogSection`, `Write-LogIteration`
- **`.cmtlog` file association** registered in Tauri config

Closes #117

## Test plan

- [ ] Open `src-tauri/tests/fixtures/cmtlog/basic.cmtlog` — verify section dividers, left-edge bands, WhatIf badge
- [ ] Right-click a log line → Mark as Bug/Investigate/Confirmed → verify row colors
- [ ] Close and reopen the file → markers persist
- [ ] Ctrl+M toggles marker on selected row
- [ ] Ctrl+Click multiple rows → Ctrl+C → paste verifies multi-line copy
- [ ] Open a regular `.log` file → no regressions (no phantom dividers or badges)
- [ ] Windows build succeeds and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)