### PR TITLE
chore(deps): bump ureq from 2 to 3 with API migration

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5697,18 +5697,31 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
  "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -5750,6 +5763,12 @@ checksum = "e58ccaaacb51ac3f769e61e1494a3856a0ef2e6749e19f5367a9e846f8c21168"
 dependencies = [
  "sonic-rs",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6105,15 +6124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,7 +66,7 @@ windows = { version = "0.58", features = [
     "Foundation_Collections",
     "Win32_System_WinRT",
 ] }
-ureq = "2"
+ureq = "3"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src-tauri/src/dsregcmd/connectivity.rs
+++ b/src-tauri/src/dsregcmd/connectivity.rs
@@ -28,7 +28,7 @@ pub fn test_endpoint_connectivity() -> Vec<DsregcmdConnectivityResult> {
             .build()
             .new_agent();
 
-        match agent.head(endpoint).call() {
+        match agent.head(*endpoint).call() {
             Ok(response) => {
                 let latency = start.elapsed().as_millis() as u64;
                 results.push(DsregcmdConnectivityResult {

--- a/src-tauri/src/dsregcmd/connectivity.rs
+++ b/src-tauri/src/dsregcmd/connectivity.rs
@@ -21,10 +21,12 @@ pub fn test_endpoint_connectivity() -> Vec<DsregcmdConnectivityResult> {
         let start = std::time::Instant::now();
         let timestamp = chrono::Utc::now().to_rfc3339();
 
-        let agent = ureq::AgentBuilder::new()
-            .timeout_connect(std::time::Duration::from_secs(ENDPOINT_TIMEOUT_SECS))
-            .timeout_read(std::time::Duration::from_secs(ENDPOINT_TIMEOUT_SECS))
-            .build();
+        let agent = ureq::Agent::config_builder()
+            .timeout_connect(Some(std::time::Duration::from_secs(ENDPOINT_TIMEOUT_SECS)))
+            .timeout_recv_response(Some(std::time::Duration::from_secs(ENDPOINT_TIMEOUT_SECS)))
+            .http_status_as_error(false)
+            .build()
+            .new_agent();
 
         match agent.head(endpoint).call() {
             Ok(response) => {
@@ -32,32 +34,20 @@ pub fn test_endpoint_connectivity() -> Vec<DsregcmdConnectivityResult> {
                 results.push(DsregcmdConnectivityResult {
                     endpoint: endpoint.to_string(),
                     reachable: true,
-                    status_code: Some(response.status()),
+                    status_code: Some(response.status().as_u16()),
                     latency_ms: Some(latency),
                     error_message: None,
                     timestamp,
                 });
             }
-            Err(ureq::Error::Status(code, _response)) => {
-                let latency = start.elapsed().as_millis() as u64;
-                // Non-2xx status but endpoint was reachable
-                results.push(DsregcmdConnectivityResult {
-                    endpoint: endpoint.to_string(),
-                    reachable: true,
-                    status_code: Some(code),
-                    latency_ms: Some(latency),
-                    error_message: None,
-                    timestamp,
-                });
-            }
-            Err(ureq::Error::Transport(transport)) => {
+            Err(e) => {
                 let latency = start.elapsed().as_millis() as u64;
                 results.push(DsregcmdConnectivityResult {
                     endpoint: endpoint.to_string(),
                     reachable: false,
                     status_code: None,
                     latency_ms: Some(latency),
-                    error_message: Some(transport.to_string()),
+                    error_message: Some(e.to_string()),
                     timestamp,
                 });
             }

--- a/src-tauri/src/graph_api.rs
+++ b/src-tauri/src/graph_api.rs
@@ -237,9 +237,10 @@ mod wam {
 const GRAPH_BETA_BASE: &str = "https://graph.microsoft.com/beta";
 
 /// Helper: parse a ureq response body as JSON.
-fn read_json(response: ureq::Response) -> Result<serde_json::Value, AppError> {
+fn read_json(response: ureq::http::Response<ureq::Body>) -> Result<serde_json::Value, AppError> {
     let body = response
-        .into_string()
+        .into_body()
+        .read_to_string()
         .map_err(|e| AppError::Internal(format!("Failed to read response body: {e}")))?;
     serde_json::from_str(&body)
         .map_err(|e| AppError::Internal(format!("Failed to parse JSON: {e}")))
@@ -258,10 +259,11 @@ fn parse_app_json(item: &serde_json::Value) -> Option<GraphAppInfo> {
 }
 
 fn make_agent() -> ureq::Agent {
-    ureq::AgentBuilder::new()
-        .timeout_read(std::time::Duration::from_secs(30))
-        .timeout_write(std::time::Duration::from_secs(10))
+    ureq::Agent::config_builder()
+        .timeout_recv_body(Some(std::time::Duration::from_secs(30)))
+        .timeout_send_body(Some(std::time::Duration::from_secs(10)))
         .build()
+        .new_agent()
 }
 
 /// Authenticate with Graph API via WAM. Returns current auth status.
@@ -457,18 +459,10 @@ fn fetch_paginated(
     while let Some(url) = next_url.take() {
         let response = agent
             .get(&url)
-            .set("Authorization", &format!("Bearer {token}"))
-            .set("ConsistencyLevel", "eventual")
+            .header("Authorization", &format!("Bearer {token}"))
+            .header("ConsistencyLevel", "eventual")
             .call()
-            .map_err(|e| {
-                if let ureq::Error::Status(code, resp) = e {
-                    let body = resp.into_string().unwrap_or_default();
-                    log::warn!("Graph API HTTP {code} for {url}: {body}");
-                    AppError::Internal(format!("Graph API HTTP {code}: {body}"))
-                } else {
-                    AppError::Internal(format!("Graph API request failed: {e}"))
-                }
-            })?;
+            .map_err(|e| AppError::Internal(format!("Graph API request failed: {e}")))?;
 
         let body = read_json(response)?;
 
@@ -517,9 +511,9 @@ fn fetch_apps_batch(
     let agent = make_agent();
     let response = agent
         .post(&format!("{GRAPH_BETA_BASE}/$batch"))
-        .set("Authorization", &format!("Bearer {token}"))
-        .set("Content-Type", "application/json")
-        .send_string(&body_str)
+        .header("Authorization", &format!("Bearer {token}"))
+        .content_type("application/json")
+        .send(&body_str)
         .map_err(|e| AppError::Internal(format!("Graph batch request failed: {e}")))?;
 
     let body = read_json(response)?;
@@ -570,14 +564,14 @@ fn fetch_single_app(token: &str, guid: &str) -> Result<Option<GraphAppInfo>, App
 
     match agent
         .get(&url)
-        .set("Authorization", &format!("Bearer {token}"))
+        .header("Authorization", &format!("Bearer {token}"))
         .call()
     {
         Ok(response) => {
             let body = read_json(response)?;
             Ok(parse_app_json(&body))
         }
-        Err(ureq::Error::Status(404, _)) => Ok(None),
+        Err(ureq::Error::StatusCode(404)) => Ok(None),
         Err(e) => Err(AppError::Internal(format!("Graph request failed: {e}"))),
     }
 }


### PR DESCRIPTION
## Summary

- Bump `ureq` from 2.12.1 to 3.3.0
- Migrate Agent builder: `AgentBuilder::new()` → `Agent::config_builder().build().new_agent()`
- Migrate timeouts to `Some()` wrappers
- `.set()` → `.header()`, `.send_string()` → `.content_type().send()`
- Error variants: `Error::Status(code, resp)` → `Error::StatusCode(code)`
- `response.into_string()` → `response.into_body().read_to_string()`

Recreates the work from closed #95 on a clean branch against current main.

## Test plan

- [ ] Windows CI build passes (dsregcmd/connectivity and graph_api compile)
- [ ] macOS/Linux builds unaffected (Windows-only code is cfg-gated)