### PR TITLE
fix: show filtered entry count in status bar

### DIFF
--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -209,10 +209,19 @@ export function StatusBar() {
       leftParts.push(elapsedText);
     }
 
+    const totalCount = entries.length;
+    const isFilterActive = filteredIds !== null && filteredCount !== totalCount;
+
     const positionText =
       selectedPosition !== null
-        ? `Entry ${selectedPosition} of ${filteredCount}`
+        ? isFilterActive
+          ? `Entry ${selectedPosition.toLocaleString()} of ${filteredCount.toLocaleString()} (${totalCount.toLocaleString()} total)`
+          : `Entry ${selectedPosition.toLocaleString()} of ${filteredCount.toLocaleString()}`
         : null;
+
+    const entriesCountText = isFilterActive
+      ? `${filteredCount.toLocaleString()} of ${totalCount.toLocaleString()} entries`
+      : `${filteredCount.toLocaleString()} entries`;
 
     const severityText =
       filteredCount > 0 ? formatSeverityCounts(severityCounts) : null;
@@ -228,7 +237,7 @@ export function StatusBar() {
       folderLoadStatusText
         ?? (entries.length > 0
         ? [
-            positionText ?? `${filteredCount} entries`,
+            positionText ?? entriesCountText,
             `${totalLines} lines`,
             sourceOpenMode === "aggregate-folder"
               ? `${aggregateFiles.length} files`
@@ -548,6 +557,7 @@ export function StatusBar() {
             whiteSpace: "nowrap",
             color: rightTone,
             fontWeight: 500,
+            fontVariantNumeric: "tabular-nums",
           }}
         >
           {rightStatusText}


### PR DESCRIPTION
## Summary
- Status bar now shows "42 of 1,234 entries" when a filter or search is active
- Entry position shows "Entry 5 of 42 (1,234 total)" when a row is selected during filtering
- Numbers use `toLocaleString()` for comma separators
- Tabular numbers (`fontVariantNumeric: tabular-nums`) prevent jitter as counts change
- Avoids redundant display when filter matches all entries

Closes #160

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Manual: open a log, verify status bar shows total count
- [ ] Manual: apply a filter, verify "Y of X entries" format
- [ ] Manual: select a row while filtered, verify position includes total

🤖 Generated with [Claude Code](https://claude.com/claude-code)