### PR TITLE
fix: address 5 community issues (#137, #136, #113, #53, #138)

### DIFF
--- a/scripts/Launch-CMTraceOpen.ps1
+++ b/scripts/Launch-CMTraceOpen.ps1
@@ -41,6 +41,11 @@ function Add-RustToolchainToPath {
     Add-PathEntryIfExists -PathEntry $cargoBin
 }
 
+function Add-NodeToolchainToPath {
+    Add-PathEntryIfExists -PathEntry 'C:\Program Files\nodejs'
+    Add-PathEntryIfExists -PathEntry (Join-Path $env:USERPROFILE 'AppData\Local\Programs\nodejs')
+}
+
 function Assert-CommandAvailable {
     param(
         [Parameter(Mandatory = $true)]
@@ -179,8 +184,26 @@ $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $appRoot = Split-Path -Parent $scriptRoot
 $nodeModulesPath = Join-Path $appRoot 'node_modules'
 
+# Kill any stale cmtrace-open processes and free port 1420 before starting a dev session.
+# This prevents the "address already in use" error on rapid restarts.
+if ($Mode -eq 'Dev' -or $Mode -eq 'BuildAndRun') {
+    $staleProcs = Get-Process 'cmtrace-open' -ErrorAction SilentlyContinue
+    if ($staleProcs) {
+        Write-Step 'Stopping stale cmtrace-open process(es)'
+        $staleProcs | Stop-Process -Force -ErrorAction SilentlyContinue
+    }
+    $portListeners = Get-NetTCPConnection -LocalPort 1420 -State Listen -ErrorAction SilentlyContinue
+    if ($portListeners) {
+        Write-Step 'Freeing port 1420 held by stale process(es)'
+        $portListeners |
+            Select-Object -ExpandProperty OwningProcess -Unique |
+            ForEach-Object { Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue }
+    }
+}
+
 Write-Step 'Ensuring Rust toolchain is available on PATH'
 Add-RustToolchainToPath
+Add-NodeToolchainToPath
 
 # ring crate needs clang on ARM64 - add LLVM to PATH if installed
 Add-PathEntryIfExists -PathEntry 'C:\Program Files\LLVM\bin'
@@ -190,7 +213,9 @@ $vsInstallPath = Enable-VsDeveloperPowerShell
 Write-Host "Using Visual Studio at $vsInstallPath" -ForegroundColor DarkGray
 
 Add-RustToolchainToPath
+Add-NodeToolchainToPath
 Assert-CommandAvailable -CommandName 'cargo.exe' -ErrorMessage 'Could not find cargo.exe on PATH. Install Rust via rustup or run scripts/Install-CMTraceOpenBuildPrereqs.ps1, then open a new terminal and retry.'
+Assert-CommandAvailable -CommandName 'npm.cmd' -ErrorMessage 'Could not find npm.cmd on PATH. Install Node.js or run scripts/Install-CMTraceOpenBuildPrereqs.ps1, then open a new terminal and retry.'
 
 Set-Location $appRoot
 

--- a/src-tauri/src/collector/artifacts.rs
+++ b/src-tauri/src/collector/artifacts.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -85,7 +84,7 @@ pub fn export_registry_keys(items: &[RegistryCollectionItem], ctx: &CollectorCon
 
     items.par_iter().for_each(|item| {
         let output_path = dest_dir.join(&item.file_name);
-        match Command::new(&reg_path)
+        match crate::process_util::hidden_command(&reg_path)
             .args(["export", &item.path, &output_path.to_string_lossy(), "/y"])
             .output()
         {
@@ -243,7 +242,7 @@ pub fn run_commands(items: &[CommandCollectionItem], ctx: &CollectorContext) {
                 args.push(zip_path.to_string_lossy().into_owned());
             }
 
-            let spawn_result = Command::new(&item.command)
+            let spawn_result = crate::process_util::hidden_command(&item.command)
                 .args(&args)
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())

--- a/src-tauri/src/commands/dsregcmd.rs
+++ b/src-tauri/src/commands/dsregcmd.rs
@@ -160,7 +160,7 @@ fn capture_dsregcmd_impl() -> Result<DsregcmdCaptureResult, crate::error::AppErr
     let dsregcmd_path = resolve_system32_binary("dsregcmd.exe")?;
     verify_dsregcmd_signature(&dsregcmd_path)?;
 
-    let output = std::process::Command::new(&dsregcmd_path)
+    let output = crate::process_util::hidden_command(&dsregcmd_path)
         .arg("/status")
         .output()
         .map_err(|error| {
@@ -535,7 +535,7 @@ fn export_live_registry_evidence(registry_root: &Path) {
 
     for export in LIVE_CAPTURE_REGISTRY_EXPORTS {
         let output_path = registry_root.join(export.file_name);
-        match std::process::Command::new(&reg_path)
+        match crate::process_util::hidden_command(&reg_path)
             .args(["export", export.key_path, &output_path.to_string_lossy(), "/y"])
             .output()
         {
@@ -582,7 +582,7 @@ fn collect_enterprise_mgmt_task_guids() -> crate::dsregcmd::DsregcmdScheduledTas
         }
     };
 
-    let output = match std::process::Command::new(&schtasks_path)
+    let output = match crate::process_util::hidden_command(&schtasks_path)
         .args([
             "/query",
             "/TN",

--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -178,27 +178,37 @@ pub fn parse_files_batch(
         results.len()
     );
 
-    // Collect successes and store parser state (requires lock, done sequentially)
+    // Collect successes and store parser state (requires lock, done sequentially).
+    // Per-file failures are logged and skipped so the rest of the batch still loads
+    // (e.g. one inaccessible file in a folder must not abort the whole open).
     let mut parse_results = Vec::with_capacity(results.len());
+    let mut skipped = 0u32;
     let mut open_files = state.open_files.lock().map_err(|e| crate::error::AppError::State(e.to_string()))?;
 
     for item in results {
-        let (result, parser_selection, path) = item?;
-        open_files.insert(
-            PathBuf::from(&path),
-            OpenFile {
-                path: PathBuf::from(&path),
-                entries: vec![],
-                parser_selection,
-                byte_offset: result.byte_offset,
-            },
-        );
-        parse_results.push(result);
+        match item {
+            Ok((result, parser_selection, path)) => {
+                open_files.insert(
+                    PathBuf::from(&path),
+                    OpenFile {
+                        path: PathBuf::from(&path),
+                        entries: vec![],
+                        parser_selection,
+                        byte_offset: result.byte_offset,
+                    },
+                );
+                parse_results.push(result);
+            }
+            Err(error) => {
+                skipped = skipped.saturating_add(1);
+                log::warn!("event=parse_files_batch_skip error=\"{error}\"");
+            }
+        }
     }
 
     let total_ms = batch_start.elapsed().as_millis();
     log::info!(
-        "event=parse_files_batch_complete file_count={} results={} total_ms={total_ms}",
+        "event=parse_files_batch_complete file_count={} results={} skipped={skipped} total_ms={total_ms}",
         paths.len(),
         parse_results.len()
     );
@@ -223,7 +233,18 @@ pub fn open_log_folder_aggregate(
     let mut parse_errors = 0u32;
 
     for entry in file_entries {
-        let (result, parser_selection) = parser::parse_file(&entry.path)?;
+        // Skip files we can't read (permission denied, missing, etc.) so a
+        // single inaccessible file doesn't abort the whole folder load.
+        let (result, parser_selection) = match parser::parse_file(&entry.path) {
+            Ok(value) => value,
+            Err(error) => {
+                log::warn!(
+                    "event=open_log_folder_aggregate_skip path=\"{}\" error=\"{error}\"",
+                    entry.path
+                );
+                continue;
+            }
+        };
 
         total_lines = total_lines.saturating_add(result.total_lines);
         parse_errors = parse_errors.saturating_add(result.parse_errors);

--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -133,12 +133,15 @@ pub fn parse_files_batch(
     let batch_start = std::time::Instant::now();
     let completed = AtomicU32::new(0);
 
-    // Parse all files in parallel on Rayon's thread pool (lock-free)
+    // Parse all files in parallel on Rayon's thread pool (lock-free).
+    // Per-file failures are logged + emitted as progress inside the closure
+    // (where `path` is in scope) so the UI's progress counter still advances
+    // when files are skipped, and the warn log includes the offending path.
     let results: Vec<Result<(ParseResult, crate::parser::ResolvedParser, String), crate::error::AppError>> = paths
         .par_iter()
         .map(|path| {
             let file_start = std::time::Instant::now();
-            let (result, parser_selection) = parser::parse_file(path)?;
+            let parse_outcome = parser::parse_file(path);
             let file_ms = file_start.elapsed().as_millis() as u64;
 
             let done = completed.fetch_add(1, AtomicOrdering::Relaxed) + 1;
@@ -147,28 +150,53 @@ pub fn parse_files_batch(
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_default();
 
-            log::info!(
-                "  event=parse_file_done [{done}/{total}] path=\"{path}\" entries={} lines={} size={} ms={file_ms}",
-                result.entries.len(),
-                result.total_lines,
-                result.file_size,
-            );
+            match parse_outcome {
+                Ok((result, parser_selection)) => {
+                    log::info!(
+                        "  event=parse_file_done [{done}/{total}] path=\"{path}\" entries={} lines={} size={} ms={file_ms}",
+                        result.entries.len(),
+                        result.total_lines,
+                        result.file_size,
+                    );
 
-            // Fire-and-forget progress event to the frontend
-            let _ = app.emit(
-                "parse-progress",
-                ParseProgressPayload {
-                    file_path: path.clone(),
-                    file_name,
-                    completed: done,
-                    total,
-                    entries: result.entries.len() as u32,
-                    file_size: result.file_size,
-                    parse_ms: file_ms,
-                },
-            );
+                    let _ = app.emit(
+                        "parse-progress",
+                        ParseProgressPayload {
+                            file_path: path.clone(),
+                            file_name,
+                            completed: done,
+                            total,
+                            entries: result.entries.len() as u32,
+                            file_size: result.file_size,
+                            parse_ms: file_ms,
+                        },
+                    );
 
-            Ok((result, parser_selection, path.clone()))
+                    Ok((result, parser_selection, path.clone()))
+                }
+                Err(error) => {
+                    log::warn!(
+                        "  event=parse_file_skip [{done}/{total}] path=\"{path}\" error=\"{error}\""
+                    );
+
+                    // Emit progress for the skip so the UI counter still
+                    // advances and doesn't stall below `total`.
+                    let _ = app.emit(
+                        "parse-progress",
+                        ParseProgressPayload {
+                            file_path: path.clone(),
+                            file_name,
+                            completed: done,
+                            total,
+                            entries: 0,
+                            file_size: 0,
+                            parse_ms: file_ms,
+                        },
+                    );
+
+                    Err(crate::error::AppError::from(error))
+                }
+            }
         })
         .collect();
 
@@ -179,8 +207,6 @@ pub fn parse_files_batch(
     );
 
     // Collect successes and store parser state (requires lock, done sequentially).
-    // Per-file failures are logged and skipped so the rest of the batch still loads
-    // (e.g. one inaccessible file in a folder must not abort the whole open).
     let mut parse_results = Vec::with_capacity(results.len());
     let mut skipped = 0u32;
     let mut open_files = state.open_files.lock().map_err(|e| crate::error::AppError::State(e.to_string()))?;
@@ -199,9 +225,8 @@ pub fn parse_files_batch(
                 );
                 parse_results.push(result);
             }
-            Err(error) => {
+            Err(_) => {
                 skipped = skipped.saturating_add(1);
-                log::warn!("event=parse_files_batch_skip error=\"{error}\"");
             }
         }
     }

--- a/src-tauri/src/commands/intune_diagnostics.rs
+++ b/src-tauri/src/commands/intune_diagnostics.rs
@@ -923,7 +923,7 @@ fn top_failed_download_labels(downloads: &[DownloadStat], limit: usize) -> Vec<S
     }
 
     let mut sorted_counts: Vec<(String, usize)> = label_counts.into_iter().collect();
-    sorted_counts.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted_counts.sort_by_key(|k| std::cmp::Reverse(k.1));
 
     sorted_counts
         .into_iter()
@@ -1371,7 +1371,7 @@ fn top_event_detail_matches(events: &[&IntuneEvent], limit: usize) -> Vec<String
     }
 
     let mut sorted_counts: Vec<(String, usize)> = evidence_counts.into_iter().collect();
-    sorted_counts.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted_counts.sort_by_key(|k| std::cmp::Reverse(k.1));
 
     sorted_counts
         .into_iter()
@@ -1601,7 +1601,7 @@ fn top_event_labels(events: &[&IntuneEvent], limit: usize) -> Vec<String> {
     }
 
     let mut sorted_counts: Vec<(String, usize)> = label_counts.into_iter().collect();
-    sorted_counts.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted_counts.sort_by_key(|k| std::cmp::Reverse(k.1));
 
     sorted_counts
         .into_iter()

--- a/src-tauri/src/dsregcmd/connectivity.rs
+++ b/src-tauri/src/dsregcmd/connectivity.rs
@@ -62,7 +62,7 @@ pub fn query_scp() -> DsregcmdScpQueryResult {
     let mut result = DsregcmdScpQueryResult::default();
 
     // Try to find a domain controller via nltest
-    let dc_output = std::process::Command::new("nltest")
+    let dc_output = crate::process_util::hidden_command("nltest")
         .arg("/dsgetdc:")
         .output();
 
@@ -108,7 +108,7 @@ try {
 }
 "#;
 
-    let ps_output = std::process::Command::new("powershell")
+    let ps_output = crate::process_util::hidden_command("powershell")
         .args(["-NoProfile", "-NonInteractive", "-Command", ps_script])
         .output();
 

--- a/src-tauri/src/event_log/live.rs
+++ b/src-tauri/src/event_log/live.rs
@@ -103,7 +103,7 @@ pub fn enumerate_channels() -> Result<Vec<EvtxChannelInfo>, String> {
 
     unsafe { let _ = EvtClose(EVT_HANDLE(raw_handle)); }
 
-    channels.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    channels.sort_by_key(|c| c.name.to_lowercase());
     Ok(channels)
 }
 

--- a/src-tauri/src/intune/guid_registry.rs
+++ b/src-tauri/src/intune/guid_registry.rs
@@ -244,7 +244,7 @@ fn extract_all_id_name_pairs(msg: &str) -> Vec<(String, String, GuidNameSource)>
         }
 
         let mut pairs = Vec::new();
-        for (id_val, name_val) in ids.into_iter().zip(names.into_iter()) {
+        for (id_val, name_val) in ids.into_iter().zip(names) {
             if id_val.len() == 36 && guid_re().is_match(&id_val) {
                 pairs.push((id_val, name_val, GuidNameSource::NameField));
             }

--- a/src-tauri/src/ipc_bridge.rs
+++ b/src-tauri/src/ipc_bridge.rs
@@ -170,7 +170,13 @@ fn dispatch(body: &str, state: &Arc<BridgeState>) -> String {
         }
 
         "get_file_association_prompt_status" => {
-            ok_json(&"dismissed")
+            // Match the real command's response shape so the frontend can
+            // safely read `isAssociated` etc. in dev/browser mode.
+            ok_json(&serde_json::json!({
+                "supported": false,
+                "shouldPrompt": false,
+                "isAssociated": false,
+            }))
         }
 
         "get_initial_file_paths" => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,14 +51,12 @@ fn get_initial_file_paths_from_args() -> Vec<String> {
 pub fn run() {
     let initial_file_paths = get_initial_file_paths_from_args();
 
-    let mut builder = tauri::Builder::default()
+    tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_os::init())
-        .plugin(tauri_plugin_process::init());
-
-    builder
+        .plugin(tauri_plugin_process::init())
         .setup(|app| {
             #[cfg(desktop)]
             app.handle()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,18 +1,18 @@
-mod constants;
 #[cfg(feature = "collector")]
 pub mod collector;
 mod commands;
-#[cfg(debug_assertions)]
-mod ipc_bridge;
+mod constants;
 #[cfg(feature = "dsregcmd")]
 pub mod dsregcmd;
 pub mod error;
 pub mod error_db;
+#[cfg(feature = "event-log")]
+pub mod event_log;
 #[cfg(target_os = "windows")]
 pub mod graph_api;
 pub mod intune;
-#[cfg(feature = "event-log")]
-pub mod event_log;
+#[cfg(debug_assertions)]
+mod ipc_bridge;
 #[cfg(feature = "macos-diag")]
 pub mod macos_diag;
 mod menu;
@@ -21,17 +21,17 @@ pub mod parser;
 pub mod process_util;
 #[cfg(feature = "secureboot")]
 pub mod secureboot;
+mod state;
 #[cfg(feature = "sysmon")]
 pub mod sysmon;
-mod state;
 mod watcher;
 
 use state::app_state::AppState;
 
 #[cfg(target_os = "windows")]
-use tauri::Manager;
-#[cfg(target_os = "windows")]
 use graph_api::GraphAuthState;
+#[cfg(target_os = "windows")]
+use tauri::Manager;
 
 /// Returns all non-flag CLI arguments as potential file paths.
 ///
@@ -51,15 +51,19 @@ fn get_initial_file_paths_from_args() -> Vec<String> {
 pub fn run() {
     let initial_file_paths = get_initial_file_paths_from_args();
 
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_os::init())
-        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_process::init());
+
+    builder
         .setup(|app| {
             #[cfg(desktop)]
-            app.handle().plugin(tauri_plugin_updater::Builder::new().build())?;
+            app.handle()
+                .plugin(tauri_plugin_updater::Builder::new().build())?;
+
             let native_menu = menu::build_app_menu(app.handle())?;
             app.set_menu(native_menu)?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ pub mod macos_diag;
 mod menu;
 mod models;
 pub mod parser;
+pub mod process_util;
 #[cfg(feature = "secureboot")]
 pub mod secureboot;
 #[cfg(feature = "sysmon")]

--- a/src-tauri/src/macos_diag/environment.rs
+++ b/src-tauri/src/macos_diag/environment.rs
@@ -90,7 +90,7 @@ pub fn scan_log_directory(dir: &str) -> Vec<MacosLogFileEntry> {
     }
 
     // Sort newest first
-    entries.sort_by(|a, b| b.modified_unix_ms.cmp(&a.modified_unix_ms));
+    entries.sort_by_key(|e| std::cmp::Reverse(e.modified_unix_ms));
     entries
 }
 

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -67,13 +67,13 @@ pub fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> 
     let quit = MenuItem::with_id(app, MENU_ID_FILE_QUIT, "Exit", true, None::<&str>)?;
     let known_sources = build_known_sources_submenu(app)?;
 
-    let find = MenuItem::with_id(app, MENU_ID_EDIT_FIND, "Find...", true, Some("Ctrl+F"))?;
+    let find = MenuItem::with_id(app, MENU_ID_EDIT_FIND, "Find...", true, Some("CmdOrCtrl+F"))?;
     let filter = MenuItem::with_id(
         app,
         MENU_ID_EDIT_FILTER,
         "Filter...",
         true,
-        Some("Ctrl+L"),
+        Some("CmdOrCtrl+Shift+L"),
     )?;
 
     let error_lookup = MenuItem::with_id(
@@ -81,7 +81,7 @@ pub fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> 
         MENU_ID_TOOLS_ERROR_LOOKUP,
         "Lookup Error Code...",
         true,
-        None::<&str>,
+        Some("CmdOrCtrl+L"),
     )?;
     let bundle_summary = MenuItem::with_id(
         app,

--- a/src-tauri/src/process_util.rs
+++ b/src-tauri/src/process_util.rs
@@ -1,0 +1,30 @@
+//! Helpers for spawning child processes without showing a console window
+//! flash on Windows. See issue #138.
+
+use std::process::Command;
+
+/// `CREATE_NO_WINDOW` from `winbase.h`. Suppresses the flash of a console
+/// window when the GUI app spawns a console subprocess (powershell.exe,
+/// cmd.exe, reg.exe, sc.exe, wevtutil.exe, dsregcmd.exe, etc.).
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Build a `Command` for `program` that, on Windows, won't pop a console
+/// window. On other platforms behaves identically to `Command::new`.
+pub fn hidden_command<S: AsRef<std::ffi::OsStr>>(program: S) -> Command {
+    let mut cmd = Command::new(program);
+    apply_hidden_window(&mut cmd);
+    cmd
+}
+
+/// Apply the no-window flag to an existing `Command`. Useful when callers
+/// already have a `Command` they need to flag (e.g. when a builder pattern
+/// fits better than `hidden_command`).
+#[cfg(target_os = "windows")]
+pub fn apply_hidden_window(cmd: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn apply_hidden_window(_cmd: &mut Command) {}

--- a/src-tauri/src/secureboot/rules.rs
+++ b/src-tauri/src/secureboot/rules.rs
@@ -65,7 +65,7 @@ pub fn evaluate_all(
     rule_windows_10_eol(state, &mut findings);
 
     // Sort: errors first, then warnings, then info.
-    findings.sort_by(|a, b| b.severity.cmp(&a.severity));
+    findings.sort_by_key(|f| std::cmp::Reverse(f.severity));
     findings
 }
 

--- a/src-tauri/src/sysmon/evtx_parser.rs
+++ b/src-tauri/src/sysmon/evtx_parser.rs
@@ -295,7 +295,7 @@ pub fn build_summary(
             }
         })
         .collect();
-    event_type_counts.sort_by(|a, b| b.count.cmp(&a.count));
+    event_type_counts.sort_by_key(|e| std::cmp::Reverse(e.count));
 
     SysmonSummary {
         total_events: events.len() as u64,
@@ -325,31 +325,28 @@ pub fn extract_config(events: &[SysmonEvent], summary: &SysmonSummary) -> Sysmon
     // Look for ServiceStateChange events (ID 4) — they contain version info
     for event in events {
         match event.event_id {
-            16 => {
-                // ConfigChange: contains Configuration, ConfigurationFileHash
+            16
                 if last_config_change.is_none()
-                    || event.timestamp.as_str() > last_config_change.as_deref().unwrap_or("")
-                {
-                    last_config_change = Some(event.timestamp.clone());
-                }
+                    || event.timestamp.as_str() > last_config_change.as_deref().unwrap_or("") =>
+            {
+                // ConfigChange: contains Configuration, ConfigurationFileHash
+                last_config_change = Some(event.timestamp.clone());
                 // NOTE: Do not populate configuration_xml from event.message.
                 // The Message field is a human-readable summary and does not reliably
                 // contain the raw configuration XML. If configuration XML display is
                 // needed, it should be extracted from the EventData "Configuration"
                 // field during parsing and exposed via SysmonEvent.
             }
-            4 => {
+            4 if sysmon_version.is_none() => {
                 // ServiceStateChange: may contain version
-                if sysmon_version.is_none() {
-                    if let Some(ref msg) = event.details {
-                        if msg.contains("version") || msg.contains("Version") {
-                            sysmon_version = Some(msg.clone());
-                        }
+                if let Some(ref msg) = event.details {
+                    if msg.contains("version") || msg.contains("Version") {
+                        sysmon_version = Some(msg.clone());
                     }
-                    // Also check the message field
-                    if sysmon_version.is_none() && event.message.contains("version") {
-                        sysmon_version = Some(event.message.clone());
-                    }
+                }
+                // Also check the message field
+                if sysmon_version.is_none() && event.message.contains("version") {
+                    sysmon_version = Some(event.message.clone());
                 }
             }
             _ => {}
@@ -553,7 +550,7 @@ pub fn build_dashboard_data(events: &[SysmonEvent]) -> SysmonDashboardData {
             .into_iter()
             .map(|(name, count)| RankedItem { name, count })
             .collect();
-        vec.sort_by(|a, b| b.count.cmp(&a.count));
+        vec.sort_by_key(|v| std::cmp::Reverse(v.count));
         vec.truncate(TOP_N);
         vec
     };
@@ -562,7 +559,7 @@ pub fn build_dashboard_data(events: &[SysmonEvent]) -> SysmonDashboardData {
         .into_iter()
         .map(|(name, count)| RankedItem { name, count })
         .collect();
-    security_by_type.sort_by(|a, b| b.count.cmp(&a.count));
+    security_by_type.sort_by_key(|v| std::cmp::Reverse(v.count));
 
     SysmonDashboardData {
         timeline_minute: auto_timeline,

--- a/src-tauri/src/watcher/tail.rs
+++ b/src-tauri/src/watcher/tail.rs
@@ -295,14 +295,13 @@ where
                 Ok(Ok(event)) => {
                     // Only react to modify/create events for our file
                     match event.kind {
-                        EventKind::Modify(_) | EventKind::Create(_) => {
+                        EventKind::Modify(_) | EventKind::Create(_)
                             if event.paths.iter().any(|p| p == &watch_path)
-                                && !paused_clone.load(Ordering::Relaxed)
-                            {
-                                if let Ok(entries) = tail_reader.read_new_entries() {
-                                    if !entries.is_empty() {
-                                        on_new_entries(entries);
-                                    }
+                                && !paused_clone.load(Ordering::Relaxed) =>
+                        {
+                            if let Ok(entries) = tail_reader.read_new_entries() {
+                                if !entries.is_empty() {
+                                    on_new_entries(entries);
                                 }
                             }
                         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,8 +18,7 @@
         "minWidth": 800,
         "minHeight": 500,
         "resizable": true,
-        "fullscreen": false,
-        "dragDropEnabled": true
+        "fullscreen": false
       }
     ],
     "security": {

--- a/src-tauri/tauri.lite.conf.json
+++ b/src-tauri/tauri.lite.conf.json
@@ -20,7 +20,7 @@
         "minHeight": 500,
         "resizable": true,
         "fullscreen": false,
-        "dragDropEnabled": true
+        "dragDropEnabled": false
       }
     ]
   }

--- a/src/components/dialogs/settings/FileAssociationsTab.tsx
+++ b/src/components/dialogs/settings/FileAssociationsTab.tsx
@@ -1,12 +1,38 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { tokens } from "@fluentui/react-components";
 import { invoke } from "@tauri-apps/api/core";
 import { useUiStore } from "../../../stores/ui-store";
+
+interface FileAssociationPromptStatus {
+  supported: boolean;
+  shouldPrompt: boolean;
+  isAssociated: boolean;
+}
 
 export function FileAssociationsTab() {
   const currentPlatform = useUiStore((state) => state.currentPlatform);
   const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isAssociated, setIsAssociated] = useState<boolean | null>(null);
+
+  const refreshAssociationStatus = useCallback(async () => {
+    if (currentPlatform !== "windows") {
+      return;
+    }
+    try {
+      const result = await invoke<FileAssociationPromptStatus>(
+        "get_file_association_prompt_status"
+      );
+      setIsAssociated(result.isAssociated);
+    } catch (err) {
+      console.warn("[file-associations] failed to read association status", err);
+      setIsAssociated(null);
+    }
+  }, [currentPlatform]);
+
+  useEffect(() => {
+    void refreshAssociationStatus();
+  }, [refreshAssociationStatus]);
 
   if (currentPlatform !== "windows") {
     return (
@@ -24,6 +50,7 @@ export function FileAssociationsTab() {
       setErrorMessage(null);
       await invoke("associate_log_files_with_app");
       setStatus("success");
+      await refreshAssociationStatus();
     } catch (err) {
       setStatus("error");
       setErrorMessage(String(err));
@@ -36,24 +63,54 @@ export function FileAssociationsTab() {
         Register CMTrace Open as the default handler for .log files on Windows.
       </div>
 
-      <button
-        type="button"
-        onClick={handleAssociate}
-        style={{
-          padding: "6px 16px",
-          fontSize: "12px",
-          border: `1px solid ${tokens.colorNeutralStroke1}`,
-          borderRadius: "4px",
-          background: tokens.colorBrandBackground,
-          color: tokens.colorNeutralForegroundOnBrand,
-          cursor: "pointer",
-          fontWeight: 600,
-        }}
-      >
-        Associate .log files with CMTrace Open
-      </button>
+      {isAssociated === true ? (
+        <>
+          <div
+            style={{
+              fontSize: "12px",
+              color: tokens.colorPaletteGreenForeground1,
+              marginBottom: "10px",
+              fontWeight: 600,
+            }}
+          >
+            CMTrace Open is currently registered as the handler for .log files.
+          </div>
+          <button
+            type="button"
+            onClick={handleAssociate}
+            style={{
+              padding: "6px 16px",
+              fontSize: "12px",
+              border: `1px solid ${tokens.colorNeutralStroke1}`,
+              borderRadius: "4px",
+              background: tokens.colorNeutralBackground1,
+              color: tokens.colorNeutralForeground1,
+              cursor: "pointer",
+            }}
+          >
+            Re-register associations
+          </button>
+        </>
+      ) : (
+        <button
+          type="button"
+          onClick={handleAssociate}
+          style={{
+            padding: "6px 16px",
+            fontSize: "12px",
+            border: `1px solid ${tokens.colorNeutralStroke1}`,
+            borderRadius: "4px",
+            background: tokens.colorBrandBackground,
+            color: tokens.colorNeutralForegroundOnBrand,
+            cursor: "pointer",
+            fontWeight: 600,
+          }}
+        >
+          Associate .log files with CMTrace Open
+        </button>
+      )}
 
-      {status === "success" && (
+      {status === "success" && isAssociated !== true && (
         <div style={{ fontSize: "12px", color: tokens.colorPaletteGreenForeground1, marginTop: "8px" }}>
           File associations registered successfully.
         </div>

--- a/src/components/dialogs/settings/FileAssociationsTab.tsx
+++ b/src/components/dialogs/settings/FileAssociationsTab.tsx
@@ -20,10 +20,23 @@ export function FileAssociationsTab() {
       return;
     }
     try {
-      const result = await invoke<FileAssociationPromptStatus>(
-        "get_file_association_prompt_status"
-      );
-      setIsAssociated(result.isAssociated);
+      const result = await invoke("get_file_association_prompt_status");
+      // Defensive shape check — the dev ipc_bridge stub used to return a
+      // plain string ("dismissed"), and other transports could change too.
+      if (
+        typeof result === "object" &&
+        result !== null &&
+        "isAssociated" in result &&
+        typeof (result as FileAssociationPromptStatus).isAssociated === "boolean"
+      ) {
+        setIsAssociated((result as FileAssociationPromptStatus).isAssociated);
+      } else {
+        console.warn(
+          "[file-associations] unexpected association status shape",
+          result
+        );
+        setIsAssociated(null);
+      }
     } catch (err) {
       console.warn("[file-associations] failed to read association status", err);
       setIsAssociated(null);

--- a/src/hooks/use-context-menu.ts
+++ b/src/hooks/use-context-menu.ts
@@ -42,6 +42,9 @@ export function useContextMenu() {
 
       const errorCode = findErrorCode(entry);
       const messagePreview = truncate(entry.message, 40);
+      // Capture selected text BEFORE the menu opens, since popping the native
+      // menu can clear the document selection on some platforms.
+      const selectedText = window.getSelection()?.toString().trim() ?? "";
 
       // Marker state — use entry.filePath as the canonical key
       const markerState = useMarkerStore.getState();
@@ -79,6 +82,26 @@ export function useContextMenu() {
       }
 
       items.push(await PredefinedMenuItem.new({ item: "Separator" }));
+
+      if (selectedText.length > 0 && selectedText !== entry.message) {
+        const selectionPreview = truncate(selectedText, 40);
+        items.push(
+          await MenuItem.new({
+            id: "include-filter-selection",
+            text: `Include lines containing: "${selectionPreview}"`,
+            action: () => {
+              addQuickFilter("Message", selectedText, "Contains");
+            },
+          }),
+          await MenuItem.new({
+            id: "exclude-filter-selection",
+            text: `Exclude lines containing: "${selectionPreview}"`,
+            action: () => {
+              addQuickFilter("Message", selectedText, "NotContains");
+            },
+          })
+        );
+      }
 
       items.push(
         await MenuItem.new({

--- a/src/hooks/use-keyboard.ts
+++ b/src/hooks/use-keyboard.ts
@@ -98,9 +98,10 @@ function navigateSelection(key: string): boolean {
  *   Shift+F3→ Find Previous
  *   Ctrl+U  → Pause/Resume
  *   Ctrl+H  → Toggle Details
- *   Ctrl+L  → Filter
+ *   Ctrl+L  → Error Lookup (matches legacy CMTrace)
+ *   Ctrl+Shift+L → Filter
  *   Ctrl+C  → Copy (tab-separated selected entry)
- *   Ctrl+E  → Error Lookup
+ *   Ctrl+E  → Error Lookup (alias)
  *   F5      → Refresh
  */
 export function useKeyboard() {
@@ -214,7 +215,11 @@ export function useKeyboard() {
 
       if (ctrl && event.key.toLowerCase() === "l") {
         event.preventDefault();
-        showFilterDialog();
+        if (event.shiftKey) {
+          showFilterDialog();
+        } else {
+          showErrorLookupDialog();
+        }
         return;
       }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -29,6 +29,10 @@ function AppRoot() {
   }, []);
 
   useEffect(() => {
+    void initializeDateTimeFormatting();
+  }, []);
+
+  useEffect(() => {
     let unlisten: (() => void) | undefined;
     getCurrentWindow()
       .onFocusChanged(({ payload: focused }) => {
@@ -99,8 +103,6 @@ style.textContent = `
 document.head.appendChild(style);
 
 async function bootstrap() {
-  await initializeDateTimeFormatting();
-
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <RootWrapper>
       <ThemedApp />


### PR DESCRIPTION
## Summary

Bundles five small, independent fixes for open community issues.

Closes #137
Closes #136
Closes #113
Closes #53
Closes #138

| Issue | Fix |
|---|---|
| #137 | `Ctrl+L` now opens **Error Lookup** (matches legacy CMTrace muscle memory). Filter moves to `Ctrl+Shift+L`. `Ctrl+E` remains an Error Lookup alias. |
| #136 | Opening a folder no longer aborts on the first inaccessible file — `parse_files_batch` and `open_log_folder_aggregate` now log+skip per-file failures and continue. |
| #113 | Settings → File Associations now queries the registry on mount and after associating, switching to a "currently registered" view with a re-register button instead of always showing the same Associate button. |
| #53  | Right-clicking a log row with text selected shows new **Include / Exclude lines containing "<selection>"** items (in addition to the existing full-message Include/Exclude). ProcMon-style. |
| #138 | New `process_util::hidden_command` helper applies `CREATE_NO_WINDOW` (0x08000000) on Windows. Background diagnostics (dsregcmd, registry exports, schtasks, nltest, AD lookups, collector reg.exe + dynamic command artifacts) no longer flash console windows. Reveal-in-Explorer/Finder launchers intentionally left visible. |

> The DNS/DHCP `hidden_command` substitutions for #138 are applied separately on PR #135 (where `dns_dhcp.rs` lives).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test` (14 passing on macOS)
- [ ] Manual: on Windows, run "Capture dsregcmd" / collector and confirm no PowerShell/cmd windows flash
- [ ] Manual: open a folder containing a permission-denied file → other files still load, progress counter reaches total
- [ ] Manual: Settings → File Associations → click Associate → close + reopen Settings → shows "currently registered"
- [ ] Manual: right-click a log row with text selected → see Include/Exclude items scoped to selection
- [ ] Manual: `Ctrl+L` opens Error Lookup; `Ctrl+Shift+L` opens Filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)