### PR TITLE
fix: wire secureboot_log module in parser detection and routing

### DIFF
--- a/src-tauri/src/parser/detect.rs
+++ b/src-tauri/src/parser/detect.rs
@@ -14,7 +14,7 @@
 
 use super::{
     burn, cbs, dhcp, dism, iis_w3c, intune_macos, msi, panther, patchmypc_detection, psadt,
-    reporting_events,
+    reporting_events, secureboot_log,
     timestamped::{self, DateOrder},
 };
 use crate::models::log_entry::{
@@ -286,6 +286,7 @@ impl ResolvedParser {
             ParserImplementation::PatchMyPcDetection => LogFormat::Timestamped,
             ParserImplementation::PlainText => LogFormat::Plain,
             ParserImplementation::Registry => LogFormat::Plain,
+            ParserImplementation::SecureBootLog => LogFormat::Timestamped,
         }
     }
 
@@ -407,6 +408,7 @@ pub fn detect_parser(path: &str, content: &str) -> ResolvedParser {
     let mut iis_w3c_count = 0u32;
     let mut burn_count = 0u32;
     let mut patchmypc_detection_count = 0u32;
+    let mut secureboot_log_count = 0u32;
     let mut timestamp_count = 0;
     let mut has_day_first = false;
 

--- a/src-tauri/src/parser/mod.rs
+++ b/src-tauri/src/parser/mod.rs
@@ -109,6 +109,9 @@ pub fn parse_lines_with_selection(
             // Registry files are parsed via a dedicated IPC command, not the log pipeline.
             (vec![], 0)
         }
+        crate::models::log_entry::ParserImplementation::SecureBootLog => {
+            secureboot_log::parse_lines(lines, file_path)
+        }
         crate::models::log_entry::ParserImplementation::GenericTimestamped => match selection.parser {
             crate::models::log_entry::ParserKind::Cbs => cbs::parse_lines(lines, file_path),
             crate::models::log_entry::ParserKind::Dism => dism::parse_lines(lines, file_path),


### PR DESCRIPTION
## Summary

- Add missing `secureboot_log` import to `detect.rs`
- Declare `secureboot_log_count` variable in detection loop
- Add `SecureBootLog` match arm in `compatibility_format()` and `parse_lines_with_selection()`

These were left incomplete when PR #110 (Secure Boot workspace) was merged, blocking CI on all open PRs.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` all pass
- [x] `cargo clippy -- -D warnings` zero warnings