### PR TITLE
fix(event-log): strip control characters from EVTX event data

### DIFF
--- a/src-tauri/src/event_log/live.rs
+++ b/src-tauri/src/event_log/live.rs
@@ -5,6 +5,7 @@ use std::sync::OnceLock;
 use regex::Regex;
 
 use super::models::{ChannelSourceType, EvtxChannelInfo, EvtxField, EvtxLevel, EvtxRecord};
+use super::sanitize_control_chars;
 
 #[cfg(target_os = "windows")]
 use windows::core::{Error, HSTRING, PCWSTR};
@@ -339,9 +340,10 @@ fn parse_xml_to_record(
 
     let event_data = extract_xml_event_data(xml);
 
-    // Use rendered message if available, otherwise build summary from EventData
+    // Use rendered message if available, otherwise build summary from EventData.
+    // Sanitize to strip control characters that would show as unexpected glyphs.
     let message = rendered_message
-        .map(|s| s.to_string())
+        .map(|s| sanitize_control_chars(s))
         .unwrap_or_else(|| build_event_data_summary(&event_data));
 
     Some(EvtxRecord {
@@ -410,6 +412,9 @@ fn extract_xml_text(xml: &str, tag: &str) -> Option<String> {
 }
 
 /// Extract `<Data Name='key'>value</Data>` pairs from EventData section.
+///
+/// All values are sanitized to strip control characters (e.g. `\r`, `\0`) that
+/// would render as unexpected glyphs in the UI.
 fn extract_xml_event_data(xml: &str) -> Vec<EvtxField> {
     fn data_name_re() -> &'static Regex {
         static CELL: OnceLock<Regex> = OnceLock::new();
@@ -422,7 +427,7 @@ fn extract_xml_event_data(xml: &str) -> Vec<EvtxField> {
         .captures_iter(xml)
         .map(|cap| EvtxField {
             name: cap[1].to_string(),
-            value: cap[2].to_string(),
+            value: sanitize_control_chars(&cap[2]),
         })
         .collect()
 }

--- a/src-tauri/src/event_log/mod.rs
+++ b/src-tauri/src/event_log/mod.rs
@@ -4,3 +4,67 @@ pub mod parser;
 
 #[cfg(target_os = "windows")]
 pub mod live;
+
+/// Strip control characters from a string, preserving newlines and tabs.
+///
+/// EVTX event data often contains trailing `\r`, `\0`, or other non-printable
+/// characters that render as unexpected glyphs in the UI. This strips all
+/// C0 control characters (U+0000–U+001F) except `\t` (U+0009) and `\n` (U+000A),
+/// plus the DEL character (U+007F), then trims leading/trailing whitespace.
+pub(crate) fn sanitize_control_chars(s: &str) -> String {
+    s.chars()
+        .filter(|&c| c == '\t' || c == '\n' || !(c.is_control() || c == '\u{7f}'))
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_control_chars;
+
+    #[test]
+    fn strips_trailing_carriage_return() {
+        assert_eq!(sanitize_control_chars("hello world\r"), "hello world");
+    }
+
+    #[test]
+    fn strips_null_bytes() {
+        assert_eq!(sanitize_control_chars("hello\0world\0"), "helloworld");
+        // Trailing null only
+        assert_eq!(sanitize_control_chars("hello\0"), "hello");
+    }
+
+    #[test]
+    fn strips_mixed_control_chars() {
+        assert_eq!(
+            sanitize_control_chars("line1\r\nline2\r\n\0"),
+            "line1\nline2"
+        );
+    }
+
+    #[test]
+    fn preserves_tabs_and_newlines() {
+        assert_eq!(sanitize_control_chars("col1\tcol2\nrow2"), "col1\tcol2\nrow2");
+    }
+
+    #[test]
+    fn trims_whitespace() {
+        assert_eq!(sanitize_control_chars("  hello  "), "hello");
+    }
+
+    #[test]
+    fn handles_empty_string() {
+        assert_eq!(sanitize_control_chars(""), "");
+    }
+
+    #[test]
+    fn strips_del_character() {
+        assert_eq!(sanitize_control_chars("hello\x7f"), "hello");
+    }
+
+    #[test]
+    fn clean_string_unchanged() {
+        assert_eq!(sanitize_control_chars("normal text"), "normal text");
+    }
+}

--- a/src-tauri/src/event_log/parser.rs
+++ b/src-tauri/src/event_log/parser.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 use super::models::{
     ChannelSourceType, EvtxChannelInfo, EvtxField, EvtxLevel, EvtxParseResult, EvtxRecord,
 };
+use super::sanitize_control_chars;
 
 /// Maximum entries to parse from a single .evtx file to prevent memory issues.
 const MAX_ENTRIES_PER_FILE: usize = 100_000;
@@ -194,6 +195,9 @@ fn extract_event_id(system: &Value) -> u32 {
 }
 
 /// Extract EventData fields as key-value pairs.
+///
+/// All values are sanitized to strip control characters (e.g. `\r`, `\0`) that
+/// would render as unexpected glyphs in the UI.
 fn extract_event_data(event_data: &Value) -> Vec<EvtxField> {
     let mut fields = Vec::new();
 
@@ -203,9 +207,9 @@ fn extract_event_data(event_data: &Value) -> Vec<EvtxField> {
                 continue;
             }
             let val_str = match value {
-                Value::String(s) => s.clone(),
+                Value::String(s) => sanitize_control_chars(s),
                 Value::Null => continue,
-                other => other.to_string(),
+                other => sanitize_control_chars(&other.to_string()),
             };
             if !val_str.is_empty() {
                 fields.push(EvtxField {

--- a/src-tauri/src/sysmon/evtx_parser.rs
+++ b/src-tauri/src/sysmon/evtx_parser.rs
@@ -15,6 +15,7 @@ use super::models::{
     RankedItem, SecuritySummary, SysmonConfig, SysmonDashboardData, SysmonEvent, SysmonEventType,
     SysmonEventTypeCount, SysmonSeverity, SysmonSummary, TimeBucket,
 };
+use super::sanitize_control_chars;
 
 /// Maximum entries to pull from the live Windows Event Log.
 #[cfg(target_os = "windows")]
@@ -180,7 +181,7 @@ pub fn parse_sysmon_evtx(path: &Path, id_offset: u64) -> Result<Vec<SysmonEvent>
         let target_image = get_data_str(event_data, "TargetImage");
         let granted_access = get_data_str(event_data, "GrantedAccess");
 
-        let message = build_message(event_id, &event_type, event_data);
+        let message = sanitize_control_chars(&build_message(event_id, &event_type, event_data));
 
         events.push(SysmonEvent {
             id: current_id,
@@ -617,11 +618,14 @@ fn parse_timestamp_ms(ts: &str) -> Option<i64> {
 }
 
 fn get_data_str(event_data: &Value, key: &str) -> Option<String> {
-    match &event_data[key] {
-        Value::String(s) if !s.is_empty() && s != "-" => Some(s.clone()),
-        Value::Number(n) => Some(n.to_string()),
-        _ => None,
-    }
+    let raw = match &event_data[key] {
+        Value::String(s) if !s.is_empty() && s != "-" => s.clone(),
+        Value::Number(n) => return Some(n.to_string()),
+        _ => return None,
+    };
+    // Strip control characters (e.g. \r, \0) that render as unexpected glyphs.
+    let sanitized = sanitize_control_chars(&raw);
+    if sanitized.is_empty() { None } else { Some(sanitized) }
 }
 
 fn get_data_u32(event_data: &Value, key: &str) -> Option<u32> {
@@ -815,6 +819,9 @@ fn extract_xml_value(text: &str, regex: &Regex) -> Option<String> {
 
 /// Extract a named Data element value from Sysmon XML EventData.
 /// Pattern: `<Data Name="FieldName">value</Data>`
+///
+/// The result is sanitized to strip control characters (e.g. `\r`, `\0`) that
+/// would render as unexpected glyphs in the UI.
 #[cfg(target_os = "windows")]
 fn extract_event_data_field(xml: &str, field_name: &str) -> Option<String> {
     // Build pattern: <Data Name="FieldName">...</Data>
@@ -825,7 +832,7 @@ fn extract_event_data_field(xml: &str, field_name: &str) -> Option<String> {
     let re = Regex::new(&pattern).ok()?;
     re.captures(xml)
         .and_then(|captures| captures.get(1))
-        .map(|value| decode_xml_text(value.as_str()))
+        .map(|value| sanitize_control_chars(&decode_xml_text(value.as_str())))
         .filter(|value| !value.is_empty() && value != "-")
 }
 
@@ -914,29 +921,32 @@ pub fn parse_sysmon_live_events() -> Result<Vec<SysmonEvent>, String> {
         let target_image = extract_event_data_field(xml, "TargetImage");
         let granted_access = extract_event_data_field(xml, "GrantedAccess");
 
-        // Build message from rendered message or from fields
-        let message = record
-            .rendered_message
-            .filter(|m| !m.trim().is_empty())
-            .unwrap_or_else(|| {
-                build_message_from_fields(&MessageFields {
-                    event_id,
-                    event_type: &event_type,
-                    image: image.as_deref(),
-                    command_line: command_line.as_deref(),
-                    user: user.as_deref(),
-                    destination_ip: destination_ip.as_deref(),
-                    destination_port,
-                    protocol: protocol.as_deref(),
-                    target_filename: target_filename.as_deref(),
-                    source_image: source_image.as_deref(),
-                    target_image: target_image.as_deref(),
-                    granted_access: granted_access.as_deref(),
-                    query_name: query_name.as_deref(),
-                    query_results: query_results.as_deref(),
-                    target_object: target_object.as_deref(),
-                })
-            });
+        // Build message from rendered message or from fields.
+        // Sanitize to strip control characters that would show as unexpected glyphs.
+        let message = sanitize_control_chars(
+            &record
+                .rendered_message
+                .filter(|m| !m.trim().is_empty())
+                .unwrap_or_else(|| {
+                    build_message_from_fields(&MessageFields {
+                        event_id,
+                        event_type: &event_type,
+                        image: image.as_deref(),
+                        command_line: command_line.as_deref(),
+                        user: user.as_deref(),
+                        destination_ip: destination_ip.as_deref(),
+                        destination_port,
+                        protocol: protocol.as_deref(),
+                        target_filename: target_filename.as_deref(),
+                        source_image: source_image.as_deref(),
+                        target_image: target_image.as_deref(),
+                        granted_access: granted_access.as_deref(),
+                        query_name: query_name.as_deref(),
+                        query_results: query_results.as_deref(),
+                        target_object: target_object.as_deref(),
+                    })
+                }),
+        );
 
         events.push(SysmonEvent {
             id: events.len() as u64,

--- a/src-tauri/src/sysmon/mod.rs
+++ b/src-tauri/src/sysmon/mod.rs
@@ -1,2 +1,16 @@
 pub mod evtx_parser;
 pub mod models;
+
+/// Strip control characters from a string, preserving newlines and tabs.
+///
+/// EVTX event data often contains trailing `\r`, `\0`, or other non-printable
+/// characters that render as unexpected glyphs in the UI. This strips all
+/// C0 control characters (U+0000–U+001F) except `\t` (U+0009) and `\n` (U+000A),
+/// plus the DEL character (U+007F), then trims leading/trailing whitespace.
+pub(crate) fn sanitize_control_chars(s: &str) -> String {
+    s.chars()
+        .filter(|&c| c == '\t' || c == '\n' || !(c.is_control() || c == '\u{7f}'))
+        .collect::<String>()
+        .trim()
+        .to_string()
+}


### PR DESCRIPTION
## Summary
- Adds `sanitize_control_chars()` utility that strips C0 control characters (U+0000–U+001F) and DEL (U+007F), preserving only `\t` and `\n`
- Applied at all EVTX parsing paths: file-based (`event_log/parser.rs`), live queries (`event_log/live.rs`), and Sysmon (`sysmon/evtx_parser.rs`)
- Root cause: EVTX data frequently contains trailing `\r`, `\0`, and other non-printable chars that rendered as visible glyphs in the UI

Closes #159

## Test plan
- [x] 8 new unit tests covering null bytes, carriage returns, mixed control chars, tab/newline preservation
- [x] All 153 Rust tests pass
- [x] Zero clippy warnings, TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)