### PR TITLE
chore(clippy): clean up --all-targets warnings in test code

### DIFF
--- a/crates/cmtraceopen-parser/src/parser/cmtlog.rs
+++ b/crates/cmtraceopen-parser/src/parser/cmtlog.rs
@@ -387,7 +387,7 @@ mod tests {
 
     #[test]
     fn test_severity_mapping() {
-        let lines = vec![
+        let lines = [
             r#"<![LOG[Policy validation failed]LOG]!><time="10:32:01.456+000" date="04-13-2026" component="Detect-WDAC" context="" type="3" thread="1234" file="">"#.to_string(),
         ];
         let line_refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();

--- a/crates/cmtraceopen-parser/src/parser/dns_debug.rs
+++ b/crates/cmtraceopen-parser/src/parser/dns_debug.rs
@@ -428,7 +428,7 @@ mod tests {
 
     #[test]
     fn test_parse_basic_query_response_pair() {
-        let lines = vec![
+        let lines = [
             "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] SOA    (4)home(4)gell(3)one(0)",
             "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Snd 127.0.0.1       d07e R Q [8085 A DR  NOERROR] SOA    (4)home(4)gell(3)one(0)",
         ];
@@ -460,7 +460,7 @@ mod tests {
 
     #[test]
     fn test_parse_with_detail_section_extracts_port() {
-        let lines = vec![
+        let lines = [
             "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] SOA    (4)home(4)gell(3)one(0)",
             "UDP question info at 000002DAEC36D650",
             "  Socket = 884",
@@ -477,7 +477,7 @@ mod tests {
 
     #[test]
     fn test_parse_severity_mapping() {
-        let lines = vec![
+        let lines = [
             "4/11/2026 8:34:00 PM 0294 PACKET  000002DAEF3AFDC0 UDP Snd 127.0.0.1       3c8a R Q [8385 A DR NXDOMAIN] A      (4)HOME(4)home(4)gell(3)one(0)",
             "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC3680D0 UDP Snd 192.168.2.9     7822 R U [02a8      SERVFAIL] SOA    (4)home(4)gell(3)one(0)",
         ];
@@ -490,7 +490,7 @@ mod tests {
 
     #[test]
     fn test_parse_skips_header() {
-        let lines = vec![
+        let lines = [
             "DNS Server log file creation at 4/11/2026 3:29:00 PM",
             "Log file wrap:",
             "Message logging key (for packets - other items use a subset):",
@@ -507,7 +507,7 @@ mod tests {
 
     #[test]
     fn test_parse_thread_display() {
-        let lines = vec![
+        let lines = [
             "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] SOA    (4)home(4)gell(3)one(0)",
         ];
         let line_refs: Vec<&str> = lines.iter().map(|s| s.as_ref()).collect();
@@ -522,7 +522,7 @@ mod tests {
 
     #[test]
     fn test_parse_us_timestamp() {
-        let lines = vec![
+        let lines = [
             "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] SOA    (4)home(4)gell(3)one(0)",
         ];
         let line_refs: Vec<&str> = lines.iter().map(|s| s.as_ref()).collect();
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn test_parse_dynamic_update_opcode() {
-        let lines = vec![
+        let lines = [
             "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC3680D0 UDP Rcv 192.168.2.9     7822   U [0028       NOERROR] SOA    (4)home(4)gell(3)one(0)",
         ];
         let line_refs: Vec<&str> = lines.iter().map(|s| s.as_ref()).collect();
@@ -550,7 +550,7 @@ mod tests {
 
     #[test]
     fn test_parse_root_query() {
-        let lines = vec![
+        let lines = [
             "4/11/2026 8:33:19 PM 0294 PACKET  000002DAECB28D10 UDP Snd 192.168.2.9     131a R Q [8081   DR  NOERROR] NS     (0)",
         ];
         let line_refs: Vec<&str> = lines.iter().map(|s| s.as_ref()).collect();

--- a/src-tauri/tests/dns_audit_real.rs
+++ b/src-tauri/tests/dns_audit_real.rs
@@ -29,7 +29,7 @@ fn test_real_dns_audit_evtx() {
 
     assert_eq!(format!("{:?}", selection.parser), "DnsAudit");
     assert_eq!(format!("{:?}", result.format_detected), "DnsAudit");
-    assert!(result.entries.len() > 0, "Should have parsed entries, got 0");
+    assert!(!result.entries.is_empty(), "Should have parsed entries, got 0");
     assert_eq!(result.parse_errors, 0, "Should have zero parse errors");
 
     // Collect event IDs

--- a/src-tauri/tests/parser_expanded_corpus.rs
+++ b/src-tauri/tests/parser_expanded_corpus.rs
@@ -157,7 +157,7 @@ fn simple_clean_fixture_detects_and_parses() {
     assert_eq!(detected.implementation, "Simple");
 
     let parsed = parse_fixture("simple/clean/basic.log");
-    assert!(parsed.entries.len() >= 1, "should parse at least 1 entry, got {}", parsed.entries.len());
+    assert!(!parsed.entries.is_empty(), "should parse at least 1 entry, got {}", parsed.entries.len());
     assert_eq!(parsed.entries[0].component.as_deref(), Some("CcmExec"));
 }
 


### PR DESCRIPTION
## Summary

Cleans up 11 pre-existing clippy warnings that only surface under `cargo clippy --all-targets` (test code). These were flagged as out-of-scope follow-ups in PR #155 during the Phase 1 parser extraction audit.

**Not critical** - CI already runs `cargo clippy -- -D warnings` *without* `--all-targets`, so these never blocked the pipeline. This is cleanup hygiene so that running clippy with `--all-targets` locally (or if we ever tighten CI) stays quiet.

## What was fixed

| File | Count | Lint |
|---|---|---|
| `crates/cmtraceopen-parser/src/parser/cmtlog.rs:390` | 1 | `clippy::useless_vec` |
| `crates/cmtraceopen-parser/src/parser/dns_debug.rs:431,463,480,493,510,525,539,553` | 8 | `clippy::useless_vec` |
| `src-tauri/tests/dns_audit_real.rs:32` | 1 | `clippy::len_zero` (`.len() > 0` -> `!is_empty()`) |
| `src-tauri/tests/parser_expanded_corpus.rs:160` | 1 | `clippy::len_zero` (`.len() >= 1` -> `!is_empty()`) |

All `vec![...]` sites were test-only fixtures that were immediately borrowed as a slice - replaced with plain array literals (`[...]`). No semantic change.

The third audit nit mentioned in the original PR review - `sort_unstable_by_key` in `src-tauri/src/commands/fonts.rs` - was already addressed in a prior commit, so nothing to do there.

## Verification

- `cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings` passes clean.
- `cargo test -p cmtraceopen-parser` - 227 tests pass.
- `src-tauri`-side clippy was not runnable locally on this aarch64-pc-windows-msvc dev machine (missing `clang` for `ring` build), but the two test-file edits are mechanical `.len() > 0` -> `!is_empty()` which are trivially correct and CI will confirm.

## Test plan

- [x] Parser crate clippy is clean under `--all-targets -- -D warnings`
- [x] Parser crate tests (227) still pass
- [ ] CI: `cargo clippy -- -D warnings` on ubuntu still passes
- [ ] CI: `cargo test` on ubuntu still passes
- [ ] CI: Tauri builds on macOS-arm64, Windows-x64, Linux-x64 still succeed