### PR TITLE
fix(ci): use --override-filename for cargo-cyclonedx SBOM generation

### DIFF
--- a/.github/workflows/cmtrace-release.yml
+++ b/.github/workflows/cmtrace-release.yml
@@ -89,7 +89,9 @@ jobs:
 
       - name: Generate Rust SBOM
         working-directory: src-tauri
-        run: cargo cyclonedx --format json --output-file ../sbom-rust.cdx.json
+        run: |
+          cargo cyclonedx --format json --override-filename sbom-rust
+          mv sbom-rust.json ../sbom-rust.cdx.json
 
       - name: Generate npm SBOM
         run: npm sbom --sbom-format cyclonedx > sbom-npm.cdx.json


### PR DESCRIPTION
cargo-cyclonedx 0.5.9 does not have --output-file. Fixes release workflow SBOM step.