### PR TITLE
feat: unified multi-file timeline with overlap-based incident detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ loginventory/
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# Git worktrees (isolated implementation branches)
+.worktrees/

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
 name = "cmtrace-open"
 version = "1.2.0"
 dependencies = [
+ "anyhow",
  "base64 0.22.1",
  "chrono",
  "criterion",
@@ -544,6 +545,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "ureq",
+ "uuid",
  "windows",
  "windows-future",
  "winreg",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,6 +57,8 @@ evtx = { version = "0.11", optional = true }
 glob = "0.3"
 sha2 = "0.10"
 tempfile = { version = "3", optional = true }
+uuid = { version = "1", features = ["v4"] }
+anyhow = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 plist = { version = "1", optional = true }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,3 +1,10 @@
+# Detach this package from any accidental parent workspace. Inside a git
+# worktree the parent checkout may contain an untracked root `Cargo.toml`
+# that would otherwise capture this crate — `cargo` walks up the directory
+# tree looking for a `[workspace]` until it finds one. An empty workspace
+# table here stops that walk and keeps the worktree self-contained.
+[workspace]
+
 [package]
 name = "cmtrace-open"
 version = "1.2.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -91,3 +91,7 @@ required-features = ["sysmon"]
 name = "intune_pipeline"
 harness = false
 required-features = ["intune-diagnostics"]
+
+[[bench]]
+name = "timeline"
+harness = false

--- a/src-tauri/benches/timeline.rs
+++ b/src-tauri/benches/timeline.rs
@@ -1,0 +1,81 @@
+use std::collections::{HashMap, HashSet};
+
+use app_lib::timeline::incidents::detect_incidents;
+use app_lib::timeline::models::*;
+use app_lib::timeline::query::query_lane_buckets;
+use app_lib::timeline::store::Timeline;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+fn make_index(source_idx: u16, n: usize, offset_ms: i64) -> Vec<EntryIndex> {
+    (0..n)
+        .map(|i| EntryIndex {
+            timestamp_ms: (i as i64) * 3 + offset_ms,
+            severity: if i % 100 == 0 {
+                Severity::Error
+            } else {
+                Severity::Info
+            },
+            source_idx,
+            byte_offset: 0,
+            line_number: (i + 1) as u32,
+            signal_flags: 0,
+        })
+        .collect()
+}
+
+fn bench_detect(c: &mut Criterion) {
+    for &n in &[10_000usize, 100_000, 1_000_000] {
+        let mut idx = HashMap::new();
+        idx.insert(0u16, make_index(0, n, 0));
+        idx.insert(1u16, make_index(1, n, 1));
+        let t = TimelineTunables::default();
+        c.bench_with_input(BenchmarkId::new("detect_incidents", n), &idx, |b, idx| {
+            b.iter(|| {
+                let _ = detect_incidents(
+                    idx,
+                    &HashMap::new(),
+                    &t,
+                    &HashSet::new(),
+                    &|_, _| None,
+                );
+            })
+        });
+    }
+}
+
+fn bench_buckets(c: &mut Criterion) {
+    let mut idx = HashMap::new();
+    idx.insert(0u16, make_index(0, 1_000_000, 0));
+    let tl = Timeline {
+        bundle: TimelineBundle {
+            id: "bench".into(),
+            sources: vec![TimelineSourceMeta {
+                idx: 0,
+                path: "x".into(),
+                display_name: "x".into(),
+                color: "#111".into(),
+                entry_count: 1_000_000,
+                kind: TimelineSourceKind::LogFile {
+                    parser_kind: ParserKind::Plain,
+                },
+            }],
+            time_range_ms: (0, 3_000_000),
+            total_entries: 1_000_000,
+            incidents: vec![],
+            denied_guids: vec![],
+            errors: vec![],
+            tunables: Default::default(),
+        },
+        indexes: idx,
+        ime_events: HashMap::new(),
+        raw_signals: vec![],
+    };
+    c.bench_function("query_lane_buckets_1M_500", |b| {
+        b.iter(|| {
+            let _ = query_lane_buckets(&tl, 500, None);
+        });
+    });
+}
+
+criterion_group!(benches, bench_detect, bench_buckets);
+criterion_main!(benches);

--- a/src-tauri/src/commands/app_config.rs
+++ b/src-tauri/src/commands/app_config.rs
@@ -31,5 +31,7 @@ pub fn get_available_workspaces() -> Vec<&'static str> {
         workspaces.push("secureboot");
     }
 
+    workspaces.push("timeline");
+
     workspaces
 }

--- a/src-tauri/src/commands/intune_diagnostics.rs
+++ b/src-tauri/src/commands/intune_diagnostics.rs
@@ -923,7 +923,7 @@ fn top_failed_download_labels(downloads: &[DownloadStat], limit: usize) -> Vec<S
     }
 
     let mut sorted_counts: Vec<(String, usize)> = label_counts.into_iter().collect();
-    sorted_counts.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted_counts.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     sorted_counts
         .into_iter()
@@ -1371,7 +1371,7 @@ fn top_event_detail_matches(events: &[&IntuneEvent], limit: usize) -> Vec<String
     }
 
     let mut sorted_counts: Vec<(String, usize)> = evidence_counts.into_iter().collect();
-    sorted_counts.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted_counts.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     sorted_counts
         .into_iter()
@@ -1601,7 +1601,7 @@ fn top_event_labels(events: &[&IntuneEvent], limit: usize) -> Vec<String> {
     }
 
     let mut sorted_counts: Vec<(String, usize)> = label_counts.into_iter().collect();
-    sorted_counts.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted_counts.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     sorted_counts
         .into_iter()

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -31,3 +31,4 @@ pub mod secureboot;
 #[cfg(feature = "sysmon")]
 pub mod sysmon;
 pub mod system_preferences;
+pub mod timeline;

--- a/src-tauri/src/commands/timeline.rs
+++ b/src-tauri/src/commands/timeline.rs
@@ -1,0 +1,169 @@
+use std::collections::HashSet;
+
+use tauri::{AppHandle, Manager, State};
+
+use crate::state::app_state::AppState;
+use crate::timeline::builder::{build_timeline, SourceRequest, DEFAULT_ENTRY_LIMIT};
+use crate::timeline::incidents::redetect_from_signals;
+use crate::timeline::models::*;
+use crate::timeline::query::{
+    query_incident_details as q_incident, query_lane_buckets as q_lane,
+    query_timeline_entries as q_entries, IncidentDetail, QueryContext, SourceRuntime,
+};
+
+/// Per-timeline runtime map kept outside `AppState.timelines` so the
+/// `HashMap<String, Timeline>` stays free of non-serializable parser
+/// runtime state that would break any future persistence work.
+pub struct TimelineRuntimeMap(
+    pub  std::sync::Mutex<
+        std::collections::HashMap<String, std::collections::HashMap<u16, SourceRuntime>>,
+    >,
+);
+
+impl TimelineRuntimeMap {
+    pub fn new() -> Self {
+        Self(std::sync::Mutex::new(std::collections::HashMap::new()))
+    }
+}
+
+impl Default for TimelineRuntimeMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[tauri::command]
+pub async fn build_timeline_cmd(
+    app: AppHandle,
+    sources: Vec<SourceRequest>,
+) -> Result<TimelineBundle, TimelineError> {
+    let (timeline, runtimes) = tokio::task::spawn_blocking(move || {
+        build_timeline(&sources, DEFAULT_ENTRY_LIMIT, Vec::new())
+    })
+    .await
+    .map_err(|e| TimelineError::Internal {
+        message: e.to_string(),
+    })??;
+
+    let state: State<AppState> = app.state();
+    let rt_state: State<TimelineRuntimeMap> = app.state();
+    let id = timeline.bundle.id.clone();
+    let bundle = timeline.bundle.clone();
+    state.timelines.lock().unwrap().insert(id.clone(), timeline);
+    rt_state.0.lock().unwrap().insert(id.clone(), runtimes);
+    Ok(bundle)
+}
+
+#[tauri::command]
+pub async fn query_timeline_entries_cmd(
+    app: AppHandle,
+    id: String,
+    range_ms: Option<(i64, i64)>,
+    source_filter: Option<Vec<u16>>,
+    offset: u64,
+    limit: u32,
+) -> Result<Vec<TimelineEntry>, TimelineError> {
+    let state: State<AppState> = app.state();
+    let rt_state: State<TimelineRuntimeMap> = app.state();
+    let tls = state.timelines.lock().unwrap();
+    let rts = rt_state.0.lock().unwrap();
+
+    let timeline = tls
+        .get(&id)
+        .ok_or(TimelineError::NotFound { id: id.clone() })?;
+    let runtimes = rts
+        .get(&id)
+        .ok_or(TimelineError::NotFound { id: id.clone() })?;
+    let filter_set: Option<HashSet<u16>> = source_filter.map(|v| v.into_iter().collect());
+    let ctx = QueryContext {
+        timeline,
+        runtimes,
+    };
+    Ok(q_entries(&ctx, range_ms, filter_set.as_ref(), offset, limit))
+}
+
+#[tauri::command]
+pub async fn query_lane_buckets_cmd(
+    app: AppHandle,
+    id: String,
+    bucket_count: u32,
+    range_ms: Option<(i64, i64)>,
+) -> Result<Vec<LaneBucket>, TimelineError> {
+    let state: State<AppState> = app.state();
+    let tls = state.timelines.lock().unwrap();
+    let timeline = tls.get(&id).ok_or(TimelineError::NotFound { id })?;
+    Ok(q_lane(timeline, bucket_count, range_ms))
+}
+
+#[tauri::command]
+pub async fn query_incident_details_cmd(
+    app: AppHandle,
+    id: String,
+    incident_id: u32,
+) -> Result<IncidentDetail, TimelineError> {
+    let state: State<AppState> = app.state();
+    let rt_state: State<TimelineRuntimeMap> = app.state();
+    let tls = state.timelines.lock().unwrap();
+    let rts = rt_state.0.lock().unwrap();
+    let timeline = tls
+        .get(&id)
+        .ok_or(TimelineError::NotFound { id: id.clone() })?;
+    let runtimes = rts
+        .get(&id)
+        .ok_or(TimelineError::NotFound { id: id.clone() })?;
+    let ctx = QueryContext {
+        timeline,
+        runtimes,
+    };
+    q_incident(&ctx, incident_id).ok_or(TimelineError::NotFound {
+        id: format!("incident:{}", incident_id),
+    })
+}
+
+#[tauri::command]
+pub async fn update_timeline_tunables_cmd(
+    app: AppHandle,
+    id: String,
+    tunables: TimelineTunables,
+) -> Result<Vec<Incident>, TimelineError> {
+    let state: State<AppState> = app.state();
+    let rt_state: State<TimelineRuntimeMap> = app.state();
+    let mut tls = state.timelines.lock().unwrap();
+    let rts = rt_state.0.lock().unwrap();
+    let timeline = tls
+        .get_mut(&id)
+        .ok_or(TimelineError::NotFound { id: id.clone() })?;
+    let runtimes = rts
+        .get(&id)
+        .ok_or(TimelineError::NotFound { id: id.clone() })?;
+    let denied: HashSet<String> = timeline.bundle.denied_guids.iter().cloned().collect();
+
+    let indexes = timeline.indexes.clone();
+    let materialize = |src: u16, eref: u32| -> Option<String> {
+        let ei = indexes.get(&src).and_then(|v| v.get(eref as usize))?;
+        let rt = runtimes.get(&src)?;
+        crate::timeline::query::materialize_msg(&rt.path, &rt.parser, ei)
+    };
+    let incidents = redetect_from_signals(
+        &timeline.raw_signals,
+        &timeline.ime_events,
+        &tunables,
+        &denied,
+        &materialize,
+    );
+    timeline.bundle.tunables = tunables;
+    timeline.bundle.incidents = incidents.clone();
+    Ok(incidents)
+}
+
+#[tauri::command]
+pub async fn close_timeline_cmd(
+    app: AppHandle,
+    id: String,
+) -> Result<(), TimelineError> {
+    let state: State<AppState> = app.state();
+    let rt_state: State<TimelineRuntimeMap> = app.state();
+    state.timelines.lock().unwrap().remove(&id);
+    rt_state.0.lock().unwrap().remove(&id);
+    Ok(())
+}

--- a/src-tauri/src/intune/guid_registry.rs
+++ b/src-tauri/src/intune/guid_registry.rs
@@ -244,7 +244,7 @@ fn extract_all_id_name_pairs(msg: &str) -> Vec<(String, String, GuidNameSource)>
         }
 
         let mut pairs = Vec::new();
-        for (id_val, name_val) in ids.into_iter().zip(names.into_iter()) {
+        for (id_val, name_val) in ids.into_iter().zip(names) {
             if id_val.len() == 36 && guid_re().is_match(&id_val) {
                 pairs.push((id_val, name_val, GuidNameSource::NameField));
             }

--- a/src-tauri/src/intune/models.rs
+++ b/src-tauri/src/intune/models.rs
@@ -158,6 +158,47 @@ pub struct IntuneEvent {
     pub parent_app_guid: Option<String>,
 }
 
+impl IntuneEvent {
+    /// Is this event in a failed state?
+    pub fn status_is_failed(&self) -> bool {
+        matches!(self.status, IntuneStatus::Failed)
+    }
+
+    /// Start time as epoch milliseconds, if known.
+    pub fn start_time_epoch_ms(&self) -> Option<i64> {
+        self.start_time_epoch
+    }
+
+    /// GUID anchoring this event (app/policy ID), if known.
+    pub fn anchor_guid(&self) -> Option<&str> {
+        self.guid.as_deref()
+    }
+
+    /// Human-readable display label (app/script name).
+    pub fn display_name(&self) -> Option<&str> {
+        if self.name.is_empty() {
+            None
+        } else {
+            Some(self.name.as_str())
+        }
+    }
+
+    /// Short label describing the kind of Intune operation this event represents.
+    pub fn event_kind_label(&self) -> Option<&str> {
+        Some(match self.event_type {
+            IntuneEventType::Win32App => "App Install",
+            IntuneEventType::WinGetApp => "WinGet Install",
+            IntuneEventType::PowerShellScript => "Script",
+            IntuneEventType::Remediation => "Remediation",
+            IntuneEventType::Esp => "ESP",
+            IntuneEventType::SyncSession => "Sync",
+            IntuneEventType::PolicyEvaluation => "Policy",
+            IntuneEventType::ContentDownload => "Download",
+            IntuneEventType::Other => "Operation",
+        })
+    }
+}
+
 /// Metadata for an app policy extracted from "Get policies" JSON payloads.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,7 +23,7 @@ pub mod secureboot;
 #[cfg(feature = "sysmon")]
 pub mod sysmon;
 mod state;
-mod timeline;
+pub mod timeline;
 mod watcher;
 
 use state::app_state::AppState;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ pub mod secureboot;
 #[cfg(feature = "sysmon")]
 pub mod sysmon;
 mod state;
+mod timeline;
 mod watcher;
 
 use state::app_state::AppState;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,6 +70,11 @@ pub fn run() {
             #[cfg(target_os = "windows")]
             app.manage(GraphAuthState::new());
 
+            {
+                use tauri::Manager as _;
+                app.manage(commands::timeline::TimelineRuntimeMap::new());
+            }
+
             // Auto-open DevTools in debug builds
             #[cfg(all(debug_assertions, desktop))]
             {
@@ -173,6 +178,12 @@ pub fn run() {
             commands::secureboot::run_secureboot_remediation,
             #[cfg(feature = "sysmon")]
             commands::sysmon::analyze_sysmon_logs,
+            commands::timeline::build_timeline_cmd,
+            commands::timeline::close_timeline_cmd,
+            commands::timeline::query_incident_details_cmd,
+            commands::timeline::query_lane_buckets_cmd,
+            commands::timeline::query_timeline_entries_cmd,
+            commands::timeline::update_timeline_tunables_cmd,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/macos_diag/environment.rs
+++ b/src-tauri/src/macos_diag/environment.rs
@@ -90,7 +90,7 @@ pub fn scan_log_directory(dir: &str) -> Vec<MacosLogFileEntry> {
     }
 
     // Sort newest first
-    entries.sort_by(|a, b| b.modified_unix_ms.cmp(&a.modified_unix_ms));
+    entries.sort_by_key(|b| std::cmp::Reverse(b.modified_unix_ms));
     entries
 }
 

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -10,6 +10,8 @@ pub const MENU_EVENT_APP_ACTION: &str = "app-menu-action";
 
 pub const MENU_ID_FILE_OPEN_LOG_FILE: &str = "file.open_log_file";
 pub const MENU_ID_FILE_OPEN_LOG_FOLDER: &str = "file.open_log_folder";
+pub const MENU_ID_FILE_NEW_TIMELINE_FROM_FOLDER: &str = "file.new_timeline_from_folder";
+pub const MENU_ID_FILE_NEW_EMPTY_TIMELINE: &str = "file.new_empty_timeline";
 pub const MENU_ID_FILE_SAVE_SESSION: &str = "file.save_session";
 pub const MENU_ID_FILE_OPEN_SESSION: &str = "file.open_session";
 pub const MENU_ID_FILE_QUIT: &str = "file.quit";
@@ -47,6 +49,20 @@ pub fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> 
         app,
         MENU_ID_FILE_OPEN_LOG_FOLDER,
         "Open Log Folder...",
+        true,
+        None::<&str>,
+    )?;
+    let new_timeline_from_folder = MenuItem::with_id(
+        app,
+        MENU_ID_FILE_NEW_TIMELINE_FROM_FOLDER,
+        "New Timeline from Folder...",
+        true,
+        None::<&str>,
+    )?;
+    let new_empty_timeline = MenuItem::with_id(
+        app,
+        MENU_ID_FILE_NEW_EMPTY_TIMELINE,
+        "New Empty Timeline",
         true,
         None::<&str>,
     )?;
@@ -140,7 +156,16 @@ pub fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> 
         app,
         "File",
         true,
-        &[&open_log_file, &open_log_folder, &save_session, &open_session, &known_sources, &quit],
+        &[
+            &open_log_file,
+            &open_log_folder,
+            &new_timeline_from_folder,
+            &new_empty_timeline,
+            &save_session,
+            &open_session,
+            &known_sources,
+            &quit,
+        ],
     )?;
     let edit_menu = Submenu::with_items(app, "Edit", true, &[&find, &filter])?;
     #[cfg(all(target_os = "windows", feature = "collector"))]
@@ -363,6 +388,22 @@ fn payload_for_menu_id(menu_id: &str) -> Option<AppMenuActionPayload> {
             version: 1,
             menu_id: MENU_ID_FILE_OPEN_LOG_FOLDER.to_string(),
             action: "open_log_folder_dialog".to_string(),
+            category: "file".to_string(),
+            trigger: "menu".to_string(),
+            source_id: None,
+        },
+        MENU_ID_FILE_NEW_TIMELINE_FROM_FOLDER => AppMenuActionPayload {
+            version: 1,
+            menu_id: MENU_ID_FILE_NEW_TIMELINE_FROM_FOLDER.to_string(),
+            action: "timeline_new_from_folder".to_string(),
+            category: "file".to_string(),
+            trigger: "menu".to_string(),
+            source_id: None,
+        },
+        MENU_ID_FILE_NEW_EMPTY_TIMELINE => AppMenuActionPayload {
+            version: 1,
+            menu_id: MENU_ID_FILE_NEW_EMPTY_TIMELINE.to_string(),
+            action: "timeline_new_empty".to_string(),
             category: "file".to_string(),
             trigger: "menu".to_string(),
             source_id: None,

--- a/src-tauri/src/parser/detect.rs
+++ b/src-tauri/src/parser/detect.rs
@@ -363,6 +363,32 @@ impl ResolvedParser {
             specialization: self.specialization,
         }
     }
+
+    /// Parse a single line of text using this resolved parser, overriding the
+    /// resulting entry's `line_number` with the provided value.
+    ///
+    /// This is a thin wrapper over `parse_lines_with_selection` intended for
+    /// on-demand materialization (e.g. the unified timeline) where we already
+    /// know the parser and the original line number, and just need to rebuild
+    /// a single `LogEntry` from the raw text.
+    pub fn parse_one_line(
+        &self,
+        text: &str,
+        line_number: u32,
+    ) -> Result<crate::models::log_entry::LogEntry, String> {
+        // Trim a single trailing newline (the raw-entry reader keeps the newline).
+        let trimmed = text.strip_suffix('\n').unwrap_or(text);
+        let trimmed = trimmed.strip_suffix('\r').unwrap_or(trimmed);
+        let lines = [trimmed];
+        let (mut entries, _parse_errors) =
+            super::parse_lines_with_selection(&lines, "", self);
+        let mut entry = entries
+            .drain(..)
+            .next()
+            .ok_or_else(|| "parser produced no entries".to_string())?;
+        entry.line_number = line_number;
+        Ok(entry)
+    }
 }
 
 /// Detect the parser selection from file content.

--- a/src-tauri/src/secureboot/rules.rs
+++ b/src-tauri/src/secureboot/rules.rs
@@ -65,7 +65,7 @@ pub fn evaluate_all(
     rule_windows_10_eol(state, &mut findings);
 
     // Sort: errors first, then warnings, then info.
-    findings.sort_by(|a, b| b.severity.cmp(&a.severity));
+    findings.sort_by_key(|b| std::cmp::Reverse(b.severity));
     findings
 }
 

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -4,6 +4,7 @@ use std::sync::Mutex;
 
 use crate::models::log_entry::LogEntry;
 use crate::parser::ResolvedParser;
+use crate::timeline::store::Timeline;
 use crate::watcher::tail::TailSession;
 
 #[allow(dead_code)]
@@ -24,6 +25,8 @@ pub struct AppState {
     /// File paths passed as CLI arguments at startup via OS file association.
     /// Consumed (cleared) on first retrieval so they are only processed once.
     pub initial_file_paths: Mutex<Vec<String>>,
+    /// Active unified multi-file timelines keyed by timeline id.
+    pub timelines: Mutex<HashMap<String, Timeline>>,
 }
 
 impl AppState {
@@ -32,6 +35,7 @@ impl AppState {
             open_files: Mutex::new(HashMap::new()),
             tail_sessions: Mutex::new(HashMap::new()),
             initial_file_paths: Mutex::new(initial_file_paths),
+            timelines: Mutex::new(HashMap::new()),
         }
     }
 }

--- a/src-tauri/src/sysmon/evtx_parser.rs
+++ b/src-tauri/src/sysmon/evtx_parser.rs
@@ -295,7 +295,7 @@ pub fn build_summary(
             }
         })
         .collect();
-    event_type_counts.sort_by(|a, b| b.count.cmp(&a.count));
+    event_type_counts.sort_by_key(|b| std::cmp::Reverse(b.count));
 
     SysmonSummary {
         total_events: events.len() as u64,
@@ -325,31 +325,27 @@ pub fn extract_config(events: &[SysmonEvent], summary: &SysmonSummary) -> Sysmon
     // Look for ServiceStateChange events (ID 4) — they contain version info
     for event in events {
         match event.event_id {
-            16 => {
+            16 if last_config_change.is_none()
+                || event.timestamp.as_str() > last_config_change.as_deref().unwrap_or("") =>
+            {
                 // ConfigChange: contains Configuration, ConfigurationFileHash
-                if last_config_change.is_none()
-                    || event.timestamp.as_str() > last_config_change.as_deref().unwrap_or("")
-                {
-                    last_config_change = Some(event.timestamp.clone());
-                }
+                last_config_change = Some(event.timestamp.clone());
                 // NOTE: Do not populate configuration_xml from event.message.
                 // The Message field is a human-readable summary and does not reliably
                 // contain the raw configuration XML. If configuration XML display is
                 // needed, it should be extracted from the EventData "Configuration"
                 // field during parsing and exposed via SysmonEvent.
             }
-            4 => {
+            4 if sysmon_version.is_none() => {
                 // ServiceStateChange: may contain version
-                if sysmon_version.is_none() {
-                    if let Some(ref msg) = event.details {
-                        if msg.contains("version") || msg.contains("Version") {
-                            sysmon_version = Some(msg.clone());
-                        }
+                if let Some(ref msg) = event.details {
+                    if msg.contains("version") || msg.contains("Version") {
+                        sysmon_version = Some(msg.clone());
                     }
-                    // Also check the message field
-                    if sysmon_version.is_none() && event.message.contains("version") {
-                        sysmon_version = Some(event.message.clone());
-                    }
+                }
+                // Also check the message field
+                if sysmon_version.is_none() && event.message.contains("version") {
+                    sysmon_version = Some(event.message.clone());
                 }
             }
             _ => {}
@@ -553,7 +549,7 @@ pub fn build_dashboard_data(events: &[SysmonEvent]) -> SysmonDashboardData {
             .into_iter()
             .map(|(name, count)| RankedItem { name, count })
             .collect();
-        vec.sort_by(|a, b| b.count.cmp(&a.count));
+        vec.sort_by_key(|b| std::cmp::Reverse(b.count));
         vec.truncate(TOP_N);
         vec
     };
@@ -562,7 +558,7 @@ pub fn build_dashboard_data(events: &[SysmonEvent]) -> SysmonDashboardData {
         .into_iter()
         .map(|(name, count)| RankedItem { name, count })
         .collect();
-    security_by_type.sort_by(|a, b| b.count.cmp(&a.count));
+    security_by_type.sort_by_key(|b| std::cmp::Reverse(b.count));
 
     SysmonDashboardData {
         timeline_minute: auto_timeline,

--- a/src-tauri/src/timeline/builder.rs
+++ b/src-tauri/src/timeline/builder.rs
@@ -1,5 +1,9 @@
 use std::path::{Path, PathBuf};
 
+/// Result of scanning a folder for timeline-eligible sources. Used by the
+/// frontend ingestion layer (and future command wrappers) to decide which
+/// paths to pass into `build_timeline` as log files vs. IME folders.
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ClassifiedSource {
     LogFile(PathBuf),
@@ -9,6 +13,7 @@ pub enum ClassifiedSource {
 /// Walk the given root (one level deep) and classify what we find.
 /// Produces log files for every recognized log path plus at most one
 /// IME-events source per IME folder detected.
+#[allow(dead_code)]
 pub fn classify_folder(root: &Path) -> Vec<ClassifiedSource> {
     let mut out: Vec<ClassifiedSource> = Vec::new();
     if !root.is_dir() {

--- a/src-tauri/src/timeline/builder.rs
+++ b/src-tauri/src/timeline/builder.rs
@@ -80,3 +80,315 @@ mod tests_classify {
         );
     }
 }
+
+use std::collections::{HashMap, HashSet};
+
+use crate::timeline::models::*;
+use crate::timeline::query::SourceRuntime;
+use crate::timeline::store::Timeline;
+
+pub const DEFAULT_ENTRY_LIMIT: u64 = 5_000_000;
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceRequest {
+    pub path: String,
+    pub display_name: Option<String>,
+}
+
+/// Build a timeline from a set of source requests. Each request is either
+/// a log file path or a folder (containing IME logs).
+pub fn build_timeline(
+    requests: &[SourceRequest],
+    limit: u64,
+    denied_seed: Vec<String>,
+) -> Result<(Timeline, HashMap<u16, SourceRuntime>), TimelineError> {
+    if requests.is_empty() {
+        return Err(TimelineError::NoSources);
+    }
+
+    const PALETTE: [&str; 8] = [
+        "#2563eb", "#a855f7", "#16a34a", "#dc2626", "#f59e0b", "#0891b2", "#ea580c", "#65a30d",
+    ];
+    let mut sources: Vec<TimelineSourceMeta> = Vec::new();
+    let mut indexes: HashMap<u16, Vec<EntryIndex>> = HashMap::new();
+    let mut ime_events: HashMap<u16, Vec<crate::intune::models::IntuneEvent>> = HashMap::new();
+    let mut runtimes: HashMap<u16, SourceRuntime> = HashMap::new();
+    let mut errors: Vec<SourceError> = Vec::new();
+    let mut total_entries: u64 = 0;
+    let mut time_min = i64::MAX;
+    let mut time_max = i64::MIN;
+
+    for (i, req) in requests.iter().enumerate() {
+        let idx = i as u16;
+        let color = PALETTE[i % PALETTE.len()].to_string();
+        let path = std::path::PathBuf::from(&req.path);
+        let display_name = req.display_name.clone().unwrap_or_else(|| {
+            path.file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("source")
+                .to_string()
+        });
+
+        if path.is_dir() {
+            match extract_ime_events(&path) {
+                Ok(events) => {
+                    for ev in &events {
+                        if let Some(ts) = ev.start_time_epoch_ms() {
+                            time_min = time_min.min(ts);
+                            time_max = time_max.max(ts);
+                        }
+                    }
+                    total_entries += events.len() as u64;
+                    if total_entries > limit {
+                        return Err(TimelineError::TooLarge {
+                            estimated: total_entries,
+                            limit,
+                        });
+                    }
+                    sources.push(TimelineSourceMeta {
+                        idx,
+                        color,
+                        display_name,
+                        kind: TimelineSourceKind::IntuneEvents,
+                        path: req.path.clone(),
+                        entry_count: events.len() as u32,
+                    });
+                    ime_events.insert(idx, events);
+                }
+                Err(e) => errors.push(SourceError {
+                    path: req.path.clone(),
+                    message: e.to_string(),
+                }),
+            }
+            continue;
+        }
+
+        match parse_to_index(&path) {
+            Ok((parser_kind, idx_vec, parser, entry_count)) => {
+                for ei in &idx_vec {
+                    time_min = time_min.min(ei.timestamp_ms);
+                    time_max = time_max.max(ei.timestamp_ms);
+                }
+                total_entries += entry_count as u64;
+                if total_entries > limit {
+                    return Err(TimelineError::TooLarge {
+                        estimated: total_entries,
+                        limit,
+                    });
+                }
+                sources.push(TimelineSourceMeta {
+                    idx,
+                    color,
+                    display_name,
+                    kind: TimelineSourceKind::LogFile { parser_kind },
+                    path: req.path.clone(),
+                    entry_count,
+                });
+                indexes.insert(idx, idx_vec);
+                runtimes.insert(idx, SourceRuntime { path, parser });
+            }
+            Err(e) => errors.push(SourceError {
+                path: req.path.clone(),
+                message: e.to_string(),
+            }),
+        }
+    }
+
+    if time_min == i64::MAX {
+        time_min = 0;
+        time_max = 0;
+    }
+
+    let mut denied: HashSet<String> = denied_seed
+        .into_iter()
+        .filter_map(|g| crate::timeline::correlation::normalize_guid(&g))
+        .collect();
+    let samples = sample_source_messages(&runtimes, &indexes, 200);
+    let samples_as_refs: HashMap<u16, Vec<&str>> = samples
+        .iter()
+        .map(|(k, v)| (*k, v.iter().map(|s| s.as_str()).collect()))
+        .collect();
+    let hf = crate::timeline::correlation::high_frequency_guids(&samples_as_refs, 0.35, 2);
+    denied.extend(hf);
+
+    let tunables = TimelineTunables::default();
+    let materialize = |src: u16, eref: u32| -> Option<String> {
+        let ei = indexes.get(&src).and_then(|v| v.get(eref as usize))?;
+        let rt = runtimes.get(&src)?;
+        crate::timeline::query::materialize_msg(&rt.path, &rt.parser, ei)
+    };
+    let (raw_signals, incidents) = crate::timeline::incidents::detect_incidents(
+        &indexes,
+        &ime_events,
+        &tunables,
+        &denied,
+        &materialize,
+    );
+
+    let bundle = TimelineBundle {
+        id: uuid::Uuid::new_v4().to_string(),
+        sources,
+        time_range_ms: (time_min, time_max),
+        total_entries,
+        incidents,
+        denied_guids: denied.into_iter().collect(),
+        errors,
+        tunables,
+    };
+    Ok((
+        Timeline {
+            bundle,
+            indexes,
+            ime_events,
+            raw_signals,
+        },
+        runtimes,
+    ))
+}
+
+/// Parse one log file. Returns parser kind, index vec, resolved parser,
+/// and entry count.
+fn parse_to_index(
+    path: &std::path::Path,
+) -> Result<
+    (
+        crate::models::log_entry::ParserKind,
+        Vec<EntryIndex>,
+        crate::parser::ResolvedParser,
+        u32,
+    ),
+    anyhow::Error,
+> {
+    let path_str = path.to_string_lossy().to_string();
+    let (parse_result, parser) = crate::parser::parse_file(&path_str)
+        .map_err(|e| anyhow::anyhow!("parse_file: {}", e))?;
+
+    // Re-read the raw bytes so we can compute per-line byte offsets.
+    // The byte offset for line N (1-based) is offsets[N - 1]. offsets[0] is 0.
+    let bytes = std::fs::read(path).map_err(|e| anyhow::anyhow!("read: {}", e))?;
+    let mut offsets: Vec<u64> = Vec::with_capacity(bytes.len() / 40 + 1);
+    offsets.push(0);
+    for (i, b) in bytes.iter().enumerate() {
+        if *b == b'\n' {
+            offsets.push((i + 1) as u64);
+        }
+    }
+
+    let parser_kind = parser.parser;
+    let mut idx_vec: Vec<EntryIndex> = Vec::with_capacity(parse_result.entries.len());
+    for entry in &parse_result.entries {
+        let timestamp_ms = entry.timestamp.unwrap_or(0);
+        let byte_offset = if entry.line_number == 0 {
+            0
+        } else {
+            offsets
+                .get((entry.line_number - 1) as usize)
+                .copied()
+                .unwrap_or(0)
+        };
+        let mut flags: u8 = 0;
+        if !entry.error_code_spans.is_empty() {
+            flags |= SIGNAL_FLAG_HAS_ERROR_CODE;
+        }
+        idx_vec.push(EntryIndex {
+            timestamp_ms,
+            severity: entry.severity,
+            source_idx: 0, // filled in by caller (we set via per-source insertion anyway, but keep zero placeholder)
+            byte_offset,
+            line_number: entry.line_number,
+            signal_flags: flags,
+        });
+    }
+    let entry_count = idx_vec.len() as u32;
+    Ok((parser_kind, idx_vec, parser, entry_count))
+}
+
+/// Walk an IME-logs folder and extract Intune events by running the same
+/// pipeline the `analyze_intune_logs` command uses: ime_parser → GuidRegistry
+/// ingest → event_tracker::extract_events → timeline::build_timeline.
+fn extract_ime_events(
+    folder: &std::path::Path,
+) -> Result<Vec<crate::intune::models::IntuneEvent>, anyhow::Error> {
+    let rd = std::fs::read_dir(folder)
+        .map_err(|e| anyhow::anyhow!("read_dir {}: {}", folder.display(), e))?;
+
+    // Collect IME-relevant log files in the folder. Match on the pattern table
+    // used by the intune command (case-insensitive substring on file name).
+    let mut files: Vec<std::path::PathBuf> = Vec::new();
+    for entry in rd.flatten() {
+        let p = entry.path();
+        if !p.is_file() {
+            continue;
+        }
+        let name_lower = p
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_ascii_lowercase())
+            .unwrap_or_default();
+        if !name_lower.ends_with(".log") {
+            continue;
+        }
+        if IME_LOG_HINTS.iter().any(|h| name_lower.contains(h)) {
+            files.push(p);
+        }
+    }
+
+    // Parse each file, build a global GUID registry, then extract events.
+    let mut per_file: Vec<(String, Vec<crate::intune::ime_parser::ImeLine>)> = Vec::new();
+    let mut registry = crate::intune::guid_registry::GuidRegistry::new();
+    for p in &files {
+        let content = std::fs::read_to_string(p)
+            .map_err(|e| anyhow::anyhow!("read_to_string {}: {}", p.display(), e))?;
+        let lines = crate::intune::ime_parser::parse_ime_content(&content);
+        registry.ingest_lines(&lines);
+        per_file.push((p.to_string_lossy().to_string(), lines));
+    }
+
+    let mut all_events: Vec<crate::intune::models::IntuneEvent> = Vec::new();
+    for (source_file, lines) in &per_file {
+        let events = crate::intune::event_tracker::extract_events(lines, source_file, &registry);
+        all_events.extend(events);
+    }
+
+    // Run the same timeline build (dedupe + sort + epoch_ms population) used
+    // by the intune command path.
+    Ok(crate::intune::timeline::build_timeline(all_events))
+}
+
+const IME_LOG_HINTS: &[&str] = &[
+    "intunemanagementextension",
+    "appworkload",
+    "appactionprocessor",
+    "agentexecutor",
+    "healthscripts",
+    "clienthealth",
+    "clientcertcheck",
+    "devicehealthmonitoring",
+    "sensor",
+    "win32appinventory",
+    "imeui",
+];
+
+fn sample_source_messages(
+    runtimes: &HashMap<u16, SourceRuntime>,
+    indexes: &HashMap<u16, Vec<EntryIndex>>,
+    per_source_cap: usize,
+) -> HashMap<u16, Vec<String>> {
+    let mut out: HashMap<u16, Vec<String>> = HashMap::new();
+    for (src, idx_vec) in indexes {
+        let rt = match runtimes.get(src) {
+            Some(r) => r,
+            None => continue,
+        };
+        let step = (idx_vec.len() / per_source_cap).max(1);
+        let mut msgs: Vec<String> = Vec::with_capacity(per_source_cap);
+        for ei in idx_vec.iter().step_by(step).take(per_source_cap) {
+            if let Some(m) = crate::timeline::query::materialize_msg(&rt.path, &rt.parser, ei) {
+                msgs.push(m);
+            }
+        }
+        out.insert(*src, msgs);
+    }
+    out
+}

--- a/src-tauri/src/timeline/builder.rs
+++ b/src-tauri/src/timeline/builder.rs
@@ -1,0 +1,82 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClassifiedSource {
+    LogFile(PathBuf),
+    ImeLogsFolder(PathBuf),
+}
+
+/// Walk the given root (one level deep) and classify what we find.
+/// Produces log files for every recognized log path plus at most one
+/// IME-events source per IME folder detected.
+pub fn classify_folder(root: &Path) -> Vec<ClassifiedSource> {
+    let mut out: Vec<ClassifiedSource> = Vec::new();
+    if !root.is_dir() {
+        return out;
+    }
+
+    let ime_hint_files = ["AgentExecutor.log", "IntuneManagementExtension.log"];
+    let mut contains_ime_logs = false;
+
+    if let Ok(rd) = std::fs::read_dir(root) {
+        for entry in rd.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if ime_hint_files.contains(&name) {
+                    contains_ime_logs = true;
+                }
+                if is_log_file(name) {
+                    out.push(ClassifiedSource::LogFile(path));
+                }
+            }
+        }
+    }
+    if contains_ime_logs {
+        out.push(ClassifiedSource::ImeLogsFolder(root.to_path_buf()));
+    }
+    out
+}
+
+fn is_log_file(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.ends_with(".log")
+        || lower.ends_with(".cmtlog")
+        || lower.ends_with(".txt")
+        || lower == "setupact.log"
+        || lower == "setupapi.app.log"
+        || lower == "setupapi.dev.log"
+}
+
+#[cfg(test)]
+mod tests_classify {
+    use super::*;
+
+    #[test]
+    fn classifies_plain_log_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("foo.log"), b"hello\n").unwrap();
+        std::fs::write(dir.path().join("bar.txt"), b"bye\n").unwrap();
+        std::fs::write(dir.path().join("ignore.bin"), b"x").unwrap();
+        let mut out = classify_folder(dir.path());
+        out.sort_by_key(|c| format!("{:?}", c));
+        assert_eq!(out.len(), 2);
+        assert!(matches!(out[0], ClassifiedSource::LogFile(_)));
+        assert!(matches!(out[1], ClassifiedSource::LogFile(_)));
+    }
+
+    #[test]
+    fn detects_ime_folder_when_agentexecutor_present() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("AgentExecutor.log"), b"hello\n").unwrap();
+        std::fs::write(dir.path().join("IntuneManagementExtension.log"), b"hi\n").unwrap();
+        let out = classify_folder(dir.path());
+        assert!(out.iter().any(|c| matches!(c, ClassifiedSource::ImeLogsFolder(_))));
+        assert_eq!(
+            out.iter()
+                .filter(|c| matches!(c, ClassifiedSource::LogFile(_)))
+                .count(),
+            2
+        );
+    }
+}

--- a/src-tauri/src/timeline/builder.rs
+++ b/src-tauri/src/timeline/builder.rs
@@ -312,6 +312,7 @@ fn parse_to_index(
 /// Walk an IME-logs folder and extract Intune events by running the same
 /// pipeline the `analyze_intune_logs` command uses: ime_parser → GuidRegistry
 /// ingest → event_tracker::extract_events → timeline::build_timeline.
+#[cfg(feature = "intune-diagnostics")]
 fn extract_ime_events(
     folder: &std::path::Path,
 ) -> Result<Vec<crate::intune::models::IntuneEvent>, anyhow::Error> {
@@ -361,6 +362,19 @@ fn extract_ime_events(
     Ok(crate::intune::timeline::build_timeline(all_events))
 }
 
+/// When built without the `intune-diagnostics` feature, IME event extraction
+/// is unavailable. The timeline builder surfaces the per-source failure as a
+/// `SourceError`, matching the pattern used for individual file read errors.
+#[cfg(not(feature = "intune-diagnostics"))]
+fn extract_ime_events(
+    _folder: &std::path::Path,
+) -> Result<Vec<crate::intune::models::IntuneEvent>, anyhow::Error> {
+    Err(anyhow::anyhow!(
+        "IME event extraction requires the `intune-diagnostics` feature"
+    ))
+}
+
+#[cfg(feature = "intune-diagnostics")]
 const IME_LOG_HINTS: &[&str] = &[
     "intunemanagementextension",
     "appworkload",

--- a/src-tauri/src/timeline/correlation.rs
+++ b/src-tauri/src/timeline/correlation.rs
@@ -35,6 +35,44 @@ pub fn extract_guids(msg: &str) -> Vec<String> {
         .collect()
 }
 
+use std::collections::{HashMap, HashSet};
+
+/// Given a per-source sample of message texts, return the set of GUIDs that
+/// appear in more than `threshold` fraction (0..=1) of sampled messages across
+/// at least `min_sources` distinct sources.
+pub fn high_frequency_guids(
+    samples: &HashMap<u16, Vec<&str>>,
+    threshold: f32,
+    min_sources: usize,
+) -> HashSet<String> {
+    let mut per_source_hit: HashMap<String, HashMap<u16, (u32, u32)>> = HashMap::new();
+    for (src, msgs) in samples {
+        let total = msgs.len() as u32;
+        for msg in msgs {
+            let guids = extract_guids(msg);
+            let unique: HashSet<String> = guids.into_iter().collect();
+            for g in unique {
+                let entry = per_source_hit.entry(g).or_default();
+                let counts = entry.entry(*src).or_insert((0, 0));
+                counts.0 += 1;
+                counts.1 = total;
+            }
+        }
+    }
+
+    let mut out: HashSet<String> = HashSet::new();
+    for (guid, srcs) in per_source_hit {
+        let qualifying = srcs
+            .values()
+            .filter(|(h, t)| *t > 0 && (*h as f32 / *t as f32) >= threshold)
+            .count();
+        if qualifying >= min_sources {
+            out.insert(guid);
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -67,5 +105,69 @@ mod tests {
         assert_eq!(g.len(), 2);
         assert!(g.contains(&"ab12cd34-56ef-7890-abcd-ef0123456789".to_string()));
         assert!(g.contains(&"ff000000-1111-2222-3333-444444444444".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod tests_hf {
+    use super::*;
+    use std::collections::HashMap;
+
+    const TENANT: &str = "ff000000-1111-2222-3333-444444444444";
+    const APP_A: &str = "ab12cd34-56ef-7890-abcd-ef0123456789";
+
+    #[test]
+    fn tenant_guid_appearing_everywhere_is_denied() {
+        // Source 0: 4 messages all mention the tenant GUID; only 1 mentions APP_A.
+        let src0 = vec![
+            "msg for tenant ff000000-1111-2222-3333-444444444444",
+            "another tenant ff000000-1111-2222-3333-444444444444 event",
+            "again tenant ff000000-1111-2222-3333-444444444444",
+            "tenant ff000000-1111-2222-3333-444444444444 and app ab12cd34-56ef-7890-abcd-ef0123456789",
+        ];
+        // Source 1: 3 messages all mention the tenant GUID; none mention APP_A.
+        let src1 = vec![
+            "sync tenant ff000000-1111-2222-3333-444444444444",
+            "tenant ff000000-1111-2222-3333-444444444444 auth",
+            "again ff000000-1111-2222-3333-444444444444",
+        ];
+        let mut samples: HashMap<u16, Vec<&str>> = HashMap::new();
+        samples.insert(0, src0);
+        samples.insert(1, src1);
+
+        let denied = high_frequency_guids(&samples, 0.8, 2);
+        assert!(
+            denied.contains(TENANT),
+            "tenant GUID should be denied, got {:?}",
+            denied
+        );
+        assert!(
+            !denied.contains(APP_A),
+            "per-app GUID should NOT be denied, got {:?}",
+            denied
+        );
+    }
+
+    #[test]
+    fn guid_in_only_one_source_not_denied_even_if_frequent() {
+        // Source 0: GUID APP_A appears in every message.
+        let src0 = vec![
+            "app ab12cd34-56ef-7890-abcd-ef0123456789 step 1",
+            "app ab12cd34-56ef-7890-abcd-ef0123456789 step 2",
+            "app ab12cd34-56ef-7890-abcd-ef0123456789 step 3",
+        ];
+        // Source 1: APP_A does not appear.
+        let src1 = vec!["unrelated log line", "another unrelated line"];
+
+        let mut samples: HashMap<u16, Vec<&str>> = HashMap::new();
+        samples.insert(0, src0);
+        samples.insert(1, src1);
+
+        let denied = high_frequency_guids(&samples, 0.8, 2);
+        assert!(
+            !denied.contains(APP_A),
+            "GUID present in only one source must not be denied, got {:?}",
+            denied
+        );
     }
 }

--- a/src-tauri/src/timeline/correlation.rs
+++ b/src-tauri/src/timeline/correlation.rs
@@ -1,0 +1,71 @@
+/// Normalize a GUID-ish string for cross-source comparison.
+/// Lowercases, strips surrounding braces, tolerates hyphenless form by re-inserting.
+pub fn normalize_guid(s: &str) -> Option<String> {
+    let trimmed = s.trim().trim_start_matches('{').trim_end_matches('}');
+    let only_hex: String = trimmed
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .map(|c| c.to_ascii_lowercase())
+        .collect();
+    if only_hex.len() != 32 {
+        return None;
+    }
+    Some(format!(
+        "{}-{}-{}-{}-{}",
+        &only_hex[0..8],
+        &only_hex[8..12],
+        &only_hex[12..16],
+        &only_hex[16..20],
+        &only_hex[20..32],
+    ))
+}
+
+/// Extract all GUID-shaped substrings from a message, normalized.
+pub fn extract_guids(msg: &str) -> Vec<String> {
+    use regex::Regex;
+    use std::sync::OnceLock;
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?i)\{?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\}?")
+            .expect("guid regex")
+    });
+    re.captures_iter(msg)
+        .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
+        .filter_map(|s| normalize_guid(&s))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_braces_and_case() {
+        assert_eq!(
+            normalize_guid("{AB12CD34-56EF-7890-ABCD-EF0123456789}").as_deref(),
+            Some("ab12cd34-56ef-7890-abcd-ef0123456789")
+        );
+    }
+
+    #[test]
+    fn normalizes_hyphenless_form() {
+        assert_eq!(
+            normalize_guid("AB12CD3456EF7890ABCDEF0123456789").as_deref(),
+            Some("ab12cd34-56ef-7890-abcd-ef0123456789")
+        );
+    }
+
+    #[test]
+    fn rejects_too_short() {
+        assert!(normalize_guid("abc").is_none());
+    }
+
+    #[test]
+    fn extracts_multiple_guids_from_message() {
+        let msg = "Starting app {AB12CD34-56EF-7890-ABCD-EF0123456789} for tenant ff000000-1111-2222-3333-444444444444";
+        let g = extract_guids(msg);
+        assert_eq!(g.len(), 2);
+        assert!(g.contains(&"ab12cd34-56ef-7890-abcd-ef0123456789".to_string()));
+        assert!(g.contains(&"ff000000-1111-2222-3333-444444444444".to_string()));
+    }
+}

--- a/src-tauri/src/timeline/incidents.rs
+++ b/src-tauri/src/timeline/incidents.rs
@@ -205,6 +205,56 @@ fn summarize(
     format!("{} signals across {} sources", errs, srcs.len())
 }
 
+/// Full detection pipeline.
+pub fn detect_incidents(
+    indexes: &HashMap<u16, Vec<EntryIndex>>,
+    ime_events: &HashMap<u16, Vec<IntuneEvent>>,
+    tunables: &TimelineTunables,
+    denied_guids: &HashSet<String>,
+    materialize_msg: &dyn Fn(u16, u32) -> Option<String>,
+) -> (Vec<Signal>, Vec<Incident>) {
+    let signals = emit_signals(indexes, ime_events, &tunables.enabled_signal_kinds);
+    let clusters = cluster_signals(
+        &signals,
+        tunables.overlap_window_ms,
+        tunables.max_incident_span_ms,
+    );
+    let incidents = qualify(QualifyInputs {
+        clusters: &clusters,
+        ime_events,
+        materialize_msg,
+        denied_guids,
+        min_source_count: tunables.min_source_count,
+    });
+    (signals, incidents)
+}
+
+pub fn redetect_from_signals(
+    signals: &[Signal],
+    ime_events: &HashMap<u16, Vec<IntuneEvent>>,
+    tunables: &TimelineTunables,
+    denied_guids: &HashSet<String>,
+    materialize_msg: &dyn Fn(u16, u32) -> Option<String>,
+) -> Vec<Incident> {
+    let filtered: Vec<Signal> = signals
+        .iter()
+        .filter(|s| tunables.enabled_signal_kinds.contains(&s.kind))
+        .cloned()
+        .collect();
+    let clusters = cluster_signals(
+        &filtered,
+        tunables.overlap_window_ms,
+        tunables.max_incident_span_ms,
+    );
+    qualify(QualifyInputs {
+        clusters: &clusters,
+        ime_events,
+        materialize_msg,
+        denied_guids,
+        min_source_count: tunables.min_source_count,
+    })
+}
+
 #[cfg(test)]
 mod tests_emit {
     use super::*;
@@ -396,5 +446,87 @@ mod tests_qualify {
         assert_eq!(incidents.len(), 1);
         assert_eq!(incidents[0].source_count, 2);
         assert!((incidents[0].confidence - 0.5).abs() < 1e-4);
+    }
+}
+
+#[cfg(test)]
+mod tests_detect {
+    use super::*;
+
+    fn ei(ts: i64, sev: Severity, flags: u8, src: u16, line: u32) -> EntryIndex {
+        EntryIndex {
+            timestamp_ms: ts,
+            severity: sev,
+            source_idx: src,
+            byte_offset: 0,
+            line_number: line,
+            signal_flags: flags,
+        }
+    }
+
+    fn noop_materialize(_s: u16, _r: u32) -> Option<String> {
+        None
+    }
+
+    #[test]
+    fn two_sources_one_incident_no_anchor() {
+        let mut indexes: HashMap<u16, Vec<EntryIndex>> = HashMap::new();
+        indexes.insert(0, vec![ei(1_000, Severity::Error, 0, 0, 1)]);
+        indexes.insert(1, vec![ei(2_000, Severity::Error, 0, 1, 1)]);
+
+        let t = TimelineTunables::default();
+        let denied: HashSet<String> = HashSet::new();
+
+        let (signals, incidents) = detect_incidents(
+            &indexes,
+            &HashMap::new(),
+            &t,
+            &denied,
+            &noop_materialize,
+        );
+
+        assert_eq!(signals.len(), 2);
+        assert_eq!(incidents.len(), 1);
+        assert_eq!(incidents[0].source_count, 2);
+        assert!(incidents[0].anchor_event_ref.is_none());
+        assert!(incidents[0].anchor_guid.is_none());
+    }
+
+    #[test]
+    fn narrower_window_splits_into_two_incidents() {
+        let mut indexes: HashMap<u16, Vec<EntryIndex>> = HashMap::new();
+        indexes.insert(
+            0,
+            vec![
+                ei(0, Severity::Error, 0, 0, 1),
+                ei(10_000, Severity::Error, 0, 0, 2),
+            ],
+        );
+        indexes.insert(
+            1,
+            vec![
+                ei(500, Severity::Error, 0, 1, 1),
+                ei(10_500, Severity::Error, 0, 1, 2),
+            ],
+        );
+
+        let mut t = TimelineTunables::default();
+        t.overlap_window_ms = 1_000;
+        let denied: HashSet<String> = HashSet::new();
+
+        let (_signals, incidents) = detect_incidents(
+            &indexes,
+            &HashMap::new(),
+            &t,
+            &denied,
+            &noop_materialize,
+        );
+
+        assert_eq!(
+            incidents.len(),
+            2,
+            "expected two incidents, got {:?}",
+            incidents
+        );
     }
 }

--- a/src-tauri/src/timeline/incidents.rs
+++ b/src-tauri/src/timeline/incidents.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::intune::models::IntuneEvent;
 use crate::models::log_entry::Severity;
@@ -96,6 +96,113 @@ pub fn cluster_signals(
         }
     }
     out
+}
+
+pub struct QualifyInputs<'a> {
+    pub clusters: &'a [Cluster],
+    pub ime_events: &'a HashMap<u16, Vec<IntuneEvent>>,
+    pub materialize_msg: &'a dyn Fn(u16, u32) -> Option<String>,
+    pub denied_guids: &'a HashSet<String>,
+    pub min_source_count: u8,
+}
+
+pub fn qualify(inp: QualifyInputs<'_>) -> Vec<Incident> {
+    let mut out: Vec<Incident> = Vec::new();
+    let mut next_id: u32 = 1;
+
+    for c in inp.clusters {
+        let mut sources: HashSet<u16> = HashSet::new();
+        for s in &c.signals {
+            sources.insert(s.source_idx);
+        }
+        if (sources.len() as u8) < inp.min_source_count {
+            continue;
+        }
+
+        let anchor_sig = c.signals.iter().find(|s| s.kind == SignalKind::ImeFailed);
+        let (anchor_event_ref, anchor_guid) = match anchor_sig {
+            Some(a) => {
+                let ev = inp
+                    .ime_events
+                    .get(&a.source_idx)
+                    .and_then(|v| v.get(a.entry_ref as usize));
+                let g = ev
+                    .and_then(|e| e.anchor_guid())
+                    .and_then(crate::timeline::correlation::normalize_guid);
+                (
+                    Some((a.source_idx, a.entry_ref)),
+                    g.filter(|g| !inp.denied_guids.contains(g)),
+                )
+            }
+            None => (None, None),
+        };
+
+        let mut guid_match_count: u32 = 0;
+        let mut stamped_signals: Vec<Signal> = c.signals.clone();
+        if let Some(g) = &anchor_guid {
+            for s in stamped_signals.iter_mut() {
+                if Some(s.source_idx) == anchor_sig.map(|a| a.source_idx)
+                    && Some(s.entry_ref) == anchor_sig.map(|a| a.entry_ref)
+                {
+                    continue;
+                }
+                if let Some(msg) = (inp.materialize_msg)(s.source_idx, s.entry_ref) {
+                    let guids = crate::timeline::correlation::extract_guids(&msg);
+                    if guids.iter().any(|gm| gm == g) {
+                        s.correlation_id = Some(g.clone());
+                        guid_match_count += 1;
+                    }
+                }
+            }
+        }
+
+        let source_count = sources.len() as u8;
+        let confidence = score(source_count, stamped_signals.len() as u32, guid_match_count);
+        let summary = summarize(&stamped_signals, anchor_event_ref, inp.ime_events);
+
+        out.push(Incident {
+            id: next_id,
+            ts_start_ms: c.ts_start_ms,
+            ts_end_ms: c.ts_end_ms,
+            signal_count: stamped_signals.len() as u32,
+            source_count,
+            confidence,
+            anchor_event_ref,
+            anchor_guid,
+            summary,
+        });
+        next_id += 1;
+    }
+    out
+}
+
+fn score(source_count: u8, signal_count: u32, guid_match: u32) -> f32 {
+    let base: f32 = match source_count {
+        0..=1 => 0.0,
+        2 => 0.5,
+        3 => 0.75,
+        _ => 0.85,
+    };
+    let guid_boost = (guid_match.min(3) as f32) * 0.08;
+    let density_boost = ((signal_count.saturating_sub(3) as f32).min(10.0)) * 0.01;
+    (base + guid_boost + density_boost).min(1.0)
+}
+
+fn summarize(
+    signals: &[Signal],
+    anchor_ref: Option<(u16, u32)>,
+    ime_events: &HashMap<u16, Vec<IntuneEvent>>,
+) -> String {
+    if let Some((sidx, eref)) = anchor_ref {
+        if let Some(ev) = ime_events.get(&sidx).and_then(|v| v.get(eref as usize)) {
+            let name = ev.display_name().unwrap_or("(unknown)");
+            let kind = ev.event_kind_label().unwrap_or("Operation");
+            return format!("{} failed: {}", kind, name);
+        }
+    }
+    let errs = signals.len();
+    let srcs: HashSet<u16> = signals.iter().map(|s| s.source_idx).collect();
+    format!("{} signals across {} sources", errs, srcs.len())
 }
 
 #[cfg(test)]
@@ -226,5 +333,68 @@ mod tests_cluster {
         // Ensure the total number of signals is preserved.
         let total: usize = clusters.iter().map(|c| c.signals.len()).sum();
         assert_eq!(total, 3);
+    }
+}
+
+#[cfg(test)]
+mod tests_qualify {
+    use super::*;
+
+    fn sig(ts: i64, src: u16, entry_ref: u32, kind: SignalKind) -> Signal {
+        Signal {
+            source_idx: src,
+            entry_ref,
+            ts_ms: ts,
+            kind,
+            correlation_id: None,
+        }
+    }
+
+    fn noop_materialize(_s: u16, _r: u32) -> Option<String> {
+        None
+    }
+
+    #[test]
+    fn single_source_cluster_discarded() {
+        let cluster = Cluster {
+            ts_start_ms: 0,
+            ts_end_ms: 1_000,
+            signals: vec![
+                sig(0, 0, 1, SignalKind::ErrorSeverity),
+                sig(1_000, 0, 2, SignalKind::ErrorSeverity),
+            ],
+        };
+        let clusters = vec![cluster];
+        let incidents = qualify(QualifyInputs {
+            clusters: &clusters,
+            ime_events: &HashMap::new(),
+            materialize_msg: &noop_materialize,
+            denied_guids: &HashSet::new(),
+            min_source_count: 2,
+        });
+        assert!(incidents.is_empty());
+    }
+
+    #[test]
+    fn two_source_cluster_emits_incident() {
+        let cluster = Cluster {
+            ts_start_ms: 0,
+            ts_end_ms: 1_000,
+            signals: vec![
+                sig(0, 0, 1, SignalKind::ErrorSeverity),
+                sig(1_000, 1, 1, SignalKind::ErrorSeverity),
+            ],
+        };
+        let clusters = vec![cluster];
+        let incidents = qualify(QualifyInputs {
+            clusters: &clusters,
+            ime_events: &HashMap::new(),
+            materialize_msg: &noop_materialize,
+            denied_guids: &HashSet::new(),
+            min_source_count: 2,
+        });
+        assert_eq!(incidents.len(), 1);
+        assert_eq!(incidents[0].source_count, 2);
+        assert!((incidents[0].confidence - 0.5).abs() < 1e-4);
     }
 }

--- a/src-tauri/src/timeline/incidents.rs
+++ b/src-tauri/src/timeline/incidents.rs
@@ -1,0 +1,128 @@
+use std::collections::HashMap;
+
+use crate::intune::models::IntuneEvent;
+use crate::models::log_entry::Severity;
+use crate::timeline::models::*;
+
+/// Walk per-source indexes and IME events, emit raw signals, sort by ts_ms.
+pub fn emit_signals(
+    indexes: &HashMap<u16, Vec<EntryIndex>>,
+    ime_events: &HashMap<u16, Vec<IntuneEvent>>,
+    enabled: &[SignalKind],
+) -> Vec<Signal> {
+    let want_err = enabled.contains(&SignalKind::ErrorSeverity);
+    let want_code = enabled.contains(&SignalKind::KnownErrorCode);
+    let want_ime = enabled.contains(&SignalKind::ImeFailed);
+
+    let mut out: Vec<Signal> = Vec::new();
+
+    for (src_idx, idx_vec) in indexes {
+        for (entry_ref, ei) in idx_vec.iter().enumerate() {
+            let entry_ref = entry_ref as u32;
+            if want_err && matches!(ei.severity, Severity::Error) {
+                out.push(Signal {
+                    source_idx: *src_idx,
+                    entry_ref,
+                    ts_ms: ei.timestamp_ms,
+                    kind: SignalKind::ErrorSeverity,
+                    correlation_id: None,
+                });
+            }
+            if want_code && (ei.signal_flags & SIGNAL_FLAG_HAS_ERROR_CODE) != 0 {
+                out.push(Signal {
+                    source_idx: *src_idx,
+                    entry_ref,
+                    ts_ms: ei.timestamp_ms,
+                    kind: SignalKind::KnownErrorCode,
+                    correlation_id: None,
+                });
+            }
+        }
+    }
+
+    if want_ime {
+        for (src_idx, evs) in ime_events {
+            for (entry_ref, ev) in evs.iter().enumerate() {
+                if ev.status_is_failed() {
+                    if let Some(ts) = ev.start_time_epoch_ms() {
+                        out.push(Signal {
+                            source_idx: *src_idx,
+                            entry_ref: entry_ref as u32,
+                            ts_ms: ts,
+                            kind: SignalKind::ImeFailed,
+                            correlation_id: None,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    out.sort_by_key(|s| s.ts_ms);
+    out
+}
+
+#[cfg(test)]
+mod tests_emit {
+    use super::*;
+
+    fn ei(ts: i64, sev: Severity, flags: u8, src: u16, line: u32) -> EntryIndex {
+        EntryIndex {
+            timestamp_ms: ts,
+            severity: sev,
+            source_idx: src,
+            byte_offset: 0,
+            line_number: line,
+            signal_flags: flags,
+        }
+    }
+
+    #[test]
+    fn emits_error_severity_signal() {
+        let mut idx = HashMap::new();
+        idx.insert(0, vec![ei(100, Severity::Error, 0, 0, 1)]);
+        let sigs = emit_signals(&idx, &HashMap::new(), &[SignalKind::ErrorSeverity]);
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].kind, SignalKind::ErrorSeverity);
+    }
+
+    #[test]
+    fn emits_error_code_signal_independent_of_severity() {
+        let mut idx = HashMap::new();
+        idx.insert(
+            0,
+            vec![ei(100, Severity::Info, SIGNAL_FLAG_HAS_ERROR_CODE, 0, 1)],
+        );
+        let sigs = emit_signals(&idx, &HashMap::new(), &[SignalKind::KnownErrorCode]);
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].kind, SignalKind::KnownErrorCode);
+    }
+
+    #[test]
+    fn disabled_kinds_are_skipped() {
+        let mut idx = HashMap::new();
+        idx.insert(
+            0,
+            vec![ei(100, Severity::Error, SIGNAL_FLAG_HAS_ERROR_CODE, 0, 1)],
+        );
+        let sigs = emit_signals(&idx, &HashMap::new(), &[SignalKind::KnownErrorCode]);
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].kind, SignalKind::KnownErrorCode);
+    }
+
+    #[test]
+    fn signals_are_sorted_by_ts() {
+        let mut idx = HashMap::new();
+        idx.insert(
+            0,
+            vec![
+                ei(300, Severity::Error, 0, 0, 1),
+                ei(100, Severity::Error, 0, 0, 2),
+                ei(200, Severity::Error, 0, 0, 3),
+            ],
+        );
+        let sigs = emit_signals(&idx, &HashMap::new(), &[SignalKind::ErrorSeverity]);
+        let ts: Vec<i64> = sigs.iter().map(|s| s.ts_ms).collect();
+        assert_eq!(ts, vec![100, 200, 300]);
+    }
+}

--- a/src-tauri/src/timeline/incidents.rs
+++ b/src-tauri/src/timeline/incidents.rs
@@ -510,8 +510,10 @@ mod tests_detect {
             ],
         );
 
-        let mut t = TimelineTunables::default();
-        t.overlap_window_ms = 1_000;
+        let t = TimelineTunables {
+            overlap_window_ms: 1_000,
+            ..TimelineTunables::default()
+        };
         let denied: HashSet<String> = HashSet::new();
 
         let (_signals, incidents) = detect_incidents(

--- a/src-tauri/src/timeline/incidents.rs
+++ b/src-tauri/src/timeline/incidents.rs
@@ -62,6 +62,42 @@ pub fn emit_signals(
     out
 }
 
+/// A raw cluster of signals. Not yet qualified/scored.
+#[derive(Debug, Clone)]
+pub struct Cluster {
+    pub signals: Vec<Signal>,
+    pub ts_start_ms: i64,
+    pub ts_end_ms: i64,
+}
+
+/// Cluster signals using a sliding window. Signals must be sorted by ts_ms.
+/// A new signal is added to the current cluster iff its ts_ms is within
+/// `window_ms` of the cluster's current end time AND its ts_ms - ts_start <= max_span_ms.
+pub fn cluster_signals(
+    signals: &[Signal],
+    window_ms: i64,
+    max_span_ms: i64,
+) -> Vec<Cluster> {
+    let mut out: Vec<Cluster> = Vec::new();
+    for s in signals {
+        match out.last_mut() {
+            Some(cur)
+                if s.ts_ms - cur.ts_end_ms <= window_ms
+                    && s.ts_ms - cur.ts_start_ms <= max_span_ms =>
+            {
+                cur.ts_end_ms = s.ts_ms;
+                cur.signals.push(s.clone());
+            }
+            _ => out.push(Cluster {
+                ts_start_ms: s.ts_ms,
+                ts_end_ms: s.ts_ms,
+                signals: vec![s.clone()],
+            }),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests_emit {
     use super::*;
@@ -124,5 +160,71 @@ mod tests_emit {
         let sigs = emit_signals(&idx, &HashMap::new(), &[SignalKind::ErrorSeverity]);
         let ts: Vec<i64> = sigs.iter().map(|s| s.ts_ms).collect();
         assert_eq!(ts, vec![100, 200, 300]);
+    }
+}
+
+#[cfg(test)]
+mod tests_cluster {
+    use super::*;
+
+    fn sig(ts: i64, src: u16, entry_ref: u32) -> Signal {
+        Signal {
+            source_idx: src,
+            entry_ref,
+            ts_ms: ts,
+            kind: SignalKind::ErrorSeverity,
+            correlation_id: None,
+        }
+    }
+
+    #[test]
+    fn singleton_cluster() {
+        let sigs = vec![sig(100, 0, 1)];
+        let clusters = cluster_signals(&sigs, 5_000, 60_000);
+        assert_eq!(clusters.len(), 1);
+        assert_eq!(clusters[0].signals.len(), 1);
+        assert_eq!(clusters[0].ts_start_ms, 100);
+        assert_eq!(clusters[0].ts_end_ms, 100);
+    }
+
+    #[test]
+    fn window_coalesce() {
+        let sigs = vec![sig(100, 0, 1), sig(2_000, 1, 1), sig(4_000, 0, 2)];
+        let clusters = cluster_signals(&sigs, 5_000, 60_000);
+        assert_eq!(clusters.len(), 1);
+        assert_eq!(clusters[0].signals.len(), 3);
+        assert_eq!(clusters[0].ts_start_ms, 100);
+        assert_eq!(clusters[0].ts_end_ms, 4_000);
+    }
+
+    #[test]
+    fn gap_beyond_window_splits() {
+        let sigs = vec![sig(100, 0, 1), sig(10_000, 1, 1)];
+        let clusters = cluster_signals(&sigs, 5_000, 60_000);
+        assert_eq!(clusters.len(), 2);
+        assert_eq!(clusters[0].signals.len(), 1);
+        assert_eq!(clusters[1].signals.len(), 1);
+    }
+
+    #[test]
+    fn transitive_merge_via_sliding_end() {
+        // Each signal is within window of the previous end, but the first and
+        // last are > window apart. Sliding should still merge them.
+        let sigs = vec![sig(0, 0, 1), sig(4_000, 1, 1), sig(8_000, 0, 2)];
+        let clusters = cluster_signals(&sigs, 5_000, 60_000);
+        assert_eq!(clusters.len(), 1);
+        assert_eq!(clusters[0].signals.len(), 3);
+    }
+
+    #[test]
+    fn max_span_cap_cuts_cluster() {
+        // Signals continuously within window_ms, but the span from first to
+        // next would exceed max_span_ms, so we must split.
+        let sigs = vec![sig(0, 0, 1), sig(4_000, 1, 1), sig(8_000, 0, 2)];
+        let clusters = cluster_signals(&sigs, 5_000, 5_000);
+        assert!(clusters.len() >= 2);
+        // Ensure the total number of signals is preserved.
+        let total: usize = clusters.iter().map(|c| c.signals.len()).sum();
+        assert_eq!(total, 3);
     }
 }

--- a/src-tauri/src/timeline/mod.rs
+++ b/src-tauri/src/timeline/mod.rs
@@ -1,0 +1,1 @@
+pub mod models;

--- a/src-tauri/src/timeline/mod.rs
+++ b/src-tauri/src/timeline/mod.rs
@@ -1,2 +1,3 @@
+pub mod correlation;
 pub mod models;
 pub mod store;

--- a/src-tauri/src/timeline/mod.rs
+++ b/src-tauri/src/timeline/mod.rs
@@ -1,4 +1,5 @@
 pub mod correlation;
 pub mod incidents;
 pub mod models;
+pub mod query;
 pub mod store;

--- a/src-tauri/src/timeline/mod.rs
+++ b/src-tauri/src/timeline/mod.rs
@@ -1,3 +1,4 @@
 pub mod correlation;
+pub mod incidents;
 pub mod models;
 pub mod store;

--- a/src-tauri/src/timeline/mod.rs
+++ b/src-tauri/src/timeline/mod.rs
@@ -1,1 +1,2 @@
 pub mod models;
+pub mod store;

--- a/src-tauri/src/timeline/mod.rs
+++ b/src-tauri/src/timeline/mod.rs
@@ -1,3 +1,4 @@
+pub mod builder;
 pub mod correlation;
 pub mod incidents;
 pub mod models;

--- a/src-tauri/src/timeline/models.rs
+++ b/src-tauri/src/timeline/models.rs
@@ -1,5 +1,11 @@
 // src-tauri/src/timeline/models.rs
 
+/// Re-exports of inner model types the `timeline` public API touches.
+/// Kept here so external consumers (integration tests, benches) can build
+/// indexes and source metadata without depending on the crate-private
+/// `models` module path.
+pub use crate::models::log_entry::{ParserKind, Severity};
+
 #[derive(Clone, Debug)]
 pub struct EntryIndex {
     pub timestamp_ms: i64,

--- a/src-tauri/src/timeline/models.rs
+++ b/src-tauri/src/timeline/models.rs
@@ -4,6 +4,11 @@
 pub struct EntryIndex {
     pub timestamp_ms: i64,
     pub severity: crate::models::log_entry::Severity,
+    /// Kept for symmetry with the outer map keying; not read directly (the
+    /// index is already looked up by source_idx elsewhere). Retained so
+    /// downstream materializers that pass an EntryIndex alone still know
+    /// which source they came from.
+    #[allow(dead_code)]
     pub source_idx: u16,
     pub byte_offset: u64,
     pub line_number: u32,
@@ -11,7 +16,10 @@ pub struct EntryIndex {
 }
 
 pub const SIGNAL_FLAG_HAS_ERROR_CODE: u8 = 0b0000_0001;
+// Reserved for future phases that stamp IME event flags directly on EntryIndex.
+#[allow(dead_code)]
 pub const SIGNAL_FLAG_IS_IME_FAILED: u8 = 0b0000_0010;
+#[allow(dead_code)]
 pub const SIGNAL_FLAG_IS_IME_EVENT: u8 = 0b0000_0100;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -126,12 +134,12 @@ pub enum TimelineEntry {
     #[serde(rename = "log", rename_all = "camelCase")]
     Log {
         source_idx: u16,
-        entry: crate::models::log_entry::LogEntry,
+        entry: Box<crate::models::log_entry::LogEntry>,
     },
     #[serde(rename = "imeEvent", rename_all = "camelCase")]
     ImeEvent {
         source_idx: u16,
-        event: crate::intune::models::IntuneEvent,
+        event: Box<crate::intune::models::IntuneEvent>,
     },
 }
 
@@ -144,6 +152,9 @@ pub enum TimelineError {
     TooLarge { estimated: u64, limit: u64 },
     #[error("no sources")]
     NoSources,
+    /// Reserved for a future phase that surfaces per-source read errors as
+    /// distinct variants rather than embedding them in `errors` on the bundle.
+    #[allow(dead_code)]
     #[error("source read error: {path}: {message}")]
     SourceRead { path: String, message: String },
     #[error("internal: {message}")]
@@ -184,7 +195,7 @@ mod tests {
         // LogEntry does not derive Default, so spell every field out explicitly.
         let e = TimelineEntry::Log {
             source_idx: 3,
-            entry: LogEntry {
+            entry: Box::new(LogEntry {
                 id: 1,
                 line_number: 1,
                 message: "x".into(),
@@ -233,7 +244,7 @@ mod tests {
                 section_color: None,
                 iteration: None,
                 tags: None,
-            },
+            }),
         };
         let json = serde_json::to_string(&e).unwrap();
         assert!(json.contains("\"kind\":\"log\""));

--- a/src-tauri/src/timeline/models.rs
+++ b/src-tauri/src/timeline/models.rs
@@ -1,5 +1,6 @@
 // src-tauri/src/timeline/models.rs
 
+#[derive(Clone, Debug)]
 pub struct EntryIndex {
     pub timestamp_ms: i64,
     pub severity: crate::models::log_entry::Severity,
@@ -21,6 +22,7 @@ pub enum SignalKind {
     ImeFailed,
 }
 
+#[derive(Clone, Debug)]
 pub struct Signal {
     pub source_idx: u16,
     pub entry_ref: u32,

--- a/src-tauri/src/timeline/models.rs
+++ b/src-tauri/src/timeline/models.rs
@@ -1,0 +1,240 @@
+// src-tauri/src/timeline/models.rs
+
+pub struct EntryIndex {
+    pub timestamp_ms: i64,
+    pub severity: crate::models::log_entry::Severity,
+    pub source_idx: u16,
+    pub byte_offset: u64,
+    pub line_number: u32,
+    pub signal_flags: u8,
+}
+
+pub const SIGNAL_FLAG_HAS_ERROR_CODE: u8 = 0b0000_0001;
+pub const SIGNAL_FLAG_IS_IME_FAILED: u8 = 0b0000_0010;
+pub const SIGNAL_FLAG_IS_IME_EVENT: u8 = 0b0000_0100;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SignalKind {
+    ErrorSeverity,
+    KnownErrorCode,
+    ImeFailed,
+}
+
+pub struct Signal {
+    pub source_idx: u16,
+    pub entry_ref: u32,
+    pub ts_ms: i64,
+    pub kind: SignalKind,
+    pub correlation_id: Option<String>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Incident {
+    pub id: u32,
+    pub ts_start_ms: i64,
+    pub ts_end_ms: i64,
+    pub signal_count: u32,
+    pub source_count: u8,
+    pub confidence: f32,
+    pub anchor_event_ref: Option<(u16, u32)>,
+    pub anchor_guid: Option<String>,
+    pub summary: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TimelineSourceKind {
+    LogFile {
+        parser_kind: crate::models::log_entry::ParserKind,
+    },
+    IntuneEvents,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TimelineSourceMeta {
+    pub idx: u16,
+    pub kind: TimelineSourceKind,
+    pub path: String,
+    pub display_name: String,
+    pub color: String,
+    pub entry_count: u32,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceError {
+    pub path: String,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TimelineBundle {
+    pub id: String,
+    pub sources: Vec<TimelineSourceMeta>,
+    pub time_range_ms: (i64, i64),
+    pub total_entries: u64,
+    pub incidents: Vec<Incident>,
+    pub denied_guids: Vec<String>,
+    pub errors: Vec<SourceError>,
+    pub tunables: TimelineTunables,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TimelineTunables {
+    pub overlap_window_ms: i64,
+    pub min_source_count: u8,
+    pub max_incident_span_ms: i64,
+    pub enabled_signal_kinds: Vec<SignalKind>,
+}
+
+impl Default for TimelineTunables {
+    fn default() -> Self {
+        Self {
+            overlap_window_ms: 5_000,
+            min_source_count: 2,
+            max_incident_span_ms: 60_000,
+            enabled_signal_kinds: vec![
+                SignalKind::ErrorSeverity,
+                SignalKind::KnownErrorCode,
+                SignalKind::ImeFailed,
+            ],
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LaneBucket {
+    pub source_idx: u16,
+    pub ts_start_ms: i64,
+    pub ts_end_ms: i64,
+    pub total_count: u32,
+    pub error_count: u32,
+    pub warn_count: u32,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum TimelineEntry {
+    #[serde(rename = "log", rename_all = "camelCase")]
+    Log {
+        source_idx: u16,
+        entry: crate::models::log_entry::LogEntry,
+    },
+    #[serde(rename = "imeEvent", rename_all = "camelCase")]
+    ImeEvent {
+        source_idx: u16,
+        event: crate::intune::models::IntuneEvent,
+    },
+}
+
+#[derive(thiserror::Error, Debug, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum TimelineError {
+    #[error("timeline not found: {id}")]
+    NotFound { id: String },
+    #[error("too large: estimated {estimated} entries exceeds limit of {limit}")]
+    TooLarge { estimated: u64, limit: u64 },
+    #[error("no sources")]
+    NoSources,
+    #[error("source read error: {path}: {message}")]
+    SourceRead { path: String, message: String },
+    #[error("internal: {message}")]
+    Internal { message: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::log_entry::{LogEntry, LogFormat, Severity};
+
+    #[test]
+    fn entry_index_is_compact() {
+        assert!(
+            std::mem::size_of::<EntryIndex>() <= 32,
+            "EntryIndex grew to {} bytes",
+            std::mem::size_of::<EntryIndex>()
+        );
+    }
+
+    #[test]
+    fn default_tunables_match_spec() {
+        let t = TimelineTunables::default();
+        assert_eq!(t.overlap_window_ms, 5_000);
+        assert_eq!(t.min_source_count, 2);
+        assert_eq!(t.max_incident_span_ms, 60_000);
+        assert!(t.enabled_signal_kinds.contains(&SignalKind::ErrorSeverity));
+    }
+
+    #[test]
+    fn signal_flag_bits_disjoint() {
+        assert_eq!(SIGNAL_FLAG_HAS_ERROR_CODE & SIGNAL_FLAG_IS_IME_FAILED, 0);
+        assert_eq!(SIGNAL_FLAG_IS_IME_FAILED & SIGNAL_FLAG_IS_IME_EVENT, 0);
+    }
+
+    #[test]
+    fn timeline_entry_serde_round_trips() {
+        // LogEntry does not derive Default, so spell every field out explicitly.
+        let e = TimelineEntry::Log {
+            source_idx: 3,
+            entry: LogEntry {
+                id: 1,
+                line_number: 1,
+                message: "x".into(),
+                component: None,
+                timestamp: Some(1000),
+                timestamp_display: None,
+                severity: Severity::Info,
+                thread: None,
+                thread_display: None,
+                source_file: None,
+                format: LogFormat::Plain,
+                file_path: "/p".into(),
+                timezone_offset: None,
+                error_code_spans: Vec::new(),
+                ip_address: None,
+                host_name: None,
+                mac_address: None,
+                result_code: None,
+                gle_code: None,
+                setup_phase: None,
+                operation_name: None,
+                http_method: None,
+                uri_stem: None,
+                uri_query: None,
+                status_code: None,
+                sub_status: None,
+                time_taken_ms: None,
+                client_ip: None,
+                server_ip: None,
+                user_agent: None,
+                server_port: None,
+                username: None,
+                win32_status: None,
+                query_name: None,
+                query_type: None,
+                response_code: None,
+                dns_direction: None,
+                dns_protocol: None,
+                source_ip: None,
+                dns_flags: None,
+                dns_event_id: None,
+                zone_name: None,
+                entry_kind: None,
+                whatif: None,
+                section_name: None,
+                section_color: None,
+                iteration: None,
+                tags: None,
+            },
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"kind\":\"log\""));
+        assert!(json.contains("\"sourceIdx\":3"));
+    }
+}

--- a/src-tauri/src/timeline/models.rs
+++ b/src-tauri/src/timeline/models.rs
@@ -56,6 +56,7 @@ pub struct Incident {
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TimelineSourceKind {
+    #[serde(rename_all = "camelCase")]
     LogFile {
         parser_kind: crate::models::log_entry::ParserKind,
     },

--- a/src-tauri/src/timeline/query.rs
+++ b/src-tauri/src/timeline/query.rs
@@ -1,0 +1,73 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+use crate::models::log_entry::LogEntry;
+use crate::parser::ResolvedParser;
+use crate::timeline::models::*;
+
+/// Read raw bytes of a single log entry starting at byte_offset, trimming at
+/// the first newline. Works for single-line formats and newline-terminated
+/// logical records. 64 KiB upper bound.
+fn read_entry_raw(path: &Path, byte_offset: u64) -> std::io::Result<Vec<u8>> {
+    let mut f = File::open(path)?;
+    f.seek(SeekFrom::Start(byte_offset))?;
+    let mut buf = vec![0u8; 64 * 1024];
+    let n = f.read(&mut buf)?;
+    buf.truncate(n);
+    if let Some(pos) = buf.iter().position(|&b| b == b'\n') {
+        buf.truncate(pos + 1);
+    }
+    Ok(buf)
+}
+
+/// Materialize a full LogEntry from its EntryIndex. Runs the source parser
+/// over the raw bytes at byte_offset.
+pub fn materialize_log_entry(
+    path: &Path,
+    parser: &ResolvedParser,
+    ei: &EntryIndex,
+) -> Option<LogEntry> {
+    let raw = read_entry_raw(path, ei.byte_offset).ok()?;
+    let text = String::from_utf8_lossy(&raw).into_owned();
+    parser.parse_one_line(&text, ei.line_number).ok()
+}
+
+/// Materialize just the message text — cheap path for GUID scanning.
+pub fn materialize_msg(
+    path: &Path,
+    parser: &ResolvedParser,
+    ei: &EntryIndex,
+) -> Option<String> {
+    materialize_log_entry(path, parser, ei).map(|e| e.message)
+}
+
+#[cfg(test)]
+mod tests_mat {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn reads_first_line_at_offset_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("t.log");
+        let mut f = File::create(&p).unwrap();
+        writeln!(f, "line-zero").unwrap();
+        writeln!(f, "line-one").unwrap();
+        let raw = read_entry_raw(&p, 0).unwrap();
+        let s = String::from_utf8_lossy(&raw);
+        assert!(s.starts_with("line-zero"));
+    }
+
+    #[test]
+    fn reads_from_mid_file_offset() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("t.log");
+        let mut f = File::create(&p).unwrap();
+        writeln!(f, "abc").unwrap();
+        writeln!(f, "defg").unwrap();
+        let raw = read_entry_raw(&p, 4).unwrap();
+        let s = String::from_utf8_lossy(&raw);
+        assert!(s.starts_with("defg"));
+    }
+}

--- a/src-tauri/src/timeline/query.rs
+++ b/src-tauri/src/timeline/query.rs
@@ -112,7 +112,7 @@ pub fn query_timeline_entries(
             if let Some(ev) = ev {
                 out.push(TimelineEntry::ImeEvent {
                     source_idx: *src,
-                    event: ev,
+                    event: Box::new(ev),
                 });
             }
         } else {
@@ -126,7 +126,7 @@ pub fn query_timeline_entries(
                 if let Some(entry) = materialize_log_entry(&rt.path, &rt.parser, ei) {
                     out.push(TimelineEntry::Log {
                         source_idx: *src,
-                        entry,
+                        entry: Box::new(entry),
                     });
                 }
             }

--- a/src-tauri/src/timeline/query.rs
+++ b/src-tauri/src/timeline/query.rs
@@ -135,6 +135,67 @@ pub fn query_timeline_entries(
     out
 }
 
+pub fn query_lane_buckets(
+    timeline: &Timeline,
+    bucket_count: u32,
+    range_ms: Option<(i64, i64)>,
+) -> Vec<LaneBucket> {
+    let (lo, hi) = range_ms.unwrap_or(timeline.bundle.time_range_ms);
+    let span = (hi - lo).max(1);
+    let bucket_count = bucket_count.max(1) as i64;
+    let step = ((span as f64) / (bucket_count as f64)).ceil() as i64;
+
+    let mut out: Vec<LaneBucket> = Vec::new();
+
+    for src in timeline.bundle.sources.iter() {
+        let mut buckets: Vec<(u32, u32, u32)> = vec![(0, 0, 0); bucket_count as usize];
+        if let Some(idx_vec) = timeline.indexes.get(&src.idx) {
+            for ei in idx_vec {
+                if ei.timestamp_ms < lo || ei.timestamp_ms > hi {
+                    continue;
+                }
+                let bi = (((ei.timestamp_ms - lo) / step).min(bucket_count - 1)) as usize;
+                buckets[bi].0 += 1;
+                match ei.severity {
+                    crate::models::log_entry::Severity::Error => buckets[bi].1 += 1,
+                    crate::models::log_entry::Severity::Warning => buckets[bi].2 += 1,
+                    _ => {}
+                }
+            }
+        }
+        if let Some(evs) = timeline.ime_events.get(&src.idx) {
+            for ev in evs {
+                if let Some(ts) = ev.start_time_epoch_ms() {
+                    if ts < lo || ts > hi {
+                        continue;
+                    }
+                    let bi = (((ts - lo) / step).min(bucket_count - 1)) as usize;
+                    buckets[bi].0 += 1;
+                    if ev.status_is_failed() {
+                        buckets[bi].1 += 1;
+                    }
+                }
+            }
+        }
+        for (i, (total, errs, warns)) in buckets.into_iter().enumerate() {
+            if total == 0 {
+                continue;
+            }
+            let start = lo + step * (i as i64);
+            let end = (start + step).min(hi);
+            out.push(LaneBucket {
+                source_idx: src.idx,
+                ts_start_ms: start,
+                ts_end_ms: end,
+                total_count: total,
+                error_count: errs,
+                warn_count: warns,
+            });
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests_mat {
     use super::*;
@@ -162,5 +223,95 @@ mod tests_mat {
         let raw = read_entry_raw(&p, 4).unwrap();
         let s = String::from_utf8_lossy(&raw);
         assert!(s.starts_with("defg"));
+    }
+}
+
+#[cfg(test)]
+mod tests_buckets {
+    use super::*;
+    use crate::models::log_entry::{ParserKind, Severity};
+
+    fn mk_source(idx: u16) -> TimelineSourceMeta {
+        TimelineSourceMeta {
+            idx,
+            kind: TimelineSourceKind::LogFile {
+                parser_kind: ParserKind::Plain,
+            },
+            path: format!("/tmp/src{idx}.log"),
+            display_name: format!("src{idx}"),
+            color: "#000".into(),
+            entry_count: 0,
+        }
+    }
+
+    fn mk_ei(ts: i64, sev: Severity, src: u16, line: u32) -> EntryIndex {
+        EntryIndex {
+            timestamp_ms: ts,
+            severity: sev,
+            source_idx: src,
+            byte_offset: 0,
+            line_number: line,
+            signal_flags: 0,
+        }
+    }
+
+    #[test]
+    fn buckets_cover_full_range_and_counts_match() {
+        let mut indexes = HashMap::new();
+        indexes.insert(
+            0u16,
+            vec![
+                mk_ei(100, Severity::Info, 0, 1),
+                mk_ei(500, Severity::Error, 0, 2),
+                mk_ei(900, Severity::Info, 0, 3),
+            ],
+        );
+        let tl = Timeline {
+            bundle: TimelineBundle {
+                id: "t".into(),
+                sources: vec![mk_source(0)],
+                time_range_ms: (100, 900),
+                total_entries: 3,
+                incidents: vec![],
+                denied_guids: vec![],
+                errors: vec![],
+                tunables: Default::default(),
+            },
+            indexes,
+            ime_events: HashMap::new(),
+            raw_signals: vec![],
+        };
+
+        let buckets = query_lane_buckets(&tl, 10, None);
+        let total: u32 = buckets.iter().map(|b| b.total_count).sum();
+        let errors: u32 = buckets.iter().map(|b| b.error_count).sum();
+        assert_eq!(total, 3);
+        assert_eq!(errors, 1);
+        // All buckets should belong to source 0.
+        assert!(buckets.iter().all(|b| b.source_idx == 0));
+    }
+
+    #[test]
+    fn empty_buckets_are_omitted() {
+        let mut indexes = HashMap::new();
+        indexes.insert(0u16, Vec::<EntryIndex>::new());
+        let tl = Timeline {
+            bundle: TimelineBundle {
+                id: "t".into(),
+                sources: vec![mk_source(0)],
+                time_range_ms: (0, 1000),
+                total_entries: 0,
+                incidents: vec![],
+                denied_guids: vec![],
+                errors: vec![],
+                tunables: Default::default(),
+            },
+            indexes,
+            ime_events: HashMap::new(),
+            raw_signals: vec![],
+        };
+
+        let buckets = query_lane_buckets(&tl, 10, None);
+        assert!(buckets.is_empty());
     }
 }

--- a/src-tauri/src/timeline/query.rs
+++ b/src-tauri/src/timeline/query.rs
@@ -196,6 +196,113 @@ pub fn query_lane_buckets(
     out
 }
 
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IncidentSignalDetail {
+    pub source_idx: u16,
+    pub source_name: String,
+    pub ts_ms: i64,
+    pub kind: SignalKind,
+    pub correlation_id: Option<String>,
+    pub line_number: u32,
+    pub preview: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IncidentDetail {
+    pub incident: Incident,
+    pub signals: Vec<IncidentSignalDetail>,
+    pub per_source_signal_counts: std::collections::HashMap<String, u32>,
+}
+
+pub fn query_incident_details(
+    ctx: &QueryContext<'_>,
+    incident_id: u32,
+) -> Option<IncidentDetail> {
+    let incident = ctx
+        .timeline
+        .bundle
+        .incidents
+        .iter()
+        .find(|i| i.id == incident_id)?
+        .clone();
+
+    let (lo, hi) = (incident.ts_start_ms, incident.ts_end_ms);
+    let mut sigs: Vec<IncidentSignalDetail> = Vec::new();
+    let mut counts: std::collections::HashMap<String, u32> = Default::default();
+
+    for s in &ctx.timeline.raw_signals {
+        if s.ts_ms < lo || s.ts_ms > hi {
+            continue;
+        }
+        if !ctx
+            .timeline
+            .bundle
+            .tunables
+            .enabled_signal_kinds
+            .contains(&s.kind)
+        {
+            continue;
+        }
+
+        let name = ctx
+            .timeline
+            .bundle
+            .sources
+            .iter()
+            .find(|m| m.idx == s.source_idx)
+            .map(|m| m.display_name.clone())
+            .unwrap_or_else(|| format!("src{}", s.source_idx));
+        *counts.entry(name.clone()).or_insert(0) += 1;
+
+        let (line_number, preview) = match ctx.runtimes.get(&s.source_idx) {
+            Some(rt) => {
+                let ei = ctx
+                    .timeline
+                    .indexes
+                    .get(&s.source_idx)
+                    .and_then(|v| v.get(s.entry_ref as usize));
+                if let Some(ei) = ei {
+                    let msg = materialize_msg(&rt.path, &rt.parser, ei).unwrap_or_default();
+                    (ei.line_number, truncate(&msg, 200))
+                } else {
+                    (0, String::new())
+                }
+            }
+            None => {
+                let evs = ctx.timeline.ime_events.get(&s.source_idx);
+                let ev = evs.and_then(|v| v.get(s.entry_ref as usize));
+                let preview = ev.map(|e| format!("{:?}", e)).unwrap_or_default();
+                (0, truncate(&preview, 200))
+            }
+        };
+        sigs.push(IncidentSignalDetail {
+            source_idx: s.source_idx,
+            source_name: name,
+            ts_ms: s.ts_ms,
+            kind: s.kind,
+            correlation_id: s.correlation_id.clone(),
+            line_number,
+            preview,
+        });
+    }
+
+    Some(IncidentDetail {
+        incident,
+        signals: sigs,
+        per_source_signal_counts: counts,
+    })
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        s.chars().take(max).collect::<String>() + "…"
+    }
+}
+
 #[cfg(test)]
 mod tests_mat {
     use super::*;

--- a/src-tauri/src/timeline/query.rs
+++ b/src-tauri/src/timeline/query.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
@@ -5,6 +6,7 @@ use std::path::Path;
 use crate::models::log_entry::LogEntry;
 use crate::parser::ResolvedParser;
 use crate::timeline::models::*;
+use crate::timeline::store::Timeline;
 
 /// Read raw bytes of a single log entry starting at byte_offset, trimming at
 /// the first newline. Works for single-line formats and newline-terminated
@@ -40,6 +42,97 @@ pub fn materialize_msg(
     ei: &EntryIndex,
 ) -> Option<String> {
     materialize_log_entry(path, parser, ei).map(|e| e.message)
+}
+
+/// A parsed source — holds path and parser for materialization.
+pub struct SourceRuntime {
+    pub path: std::path::PathBuf,
+    pub parser: ResolvedParser,
+}
+
+pub struct QueryContext<'a> {
+    pub timeline: &'a Timeline,
+    pub runtimes: &'a HashMap<u16, SourceRuntime>,
+}
+
+/// Return entries within [range_start, range_end] inclusive, filtered by optional
+/// source set, paged by (offset, limit). Sorted by timestamp_ms, ties broken by
+/// (source_idx, line_number / entry_ref) for stability.
+pub fn query_timeline_entries(
+    ctx: &QueryContext<'_>,
+    range_ms: Option<(i64, i64)>,
+    source_filter: Option<&std::collections::HashSet<u16>>,
+    offset: u64,
+    limit: u32,
+) -> Vec<TimelineEntry> {
+    let mut view: Vec<(i64, u16, u32, bool)> = Vec::new();
+    let (lo, hi) = range_ms.unwrap_or((i64::MIN, i64::MAX));
+
+    for (src, idx_vec) in &ctx.timeline.indexes {
+        if let Some(f) = source_filter {
+            if !f.contains(src) {
+                continue;
+            }
+        }
+        for (eref, ei) in idx_vec.iter().enumerate() {
+            if ei.timestamp_ms >= lo && ei.timestamp_ms <= hi {
+                view.push((ei.timestamp_ms, *src, eref as u32, false));
+            }
+        }
+    }
+    for (src, ev_vec) in &ctx.timeline.ime_events {
+        if let Some(f) = source_filter {
+            if !f.contains(src) {
+                continue;
+            }
+        }
+        for (eref, ev) in ev_vec.iter().enumerate() {
+            if let Some(ts) = ev.start_time_epoch_ms() {
+                if ts >= lo && ts <= hi {
+                    view.push((ts, *src, eref as u32, true));
+                }
+            }
+        }
+    }
+    view.sort_by_key(|k| (k.0, k.1, k.2));
+
+    let end = (offset + limit as u64).min(view.len() as u64) as usize;
+    let start = (offset as usize).min(view.len());
+    let slice = &view[start..end];
+
+    let mut out = Vec::with_capacity(slice.len());
+    for (_ts, src, eref, is_ime) in slice {
+        if *is_ime {
+            let ev = ctx
+                .timeline
+                .ime_events
+                .get(src)
+                .and_then(|v| v.get(*eref as usize))
+                .cloned();
+            if let Some(ev) = ev {
+                out.push(TimelineEntry::ImeEvent {
+                    source_idx: *src,
+                    event: ev,
+                });
+            }
+        } else {
+            let ei = ctx
+                .timeline
+                .indexes
+                .get(src)
+                .and_then(|v| v.get(*eref as usize));
+            let rt = ctx.runtimes.get(src);
+            if let (Some(ei), Some(rt)) = (ei, rt) {
+                if let Some(entry) = materialize_log_entry(&rt.path, &rt.parser, ei) {
+                    out.push(TimelineEntry::Log {
+                        source_idx: *src,
+                        entry,
+                    });
+                }
+            }
+        }
+    }
+    out
 }
 
 #[cfg(test)]

--- a/src-tauri/src/timeline/store.rs
+++ b/src-tauri/src/timeline/store.rs
@@ -1,0 +1,56 @@
+use std::collections::HashMap;
+use crate::intune::models::IntuneEvent;
+use crate::timeline::models::*;
+
+/// Server-side timeline. Holds compact indexes per source and sparse IME event arrays.
+/// Full LogEntry text is NOT retained — it is re-materialized from file offset on demand.
+pub struct Timeline {
+    pub bundle: TimelineBundle,
+    pub indexes: HashMap<u16, Vec<EntryIndex>>,
+    pub ime_events: HashMap<u16, Vec<IntuneEvent>>,
+    pub raw_signals: Vec<Signal>, // cached for tunable re-runs
+}
+
+impl Timeline {
+    pub fn total_entries(&self) -> u64 {
+        self.indexes.values().map(|v| v.len() as u64).sum::<u64>()
+            + self.ime_events.values().map(|v| v.len() as u64).sum::<u64>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::log_entry::Severity;
+
+    #[test]
+    fn total_entries_sums_across_sources() {
+        let mut indexes = HashMap::new();
+        indexes.insert(0u16, vec![
+            EntryIndex { timestamp_ms: 1, severity: Severity::Info,
+                source_idx: 0, byte_offset: 0, line_number: 1, signal_flags: 0 },
+            EntryIndex { timestamp_ms: 2, severity: Severity::Error,
+                source_idx: 0, byte_offset: 10, line_number: 2, signal_flags: 1 },
+        ]);
+        indexes.insert(1u16, vec![
+            EntryIndex { timestamp_ms: 3, severity: Severity::Info,
+                source_idx: 1, byte_offset: 0, line_number: 1, signal_flags: 0 },
+        ]);
+        let tl = Timeline {
+            bundle: TimelineBundle {
+                id: "t1".into(),
+                sources: vec![],
+                time_range_ms: (1, 3),
+                total_entries: 3,
+                incidents: vec![],
+                denied_guids: vec![],
+                errors: vec![],
+                tunables: Default::default(),
+            },
+            indexes,
+            ime_events: HashMap::new(),
+            raw_signals: vec![],
+        };
+        assert_eq!(tl.total_entries(), 3);
+    }
+}

--- a/src-tauri/src/timeline/store.rs
+++ b/src-tauri/src/timeline/store.rs
@@ -12,6 +12,9 @@ pub struct Timeline {
 }
 
 impl Timeline {
+    /// Fresh recount across indexes + IME events. `bundle.total_entries` is
+    /// the canonical value; this helper is retained for tests/diagnostics.
+    #[allow(dead_code)]
     pub fn total_entries(&self) -> u64 {
         self.indexes.values().map(|v| v.len() as u64).sum::<u64>()
             + self.ime_events.values().map(|v| v.len() as u64).sum::<u64>()

--- a/src-tauri/src/watcher/tail.rs
+++ b/src-tauri/src/watcher/tail.rs
@@ -295,14 +295,13 @@ where
                 Ok(Ok(event)) => {
                     // Only react to modify/create events for our file
                     match event.kind {
-                        EventKind::Modify(_) | EventKind::Create(_) => {
+                        EventKind::Modify(_) | EventKind::Create(_)
                             if event.paths.iter().any(|p| p == &watch_path)
-                                && !paused_clone.load(Ordering::Relaxed)
-                            {
-                                if let Ok(entries) = tail_reader.read_new_entries() {
-                                    if !entries.is_empty() {
-                                        on_new_entries(entries);
-                                    }
+                                && !paused_clone.load(Ordering::Relaxed) =>
+                        {
+                            if let Ok(entries) = tail_reader.read_new_entries() {
+                                if !entries.is_empty() {
+                                    on_new_entries(entries);
                                 }
                             }
                         }

--- a/src-tauri/tests/corpus/timeline/scenario_logs_only/agent.log
+++ b/src-tauri/tests/corpus/timeline/scenario_logs_only/agent.log
@@ -1,0 +1,4 @@
+<![LOG[Worker start]LOG]!><time="10:00:00.000+000" date="04-19-2026" component="Worker" context="" type="1" thread="1" file="w.cs:1">
+<![LOG[Queue job 123]LOG]!><time="10:00:01.500+000" date="04-19-2026" component="Worker" context="" type="1" thread="1" file="w.cs:2">
+<![LOG[Connection refused on port 443]LOG]!><time="10:00:02.100+000" date="04-19-2026" component="Worker" context="" type="3" thread="1" file="w.cs:4">
+<![LOG[Retry exhausted after 5 attempts]LOG]!><time="10:00:02.900+000" date="04-19-2026" component="Worker" context="" type="3" thread="1" file="w.cs:5">

--- a/src-tauri/tests/corpus/timeline/scenario_logs_only/network.log
+++ b/src-tauri/tests/corpus/timeline/scenario_logs_only/network.log
@@ -1,0 +1,4 @@
+<![LOG[Net bring-up]LOG]!><time="10:00:00.050+000" date="04-19-2026" component="Net" context="" type="1" thread="2" file="n.cs:1">
+<![LOG[Interface eth0 up]LOG]!><time="10:00:01.800+000" date="04-19-2026" component="Net" context="" type="1" thread="2" file="n.cs:3">
+<![LOG[Socket create failed EADDRNOTAVAIL]LOG]!><time="10:00:02.300+000" date="04-19-2026" component="Net" context="" type="3" thread="2" file="n.cs:5">
+<![LOG[Handshake aborted]LOG]!><time="10:00:03.050+000" date="04-19-2026" component="Net" context="" type="3" thread="2" file="n.cs:7">

--- a/src-tauri/tests/corpus/timeline/scenario_multiple_failures/AgentExecutor.log
+++ b/src-tauri/tests/corpus/timeline/scenario_multiple_failures/AgentExecutor.log
@@ -1,0 +1,4 @@
+<![LOG[App Install starting {AA11AA11-AA11-AA11-AA11-AA11AA11AA11}]LOG]!><time="09:00:00.000+000" date="04-19-2026" component="AgentExecutor" context="" type="1" thread="100" file="a.cs:1">
+<![LOG[Install failed {AA11AA11-AA11-AA11-AA11-AA11AA11AA11}]LOG]!><time="09:00:02.500+000" date="04-19-2026" component="AgentExecutor" context="" type="3" thread="100" file="a.cs:3">
+<![LOG[App Install starting {BB22BB22-BB22-BB22-BB22-BB22BB22BB22}]LOG]!><time="09:15:00.000+000" date="04-19-2026" component="AgentExecutor" context="" type="1" thread="100" file="a.cs:5">
+<![LOG[Install failed {BB22BB22-BB22-BB22-BB22-BB22BB22BB22}]LOG]!><time="09:15:04.000+000" date="04-19-2026" component="AgentExecutor" context="" type="3" thread="100" file="a.cs:7">

--- a/src-tauri/tests/corpus/timeline/scenario_multiple_failures/IntuneManagementExtension.log
+++ b/src-tauri/tests/corpus/timeline/scenario_multiple_failures/IntuneManagementExtension.log
@@ -1,0 +1,4 @@
+<![LOG[Policy check {AA11AA11-AA11-AA11-AA11-AA11AA11AA11}]LOG]!><time="09:00:01.000+000" date="04-19-2026" component="IntuneMgmt" context="" type="1" thread="50" file="i.cs:1">
+<![LOG[Assignment error 0x80004005 for {AA11AA11-AA11-AA11-AA11-AA11AA11AA11}]LOG]!><time="09:00:02.200+000" date="04-19-2026" component="IntuneMgmt" context="" type="3" thread="50" file="i.cs:3">
+<![LOG[Policy check {BB22BB22-BB22-BB22-BB22-BB22BB22BB22}]LOG]!><time="09:15:01.500+000" date="04-19-2026" component="IntuneMgmt" context="" type="1" thread="50" file="i.cs:5">
+<![LOG[Assignment error 0x80070005 for {BB22BB22-BB22-BB22-BB22-BB22BB22BB22}]LOG]!><time="09:15:03.500+000" date="04-19-2026" component="IntuneMgmt" context="" type="3" thread="50" file="i.cs:7">

--- a/src-tauri/tests/corpus/timeline/scenario_win32app_failure/AgentExecutor.log
+++ b/src-tauri/tests/corpus/timeline/scenario_win32app_failure/AgentExecutor.log
@@ -1,0 +1,5 @@
+<![LOG[Win32App discovery starting]LOG]!><time="09:42:01.103+000" date="04-19-2026" component="AgentExecutor" context="" type="1" thread="100" file="agent.cs:10">
+<![LOG[Downloading content for app {AB12CD34-56EF-7890-ABCD-EF0123456789}]LOG]!><time="09:42:01.402+000" date="04-19-2026" component="AgentExecutor" context="" type="1" thread="100" file="agent.cs:12">
+<![LOG[Content hash verify for {AB12CD34-56EF-7890-ABCD-EF0123456789}]LOG]!><time="09:42:03.118+000" date="04-19-2026" component="AgentExecutor" context="" type="1" thread="100" file="agent.cs:14">
+<![LOG[Detection script returned 0x87D1041C for {AB12CD34-56EF-7890-ABCD-EF0123456789}]LOG]!><time="09:42:05.770+000" date="04-19-2026" component="AgentExecutor" context="" type="3" thread="100" file="agent.cs:18">
+<![LOG[Install failed for app {AB12CD34-56EF-7890-ABCD-EF0123456789}]LOG]!><time="09:42:05.812+000" date="04-19-2026" component="AgentExecutor" context="" type="3" thread="100" file="agent.cs:19">

--- a/src-tauri/tests/corpus/timeline/scenario_win32app_failure/IntuneManagementExtension.log
+++ b/src-tauri/tests/corpus/timeline/scenario_win32app_failure/IntuneManagementExtension.log
@@ -1,0 +1,3 @@
+<![LOG[Policy evaluation for tenant FF000000-1111-2222-3333-444444444444 app {AB12CD34-56EF-7890-ABCD-EF0123456789}]LOG]!><time="09:42:00.000+000" date="04-19-2026" component="IntuneMgmt" context="" type="1" thread="50" file="policy.cs:1">
+<![LOG[App assignment check failed 0x80070005 for {AB12CD34-56EF-7890-ABCD-EF0123456789}]LOG]!><time="09:42:05.500+000" date="04-19-2026" component="IntuneMgmt" context="" type="3" thread="50" file="policy.cs:5">
+<![LOG[Retry app install tenant FF000000-1111-2222-3333-444444444444]LOG]!><time="09:42:06.100+000" date="04-19-2026" component="IntuneMgmt" context="" type="2" thread="50" file="policy.cs:7">

--- a/src-tauri/tests/timeline_integration.rs
+++ b/src-tauri/tests/timeline_integration.rs
@@ -1,0 +1,49 @@
+use app_lib::timeline::builder::{build_timeline, SourceRequest, DEFAULT_ENTRY_LIMIT};
+use app_lib::timeline::query::*;
+
+fn fixture(rel: &str) -> String {
+    let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/corpus/timeline/scenario_win32app_failure")
+        .join(rel);
+    p.to_string_lossy().into_owned()
+}
+
+#[test]
+fn win32app_failure_yields_multi_source_incident() {
+    let requests = vec![
+        SourceRequest {
+            path: fixture("AgentExecutor.log"),
+            display_name: None,
+        },
+        SourceRequest {
+            path: fixture("IntuneManagementExtension.log"),
+            display_name: None,
+        },
+    ];
+    let (timeline, runtimes) = build_timeline(&requests, DEFAULT_ENTRY_LIMIT, Vec::new())
+        .expect("build ok");
+
+    assert!(
+        !timeline.bundle.incidents.is_empty(),
+        "expected at least one incident"
+    );
+    let top = &timeline.bundle.incidents[0];
+    assert!(top.source_count >= 2, "source_count was {}", top.source_count);
+    assert!(top.confidence >= 0.5, "low confidence: {}", top.confidence);
+    if let Some(g) = &top.anchor_guid {
+        // Tenant GUID must not leak through as the anchor for an incident.
+        assert!(
+            !g.starts_with("ff000000"),
+            "tenant GUID leaked as anchor"
+        );
+    }
+
+    let buckets = query_lane_buckets(&timeline, 50, None);
+    assert!(!buckets.is_empty(), "expected at least one lane bucket");
+    let ctx = QueryContext {
+        timeline: &timeline,
+        runtimes: &runtimes,
+    };
+    let entries = query_timeline_entries(&ctx, None, None, 0, 100);
+    assert!(!entries.is_empty(), "expected materialized entries");
+}

--- a/src-tauri/tests/timeline_integration.rs
+++ b/src-tauri/tests/timeline_integration.rs
@@ -8,6 +8,20 @@ fn fixture(rel: &str) -> String {
     p.to_string_lossy().into_owned()
 }
 
+fn fixture_logs_only(rel: &str) -> String {
+    let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/corpus/timeline/scenario_logs_only")
+        .join(rel);
+    p.to_string_lossy().into_owned()
+}
+
+fn fixture_multi(rel: &str) -> String {
+    let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/corpus/timeline/scenario_multiple_failures")
+        .join(rel);
+    p.to_string_lossy().into_owned()
+}
+
 #[test]
 fn win32app_failure_yields_multi_source_incident() {
     let requests = vec![
@@ -46,4 +60,67 @@ fn win32app_failure_yields_multi_source_incident() {
     };
     let entries = query_timeline_entries(&ctx, None, None, 0, 100);
     assert!(!entries.is_empty(), "expected materialized entries");
+}
+
+#[test]
+fn logs_only_scenario_detects_moderate_confidence_incident() {
+    let requests = vec![
+        SourceRequest {
+            path: fixture_logs_only("agent.log"),
+            display_name: None,
+        },
+        SourceRequest {
+            path: fixture_logs_only("network.log"),
+            display_name: None,
+        },
+    ];
+    let (timeline, _) =
+        build_timeline(&requests, DEFAULT_ENTRY_LIMIT, Vec::new()).expect("build ok");
+
+    assert!(
+        !timeline.bundle.incidents.is_empty(),
+        "expected an incident"
+    );
+    let top = &timeline.bundle.incidents[0];
+    assert_eq!(top.source_count, 2);
+    assert!(
+        top.confidence >= 0.4 && top.confidence < 0.75,
+        "logs-only should be mid confidence, got {}",
+        top.confidence
+    );
+    assert!(
+        top.anchor_guid.is_none(),
+        "no IME source should mean no anchor GUID"
+    );
+}
+
+#[test]
+fn multiple_failures_scenario_yields_two_distinct_incidents() {
+    let requests = vec![
+        SourceRequest {
+            path: fixture_multi("AgentExecutor.log"),
+            display_name: None,
+        },
+        SourceRequest {
+            path: fixture_multi("IntuneManagementExtension.log"),
+            display_name: None,
+        },
+    ];
+    let (timeline, _) =
+        build_timeline(&requests, DEFAULT_ENTRY_LIMIT, Vec::new()).expect("build ok");
+
+    assert!(
+        timeline.bundle.incidents.len() >= 2,
+        "expected 2 incidents, got {}",
+        timeline.bundle.incidents.len()
+    );
+
+    // Incidents are sorted by ts_start_ms. The 15-minute gap means they
+    // cannot be clustered together regardless of window.
+    let first = &timeline.bundle.incidents[0];
+    let second = &timeline.bundle.incidents[1];
+    assert!(
+        second.ts_start_ms > first.ts_end_ms + 60_000,
+        "incidents should be far apart in time"
+    );
 }

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -42,15 +42,32 @@ import {
   getCanvasFont,
   LOG_UI_FONT_FAMILY,
 } from "../../lib/log-accessibility";
+import type { LogListDataSource } from "./log-list-data-source";
 
-export function LogListView() {
-  const entries = useLogStore((s) => s.entries);
-  const selectedId = useLogStore((s) => s.selectedId);
-  const selectEntry = useLogStore((s) => s.selectEntry);
-  const highlightText = useLogStore((s) => s.highlightText);
-  const highlightCaseSensitive = useLogStore((s) => s.highlightCaseSensitive);
-  const isPaused = useLogStore((s) => s.isPaused);
-  const findMatchIds = useLogStore((s) => s.findMatchIds);
+const defaultLogStoreDataSource: LogListDataSource = {
+  useEntries: () => useLogStore((s) => s.entries),
+  useSelectedId: () => useLogStore((s) => s.selectedId),
+  useHighlightText: () => useLogStore((s) => s.highlightText),
+  useHighlightCaseSensitive: () => useLogStore((s) => s.highlightCaseSensitive),
+  useIsPaused: () => useLogStore((s) => s.isPaused),
+  useFindMatchIds: () => {
+    const arr = useLogStore((s) => s.findMatchIds);
+    return useMemo(() => new Set(arr), [arr]);
+  },
+  selectEntry: (id) => useLogStore.getState().selectEntry(id),
+};
+
+export function LogListView({ dataSource }: { dataSource?: LogListDataSource } = {}) {
+  const ds = dataSource ?? defaultLogStoreDataSource;
+  const entries = ds.useEntries();
+  const selectedId = ds.useSelectedId();
+  const highlightText = ds.useHighlightText();
+  const highlightCaseSensitive = ds.useHighlightCaseSensitive();
+  const isPaused = ds.useIsPaused();
+  const findMatchIds = ds.useFindMatchIds();
+  const externalFilterRange = ds.useExternalFilterRange?.() ?? null;
+  const highlightedRange = ds.useHighlightedRange?.() ?? null;
+  const selectEntry = ds.selectEntry;
   const showDetails = useUiStore((s) => s.showDetails);
 
   const sourceOpenMode = useLogStore((s) => s.sourceOpenMode);
@@ -92,7 +109,7 @@ export function LogListView() {
   }, []);
 
   const findMatchSet = useMemo(
-    () => new Set(findMatchIds),
+    () => findMatchIds ?? new Set<number>(),
     [findMatchIds]
   );
 
@@ -103,8 +120,14 @@ export function LogListView() {
 
   const displayEntries = useMemo(() => {
     let result = entries;
+    if (externalFilterRange) {
+      const [lo, hi] = externalFilterRange;
+      result = result.filter(
+        (e) => e.timestamp != null && e.timestamp >= lo && e.timestamp <= hi,
+      );
+    }
     if (filteredIds) {
-      result = entries.filter((entry) => filteredIds.has(entry.id));
+      result = result.filter((entry) => filteredIds.has(entry.id));
     }
     if (sortColumn) {
       const col = getColumnDef(sortColumn);
@@ -133,7 +156,7 @@ export function LogListView() {
       return sorted;
     }
     return result;
-  }, [entries, filteredIds, sortColumn, sortDir]);
+  }, [entries, externalFilterRange, filteredIds, sortColumn, sortDir]);
 
   const selectedEntryIndex = useMemo(
     () => displayEntries.findIndex((entry) => entry.id === selectedId),
@@ -670,9 +693,16 @@ export function LogListView() {
               ? (entry.sectionColor ?? sectionColorMap.get(entry.sectionName) ?? null)
               : null;
 
+            const isInHighlightedRange =
+              highlightedRange != null &&
+              entry.timestamp != null &&
+              entry.timestamp >= highlightedRange[0] &&
+              entry.timestamp <= highlightedRange[1];
+
             return (
               <div
                 key={entry.id}
+                data-highlighted={isInHighlightedRange ? "true" : undefined}
                 style={{
                   position: "absolute",
                   top: 0,
@@ -680,6 +710,9 @@ export function LogListView() {
                   width: "100%",
                   height: `${virtualRow.size}px`,
                   transform: `translateY(${virtualRow.start}px)`,
+                  boxShadow: isInHighlightedRange
+                    ? `inset 3px 0 0 ${tokens.colorBrandStroke1}`
+                    : undefined,
                 }}
               >
                 {isSectionDivider ? (

--- a/src/components/log-view/log-list-data-source.ts
+++ b/src/components/log-view/log-list-data-source.ts
@@ -1,0 +1,23 @@
+import type { LogEntry } from "../../types/log";
+
+/**
+ * Abstraction that lets LogListView render entries from either the log-store
+ * (normal log view) or the timeline-store (timeline mode). All methods are
+ * hooks — subscribe inside selectors so LogListView re-renders on change.
+ *
+ * The optional methods give the timeline mode a way to restrict the rendered
+ * entries to a time range and highlight a sub-range. Log view mode omits them.
+ */
+export interface LogListDataSource {
+  useEntries(): LogEntry[];
+  useSelectedId(): number | null;
+  useHighlightText(): string;
+  useHighlightCaseSensitive(): boolean;
+  useIsPaused(): boolean;
+  useFindMatchIds(): Set<number> | null;
+
+  selectEntry(id: number | null): void;
+
+  useExternalFilterRange?(): [number, number] | null;
+  useHighlightedRange?(): [number, number] | null;
+}

--- a/src/components/timeline/BrushOverlay.tsx
+++ b/src/components/timeline/BrushOverlay.tsx
@@ -1,0 +1,101 @@
+import { useRef, useState } from "react";
+import { useTimelineStore } from "../../stores/timeline-store";
+
+interface Props {
+  timeRangeMs: [number, number];
+  width: number;
+  height: number;
+}
+
+export function BrushOverlay({ timeRangeMs, width, height }: Props) {
+  const brushRange = useTimelineStore((s) => s.brushRange);
+  const setBrushRange = useTimelineStore((s) => s.setBrushRange);
+  const clearBrushRange = useTimelineStore((s) => s.clearBrushRange);
+
+  const [dragStart, setDragStart] = useState<number | null>(null);
+  const [dragEnd, setDragEnd] = useState<number | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [lo, hi] = timeRangeMs;
+  const span = Math.max(1, hi - lo);
+
+  const pxToTs = (px: number) => lo + (px / width) * span;
+  const tsToPx = (ts: number) => ((ts - lo) / span) * width;
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    const rect = rootRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = e.clientX - rect.left;
+    setDragStart(x);
+    setDragEnd(x);
+  };
+  const onMouseMove = (e: React.MouseEvent) => {
+    if (dragStart == null) return;
+    const rect = rootRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setDragEnd(e.clientX - rect.left);
+  };
+  const onMouseUp = () => {
+    if (dragStart == null || dragEnd == null) {
+      setDragStart(null);
+      setDragEnd(null);
+      return;
+    }
+    const s = Math.min(dragStart, dragEnd);
+    const e = Math.max(dragStart, dragEnd);
+    if (Math.abs(e - s) < 3) {
+      clearBrushRange();
+    } else {
+      setBrushRange([pxToTs(s), pxToTs(e)]);
+    }
+    setDragStart(null);
+    setDragEnd(null);
+  };
+
+  const selection = (() => {
+    if (dragStart != null && dragEnd != null) {
+      return {
+        x: Math.min(dragStart, dragEnd),
+        w: Math.abs(dragEnd - dragStart),
+      };
+    }
+    if (brushRange) {
+      const x = tsToPx(brushRange[0]);
+      const w = tsToPx(brushRange[1]) - x;
+      return { x, w };
+    }
+    return null;
+  })();
+
+  return (
+    <div
+      ref={rootRef}
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
+      onMouseUp={onMouseUp}
+      onMouseLeave={onMouseUp}
+      style={{
+        position: "absolute",
+        inset: 0,
+        width,
+        height,
+        cursor: "crosshair",
+      }}
+    >
+      {selection && (
+        <div
+          style={{
+            position: "absolute",
+            left: selection.x,
+            width: selection.w,
+            top: 0,
+            bottom: 0,
+            background: "rgba(37,99,235,.10)",
+            borderLeft: "1px dashed #2563eb",
+            borderRight: "1px dashed #2563eb",
+            pointerEvents: "none",
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/timeline/IncidentChipBar.tsx
+++ b/src/components/timeline/IncidentChipBar.tsx
@@ -1,0 +1,65 @@
+import { useTimelineStore } from "../../stores/timeline-store";
+
+export function IncidentChipBar() {
+  const bundle = useTimelineStore((s) => s.bundle);
+  const selectedIncidentId = useTimelineStore((s) => s.selectedIncidentId);
+  const selectIncident = useTimelineStore((s) => s.selectIncident);
+
+  if (!bundle) return null;
+  if (bundle.incidents.length === 0) {
+    return (
+      <div style={{ padding: "6px 10px", fontSize: 11, color: "#6b7280" }}>
+        No incidents detected — adjust signal settings in the gear menu.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 6,
+        padding: "6px 10px",
+        overflowX: "auto",
+      }}
+    >
+      {bundle.incidents.map((inc) => {
+        const isSel = inc.id === selectedIncidentId;
+        const color =
+          inc.confidence >= 0.8
+            ? "#dc2626"
+            : inc.confidence >= 0.6
+              ? "#b45309"
+              : "#6b7280";
+        return (
+          <button
+            key={inc.id}
+            onClick={() => selectIncident(isSel ? null : inc.id)}
+            style={{
+              display: "inline-flex",
+              gap: 6,
+              alignItems: "center",
+              padding: "3px 10px",
+              borderRadius: 999,
+              border: `1px solid ${isSel ? color : "#e5e7eb"}`,
+              background: isSel ? `${color}10` : "white",
+              fontSize: 11,
+              whiteSpace: "nowrap",
+              cursor: "pointer",
+            }}
+          >
+            <span
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: 999,
+                background: color,
+              }}
+            />
+            #{inc.id} · {inc.summary}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/timeline/IncidentDetailPanel.tsx
+++ b/src/components/timeline/IncidentDetailPanel.tsx
@@ -1,0 +1,125 @@
+import { useIncidentDetail } from "./hooks/useIncidentDetail";
+import { useTimelineStore } from "../../stores/timeline-store";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+
+export function IncidentDetailPanel() {
+  const selectedIncidentId = useTimelineStore((s) => s.selectedIncidentId);
+  const selectIncident = useTimelineStore((s) => s.selectIncident);
+  const detail = useIncidentDetail(selectedIncidentId);
+
+  if (!detail) return null;
+  const i = detail.incident;
+
+  return (
+    <aside
+      style={{
+        width: 340,
+        borderLeft: "1px solid #e5e7eb",
+        overflowY: "auto",
+        padding: 12,
+        fontSize: 12,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 8,
+        }}
+      >
+        <strong>Incident #{i.id}</strong>
+        <button onClick={() => selectIncident(null)}>Close</button>
+      </div>
+
+      <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
+        {i.summary}
+      </div>
+      <div style={{ color: "#6b7280", marginBottom: 10 }}>
+        {new Date(i.tsStartMs).toLocaleTimeString()}–
+        {new Date(i.tsEndMs).toLocaleTimeString()} · confidence{" "}
+        {Math.round(i.confidence * 100)}%
+      </div>
+
+      <div style={{ marginBottom: 10 }}>
+        <div
+          style={{
+            fontSize: 10,
+            color: "#6b7280",
+            textTransform: "uppercase",
+          }}
+        >
+          Sources
+        </div>
+        {Object.entries(detail.perSourceSignalCounts).map(([name, count]) => (
+          <div
+            key={name}
+            style={{ display: "flex", justifyContent: "space-between" }}
+          >
+            <span>{name}</span>
+            <span>{count}</span>
+          </div>
+        ))}
+      </div>
+
+      {i.anchorGuid && (
+        <div style={{ marginBottom: 10 }}>
+          <div
+            style={{
+              fontSize: 10,
+              color: "#6b7280",
+              textTransform: "uppercase",
+            }}
+          >
+            Anchor GUID
+          </div>
+          <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+            <code
+              style={{
+                background: "#f3f4f6",
+                padding: "1px 4px",
+                borderRadius: 2,
+              }}
+            >
+              {i.anchorGuid}
+            </code>
+            <button
+              onClick={() => {
+                void writeText(i.anchorGuid!);
+              }}
+            >
+              Copy
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div>
+        <div
+          style={{
+            fontSize: 10,
+            color: "#6b7280",
+            textTransform: "uppercase",
+          }}
+        >
+          Signals ({detail.signals.length})
+        </div>
+        {detail.signals.map((s, idx) => (
+          <div
+            key={idx}
+            style={{ padding: "4px 0", borderBottom: "1px solid #f3f4f6" }}
+          >
+            <div style={{ fontSize: 10, color: "#9ca3af" }}>
+              {new Date(s.tsMs).toLocaleTimeString()} · {s.sourceName} ·{" "}
+              {s.kind}
+              {s.correlationId && " · (correlated)"}
+            </div>
+            <div style={{ fontFamily: "ui-monospace, monospace", fontSize: 11 }}>
+              {s.preview}
+            </div>
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/timeline/LaneLegend.tsx
+++ b/src/components/timeline/LaneLegend.tsx
@@ -1,0 +1,63 @@
+import { useTimelineStore } from "../../stores/timeline-store";
+
+export function LaneLegend() {
+  const bundle = useTimelineStore((s) => s.bundle);
+  const laneVisibility = useTimelineStore((s) => s.laneVisibility);
+  const soloSourceIdx = useTimelineStore((s) => s.soloSourceIdx);
+  const setSolo = useTimelineStore((s) => s.setSolo);
+  const toggleMute = useTimelineStore((s) => s.toggleMute);
+  if (!bundle) return null;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 8,
+        padding: "6px 10px",
+        flexWrap: "wrap",
+      }}
+    >
+      {bundle.sources.map((src) => {
+        const muted = laneVisibility[src.idx] === false;
+        const isSolo = soloSourceIdx === src.idx;
+        return (
+          <button
+            key={src.idx}
+            onClick={(e) => {
+              if (e.shiftKey) {
+                toggleMute(src.idx);
+              } else {
+                setSolo(isSolo ? null : src.idx);
+              }
+            }}
+            title="Click: solo this lane. Shift-click: mute this lane."
+            style={{
+              display: "inline-flex",
+              gap: 6,
+              alignItems: "center",
+              padding: "2px 8px",
+              borderRadius: 999,
+              border: `1px solid ${isSolo ? src.color : "#d1d5db"}`,
+              background: muted ? "#f3f4f6" : "white",
+              color: muted ? "#9ca3af" : "#111",
+              opacity: muted ? 0.6 : 1,
+              fontSize: 12,
+              cursor: "pointer",
+            }}
+          >
+            <span
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: 2,
+                background: src.color,
+              }}
+            />
+            {src.displayName}
+            <span style={{ color: "#9ca3af" }}>{src.entryCount}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/timeline/SwimLaneCanvas.tsx
+++ b/src/components/timeline/SwimLaneCanvas.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from "react";
+import type { LaneBucket, TimelineSourceMeta } from "../../types/timeline";
+
+interface Props {
+  sources: TimelineSourceMeta[];
+  buckets: LaneBucket[];
+  timeRangeMs: [number, number];
+  width: number;
+  laneHeight: number;
+  laneVisibility: Record<number, boolean>;
+  soloSourceIdx: number | null;
+  onBucketHover?: (b: LaneBucket | null) => void;
+  onBucketDoubleClick?: (b: LaneBucket) => void;
+}
+
+export function SwimLaneCanvas(props: Props) {
+  const {
+    sources,
+    buckets,
+    timeRangeMs,
+    width,
+    laneHeight,
+    laneVisibility,
+    soloSourceIdx,
+    onBucketHover,
+    onBucketDoubleClick,
+  } = props;
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [lo, hi] = timeRangeMs;
+  const span = Math.max(1, hi - lo);
+
+  const visible = sources.filter(
+    (s) =>
+      (soloSourceIdx == null || s.idx === soloSourceIdx) &&
+      laneVisibility[s.idx] !== false,
+  );
+  const height = visible.length * laneHeight;
+
+  useEffect(() => {
+    const cv = canvasRef.current;
+    const ctx = cv?.getContext("2d");
+    if (!cv || !ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    cv.width = Math.max(1, width * dpr);
+    cv.height = Math.max(1, height * dpr);
+    cv.style.width = `${width}px`;
+    cv.style.height = `${height}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+
+    visible.forEach((src, laneIdx) => {
+      const y = laneIdx * laneHeight;
+      ctx.fillStyle = "#f9fafb";
+      ctx.fillRect(0, y, width, laneHeight - 2);
+
+      const laneBuckets = buckets.filter((b) => b.sourceIdx === src.idx);
+      laneBuckets.forEach((b) => {
+        const x = ((b.tsStartMs - lo) / span) * width;
+        const w = Math.max(1, ((b.tsEndMs - b.tsStartMs) / span) * width);
+        let fill = src.color;
+        if (b.errorCount > 0) fill = "#dc2626";
+        else if (b.warnCount > 0) fill = "#f59e0b";
+        const density = Math.min(1, b.totalCount / 20);
+        ctx.globalAlpha = 0.35 + 0.6 * density;
+        ctx.fillStyle = fill;
+        ctx.fillRect(x, y + 2, w, laneHeight - 6);
+      });
+      ctx.globalAlpha = 1;
+    });
+  }, [buckets, visible, lo, span, width, height, laneHeight]);
+
+  const bucketAt = (e: React.MouseEvent): LaneBucket | null => {
+    const cv = canvasRef.current;
+    if (!cv) return null;
+    const rect = cv.getBoundingClientRect();
+    const xPx = e.clientX - rect.left;
+    const yPx = e.clientY - rect.top;
+    const laneIdx = Math.floor(yPx / laneHeight);
+    const src = visible[laneIdx];
+    if (!src) return null;
+    const tsAt = lo + (xPx / width) * span;
+    return (
+      buckets.find(
+        (b) =>
+          b.sourceIdx === src.idx &&
+          tsAt >= b.tsStartMs &&
+          tsAt <= b.tsEndMs,
+      ) ?? null
+    );
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      onMouseMove={(e) => onBucketHover?.(bucketAt(e))}
+      onMouseLeave={() => onBucketHover?.(null)}
+      onDoubleClick={(e) => {
+        const hit = bucketAt(e);
+        if (hit) onBucketDoubleClick?.(hit);
+      }}
+      style={{ display: "block", cursor: "pointer" }}
+    />
+  );
+}

--- a/src/components/timeline/TimelineRuler.tsx
+++ b/src/components/timeline/TimelineRuler.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+
+interface Props {
+  timeRangeMs: [number, number];
+  width: number;
+}
+
+export function TimelineRuler({ timeRangeMs, width }: Props) {
+  const [lo, hi] = timeRangeMs;
+  const ticks = useMemo(() => {
+    const count = Math.max(4, Math.min(12, Math.floor(width / 120)));
+    const step = (hi - lo) / count;
+    return Array.from({ length: count + 1 }, (_, i) => {
+      const ts = lo + step * i;
+      const x = ((ts - lo) / (hi - lo || 1)) * width;
+      return { ts, x, label: formatTime(ts) };
+    });
+  }, [lo, hi, width]);
+
+  return (
+    <svg width={width} height={20} role="presentation">
+      {ticks.map((t, i) => (
+        <g key={i} transform={`translate(${t.x},0)`}>
+          <line y2={6} stroke="#6b7280" />
+          <text y={18} fontSize={10} fill="#6b7280" textAnchor="middle">
+            {t.label}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}

--- a/src/components/timeline/TimelineWorkspace.tsx
+++ b/src/components/timeline/TimelineWorkspace.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from "react";
+import { useTimelineStore } from "../../stores/timeline-store";
+import { useLaneBuckets } from "./hooks/useLaneBuckets";
+import { SwimLaneCanvas } from "./SwimLaneCanvas";
+import { LaneLegend } from "./LaneLegend";
+import { IncidentChipBar } from "./IncidentChipBar";
+import { IncidentDetailPanel } from "./IncidentDetailPanel";
+import { TimelineRuler } from "./TimelineRuler";
+import { BrushOverlay } from "./BrushOverlay";
+import { LogListView } from "../log-view/LogListView";
+import { timelineLogListDataSource } from "./log-list-adapter";
+
+const LANE_HEIGHT = 22;
+
+export function TimelineWorkspace() {
+  const bundle = useTimelineStore((s) => s.bundle);
+  const laneVisibility = useTimelineStore((s) => s.laneVisibility);
+  const soloSourceIdx = useTimelineStore((s) => s.soloSourceIdx);
+  const [hover, setHover] = useState<string | null>(null);
+
+  // Resize-observer for lane width so the canvas/ruler/brush all match.
+  const laneBoxRef = useRef<HTMLDivElement>(null);
+  const [laneWidth, setLaneWidth] = useState(800);
+  useEffect(() => {
+    const el = laneBoxRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const w = Math.floor(entry.contentRect.width);
+        if (w > 0) setLaneWidth(w);
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const buckets = useLaneBuckets(
+    Math.max(100, Math.min(800, Math.floor(laneWidth))),
+  );
+
+  if (!bundle) {
+    return (
+      <div style={{ padding: 40, textAlign: "center", color: "#6b7280" }}>
+        Timeline is empty. Open a folder via File → New Timeline from Folder…
+      </div>
+    );
+  }
+
+  const visibleCount = bundle.sources.filter(
+    (s) =>
+      (soloSourceIdx == null || s.idx === soloSourceIdx) &&
+      laneVisibility[s.idx] !== false,
+  ).length;
+  const laneAreaHeight = Math.max(LANE_HEIGHT, visibleCount * LANE_HEIGHT);
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr 340px",
+        gridTemplateRows: "auto auto auto 1fr",
+        height: "100%",
+      }}
+    >
+      <LaneLegend />
+      <div />
+      <IncidentChipBar />
+      <div />
+      <div
+        ref={laneBoxRef}
+        style={{
+          position: "relative",
+          borderTop: "1px solid #e5e7eb",
+          borderBottom: "1px solid #e5e7eb",
+          padding: "0 0 2px 0",
+        }}
+      >
+        <TimelineRuler timeRangeMs={bundle.timeRangeMs} width={laneWidth} />
+        <SwimLaneCanvas
+          sources={bundle.sources}
+          buckets={buckets}
+          timeRangeMs={bundle.timeRangeMs}
+          width={laneWidth}
+          laneHeight={LANE_HEIGHT}
+          laneVisibility={laneVisibility}
+          soloSourceIdx={soloSourceIdx}
+          onBucketHover={(b) =>
+            setHover(
+              b ? `${b.totalCount} rows · ${b.errorCount} errors` : null,
+            )
+          }
+        />
+        <BrushOverlay
+          timeRangeMs={bundle.timeRangeMs}
+          width={laneWidth}
+          height={20 + laneAreaHeight}
+        />
+        {hover && (
+          <div
+            style={{
+              position: "absolute",
+              right: 8,
+              top: 2,
+              fontSize: 10,
+              color: "#6b7280",
+              background: "#fff",
+              padding: "1px 4px",
+              pointerEvents: "none",
+            }}
+          >
+            {hover}
+          </div>
+        )}
+      </div>
+      <div />
+      <LogListView dataSource={timelineLogListDataSource} />
+      <IncidentDetailPanel />
+    </div>
+  );
+}

--- a/src/components/timeline/TimelineWorkspace.tsx
+++ b/src/components/timeline/TimelineWorkspace.tsx
@@ -9,6 +9,7 @@ import { TimelineRuler } from "./TimelineRuler";
 import { BrushOverlay } from "./BrushOverlay";
 import { LogListView } from "../log-view/LogListView";
 import { timelineLogListDataSource } from "./log-list-adapter";
+import { buildTimelineFromSources } from "./hooks/useTimelineBundle";
 
 const LANE_HEIGHT = 22;
 
@@ -38,10 +39,50 @@ export function TimelineWorkspace() {
     Math.max(100, Math.min(800, Math.floor(laneWidth))),
   );
 
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault();
+    const files = Array.from(e.dataTransfer.files);
+    const paths = files
+      .map((f) => (f as File & { path?: string }).path)
+      .filter((p): p is string => typeof p === "string" && p.length > 0);
+    if (paths.length === 0) return;
+    const existing =
+      useTimelineStore.getState().bundle?.sources.map((s) => s.path) ?? [];
+    const merged = Array.from(new Set([...existing, ...paths])).map(
+      (path) => ({ path }),
+    );
+    try {
+      await buildTimelineFromSources(merged);
+    } catch (err) {
+      console.error("[timeline] failed to add sources to timeline", err);
+    }
+  };
+
   if (!bundle) {
     return (
-      <div style={{ padding: 40, textAlign: "center", color: "#6b7280" }}>
-        Timeline is empty. Open a folder via File → New Timeline from Folder…
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        style={{
+          padding: 40,
+          textAlign: "center",
+          color: "#6b7280",
+          border: "2px dashed #d1d5db",
+          margin: 40,
+          borderRadius: 8,
+        }}
+      >
+        <div style={{ fontSize: 14, marginBottom: 6 }}>
+          Drop log files here
+        </div>
+        <div style={{ fontSize: 11 }}>
+          Or use File → New Timeline from Folder…
+        </div>
       </div>
     );
   }
@@ -55,6 +96,8 @@ export function TimelineWorkspace() {
 
   return (
     <div
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
       style={{
         display: "grid",
         gridTemplateColumns: "1fr 340px",

--- a/src/components/timeline/hooks/useIncidentDetail.ts
+++ b/src/components/timeline/hooks/useIncidentDetail.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useTimelineStore } from "../../../stores/timeline-store";
+import type { IncidentDetail } from "../../../types/timeline";
+
+export function useIncidentDetail(
+  incidentId: number | null,
+): IncidentDetail | null {
+  const bundleId = useTimelineStore((s) => s.bundle?.id);
+  const [detail, setDetail] = useState<IncidentDetail | null>(null);
+
+  useEffect(() => {
+    if (!bundleId || incidentId == null) {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    invoke<IncidentDetail>("query_incident_details_cmd", {
+      id: bundleId,
+      incidentId,
+    })
+      .then((v) => {
+        if (!cancelled) setDetail(v);
+      })
+      .catch(() => {
+        if (!cancelled) setDetail(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [bundleId, incidentId]);
+
+  return detail;
+}

--- a/src/components/timeline/hooks/useLaneBuckets.ts
+++ b/src/components/timeline/hooks/useLaneBuckets.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useTimelineStore } from "../../../stores/timeline-store";
+import type { LaneBucket } from "../../../types/timeline";
+
+export function useLaneBuckets(bucketCount: number): LaneBucket[] {
+  const bundle = useTimelineStore((s) => s.bundle);
+  const brushRange = useTimelineStore((s) => s.brushRange);
+  const putBuckets = useTimelineStore((s) => s.putBuckets);
+  const cache = useTimelineStore((s) => s.bucketCache);
+
+  const rangeKey = brushRange ? `${brushRange[0]}-${brushRange[1]}` : "full";
+  const key = `${bundle?.id ?? ""}:${bucketCount}:${rangeKey}`;
+  const cached = cache.get(key);
+
+  useEffect(() => {
+    if (!bundle || cached) return;
+    let cancelled = false;
+    invoke<LaneBucket[]>("query_lane_buckets_cmd", {
+      id: bundle.id,
+      bucketCount,
+      rangeMs: brushRange ?? null,
+    })
+      .then((v) => {
+        if (!cancelled) putBuckets(key, v);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [bundle, bucketCount, brushRange, key, putBuckets, cached]);
+
+  return cached ?? [];
+}

--- a/src/components/timeline/hooks/useTimelineBundle.ts
+++ b/src/components/timeline/hooks/useTimelineBundle.ts
@@ -1,0 +1,41 @@
+import { useCallback, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useTimelineStore } from "../../../stores/timeline-store";
+import type { TimelineBundle } from "../../../types/timeline";
+
+export async function buildTimelineFromSources(
+  sources: { path: string; displayName?: string }[],
+): Promise<TimelineBundle> {
+  const bundle = await invoke<TimelineBundle>("build_timeline_cmd", { sources });
+  useTimelineStore.getState().setBundle(bundle);
+  return bundle;
+}
+
+export function useTimelineBundle() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const build = useCallback(
+    async (sources: { path: string; displayName?: string }[]) => {
+      setLoading(true);
+      setError(null);
+      try {
+        return await buildTimelineFromSources(sources);
+      } catch (e: unknown) {
+        const msg =
+          typeof e === "string"
+            ? e
+            : e && typeof e === "object" && "message" in e
+              ? String((e as { message: unknown }).message)
+              : JSON.stringify(e);
+        setError(msg);
+        throw e;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  return { build, loading, error };
+}

--- a/src/components/timeline/hooks/useTimelineEntries.ts
+++ b/src/components/timeline/hooks/useTimelineEntries.ts
@@ -1,0 +1,57 @@
+import { useEffect, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useTimelineStore } from "../../../stores/timeline-store";
+import type { TimelineEntry } from "../../../types/timeline";
+
+const PAGE_SIZE = 1000;
+
+export function useTimelineEntries(offset: number): TimelineEntry[] {
+  const bundle = useTimelineStore((s) => s.bundle);
+  const brushRange = useTimelineStore((s) => s.brushRange);
+  const laneVisibility = useTimelineStore((s) => s.laneVisibility);
+  const soloSourceIdx = useTimelineStore((s) => s.soloSourceIdx);
+  const putEntries = useTimelineStore((s) => s.putEntries);
+  const cache = useTimelineStore((s) => s.entryCache);
+
+  const sourceFilter = useMemo(() => {
+    if (soloSourceIdx != null) return [soloSourceIdx];
+    return Object.entries(laneVisibility)
+      .filter(([, v]) => v)
+      .map(([k]) => Number(k));
+  }, [laneVisibility, soloSourceIdx]);
+
+  const rangeKey = brushRange ? `${brushRange[0]}-${brushRange[1]}` : "full";
+  const filterKey = [...sourceFilter].sort((a, b) => a - b).join(",");
+  const key = `${bundle?.id ?? ""}:${offset}:${PAGE_SIZE}:${rangeKey}:${filterKey}`;
+  const cached = cache.get(key);
+
+  useEffect(() => {
+    if (!bundle || cached) return;
+    let cancelled = false;
+    invoke<TimelineEntry[]>("query_timeline_entries_cmd", {
+      id: bundle.id,
+      rangeMs: brushRange ?? null,
+      sourceFilter,
+      offset,
+      limit: PAGE_SIZE,
+    })
+      .then((v) => {
+        if (!cancelled) putEntries(key, v);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    bundle,
+    offset,
+    brushRange,
+    filterKey,
+    key,
+    putEntries,
+    cached,
+    sourceFilter,
+  ]);
+
+  return cached ?? [];
+}

--- a/src/components/timeline/log-list-adapter.ts
+++ b/src/components/timeline/log-list-adapter.ts
@@ -17,7 +17,12 @@ export const timelineLogListDataSource: LogListDataSource = {
       () =>
         entries
           .filter((e): e is Extract<typeof e, { kind: "log" }> => e.kind === "log")
-          .map((e) => e.entry),
+          .map((e) => ({
+            ...e.entry,
+            // Backend's single-line materializer reuses id=0 for every entry;
+            // synthesize a stable cross-source unique id so React keys work.
+            id: e.sourceIdx * 10_000_000 + e.entry.lineNumber,
+          })),
       [entries],
     );
   },

--- a/src/components/timeline/log-list-adapter.ts
+++ b/src/components/timeline/log-list-adapter.ts
@@ -1,0 +1,54 @@
+import { useMemo } from "react";
+import type { LogListDataSource } from "../log-view/log-list-data-source";
+import { useTimelineStore } from "../../stores/timeline-store";
+import { useTimelineEntries } from "./hooks/useTimelineEntries";
+import type { LogEntry } from "../../types/log";
+
+/**
+ * Data source for LogListView when running in the unified timeline's
+ * log-stream pane. Pulls the current page of entries from the timeline
+ * store, filters down to the log-entry subset (drops IME events), and
+ * exposes the brush range as the external filter range.
+ */
+export const timelineLogListDataSource: LogListDataSource = {
+  useEntries(): LogEntry[] {
+    const entries = useTimelineEntries(0);
+    return useMemo(
+      () =>
+        entries
+          .filter((e): e is Extract<typeof e, { kind: "log" }> => e.kind === "log")
+          .map((e) => e.entry),
+      [entries],
+    );
+  },
+  useSelectedId() {
+    // Timeline doesn't have per-row selection v1; the chip and detail drive state.
+    return useTimelineStore((s) => s.selectedIncidentId);
+  },
+  useHighlightText() {
+    return "";
+  },
+  useHighlightCaseSensitive() {
+    return false;
+  },
+  useIsPaused() {
+    return true;
+  },
+  useFindMatchIds() {
+    return null;
+  },
+  selectEntry(_id) {
+    /* no-op in v1 */
+    void _id;
+  },
+  useExternalFilterRange() {
+    return useTimelineStore((s) => s.brushRange);
+  },
+  useHighlightedRange() {
+    const sel = useTimelineStore((s) => s.selectedIncidentId);
+    const bundle = useTimelineStore((s) => s.bundle);
+    if (sel == null) return null;
+    const inc = bundle?.incidents.find((i) => i.id === sel);
+    return inc ? [inc.tsStartMs, inc.tsEndMs] : null;
+  },
+};

--- a/src/hooks/use-app-menu.ts
+++ b/src/hooks/use-app-menu.ts
@@ -109,6 +109,48 @@ export function useAppMenu() {
             }
             return;
           }
+          case "timeline_new_from_folder": {
+            const { open: openDialog } = await import("@tauri-apps/plugin-dialog");
+            const folder = await openDialog({ directory: true });
+            if (!folder || Array.isArray(folder)) return;
+            const folderPath = folder as string;
+            try {
+              const { listLogFolder } = await import("../lib/commands");
+              const listing = await listLogFolder(folderPath);
+              const childPaths = listing.entries
+                .filter((entry) => !entry.isDir)
+                .map((entry) => entry.path);
+              const sources: { path: string }[] = childPaths.map((path) => ({ path }));
+              // If the folder contains IME logs, add the folder itself as a source
+              // so the backend can detect and apply IME-specialised parsing.
+              const hasIme = childPaths.some((p) => {
+                const lower = p.toLowerCase();
+                return (
+                  lower.endsWith("agentexecutor.log") ||
+                  lower.endsWith("intunemanagementextension.log")
+                );
+              });
+              if (hasIme) sources.push({ path: folderPath });
+              if (sources.length === 0) return;
+              const { buildTimelineFromSources } = await import(
+                "../components/timeline/hooks/useTimelineBundle"
+              );
+              await buildTimelineFromSources(sources);
+              useUiStore.getState().ensureWorkspaceVisible("timeline", "native-menu.timeline-new-from-folder");
+            } catch (error) {
+              console.error("[app-menu] failed to build timeline from folder", {
+                folderPath,
+                error,
+              });
+            }
+            return;
+          }
+          case "timeline_new_empty": {
+            const { useTimelineStore } = await import("../stores/timeline-store");
+            useTimelineStore.getState().setBundle(null);
+            useUiStore.getState().ensureWorkspaceVisible("timeline", "native-menu.timeline-new-empty");
+            return;
+          }
           default:
             console.warn("[app-menu] unhandled native menu action", { payload });
         }

--- a/src/hooks/use-drag-drop.ts
+++ b/src/hooks/use-drag-drop.ts
@@ -26,10 +26,26 @@ export function useDragDrop() {
       }
 
       try {
+        const activeWorkspace = useUiStore.getState().activeWorkspace;
+
+        if (activeWorkspace === "timeline") {
+          const { useTimelineStore } = await import("../stores/timeline-store");
+          const { buildTimelineFromSources } = await import(
+            "../components/timeline/hooks/useTimelineBundle"
+          );
+          const existing =
+            useTimelineStore.getState().bundle?.sources.map((s) => s.path) ?? [];
+          const merged = Array.from(new Set([...existing, ...paths])).map(
+            (path) => ({ path }),
+          );
+          if (merged.length === 0) return;
+          await buildTimelineFromSources(merged);
+          return;
+        }
+
         if (paths.length === 1) {
           await openPathForActiveWorkspace(paths[0]);
         } else {
-          const activeWorkspace = useUiStore.getState().activeWorkspace;
           if (activeWorkspace === "log") {
             await loadFilesAsLogSource(paths);
           } else {

--- a/src/stores/timeline-store.test.ts
+++ b/src/stores/timeline-store.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useTimelineStore } from "./timeline-store";
+import type { TimelineBundle } from "../types/timeline";
+
+const bundle: TimelineBundle = {
+  id: "t1",
+  sources: [
+    {
+      idx: 0,
+      kind: { logFile: { parser_kind: "ccm" } },
+      path: "/a.log",
+      displayName: "a",
+      color: "#111",
+      entryCount: 10,
+    },
+    {
+      idx: 1,
+      kind: { logFile: { parser_kind: "ccm" } },
+      path: "/b.log",
+      displayName: "b",
+      color: "#222",
+      entryCount: 10,
+    },
+  ],
+  timeRangeMs: [0, 10000],
+  totalEntries: 20,
+  incidents: [],
+  deniedGuids: [],
+  errors: [],
+  tunables: {
+    overlapWindowMs: 5000,
+    minSourceCount: 2,
+    maxIncidentSpanMs: 60000,
+    enabledSignalKinds: ["errorSeverity"],
+  },
+};
+
+describe("timeline-store", () => {
+  beforeEach(() => {
+    useTimelineStore.getState().reset();
+  });
+
+  it("sets bundle and initializes laneVisibility from sources", () => {
+    useTimelineStore.getState().setBundle(bundle);
+    const s = useTimelineStore.getState();
+    expect(s.bundle?.id).toBe("t1");
+    expect(s.laneVisibility).toEqual({ 0: true, 1: true });
+  });
+
+  it("solo toggle sets and clears soloSourceIdx", () => {
+    useTimelineStore.getState().setBundle(bundle);
+    useTimelineStore.getState().setSolo(1);
+    expect(useTimelineStore.getState().soloSourceIdx).toBe(1);
+    useTimelineStore.getState().setSolo(null);
+    expect(useTimelineStore.getState().soloSourceIdx).toBeNull();
+  });
+
+  it("toggleMute flips just one lane", () => {
+    useTimelineStore.getState().setBundle(bundle);
+    useTimelineStore.getState().toggleMute(0);
+    expect(useTimelineStore.getState().laneVisibility[0]).toBe(false);
+    useTimelineStore.getState().toggleMute(0);
+    expect(useTimelineStore.getState().laneVisibility[0]).toBe(true);
+  });
+
+  it("brushRange defaults to null, can be set and cleared", () => {
+    useTimelineStore.getState().setBundle(bundle);
+    expect(useTimelineStore.getState().brushRange).toBeNull();
+    useTimelineStore.getState().setBrushRange([1000, 2000]);
+    expect(useTimelineStore.getState().brushRange).toEqual([1000, 2000]);
+    useTimelineStore.getState().clearBrushRange();
+    expect(useTimelineStore.getState().brushRange).toBeNull();
+  });
+
+  it("selectIncident sets brushRange with 2s pad when incident found", () => {
+    const withIncident: TimelineBundle = {
+      ...bundle,
+      incidents: [
+        {
+          id: 1,
+          tsStartMs: 5000,
+          tsEndMs: 5500,
+          signalCount: 3,
+          sourceCount: 2,
+          confidence: 0.7,
+          summary: "x",
+        },
+      ],
+    };
+    useTimelineStore.getState().setBundle(withIncident);
+    useTimelineStore.getState().selectIncident(1);
+    expect(useTimelineStore.getState().selectedIncidentId).toBe(1);
+    expect(useTimelineStore.getState().brushRange).toEqual([3000, 7500]);
+  });
+});

--- a/src/stores/timeline-store.test.ts
+++ b/src/stores/timeline-store.test.ts
@@ -7,7 +7,7 @@ const bundle: TimelineBundle = {
   sources: [
     {
       idx: 0,
-      kind: { logFile: { parser_kind: "ccm" } },
+      kind: { logFile: { parserKind: "ccm" } },
       path: "/a.log",
       displayName: "a",
       color: "#111",
@@ -15,7 +15,7 @@ const bundle: TimelineBundle = {
     },
     {
       idx: 1,
-      kind: { logFile: { parser_kind: "ccm" } },
+      kind: { logFile: { parserKind: "ccm" } },
       path: "/b.log",
       displayName: "b",
       color: "#222",

--- a/src/stores/timeline-store.ts
+++ b/src/stores/timeline-store.ts
@@ -1,0 +1,133 @@
+import { create } from "zustand";
+import type {
+  TimelineBundle,
+  Incident,
+  LaneBucket,
+  TimelineEntry,
+} from "../types/timeline";
+
+interface TimelineState {
+  bundle: TimelineBundle | null;
+  selectedIncidentId: number | null;
+  brushRange: [number, number] | null;
+  laneVisibility: Record<number, boolean>;
+  soloSourceIdx: number | null;
+
+  bucketCache: Map<string, LaneBucket[]>;
+  entryCache: Map<string, TimelineEntry[]>;
+
+  setBundle(b: TimelineBundle | null): void;
+  reset(): void;
+  setBrushRange(r: [number, number]): void;
+  clearBrushRange(): void;
+  selectIncident(id: number | null): void;
+  toggleMute(sourceIdx: number): void;
+  setSolo(sourceIdx: number | null): void;
+  replaceIncidents(incidents: Incident[]): void;
+
+  putBuckets(key: string, v: LaneBucket[]): void;
+  putEntries(key: string, v: TimelineEntry[]): void;
+  invalidateCaches(): void;
+}
+
+const MAX_BUCKET_CACHE = 32;
+const MAX_ENTRY_CACHE = 128;
+
+export const useTimelineStore = create<TimelineState>((set, get) => ({
+  bundle: null,
+  selectedIncidentId: null,
+  brushRange: null,
+  laneVisibility: {},
+  soloSourceIdx: null,
+  bucketCache: new Map(),
+  entryCache: new Map(),
+
+  setBundle(b) {
+    const laneVisibility: Record<number, boolean> = {};
+    b?.sources.forEach((s) => {
+      laneVisibility[s.idx] = true;
+    });
+    set({
+      bundle: b,
+      selectedIncidentId: null,
+      brushRange: null,
+      laneVisibility,
+      soloSourceIdx: null,
+      bucketCache: new Map(),
+      entryCache: new Map(),
+    });
+  },
+
+  reset() {
+    get().setBundle(null);
+  },
+
+  setBrushRange(r) {
+    set({ brushRange: r });
+    get().invalidateCaches();
+  },
+
+  clearBrushRange() {
+    set({ brushRange: null });
+    get().invalidateCaches();
+  },
+
+  selectIncident(id) {
+    const b = get().bundle;
+    const inc =
+      id == null ? null : (b?.incidents.find((i) => i.id === id) ?? null);
+    if (inc) {
+      const pad = 2000;
+      set({
+        selectedIncidentId: id,
+        brushRange: [inc.tsStartMs - pad, inc.tsEndMs + pad],
+      });
+      get().invalidateCaches();
+    } else {
+      set({ selectedIncidentId: id });
+    }
+  },
+
+  toggleMute(sourceIdx) {
+    set((s) => ({
+      laneVisibility: {
+        ...s.laneVisibility,
+        [sourceIdx]: !s.laneVisibility[sourceIdx],
+      },
+    }));
+    get().invalidateCaches();
+  },
+
+  setSolo(sourceIdx) {
+    set({ soloSourceIdx: sourceIdx });
+    get().invalidateCaches();
+  },
+
+  replaceIncidents(incidents) {
+    set((s) => (s.bundle ? { bundle: { ...s.bundle, incidents } } : s));
+  },
+
+  putBuckets(key, v) {
+    const m = new Map(get().bucketCache);
+    if (m.size >= MAX_BUCKET_CACHE) {
+      const first = m.keys().next().value;
+      if (first !== undefined) m.delete(first);
+    }
+    m.set(key, v);
+    set({ bucketCache: m });
+  },
+
+  putEntries(key, v) {
+    const m = new Map(get().entryCache);
+    if (m.size >= MAX_ENTRY_CACHE) {
+      const first = m.keys().next().value;
+      if (first !== undefined) m.delete(first);
+    }
+    m.set(key, v);
+    set({ entryCache: m });
+  },
+
+  invalidateCaches() {
+    set({ bucketCache: new Map(), entryCache: new Map() });
+  },
+}));

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -60,7 +60,8 @@ export type WorkspaceId =
   | "deployment"
   | "event-log"
   | "secureboot"
-  | "sysmon";
+  | "sysmon"
+  | "timeline";
 export type KnownSourceDefaultFileSelectionBehavior =
   | "none"
   | "preferFileName"

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -6,16 +6,12 @@ export type SignalKind = "errorSeverity" | "knownErrorCode" | "imeFailed";
 /**
  * Mirrors Rust `TimelineSourceKind` in `src-tauri/src/timeline/models.rs`.
  *
- * The enum uses the default (externally-tagged) serde representation with
- * `#[serde(rename_all = "camelCase")]` on the enum itself. That renames the
- * variant names (`logFile`, `intuneEvents`) but — crucially — does NOT
- * cascade into the fields of struct-like variants. As a result, the inner
- * field of `LogFile` serializes as `parser_kind`, not `parserKind`.
- *
- * Verified empirically by serializing both variants to JSON.
+ * The enum uses the default (externally-tagged) serde representation; the
+ * variant names are renamed to camelCase and `LogFile` carries an inner
+ * `#[serde(rename_all = "camelCase")]` so its field also camelCases.
  */
 export type TimelineSourceKind =
-  | { logFile: { parser_kind: ParserKind } }
+  | { logFile: { parserKind: ParserKind } }
   | "intuneEvents";
 
 export interface TimelineSourceMeta {

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -1,0 +1,102 @@
+import type { LogEntry, ParserKind } from "./log";
+import type { IntuneEvent } from "../workspaces/intune/types";
+
+export type SignalKind = "errorSeverity" | "knownErrorCode" | "imeFailed";
+
+/**
+ * Mirrors Rust `TimelineSourceKind` in `src-tauri/src/timeline/models.rs`.
+ *
+ * The enum uses the default (externally-tagged) serde representation with
+ * `#[serde(rename_all = "camelCase")]` on the enum itself. That renames the
+ * variant names (`logFile`, `intuneEvents`) but — crucially — does NOT
+ * cascade into the fields of struct-like variants. As a result, the inner
+ * field of `LogFile` serializes as `parser_kind`, not `parserKind`.
+ *
+ * Verified empirically by serializing both variants to JSON.
+ */
+export type TimelineSourceKind =
+  | { logFile: { parser_kind: ParserKind } }
+  | "intuneEvents";
+
+export interface TimelineSourceMeta {
+  idx: number;
+  kind: TimelineSourceKind;
+  path: string;
+  displayName: string;
+  color: string;
+  entryCount: number;
+}
+
+export interface Incident {
+  id: number;
+  tsStartMs: number;
+  tsEndMs: number;
+  signalCount: number;
+  sourceCount: number;
+  confidence: number;
+  anchorEventRef?: [number, number];
+  anchorGuid?: string;
+  summary: string;
+}
+
+export interface TimelineTunables {
+  overlapWindowMs: number;
+  minSourceCount: number;
+  maxIncidentSpanMs: number;
+  enabledSignalKinds: SignalKind[];
+}
+
+export interface SourceError {
+  path: string;
+  message: string;
+}
+
+export interface TimelineBundle {
+  id: string;
+  sources: TimelineSourceMeta[];
+  timeRangeMs: [number, number];
+  totalEntries: number;
+  incidents: Incident[];
+  deniedGuids: string[];
+  errors: SourceError[];
+  tunables: TimelineTunables;
+}
+
+export interface LaneBucket {
+  sourceIdx: number;
+  tsStartMs: number;
+  tsEndMs: number;
+  totalCount: number;
+  errorCount: number;
+  warnCount: number;
+}
+
+export type TimelineEntry =
+  | { kind: "log"; sourceIdx: number; entry: LogEntry }
+  | { kind: "imeEvent"; sourceIdx: number; event: IntuneEvent };
+
+export interface IncidentSignalDetail {
+  sourceIdx: number;
+  sourceName: string;
+  tsMs: number;
+  kind: SignalKind;
+  correlationId?: string;
+  lineNumber: number;
+  preview: string;
+}
+
+export interface IncidentDetail {
+  incident: Incident;
+  signals: IncidentSignalDetail[];
+  perSourceSignalCounts: Record<string, number>;
+}
+
+/**
+ * Mirrors Rust `TimelineError` (tagged union via `#[serde(tag = "kind", rename_all = "camelCase")]`).
+ */
+export type TimelineError =
+  | { kind: "notFound"; id: string }
+  | { kind: "tooLarge"; estimated: number; limit: number }
+  | { kind: "noSources" }
+  | { kind: "sourceRead"; path: string; message: string }
+  | { kind: "internal"; message: string };

--- a/src/workspaces/registry.ts
+++ b/src/workspaces/registry.ts
@@ -10,6 +10,7 @@ import { deploymentWorkspace } from "./deployment";
 import { eventLogWorkspace } from "./event-log";
 import { sysmonWorkspace } from "./sysmon";
 import { securebootWorkspace } from "./secureboot";
+import { timelineWorkspace } from "./timeline";
 
 const ALL_WORKSPACES: WorkspaceDefinition[] = [
   logWorkspace,
@@ -21,6 +22,7 @@ const ALL_WORKSPACES: WorkspaceDefinition[] = [
   eventLogWorkspace,
   sysmonWorkspace,
   securebootWorkspace,
+  timelineWorkspace,
 ];
 
 export const workspaceRegistry = new Map<WorkspaceId, WorkspaceDefinition>(

--- a/src/workspaces/timeline/index.ts
+++ b/src/workspaces/timeline/index.ts
@@ -1,0 +1,26 @@
+// src/workspaces/timeline/index.ts
+import { lazy } from "react";
+import type { WorkspaceDefinition } from "../types";
+
+export const timelineWorkspace: WorkspaceDefinition = {
+  id: "timeline",
+  label: "Timeline",
+  statusLabel: "Timeline",
+  platforms: "all",
+  component: lazy(() =>
+    import("../../components/timeline/TimelineWorkspace").then((m) => ({
+      default: m.TimelineWorkspace,
+    }))
+  ),
+  capabilities: {
+    multiFileDrop: true,
+    fontSizing: true,
+  },
+  fileFilters: [
+    { name: "Log Files", extensions: ["log", "cmtlog", "evtx"] },
+    { name: "All Files", extensions: ["*"] },
+  ],
+  actionLabels: {
+    placeholder: "Open Timeline Source...",
+  },
+};


### PR DESCRIPTION
## Summary

Adds a new Timeline workspace that merges multiple log files and Intune IME events into one time-ordered view, detects incidents as points where error signals from ≥2 sources overlap, and event-anchors correlation via IME GUIDs (tenant/device IDs auto-denylisted).

- Swim-lane overview on top (canvas-rendered from aggregated bucket queries, not per-row), brush-to-filter time range, solo/mute per lane
- Merged log stream below reuses the existing \`LogListView\` via a new \`dataSource\` prop + adapter
- Incident chip bar + detail panel (per-source signal counts, copyable anchor GUID, signal previews)
- Streaming-ready data model: compact per-entry \`EntryIndex\` (~24 bytes) separated from on-demand materialization by byte offset — Phase 2 can swap the in-memory store without touching contracts
- New IPC commands: \`build_timeline_cmd\`, \`query_timeline_entries_cmd\`, \`query_lane_buckets_cmd\`, \`query_incident_details_cmd\`, \`update_timeline_tunables_cmd\`, \`close_timeline_cmd\`
- Native menu entries (\"New Timeline from Folder…\", \"New Empty Timeline\") + drop-zone for adding sources to an existing timeline

Also resolves two clippy errors that broke main's CI under Rust 1.95 (useless-conversion in \`guid_registry.rs\`, collapsible-match in \`watcher/tail.rs\`).

## Test plan

- [x] \`cargo test --lib\` — 504 tests passing
- [x] \`cargo test --test timeline_integration\` — 3 scenarios (Win32 app failure, logs-only, multi-failure) passing
- [x] \`cargo clippy -- -D warnings\` — clean (default and \`--no-default-features\`)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 86 tests passing
- [x] Manual smoke: Timeline workspace activates via File → New Timeline from Folder…, swim lanes render, log stream populates
- [ ] Playwright e2e deferred — requires running Tauri app
- [ ] Real-world multi-GB folder smoke — pending

## Notes

- Spec: \`docs/superpowers/specs/2026-04-19-unified-multi-file-timeline-design.md\` (local, not committed — \`docs/\` is gitignored)
- Plan: \`docs/superpowers/plans/2026-04-19-unified-multi-file-timeline.md\` (same)
- The \`TimelineEntry\` Log variant stores \`Box<LogEntry>\` to avoid \`clippy::large_enum_variant\`
- One known adapter-side band-aid: backend's \`parse_one_line\` returns \`id=0\` for every single-line materialize; \`log-list-adapter.ts\` synthesizes \`sourceIdx * 10M + lineNumber\` so React keys are unique. Worth fixing in the backend as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)