### PR TITLE
fix(parser): accept all components in CBS/DISM log parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
  "ureq",
  "windows",
  "windows-future",
- "winreg",
+ "winreg 0.56.0",
 ]
 
 [[package]]
@@ -1121,7 +1121,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -6697,6 +6697,16 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/cmtraceopen-parser/src/parser/cbs.rs
+++ b/crates/cmtraceopen-parser/src/parser/cbs.rs
@@ -100,22 +100,17 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
 }
 
 fn parse_header(line: &str, file_path: &str) -> Option<LogEntry> {
+    // The strict regex matches known severity keywords — accept any component.
+    // CBS/DISM/Panther logs all share the same format; once a file is detected
+    // as CBS, every well-formed line should be parsed regardless of component
+    // (e.g. DISM entries interleaved in CBS.log).
     if let Some(caps) = cbs_header_re().captures(line) {
         return build_entry_from_caps(&caps, file_path);
     }
 
+    // Relaxed regex: non-standard severity token.  Accept any component so
+    // that mixed CBS/DISM logs parse fully.
     let caps = cbs_relaxed_header_re().captures(line)?;
-    let component = caps.get(8)?.as_str().to_ascii_uppercase();
-    let message = caps.get(9).map(|m| m.as_str()).unwrap_or("");
-
-    if !matches!(
-        component.as_str(),
-        "CBS" | "CSI" | "TI" | "SR" | "SFC" | "RIBS" | "OC" | "POQ" | "SQM" | "DWLD"
-    ) && !message.starts_with("[SR]")
-    {
-        return None;
-    }
-
     build_entry_from_caps(&caps, file_path)
 }
 
@@ -327,5 +322,54 @@ mod tests {
         assert_eq!(entries[2].component.as_deref(), Some("CBS"));
         assert_eq!(entries[3].severity, Severity::Warning);
         assert_eq!(entries[3].component.as_deref(), Some("CSI"));
+    }
+
+    #[test]
+    fn test_parse_lines_accepts_dism_components_in_cbs_log() {
+        // Real CBS logs often contain DISM, DPX, CMIV, WCP entries interleaved
+        // with CBS/CSI lines.  The parser must accept them all (#154).
+        let lines = [
+            "2024-01-15 08:00:00, Info                  CBS    Exec: Processing package",
+            "2024-01-15 08:00:01, Info                  DISM   DISM Package Manager: PID=1234 TID=5678 loaded provider",
+            "2024-01-15 08:00:02, Warning               DPX    DPX detected pending reboot",
+            "2024-01-15 08:00:03, Info                  CMIV   Validating manifest",
+            "2024-01-15 08:00:04, Error                 WCP    WCP transaction commit failed",
+            "2024-01-15 08:00:05, Info                  CSI    [SR] Repair completed",
+        ];
+
+        let (entries, parse_errors) = parse_lines(&lines, "C:/Windows/Logs/CBS/CBS.log");
+
+        assert_eq!(parse_errors, 0);
+        assert_eq!(entries.len(), 6);
+        assert_eq!(entries[0].component.as_deref(), Some("CBS"));
+        assert_eq!(entries[1].component.as_deref(), Some("DISM"));
+        assert_eq!(entries[2].component.as_deref(), Some("DPX"));
+        assert_eq!(entries[2].severity, Severity::Warning);
+        assert_eq!(entries[3].component.as_deref(), Some("CMIV"));
+        assert_eq!(entries[4].component.as_deref(), Some("WCP"));
+        assert_eq!(entries[4].severity, Severity::Error);
+        assert_eq!(entries[5].component.as_deref(), Some("CSI"));
+    }
+
+    #[test]
+    fn test_parse_lines_mixed_cbs_dism_with_continuations() {
+        // Verify multi-line records work across component boundaries.
+        let lines = [
+            "2024-01-15 08:00:00, Info                  DISM   DISM Provider Store: Loading provider",
+            "  Provider: Package Manager",
+            "  State: Active",
+            "2024-01-15 08:00:01, Info                  CBS    Exec: Servicing stack version check",
+        ];
+
+        let (entries, parse_errors) = parse_lines(&lines, "C:/Windows/Logs/CBS/CBS.log");
+
+        assert_eq!(parse_errors, 0);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].component.as_deref(), Some("DISM"));
+        assert_eq!(
+            entries[0].message,
+            "DISM Provider Store: Loading provider\n  Provider: Package Manager\n  State: Active"
+        );
+        assert_eq!(entries[1].component.as_deref(), Some("CBS"));
     }
 }

--- a/crates/cmtraceopen-parser/src/parser/dism.rs
+++ b/crates/cmtraceopen-parser/src/parser/dism.rs
@@ -93,24 +93,21 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
 }
 
 fn parse_header(line: &str, file_path: &str) -> Option<LogEntry> {
+    // The strict regex matches known severity keywords — accept any component.
+    // DISM logs frequently contain CBS/CSI/DPX/WCP entries alongside DISM ones;
+    // once a file is detected as DISM, every well-formed line should parse.
     if let Some(caps) = dism_header_re().captures(line) {
         return build_entry_from_caps(&caps, file_path);
     }
 
+    // Relaxed regex: non-standard severity token.  Accept any component so
+    // that mixed DISM/CBS logs parse fully.
     let caps = dism_relaxed_header_re().captures(line)?;
-    let component = caps.get(8)?.as_str().to_ascii_uppercase();
-    if !component.starts_with("DISM") {
-        return None;
-    }
-
     build_entry_from_caps(&caps, file_path)
 }
 
 fn build_entry_from_caps(caps: &regex::Captures<'_>, file_path: &str) -> Option<LogEntry> {
     let component = caps.get(8)?.as_str().to_string();
-    if !component.to_ascii_uppercase().starts_with("DISM") {
-        return None;
-    }
 
     let year: i32 = caps.get(1)?.as_str().parse().ok()?;
     let month: u32 = caps.get(2)?.as_str().parse().ok()?;
@@ -317,5 +314,52 @@ mod tests {
         assert_eq!(entries[2].component.as_deref(), Some("DISM"));
         assert_eq!(entries[3].severity, Severity::Error);
         assert_eq!(entries[3].component.as_deref(), Some("DISM"));
+    }
+
+    #[test]
+    fn test_parse_lines_accepts_cbs_components_in_dism_log() {
+        // Real DISM logs contain CBS/CSI/DPX/WCP entries alongside DISM lines.
+        // The parser must accept them all (#154).
+        let lines = [
+            "2024-01-15 08:00:00, Info                  DISM   DISM Provider Store: PID=100 TID=200 loaded provider",
+            "2024-01-15 08:00:01, Info                  CBS    Exec: Processing package",
+            "2024-01-15 08:00:02, Warning               CSI    [SR] Cannot repair file",
+            "2024-01-15 08:00:03, Info                  DPX    DPX scheduled restart",
+            "2024-01-15 08:00:04, Error                 WCP    WCP transaction commit failed",
+        ];
+
+        let (entries, parse_errors) = parse_lines(&lines, "C:/Windows/Logs/DISM/dism.log");
+
+        assert_eq!(parse_errors, 0);
+        assert_eq!(entries.len(), 5);
+        assert_eq!(entries[0].component.as_deref(), Some("DISM"));
+        assert_eq!(entries[1].component.as_deref(), Some("CBS"));
+        assert_eq!(entries[2].component.as_deref(), Some("CSI"));
+        assert_eq!(entries[2].severity, Severity::Warning);
+        assert_eq!(entries[3].component.as_deref(), Some("DPX"));
+        assert_eq!(entries[4].component.as_deref(), Some("WCP"));
+        assert_eq!(entries[4].severity, Severity::Error);
+    }
+
+    #[test]
+    fn test_parse_lines_mixed_dism_cbs_with_continuations() {
+        // Verify multi-line records work across component boundaries.
+        let lines = [
+            "2024-01-15 08:00:00, Info                  CBS    Exec: Started servicing",
+            "  Package: KB5034123",
+            "  State: Staged",
+            "2024-01-15 08:00:01, Info                  DISM   DISM Package Manager: Finalizing",
+        ];
+
+        let (entries, parse_errors) = parse_lines(&lines, "C:/Windows/Logs/DISM/dism.log");
+
+        assert_eq!(parse_errors, 0);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].component.as_deref(), Some("CBS"));
+        assert_eq!(
+            entries[0].message,
+            "Exec: Started servicing\n  Package: KB5034123\n  State: Staged"
+        );
+        assert_eq!(entries[1].component.as_deref(), Some("DISM"));
     }
 }

--- a/src-tauri/tests/corpus/cbs/mixed_components/CBS.log
+++ b/src-tauri/tests/corpus/cbs/mixed_components/CBS.log
@@ -1,0 +1,10 @@
+2024-01-15 08:00:00, Info                  CBS    Loaded Servicing Stack v10.0.19041.3636 with Core: C:\Windows\winsxs\amd64_microsoft-windows-servicingstack_31bf3856ad364e35_10.0.19041.3636_none_24bcda3e7bad3a5c\cbscore.dll
+2024-01-15 08:00:01, Info                  CBS    Exec: Processing started. Session: 30546354_3536635320
+2024-01-15 08:00:02, Info                  DISM   DISM Provider Store: PID=4652 TID=7080 Getting Provider DISMLogger - CDISMProviderStore::GetProvider
+2024-01-15 08:00:03, Info                  DISM   DISM Provider Store: PID=4652 TID=7080 Provider has previously been initialized.  Returning the existing instance. - CDISMProviderStore::Internal_GetProvider
+2024-01-15 08:00:04, Info                  CSI    @0x814 (F) CSI Transaction commit
+  Component: amd64_microsoft-windows-servicingstack
+2024-01-15 08:00:06, Warning               DPX    DPX detected pending reboot from a previous servicing operation
+2024-01-15 08:00:07, Info                  CMIV   Validating component manifest integrity
+2024-01-15 08:00:08, Info                  CBS    Exec: Package: KB5034123, current state: Staged, target state: Installed
+2024-01-15 08:00:09, Error                 WCP    WCP transaction rollback initiated

--- a/src-tauri/tests/corpus/dism/mixed_components/dism.log
+++ b/src-tauri/tests/corpus/dism/mixed_components/dism.log
@@ -1,0 +1,8 @@
+2024-01-15 08:00:00, Info                  DISM   DISM Provider Store: PID=4652 TID=7080 Initializing provider - CDISMProviderStore::Internal_LoadProvider
+2024-01-15 08:00:01, Info                  DISM   DISM Package Manager: PID=4652 TID=7080 Processing package operation
+2024-01-15 08:00:02, Info                  CBS    Loaded Servicing Stack v10.0.19041.3636
+2024-01-15 08:00:03, Info                  CBS    Exec: Servicing session 30546354
+2024-01-15 08:00:04, Warning               CSI    [SR] Cannot repair member file [l:24{12}]"comctl32.dll"
+2024-01-15 08:00:05, Info                  DPX    DPX scheduled restart after servicing
+  Restart reason: Component store corruption repaired
+2024-01-15 08:00:07, Error                 DISM   DISM Package Manager: PID=4652 TID=7080 Failed finalizing changes. Error: 0x800f0922

--- a/src-tauri/tests/parser_regression_corpus.rs
+++ b/src-tauri/tests/parser_regression_corpus.rs
@@ -327,6 +327,93 @@ fn dism_mixed_fixture_preserves_fallback_segments() {
 }
 
 #[test]
+fn cbs_mixed_components_fixture_parses_dism_and_other_components() {
+    let detected = detect_fixture("cbs/mixed_components/CBS.log");
+    assert_selection(
+        &detected,
+        "Cbs",
+        "GenericTimestamped",
+        "Dedicated",
+        "SemiStructured",
+        "LogicalRecord",
+    );
+
+    let parsed = parse_fixture("cbs/mixed_components/CBS.log");
+    assert_parsed_selection(
+        &parsed,
+        "Cbs",
+        "GenericTimestamped",
+        "Dedicated",
+        "SemiStructured",
+        "LogicalRecord",
+        "Timestamped",
+    );
+    assert_eq!(parsed.total_lines, 10);
+    assert_eq!(parsed.parse_errors, 0, "all lines should parse as structured entries");
+    // 9 header lines, 1 continuation => 9 entries
+    assert_eq!(parsed.entries.len(), 9, "CSI multi-line record merges continuation into 1 entry");
+    // CBS lines
+    assert_eq!(parsed.entries[0].component.as_deref(), Some("CBS"));
+    assert_eq!(parsed.entries[1].component.as_deref(), Some("CBS"));
+    // DISM lines interleaved in CBS log
+    assert_eq!(parsed.entries[2].component.as_deref(), Some("DISM"));
+    assert_eq!(parsed.entries[3].component.as_deref(), Some("DISM"));
+    // CSI multi-line entry (line 5 + continuation at line 6)
+    assert_eq!(parsed.entries[4].component.as_deref(), Some("CSI"));
+    assert!(parsed.entries[4].message.contains("Component: amd64_microsoft-windows-servicingstack"));
+    // DPX, CMIV components
+    assert_eq!(parsed.entries[5].component.as_deref(), Some("DPX"));
+    assert_eq!(parsed.entries[5].severity, "Warning");
+    assert_eq!(parsed.entries[6].component.as_deref(), Some("CMIV"));
+    // CBS again, then WCP error
+    assert_eq!(parsed.entries[7].component.as_deref(), Some("CBS"));
+    assert_eq!(parsed.entries[8].component.as_deref(), Some("WCP"));
+    assert_eq!(parsed.entries[8].severity, "Error");
+}
+
+#[test]
+fn dism_mixed_components_fixture_parses_cbs_and_other_components() {
+    let detected = detect_fixture("dism/mixed_components/dism.log");
+    assert_selection(
+        &detected,
+        "Dism",
+        "GenericTimestamped",
+        "Dedicated",
+        "SemiStructured",
+        "LogicalRecord",
+    );
+
+    let parsed = parse_fixture("dism/mixed_components/dism.log");
+    assert_parsed_selection(
+        &parsed,
+        "Dism",
+        "GenericTimestamped",
+        "Dedicated",
+        "SemiStructured",
+        "LogicalRecord",
+        "Timestamped",
+    );
+    assert_eq!(parsed.total_lines, 8);
+    assert_eq!(parsed.parse_errors, 0, "all lines should parse as structured entries");
+    // DISM lines
+    assert_eq!(parsed.entries[0].component.as_deref(), Some("DISM"));
+    assert_eq!(parsed.entries[1].component.as_deref(), Some("DISM"));
+    // CBS lines interleaved in DISM log
+    assert_eq!(parsed.entries[2].component.as_deref(), Some("CBS"));
+    assert_eq!(parsed.entries[3].component.as_deref(), Some("CBS"));
+    // CSI warning
+    assert_eq!(parsed.entries[4].component.as_deref(), Some("CSI"));
+    assert_eq!(parsed.entries[4].severity, "Warning");
+    // DPX with continuation
+    assert_eq!(parsed.entries[5].component.as_deref(), Some("DPX"));
+    assert!(parsed.entries[5].message.contains("Restart reason:"));
+    // DISM error
+    let last = parsed.entries.last().unwrap();
+    assert_eq!(last.component.as_deref(), Some("DISM"));
+    assert_eq!(last.severity, "Error");
+}
+
+#[test]
 fn reporting_events_clean_fixture_detects_and_parses_rows() {
     let detected = detect_fixture("reporting_events/clean/ReportingEvents.log");
     assert_selection(


### PR DESCRIPTION
## Summary
- Removes overly restrictive component allowlists from CBS and DISM `parse_header()` functions
- CBS parser previously only accepted `CBS|CSI|TI|SR|SFC|RIBS|OC|POQ|SQM|DWLD` — entries from other components (DPX, WCP, CMIV, etc.) fell through to plain text
- DISM parser only accepted components starting with `DISM` — same issue
- Detection logic (`matches_cbs_record` / `matches_dism_record`) still uses allowlists for format auto-detection, but once identified, all well-formed lines are parsed as structured entries

Closes #154

## Test plan
- [x] 4 new unit tests for mixed-component parsing in CBS and DISM
- [x] 2 new corpus fixture files with realistic interleaved entries
- [x] 2 new regression tests in `parser_regression_corpus.rs`
- [x] All 207 tests pass, zero clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)