### PR TITLE
fix: add filter toggle button and fix Open All for file-type sources

### DIFF
--- a/src/components/layout/Toolbar.tsx
+++ b/src/components/layout/Toolbar.tsx
@@ -21,6 +21,7 @@ import { platform } from "@tauri-apps/plugin-os";
 import {
   getAvailableWorkspaces as getAvailableBackendWorkspaces,
   inspectPathKind,
+  listLogFolder,
 } from "../../lib/commands";
 import {
   analyzeDsregcmdPath,
@@ -44,7 +45,7 @@ import {
   resolveKnownSourceIdFromCatalogAction,
   type KnownSourceCatalogActionIds,
 } from "../../lib/log-source";
-import { listLogFolder } from "../../lib/commands";
+import { matchesAnyPattern } from "../../lib/glob";
 import type { LogSource } from "../../types/log";
 
 function normalizeDialogSelection(
@@ -73,19 +74,6 @@ function resolveRefreshSource(
 }
 
 const LIVE_SYSMON_SOURCE_ID = "windows-sysmon-live-events";
-
-/** Check if a filename matches any glob pattern (supports *.ext wildcards). */
-function matchesAnyPattern(name: string, patterns: string[]): boolean {
-  if (patterns.length === 0) return true;
-  const lower = name.toLowerCase();
-  return patterns.some((p) => {
-    if (p === "*") return true;
-    if (p.startsWith("*.")) {
-      return lower.endsWith(p.slice(1).toLowerCase());
-    }
-    return lower === p.toLowerCase();
-  });
-}
 
 async function inferPathKind(path: string): Promise<"file" | "folder" | "unknown"> {
   try {
@@ -648,25 +636,46 @@ export function Toolbar() {
       const family = families.find((f) => f.id === familyId);
       if (!family) return;
 
-      const folderSources: Array<{ path: string; patterns: string[] }> = [];
+      const folderSources: Array<{ folderPath: string; patterns: string[] }> = [];
+      const directFilePaths = new Set<string>();
+
       for (const group of family.groups) {
         for (const source of group.sources) {
-          if (source.source.kind === "known" && source.source.pathKind === "folder") {
-            folderSources.push({
-              path: source.source.defaultPath,
-              patterns: source.filePatterns ?? [],
-            });
+          if (source.source.kind === "known") {
+            if (source.source.pathKind === "folder") {
+              folderSources.push({
+                folderPath: source.source.defaultPath,
+                patterns: source.filePatterns ?? [],
+              });
+            } else if (source.source.pathKind === "file") {
+              directFilePaths.add(source.source.defaultPath);
+            }
           }
         }
       }
 
-      if (folderSources.length === 0) return;
+      if (folderSources.length === 0 && directFilePaths.size === 0) return;
 
       useUiStore.getState().ensureLogViewVisible("toolbar.open-all-family");
       useFilterStore.getState().clearFilter();
 
-      const allFilePaths = new Set<string>();
-      for (const { path: folderPath, patterns } of folderSources) {
+      // Verify direct file paths actually exist on disk before including them
+      const verifiedFilePaths = new Set<string>();
+      await Promise.all(
+        [...directFilePaths].map(async (filePath) => {
+          try {
+            const kind = await inspectPathKind(filePath);
+            if (kind === "file") {
+              verifiedFilePaths.add(filePath);
+            }
+          } catch {
+            // Path doesn't exist or isn't accessible — skip silently
+          }
+        }),
+      );
+
+      const allFilePaths = new Set<string>(verifiedFilePaths);
+      for (const { folderPath, patterns } of folderSources) {
         try {
           const listing = await listLogFolder(folderPath);
           for (const entry of listing.entries) {
@@ -693,10 +702,15 @@ export function Toolbar() {
     openKnownSourceCatalogAction,
     pasteDsregcmdSource,
     captureDsregcmdSource,
+    showFilterDialog,
     showErrorLookupDialog,
     toggleDetailsPane,
     toggleInfoPane,
   } = useAppActions();
+
+  const clearFilter = useCallback(() => {
+    useFilterStore.getState().clearFilter();
+  }, []);
 
 
   useEffect(() => {
@@ -922,6 +936,23 @@ export function Toolbar() {
       )}
 
       <Divider vertical />
+
+      <Button
+        onClick={commandState.activeFilterCount > 0 ? clearFilter : showFilterDialog}
+        title={
+          commandState.activeFilterCount > 0
+            ? `Clear active filter (${commandState.activeFilterCount} clause${commandState.activeFilterCount === 1 ? "" : "s"}) — click to remove`
+            : "Filter... (Ctrl+Shift+L)"
+        }
+        disabled={commandState.activeFilterCount === 0 && !commandState.canFilter}
+        aria-pressed={commandState.activeFilterCount > 0}
+        size="small"
+        appearance={commandState.activeFilterCount > 0 ? "primary" : "secondary"}
+      >
+        {commandState.activeFilterCount > 0
+          ? `Filter (${commandState.activeFilterCount})`
+          : "Filter..."}
+      </Button>
 
       <Button
         onClick={showErrorLookupDialog}

--- a/src/lib/glob.test.ts
+++ b/src/lib/glob.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { matchesAnyPattern } from "./glob";
+
+describe("matchesAnyPattern", () => {
+  describe("empty patterns", () => {
+    it("returns true for any filename when patterns array is empty", () => {
+      expect(matchesAnyPattern("anything.log", [])).toBe(true);
+      expect(matchesAnyPattern("", [])).toBe(true);
+    });
+  });
+
+  describe("wildcard-all pattern", () => {
+    it("matches everything with '*'", () => {
+      expect(matchesAnyPattern("foo.txt", ["*"])).toBe(true);
+      expect(matchesAnyPattern("", ["*"])).toBe(true);
+    });
+  });
+
+  describe("exact match (no wildcard)", () => {
+    it("matches exact name case-insensitively", () => {
+      expect(matchesAnyPattern("setupact.log", ["setupact.log"])).toBe(true);
+      expect(matchesAnyPattern("SetupAct.log", ["setupact.log"])).toBe(true);
+      expect(matchesAnyPattern("setupact.log", ["SETUPACT.LOG"])).toBe(true);
+    });
+
+    it("rejects non-matching exact names", () => {
+      expect(matchesAnyPattern("other.log", ["setupact.log"])).toBe(false);
+    });
+  });
+
+  describe("suffix wildcard (*.ext)", () => {
+    it("matches files by extension", () => {
+      expect(matchesAnyPattern("trace.log", ["*.log"])).toBe(true);
+      expect(matchesAnyPattern("data.LOG", ["*.log"])).toBe(true);
+    });
+
+    it("rejects files with different extension", () => {
+      expect(matchesAnyPattern("trace.txt", ["*.log"])).toBe(false);
+    });
+  });
+
+  describe("prefix wildcard (prefix*)", () => {
+    it("matches files starting with prefix", () => {
+      expect(matchesAnyPattern("IntuneManagementExtension.log", ["Intune*"])).toBe(true);
+    });
+
+    it("rejects files not starting with prefix", () => {
+      expect(matchesAnyPattern("Other.log", ["Intune*"])).toBe(false);
+    });
+  });
+
+  describe("prefix and suffix (prefix*.ext)", () => {
+    it("matches files matching both prefix and extension", () => {
+      expect(matchesAnyPattern("IntuneManagementExtension.log", ["Intune*.log"])).toBe(true);
+    });
+
+    it("rejects files matching prefix but not extension", () => {
+      expect(matchesAnyPattern("IntuneManagementExtension.txt", ["Intune*.log"])).toBe(false);
+    });
+
+    it("rejects files matching extension but not prefix", () => {
+      expect(matchesAnyPattern("Other.log", ["Intune*.log"])).toBe(false);
+    });
+  });
+
+  describe("middle wildcard (*middle*)", () => {
+    it("matches when middle substring is present", () => {
+      expect(matchesAnyPattern("my-setup-trace.log", ["*setup*"])).toBe(true);
+    });
+
+    it("rejects when middle substring is absent", () => {
+      expect(matchesAnyPattern("my-trace.log", ["*setup*"])).toBe(false);
+    });
+  });
+
+  describe("multiple patterns (OR logic)", () => {
+    it("matches if any pattern matches", () => {
+      expect(matchesAnyPattern("trace.log", ["*.txt", "*.log"])).toBe(true);
+      expect(matchesAnyPattern("notes.txt", ["*.txt", "*.log"])).toBe(true);
+    });
+
+    it("rejects if no pattern matches", () => {
+      expect(matchesAnyPattern("data.csv", ["*.txt", "*.log"])).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles overlapping prefix and suffix segments", () => {
+      // Pattern "ab*ab" on name "ab" should fail because the prefix and suffix
+      // segments cannot both fit in a 2-character string.
+      expect(matchesAnyPattern("ab", ["ab*ab"])).toBe(false);
+      expect(matchesAnyPattern("abab", ["ab*ab"])).toBe(true);
+      expect(matchesAnyPattern("abXab", ["ab*ab"])).toBe(true);
+    });
+
+    it("handles pattern with consecutive wildcards", () => {
+      expect(matchesAnyPattern("foo.log", ["**foo**"])).toBe(true);
+    });
+
+    it("handles single character filenames", () => {
+      expect(matchesAnyPattern("a", ["a"])).toBe(true);
+      expect(matchesAnyPattern("a", ["b"])).toBe(false);
+    });
+  });
+});

--- a/src/lib/glob.ts
+++ b/src/lib/glob.ts
@@ -1,0 +1,52 @@
+/**
+ * Simple glob-style pattern matching for filenames.
+ *
+ * Supports:
+ *  - `*` (match everything)
+ *  - `*.ext` (suffix matching)
+ *  - `prefix*` (prefix matching)
+ *  - `prefix*.ext` / `*middle*` (segment-based matching)
+ *  - exact names (no wildcard)
+ *
+ * All comparisons are case-insensitive.
+ *
+ * @param name     The filename to test.
+ * @param patterns Array of glob patterns. An empty array is treated as
+ *                 "no restriction" and always returns `true`.
+ */
+export function matchesAnyPattern(name: string, patterns: string[]): boolean {
+  if (patterns.length === 0) return true;
+  const lower = name.toLowerCase();
+  return patterns.some((p) => {
+    if (p === "*") return true;
+    const lowerP = p.toLowerCase();
+    // Fast path: no wildcard means exact match
+    if (!lowerP.includes("*")) return lower === lowerP;
+    // Split on `*` and verify each segment appears in order
+    const segments = lowerP.split("*");
+    let pos = 0;
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i];
+      if (seg === "") {
+        // Empty segments arise from leading `*`, trailing `*`, or `**`.
+        continue;
+      }
+      if (i === 0) {
+        // First segment (no leading `*`) must anchor at the start
+        if (!lower.startsWith(seg)) return false;
+        pos = seg.length;
+      } else if (i === segments.length - 1) {
+        // Last segment (no trailing `*`) must anchor at the end
+        if (!lower.endsWith(seg)) return false;
+        // Ensure the end segment doesn't overlap with already-matched content
+        if (lower.length - seg.length < pos) return false;
+      } else {
+        // Middle segments — find next occurrence at or after `pos`
+        const idx = lower.indexOf(seg, pos);
+        if (idx === -1) return false;
+        pos = idx + seg.length;
+      }
+    }
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a Filter toolbar button that toggles between opening the filter dialog and clearing an active filter (shows "Filter (N)" with count when active)
- Fixes "Open All" for known log source families that contain file-type sources (e.g., CBS.log, setupact.log) — not just folder sources
- Direct file paths are existence-checked via `inspectPathKind` before loading — non-existent paths are silently skipped
- Extracts `matchesAnyPattern` to `src/lib/glob.ts` with 18 unit tests

Closes #152
Supersedes #153

## Test plan
- [x] 18 new glob pattern tests covering all pattern types + edge cases
- [x] `npx tsc --noEmit` clean
- [x] All 99 tests pass
- [ ] Manual: verify filter toggle in log view workspace
- [ ] Manual: verify "Open All" works for ConfigMgr, Windows Setup, Windows Servicing families

🤖 Generated with [Claude Code](https://claude.com/claude-code)