### PR TITLE
Fix review findings

### DIFF
--- a/src-tauri/src/commands/filter.rs
+++ b/src-tauri/src/commands/filter.rs
@@ -36,6 +36,8 @@ pub struct FilterClause {
 
 /// Apply filter clauses to a list of entries.
 /// Returns the IDs of entries that match ALL clauses (AND logic).
+/// Returns `Err(AppError::InvalidInput)` if a timestamp clause has an
+/// unparseable value so the caller can surface it to the user.
 #[tauri::command]
 pub fn apply_filter(
     entries: Vec<LogEntry>,
@@ -79,7 +81,7 @@ fn matches_clause(entry: &LogEntry, clause: &FilterClause) -> Result<bool, crate
         }
         FilterField::Timestamp => {
             let ts = entry.timestamp.unwrap_or(0);
-            return match_timestamp(ts, &clause.op, &clause.value);
+            match_timestamp(ts, &clause.op, &clause.value)?
         }
         FilterField::Severity => {
             let sev_str = match &entry.severity {
@@ -109,19 +111,15 @@ fn match_string(haystack: &str, op: &FilterOp, needle: &str) -> bool {
 }
 
 fn match_timestamp(ts: i64, op: &FilterOp, value: &str) -> Result<bool, crate::error::AppError> {
-    if matches!(op, FilterOp::Contains | FilterOp::NotContains) {
-        return Ok(true);
+    match op {
+        // Substring ops aren't meaningful for timestamps; treat as a no-op match
+        // so they don't filter anything out and don't require a parseable value.
+        FilterOp::Contains | FilterOp::NotContains => Ok(true),
+        FilterOp::Before => Ok(ts < parse_filter_timestamp_millis(value)?),
+        FilterOp::After => Ok(ts > parse_filter_timestamp_millis(value)?),
+        FilterOp::Equals => Ok(ts == parse_filter_timestamp_millis(value)?),
+        FilterOp::NotEquals => Ok(ts != parse_filter_timestamp_millis(value)?),
     }
-
-    let target = parse_filter_timestamp_millis(value)?;
-
-    Ok(match op {
-        FilterOp::Before => ts < target,
-        FilterOp::After => ts > target,
-        FilterOp::Equals => ts == target,
-        FilterOp::NotEquals => ts != target,
-        FilterOp::Contains | FilterOp::NotContains => true,
-    })
 }
 
 fn parse_filter_timestamp_millis(value: &str) -> Result<i64, crate::error::AppError> {
@@ -139,10 +137,16 @@ fn parse_filter_timestamp_millis(value: &str) -> Result<i64, crate::error::AppEr
         return Ok(parsed.timestamp_millis());
     }
 
+    // chrono's `%.f` requires a leading dot, so list whole-second variants
+    // separately. Order: most-specific first so a millisecond input doesn't
+    // get truncated by an earlier whole-second match.
     for format in [
         "%Y-%m-%dT%H:%M:%S%.f",
+        "%Y-%m-%dT%H:%M:%S",
         "%Y-%m-%d %H:%M:%S%.f",
+        "%Y-%m-%d %H:%M:%S",
         "%m/%d/%Y %H:%M:%S%.f",
+        "%m/%d/%Y %H:%M:%S",
         "%m/%d/%Y %I:%M:%S %p",
     ] {
         if let Ok(parsed) = NaiveDateTime::parse_from_str(trimmed, format) {
@@ -194,6 +198,26 @@ mod tests {
             .timestamp_millis();
 
         assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn timestamp_filter_accepts_whole_second_datetimes() {
+        let expected = NaiveDate::from_ymd_opt(2026, 4, 1)
+            .expect("valid date")
+            .and_hms_opt(12, 30, 0)
+            .expect("valid time")
+            .and_utc()
+            .timestamp_millis();
+
+        for input in [
+            "2026-04-01 12:30:00",
+            "2026-04-01T12:30:00",
+            "04/01/2026 12:30:00",
+        ] {
+            let parsed = parse_filter_timestamp_millis(input)
+                .unwrap_or_else(|e| panic!("'{input}' should parse: {e}"));
+            assert_eq!(parsed, expected, "input={input}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/filter.rs
+++ b/src-tauri/src/commands/filter.rs
@@ -1,4 +1,5 @@
 use crate::models::log_entry::LogEntry;
+use chrono::{DateTime, NaiveDate, NaiveDateTime};
 use serde::{Deserialize, Serialize};
 
 /// The types of filter clause operations.
@@ -45,17 +46,28 @@ pub fn apply_filter(
         return Ok(entries.iter().map(|e| e.id).collect());
     }
 
-    let matching_ids: Vec<u64> = entries
-        .iter()
-        .filter(|entry| clauses.iter().all(|clause| matches_clause(entry, clause)))
-        .map(|entry| entry.id)
-        .collect();
+    let mut matching_ids = Vec::new();
+
+    for entry in &entries {
+        let mut matches_all = true;
+
+        for clause in &clauses {
+            if !matches_clause(entry, clause)? {
+                matches_all = false;
+                break;
+            }
+        }
+
+        if matches_all {
+            matching_ids.push(entry.id);
+        }
+    }
 
     Ok(matching_ids)
 }
 
-fn matches_clause(entry: &LogEntry, clause: &FilterClause) -> bool {
-    match clause.field {
+fn matches_clause(entry: &LogEntry, clause: &FilterClause) -> Result<bool, crate::error::AppError> {
+    let matches = match clause.field {
         FilterField::Message => match_string(&entry.message, &clause.op, &clause.value),
         FilterField::Component => {
             let comp = entry.component.as_deref().unwrap_or("");
@@ -67,7 +79,7 @@ fn matches_clause(entry: &LogEntry, clause: &FilterClause) -> bool {
         }
         FilterField::Timestamp => {
             let ts = entry.timestamp.unwrap_or(0);
-            match_timestamp(ts, &clause.op, &clause.value)
+            return match_timestamp(ts, &clause.op, &clause.value);
         }
         FilterField::Severity => {
             let sev_str = match &entry.severity {
@@ -77,7 +89,9 @@ fn matches_clause(entry: &LogEntry, clause: &FilterClause) -> bool {
             };
             match_string(sev_str, &clause.op, &clause.value)
         }
-    }
+    };
+
+    Ok(matches)
 }
 
 fn match_string(haystack: &str, op: &FilterOp, needle: &str) -> bool {
@@ -94,18 +108,107 @@ fn match_string(haystack: &str, op: &FilterOp, needle: &str) -> bool {
     }
 }
 
-fn match_timestamp(ts: i64, op: &FilterOp, value: &str) -> bool {
-    // Parse value as millisecond timestamp
-    let target: i64 = match value.parse() {
-        Ok(v) => v,
-        Err(_) => return true, // If can't parse, don't filter
-    };
+fn match_timestamp(ts: i64, op: &FilterOp, value: &str) -> Result<bool, crate::error::AppError> {
+    if matches!(op, FilterOp::Contains | FilterOp::NotContains) {
+        return Ok(true);
+    }
 
-    match op {
+    let target = parse_filter_timestamp_millis(value)?;
+
+    Ok(match op {
         FilterOp::Before => ts < target,
         FilterOp::After => ts > target,
         FilterOp::Equals => ts == target,
         FilterOp::NotEquals => ts != target,
         FilterOp::Contains | FilterOp::NotContains => true,
+    })
+}
+
+fn parse_filter_timestamp_millis(value: &str) -> Result<i64, crate::error::AppError> {
+    let trimmed = value.trim();
+
+    if trimmed.is_empty() {
+        return Err(invalid_timestamp_filter_value(value));
+    }
+
+    if let Ok(epoch_millis) = trimmed.parse::<i64>() {
+        return Ok(epoch_millis);
+    }
+
+    if let Ok(parsed) = DateTime::parse_from_rfc3339(trimmed) {
+        return Ok(parsed.timestamp_millis());
+    }
+
+    for format in [
+        "%Y-%m-%dT%H:%M:%S%.f",
+        "%Y-%m-%d %H:%M:%S%.f",
+        "%m/%d/%Y %H:%M:%S%.f",
+        "%m/%d/%Y %I:%M:%S %p",
+    ] {
+        if let Ok(parsed) = NaiveDateTime::parse_from_str(trimmed, format) {
+            return Ok(parsed.and_utc().timestamp_millis());
+        }
+    }
+
+    for format in ["%Y-%m-%d", "%m/%d/%Y"] {
+        if let Ok(parsed) = NaiveDate::parse_from_str(trimmed, format) {
+            let start_of_day = parsed
+                .and_hms_opt(0, 0, 0)
+                .ok_or_else(|| invalid_timestamp_filter_value(value))?;
+            return Ok(start_of_day.and_utc().timestamp_millis());
+        }
+    }
+
+    Err(invalid_timestamp_filter_value(value))
+}
+
+fn invalid_timestamp_filter_value(value: &str) -> crate::error::AppError {
+    crate::error::AppError::InvalidInput(format!(
+        "Invalid timestamp filter value '{value}'. Use epoch milliseconds, YYYY-MM-DD, MM/DD/YYYY, or an ISO-8601 date/time."
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_filter_accepts_plain_iso_date() {
+        let parsed = parse_filter_timestamp_millis("2026-04-01").expect("date should parse");
+        let expected = NaiveDate::from_ymd_opt(2026, 4, 1)
+            .expect("valid date")
+            .and_hms_opt(0, 0, 0)
+            .expect("valid time")
+            .and_utc()
+            .timestamp_millis();
+
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn timestamp_filter_accepts_rfc3339_datetime() {
+        let parsed =
+            parse_filter_timestamp_millis("2026-04-01T12:30:00Z").expect("datetime should parse");
+        let expected = DateTime::parse_from_rfc3339("2026-04-01T12:30:00Z")
+            .expect("valid datetime")
+            .timestamp_millis();
+
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn timestamp_filter_rejects_invalid_values() {
+        let error = match_timestamp(0, &FilterOp::Before, "yesterday")
+            .expect_err("invalid value should fail");
+
+        assert!(error.to_string().contains("Invalid timestamp filter value"));
+    }
+
+    #[test]
+    fn timestamp_before_uses_parsed_date() {
+        let target = parse_filter_timestamp_millis("2026-04-01").expect("date should parse");
+
+        assert!(match_timestamp(target - 1, &FilterOp::Before, "2026-04-01").unwrap());
+        assert!(!match_timestamp(target, &FilterOp::Before, "2026-04-01").unwrap());
     }
 }

--- a/src-tauri/src/commands/filter.rs
+++ b/src-tauri/src/commands/filter.rs
@@ -1,5 +1,5 @@
 use crate::models::log_entry::LogEntry;
-use chrono::{DateTime, NaiveDate, NaiveDateTime};
+use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, TimeZone};
 use serde::{Deserialize, Serialize};
 
 /// The types of filter clause operations.
@@ -34,6 +34,42 @@ pub struct FilterClause {
     pub value: String,
 }
 
+/// A clause whose value-side work has been done once up-front so the
+/// per-entry hot loop in `apply_filter` does not redo it.
+struct CompiledClause<'a> {
+    clause: &'a FilterClause,
+    /// Pre-parsed target for timestamp ops that need one (Before/After/
+    /// Equals/NotEquals). `None` for non-timestamp fields and for the
+    /// substring ops, which treat timestamps as a no-op.
+    timestamp_target: Option<i64>,
+    /// Lower-cased needle for string ops.
+    needle_lower: String,
+}
+
+fn compile_clauses<'a>(
+    clauses: &'a [FilterClause],
+) -> Result<Vec<CompiledClause<'a>>, crate::error::AppError> {
+    clauses
+        .iter()
+        .map(|clause| {
+            let needs_timestamp_parse = matches!(clause.field, FilterField::Timestamp)
+                && !matches!(clause.op, FilterOp::Contains | FilterOp::NotContains);
+
+            let timestamp_target = if needs_timestamp_parse {
+                Some(parse_filter_timestamp_millis(&clause.value)?)
+            } else {
+                None
+            };
+
+            Ok(CompiledClause {
+                clause,
+                timestamp_target,
+                needle_lower: clause.value.to_lowercase(),
+            })
+        })
+        .collect()
+}
+
 /// Apply filter clauses to a list of entries.
 /// Returns the IDs of entries that match ALL clauses (AND logic).
 /// Returns `Err(AppError::InvalidInput)` if a timestamp clause has an
@@ -48,19 +84,14 @@ pub fn apply_filter(
         return Ok(entries.iter().map(|e| e.id).collect());
     }
 
+    // Compile once: parse timestamp targets and lowercase needles up-front
+    // so the per-entry loop below is pure comparison work.
+    let compiled = compile_clauses(&clauses)?;
+
     let mut matching_ids = Vec::new();
 
     for entry in &entries {
-        let mut matches_all = true;
-
-        for clause in &clauses {
-            if !matches_clause(entry, clause)? {
-                matches_all = false;
-                break;
-            }
-        }
-
-        if matches_all {
+        if compiled.iter().all(|c| matches_clause(entry, c)) {
             matching_ids.push(entry.id);
         }
     }
@@ -68,20 +99,26 @@ pub fn apply_filter(
     Ok(matching_ids)
 }
 
-fn matches_clause(entry: &LogEntry, clause: &FilterClause) -> Result<bool, crate::error::AppError> {
-    let matches = match clause.field {
-        FilterField::Message => match_string(&entry.message, &clause.op, &clause.value),
+fn matches_clause(entry: &LogEntry, compiled: &CompiledClause) -> bool {
+    let CompiledClause {
+        clause,
+        timestamp_target,
+        needle_lower,
+    } = compiled;
+
+    match clause.field {
+        FilterField::Message => match_string(&entry.message, &clause.op, needle_lower),
         FilterField::Component => {
             let comp = entry.component.as_deref().unwrap_or("");
-            match_string(comp, &clause.op, &clause.value)
+            match_string(comp, &clause.op, needle_lower)
         }
         FilterField::Thread => {
             let thread_str = entry.thread.map(|t| t.to_string()).unwrap_or_default();
-            match_string(&thread_str, &clause.op, &clause.value)
+            match_string(&thread_str, &clause.op, needle_lower)
         }
         FilterField::Timestamp => {
             let ts = entry.timestamp.unwrap_or(0);
-            match_timestamp(ts, &clause.op, &clause.value)?
+            match_timestamp(ts, &clause.op, *timestamp_target)
         }
         FilterField::Severity => {
             let sev_str = match &entry.severity {
@@ -89,36 +126,36 @@ fn matches_clause(entry: &LogEntry, clause: &FilterClause) -> Result<bool, crate
                 crate::models::log_entry::Severity::Warning => "Warning",
                 crate::models::log_entry::Severity::Info => "Info",
             };
-            match_string(sev_str, &clause.op, &clause.value)
+            match_string(sev_str, &clause.op, needle_lower)
         }
-    };
-
-    Ok(matches)
+    }
 }
 
-fn match_string(haystack: &str, op: &FilterOp, needle: &str) -> bool {
+/// `needle_lower` must already be lowercased; comparisons are
+/// case-insensitive against a lowercased haystack.
+fn match_string(haystack: &str, op: &FilterOp, needle_lower: &str) -> bool {
     let hay_lower = haystack.to_lowercase();
-    let needle_lower = needle.to_lowercase();
 
     match op {
         FilterOp::Equals => hay_lower == needle_lower,
         FilterOp::NotEquals => hay_lower != needle_lower,
-        FilterOp::Contains => hay_lower.contains(&needle_lower),
-        FilterOp::NotContains => !hay_lower.contains(&needle_lower),
+        FilterOp::Contains => hay_lower.contains(needle_lower),
+        FilterOp::NotContains => !hay_lower.contains(needle_lower),
         // Before/After don't make sense for strings, always true
         FilterOp::Before | FilterOp::After => true,
     }
 }
 
-fn match_timestamp(ts: i64, op: &FilterOp, value: &str) -> Result<bool, crate::error::AppError> {
+/// `target` is the pre-parsed timestamp clause value (set by
+/// `compile_clauses` for ops that need it). For the substring ops we
+/// match every row, mirroring `match_string`'s no-op for Before/After.
+fn match_timestamp(ts: i64, op: &FilterOp, target: Option<i64>) -> bool {
     match op {
-        // Substring ops aren't meaningful for timestamps; treat as a no-op match
-        // so they don't filter anything out and don't require a parseable value.
-        FilterOp::Contains | FilterOp::NotContains => Ok(true),
-        FilterOp::Before => Ok(ts < parse_filter_timestamp_millis(value)?),
-        FilterOp::After => Ok(ts > parse_filter_timestamp_millis(value)?),
-        FilterOp::Equals => Ok(ts == parse_filter_timestamp_millis(value)?),
-        FilterOp::NotEquals => Ok(ts != parse_filter_timestamp_millis(value)?),
+        FilterOp::Contains | FilterOp::NotContains => true,
+        FilterOp::Before => target.is_some_and(|t| ts < t),
+        FilterOp::After => target.is_some_and(|t| ts > t),
+        FilterOp::Equals => target.is_some_and(|t| ts == t),
+        FilterOp::NotEquals => target.is_some_and(|t| ts != t),
     }
 }
 
@@ -150,7 +187,8 @@ fn parse_filter_timestamp_millis(value: &str) -> Result<i64, crate::error::AppEr
         "%m/%d/%Y %I:%M:%S %p",
     ] {
         if let Ok(parsed) = NaiveDateTime::parse_from_str(trimmed, format) {
-            return Ok(parsed.and_utc().timestamp_millis());
+            return naive_to_local_millis(parsed)
+                .ok_or_else(|| invalid_timestamp_filter_value(value));
         }
     }
 
@@ -159,11 +197,25 @@ fn parse_filter_timestamp_millis(value: &str) -> Result<i64, crate::error::AppEr
             let start_of_day = parsed
                 .and_hms_opt(0, 0, 0)
                 .ok_or_else(|| invalid_timestamp_filter_value(value))?;
-            return Ok(start_of_day.and_utc().timestamp_millis());
+            return naive_to_local_millis(start_of_day)
+                .ok_or_else(|| invalid_timestamp_filter_value(value));
         }
     }
 
     Err(invalid_timestamp_filter_value(value))
+}
+
+/// Interpret a naive (timezone-less) datetime as local time, then convert to
+/// UTC milliseconds. Filter inputs are typed by the user against the
+/// log-list display, which the frontend formats in the local timezone.
+/// Falls back to the earlier candidate when the wall-clock instant is
+/// ambiguous (DST fall-back) and returns `None` for nonexistent times.
+fn naive_to_local_millis(naive: NaiveDateTime) -> Option<i64> {
+    match Local.from_local_datetime(&naive) {
+        chrono::LocalResult::Single(dt) => Some(dt.timestamp_millis()),
+        chrono::LocalResult::Ambiguous(earlier, _) => Some(earlier.timestamp_millis()),
+        chrono::LocalResult::None => None,
+    }
 }
 
 fn invalid_timestamp_filter_value(value: &str) -> crate::error::AppError {
@@ -179,12 +231,11 @@ mod tests {
     #[test]
     fn timestamp_filter_accepts_plain_iso_date() {
         let parsed = parse_filter_timestamp_millis("2026-04-01").expect("date should parse");
-        let expected = NaiveDate::from_ymd_opt(2026, 4, 1)
+        let naive = NaiveDate::from_ymd_opt(2026, 4, 1)
             .expect("valid date")
             .and_hms_opt(0, 0, 0)
-            .expect("valid time")
-            .and_utc()
-            .timestamp_millis();
+            .expect("valid time");
+        let expected = naive_to_local_millis(naive).expect("local datetime should resolve");
 
         assert_eq!(parsed, expected);
     }
@@ -202,12 +253,11 @@ mod tests {
 
     #[test]
     fn timestamp_filter_accepts_whole_second_datetimes() {
-        let expected = NaiveDate::from_ymd_opt(2026, 4, 1)
+        let naive = NaiveDate::from_ymd_opt(2026, 4, 1)
             .expect("valid date")
             .and_hms_opt(12, 30, 0)
-            .expect("valid time")
-            .and_utc()
-            .timestamp_millis();
+            .expect("valid time");
+        let expected = naive_to_local_millis(naive).expect("local datetime should resolve");
 
         for input in [
             "2026-04-01 12:30:00",
@@ -221,9 +271,35 @@ mod tests {
     }
 
     #[test]
+    fn timestamp_filter_naive_input_is_local_time() {
+        // A naive input should match an entry whose UTC millis correspond to
+        // that wall-clock instant in the local timezone.
+        let naive = NaiveDate::from_ymd_opt(2026, 4, 1)
+            .expect("valid date")
+            .and_hms_opt(12, 30, 0)
+            .expect("valid time");
+        let local_millis = Local
+            .from_local_datetime(&naive)
+            .single()
+            .expect("local datetime should resolve unambiguously")
+            .timestamp_millis();
+
+        assert_eq!(
+            parse_filter_timestamp_millis("2026-04-01 12:30:00").unwrap(),
+            local_millis,
+        );
+    }
+
+    #[test]
     fn timestamp_filter_rejects_invalid_values() {
-        let error = match_timestamp(0, &FilterOp::Before, "yesterday")
-            .expect_err("invalid value should fail");
+        let clauses = vec![FilterClause {
+            field: FilterField::Timestamp,
+            op: FilterOp::Before,
+            value: "yesterday".into(),
+        }];
+        let error = compile_clauses(&clauses)
+            .err()
+            .expect("invalid value should fail");
 
         assert!(error.to_string().contains("Invalid timestamp filter value"));
     }
@@ -232,7 +308,33 @@ mod tests {
     fn timestamp_before_uses_parsed_date() {
         let target = parse_filter_timestamp_millis("2026-04-01").expect("date should parse");
 
-        assert!(match_timestamp(target - 1, &FilterOp::Before, "2026-04-01").unwrap());
-        assert!(!match_timestamp(target, &FilterOp::Before, "2026-04-01").unwrap());
+        assert!(match_timestamp(target - 1, &FilterOp::Before, Some(target)));
+        assert!(!match_timestamp(target, &FilterOp::Before, Some(target)));
+    }
+
+    #[test]
+    fn compile_clauses_parses_each_timestamp_value_once() {
+        let clauses = vec![FilterClause {
+            field: FilterField::Timestamp,
+            op: FilterOp::Before,
+            value: "2026-04-01".into(),
+        }];
+        let compiled = compile_clauses(&clauses).expect("clause should compile");
+
+        assert_eq!(compiled.len(), 1);
+        assert!(compiled[0].timestamp_target.is_some());
+    }
+
+    #[test]
+    fn compile_clauses_skips_parse_for_substring_ops_on_timestamps() {
+        let clauses = vec![FilterClause {
+            field: FilterField::Timestamp,
+            op: FilterOp::Contains,
+            value: "not-a-date".into(),
+        }];
+        let compiled = compile_clauses(&clauses)
+            .expect("substring op should not require parseable value");
+
+        assert!(compiled[0].timestamp_target.is_none());
     }
 }

--- a/src-tauri/src/watcher/tail.rs
+++ b/src-tauri/src/watcher/tail.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
 use crate::models::log_entry::{LogEntry, ParserSpecialization, RecordFraming};
-use crate::parser::{self, ResolvedParser, FileEncoding};
+use crate::parser::{self, FileEncoding, ResolvedParser};
 
 const IME_RECORD_START: &str = "<![LOG[";
 const IME_RECORD_ATTRS_START: &str = "]LOG]!><";
@@ -55,12 +55,9 @@ impl TailReader {
     /// Read new content from the file since last read, parse into entries.
     /// Returns new entries and updates internal byte_offset.
     pub fn read_new_entries(&mut self) -> Result<Vec<LogEntry>, crate::error::AppError> {
-        let mut file = std::fs::File::open(&self.path)
-            .map_err(crate::error::AppError::Io)?;
+        let mut file = std::fs::File::open(&self.path).map_err(crate::error::AppError::Io)?;
 
-        let metadata = file
-            .metadata()
-            .map_err(crate::error::AppError::Io)?;
+        let metadata = file.metadata().map_err(crate::error::AppError::Io)?;
 
         let file_size = metadata.len();
 
@@ -105,8 +102,9 @@ impl TailReader {
         };
         let _ = leftover; // suppress unused warning
 
-        let new_text = crate::parser::decode_bytes(to_decode, self.encoding)
-            .map_err(|e| crate::error::AppError::Internal(format!("Failed to decode tailed bytes: {}", e)))?;
+        let new_text = crate::parser::decode_bytes(to_decode, self.encoding).map_err(|e| {
+            crate::error::AppError::Internal(format!("Failed to decode tailed bytes: {}", e))
+        })?;
 
         // Prepend any partial record fragment from the last read.
         let full_text = if self.pending_fragment.is_empty() {
@@ -140,7 +138,8 @@ impl TailReader {
 
         // Parse the new complete records through the same dispatch path as initial parsing.
         let path_str = self.path.to_string_lossy().to_string();
-        let (mut entries, _) = parser::parse_lines_with_selection(&lines, &path_str, &self.parser_selection);
+        let (mut entries, _) =
+            parser::parse_lines_with_selection(&lines, &path_str, &self.parser_selection);
 
         // Update IDs and line numbers to be sequential from where we left off
         for entry in &mut entries {
@@ -150,8 +149,9 @@ impl TailReader {
             self.next_line += 1;
         }
 
-        // Update byte offset (subtract the pending fragment bytes we kept).
-        self.byte_offset = file_size - self.pending_fragment.len() as u64;
+        // We already keep incomplete text in pending_fragment. Advance to the
+        // actual file size so the same bytes are not read and prepended again.
+        self.byte_offset = file_size;
 
         Ok(entries)
     }
@@ -257,7 +257,8 @@ where
     let watch_path = path.clone();
 
     std::thread::spawn(move || {
-        let mut tail_reader = TailReader::new(path, byte_offset, parser_selection, next_id, next_line);
+        let mut tail_reader =
+            TailReader::new(path, byte_offset, parser_selection, next_id, next_line);
 
         // Create a channel for notify events
         let (tx, rx) = std::sync::mpsc::channel();
@@ -405,9 +406,7 @@ mod tests {
         let initial = "15/01/2024 08:00:00 Initial entry\n";
         fs::write(&path, initial).expect("should write initial file");
 
-        let byte_offset = fs::metadata(&path)
-            .expect("metadata should exist")
-            .len();
+        let byte_offset = fs::metadata(&path).expect("metadata should exist").len();
 
         let selection = ResolvedParser::generic_timestamped(DateOrder::DayFirst);
         let mut reader = TailReader::new(path.clone(), byte_offset, selection, 1, 2);
@@ -429,6 +428,50 @@ mod tests {
             entries[0].timestamp_display.as_deref(),
             Some("2024-01-16 09:30:00.000")
         );
+
+        fs::remove_file(path).expect("should clean up temp file");
+    }
+
+    #[test]
+    fn test_tail_reader_does_not_duplicate_buffered_partial_line() {
+        let path = unique_test_path("tail-reader-partial-line");
+        fs::write(&path, "initial\n").expect("should write initial file");
+
+        let byte_offset = fs::metadata(&path).expect("metadata should exist").len();
+
+        let mut reader = TailReader::new(
+            path.clone(),
+            byte_offset,
+            ResolvedParser::plain_text(),
+            1,
+            2,
+        );
+
+        let mut file = OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("should reopen temp file");
+        write!(file, "complete\npartial").expect("should append complete and partial lines");
+        drop(file);
+
+        let first_entries = reader
+            .read_new_entries()
+            .expect("first tail read should succeed");
+        assert_eq!(first_entries.len(), 1);
+        assert_eq!(first_entries[0].message, "complete");
+
+        let mut file = OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("should reopen temp file");
+        writeln!(file, " done").expect("should complete buffered partial line");
+        drop(file);
+
+        let second_entries = reader
+            .read_new_entries()
+            .expect("second tail read should succeed");
+        assert_eq!(second_entries.len(), 1);
+        assert_eq!(second_entries[0].message, "partial done");
 
         fs::remove_file(path).expect("should clean up temp file");
     }
@@ -498,10 +541,16 @@ mod tests {
             drop(file);
 
             let tail_entries = reader.read_new_entries().expect("tail read should succeed");
-            let (full_result, _) = parser::parse_file(&path_str).expect("full fixture should parse");
+            let (full_result, _) =
+                parser::parse_file(&path_str).expect("full fixture should parse");
             let expected_entries = &full_result.entries[initial_result.entries.len()..];
 
-            assert_eq!(tail_entries.len(), expected_entries.len(), "case={}", case.name);
+            assert_eq!(
+                tail_entries.len(),
+                expected_entries.len(),
+                "case={}",
+                case.name
+            );
 
             for (actual, expected) in tail_entries.iter().zip(expected_entries.iter()) {
                 assert_entries_match(actual, expected);

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -43,14 +43,18 @@ import { useParseProgressListener } from "../../hooks/use-parse-progress-listene
 import { useUpdateChecker } from "../../hooks/use-update-checker";
 import { QuickStatsPanel } from "../panels/QuickStatsPanel";
 
-function buildFilterRunSignature(entries: LogEntry[], clauses: FilterClause[]): string {
+function buildFilterRunSignature(
+  entries: LogEntry[],
+  clauses: FilterClause[],
+  entriesRevision: number
+): string {
   const lastId = entries.length > 0 ? entries[entries.length - 1].id : -1;
   const lastLineNumber = entries.length > 0 ? entries[entries.length - 1].lineNumber : -1;
   const clauseSignature = clauses
     .map((clause) => `${clause.field}:${clause.op}:${clause.value}`)
     .join("|");
 
-  return `${clauseSignature}:${entries.length}:${lastId}:${lastLineNumber}`;
+  return `${clauseSignature}:${entriesRevision}:${entries.length}:${lastId}:${lastLineNumber}`;
 }
 
 export function AppShell() {
@@ -166,6 +170,21 @@ export function AppShell() {
   const filterRequestIdRef = useRef(0);
   const inFlightSignatureRef = useRef<string | null>(null);
   const lastAppliedSignatureRef = useRef<string | null>(null);
+  const entriesRevisionRef = useRef<{ entries: LogEntry[] | null; revision: number }>({
+    entries: null,
+    revision: 0,
+  });
+
+  const getEntriesRevision = useCallback((entriesSnapshot: LogEntry[]) => {
+    if (entriesRevisionRef.current.entries !== entriesSnapshot) {
+      entriesRevisionRef.current = {
+        entries: entriesSnapshot,
+        revision: entriesRevisionRef.current.revision + 1,
+      };
+    }
+
+    return entriesRevisionRef.current.revision;
+  }, []);
 
   const runFilter = useCallback(
     async (clauses: FilterClause[], entriesSnapshot: LogEntry[], trigger: string) => {
@@ -178,7 +197,11 @@ export function AppShell() {
         return;
       }
 
-      const signature = buildFilterRunSignature(entriesSnapshot, clauses);
+      const signature = buildFilterRunSignature(
+        entriesSnapshot,
+        clauses,
+        getEntriesRevision(entriesSnapshot)
+      );
 
       if (
         signature === inFlightSignatureRef.current ||
@@ -237,7 +260,7 @@ export function AppShell() {
         }
       }
     },
-    [setFilterError, setFilteredIds, setIsFiltering]
+    [getEntriesRevision, setFilterError, setFilteredIds, setIsFiltering]
   );
 
   useEffect(() => {

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -15,7 +15,6 @@ import { LogRow } from "./LogRow";
 import { SectionDividerRow } from "./SectionDividerRow";
 import { MergeLegendBar } from "./MergeLegendBar";
 import type { ErrorCodeSpan } from "../../types/log";
-import type { Marker } from "../../types/markers";
 import { useMarkerStore } from "../../stores/marker-store";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { formatLogEntryTimestamp } from "../../lib/date-time-format";
@@ -209,6 +208,11 @@ export function LogListView({ dataSource }: { dataSource?: LogListDataSource } =
   }, [displayEntries, severityPalette.mergeColors]);
 
   // ── Marker store wiring ───────────────────────────────────────────────
+  // Markers are scoped per source file (entry.filePath), not per tab. In
+  // single-file mode every entry shares one filePath; in aggregate-folder
+  // mode each row may belong to a different file. Reading and writing
+  // both go through entry.filePath so the two stay in sync regardless of
+  // how the tab was opened.
   const isMerged = sourceOpenMode === "merged";
   const markersByFile = useMarkerStore((s) => s.markersByFile);
   const loadMarkers = useMarkerStore((s) => s.loadMarkers);
@@ -217,59 +221,70 @@ export function LogListView({ dataSource }: { dataSource?: LogListDataSource } =
   const setMarkerCategory = useMarkerStore((s) => s.setMarkerCategory);
   const markerCategories = useMarkerStore((s) => s.categories);
 
-  // Use openFilePath if set, otherwise derive from the first entry's filePath
-  const activeFilePath = openFilePath ?? (entries.length > 0 ? entries[0].filePath : "");
-  const fileMarkers: Map<number, Marker> = useMemo(
-    () => isMerged ? new Map() : (markersByFile.get(activeFilePath) ?? new Map()),
-    [markersByFile, activeFilePath, isMerged]
-  );
-
-  // Load markers when tab changes (skip in merged mode)
-  useEffect(() => {
-    if (isMerged) return;
-    if (activeFilePath) {
-      loadMarkers(activeFilePath);
+  // Unique source-file paths referenced by the displayed entries. Recomputes
+  // only when the entry set or its file membership changes, so the load
+  // effect below doesn't re-fire on unrelated state churn.
+  const markerFilePaths = useMemo(() => {
+    if (isMerged) return [] as string[];
+    const set = new Set<string>();
+    for (const e of displayEntries) {
+      if (e.filePath) set.add(e.filePath);
     }
-  }, [activeFilePath, loadMarkers, isMerged]);
+    return Array.from(set);
+  }, [displayEntries, isMerged]);
+  // Stable JSON key so loadMarkers fires on set membership change, not on
+  // every new array reference.
+  const markerFilePathsKey = markerFilePaths.join(" ");
 
-  // Auto-save markers on changes with 1-second debounce.
-  // markersDirtyRef prevents save from firing after loadMarkers hydrates state.
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const markersDirtyRef = useRef(false);
   useEffect(() => {
     if (isMerged) return;
-    if (!activeFilePath) return;
-    if (!markersDirtyRef.current) return;
+    for (const fp of markerFilePaths) {
+      loadMarkers(fp);
+    }
+    // markerFilePaths is captured by markerFilePathsKey
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [markerFilePathsKey, loadMarkers, isMerged]);
+
+  // Per-file dirty set; debounced flush saves all dirty files at once. A
+  // single timer is fine because saveMarkers calls are independent.
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dirtyFilesRef = useRef<Set<string>>(new Set());
+
+  const scheduleMarkerSave = useCallback(() => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
-      saveMarkers(activeFilePath);
-      markersDirtyRef.current = false;
+      const dirty = Array.from(dirtyFilesRef.current);
+      dirtyFilesRef.current.clear();
+      for (const fp of dirty) {
+        saveMarkers(fp);
+      }
     }, 1000);
+  }, [saveMarkers]);
+
+  useEffect(() => {
     return () => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     };
-  }, [fileMarkers, activeFilePath, saveMarkers, isMerged]);
+  }, []);
 
   const handleToggleMarker = useCallback(
-    (lineId: number) => {
-      if (isMerged) return;
-      if (activeFilePath) {
-        markersDirtyRef.current = true;
-        toggleMarker(activeFilePath, lineId);
-      }
+    (filePath: string, lineId: number) => {
+      if (isMerged || !filePath) return;
+      dirtyFilesRef.current.add(filePath);
+      toggleMarker(filePath, lineId);
+      scheduleMarkerSave();
     },
-    [activeFilePath, toggleMarker, isMerged]
+    [toggleMarker, isMerged, scheduleMarkerSave]
   );
 
   const handleSetMarkerCategory = useCallback(
-    (lineId: number, category: string) => {
-      if (isMerged) return;
-      if (activeFilePath) {
-        markersDirtyRef.current = true;
-        setMarkerCategory(activeFilePath, lineId, category);
-      }
+    (filePath: string, lineId: number, category: string) => {
+      if (isMerged || !filePath) return;
+      dirtyFilesRef.current.add(filePath);
+      setMarkerCategory(filePath, lineId, category);
+      scheduleMarkerSave();
     },
-    [activeFilePath, setMarkerCategory, isMerged]
+    [setMarkerCategory, isMerged, scheduleMarkerSave]
   );
 
   // ── Multi-select state ─────────────────────────────────────────────
@@ -650,7 +665,10 @@ export function LogListView({ dataSource }: { dataSource?: LogListDataSource } =
           if (mod && e.key === "m") {
             e.preventDefault();
             if (selectedId !== null) {
-              handleToggleMarker(selectedId);
+              const target = displayEntries.find((entry) => entry.id === selectedId);
+              if (target?.filePath) {
+                handleToggleMarker(target.filePath, selectedId);
+              }
             }
           }
           // Ctrl+A / Cmd+A: select all visible entries
@@ -744,7 +762,11 @@ export function LogListView({ dataSource }: { dataSource?: LogListDataSource } =
                     isCorrelated={sourceOpenMode === "merged" && correlatedIdSet.has(entry.id)}
                     correlationColor={sourceOpenMode === "merged" ? mergedTabState?.colorAssignments[entry.filePath] ?? null : null}
                     sectionBandColor={sectionBandColor}
-                    marker={isMerged ? null : (fileMarkers.get(entry.id) ?? null)}
+                    marker={
+                      isMerged
+                        ? null
+                        : (markersByFile.get(entry.filePath)?.get(entry.id) ?? null)
+                    }
                     onToggleMarker={handleToggleMarker}
                     onSetMarkerCategory={handleSetMarkerCategory}
                     markerCategories={isMerged ? [] : markerCategories}

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -561,9 +561,10 @@ export function LogListView({ dataSource }: { dataSource?: LogListDataSource } =
   const onDragEnd = useCallback(() => setDragState(null), []);
 
   // ── Auto-fit column width ────────────────────────────────────────────────
+  // Message column is sized via 98th-percentile of entry length inside
+  // calcAutoFitWidth, so callers no longer need to skip it.
   const handleHeaderDoubleClick = useCallback(
     (colId: ColumnId) => {
-      if (colId === "message") return;
       const def = getColumnDef(colId);
       if (!def) return;
       // Use a rendered row element so the font-family is fully resolved (no CSS variables)
@@ -581,7 +582,6 @@ export function LogListView({ dataSource }: { dataSource?: LogListDataSource } =
     const headerFont = getCanvasFont(listMetrics.headerFontSize, true, rowEl);
     const updates: Record<string, number> = {};
     for (const col of visibleColumns) {
-      if (col.id === "message") continue;
       updates[col.id] = calcAutoFitWidth(col, displayEntries, contentFont, headerFont);
     }
     setColumnWidths(updates);

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -561,8 +561,9 @@ export function LogListView({ dataSource }: { dataSource?: LogListDataSource } =
   const onDragEnd = useCallback(() => setDragState(null), []);
 
   // ── Auto-fit column width ────────────────────────────────────────────────
-  // Message column is sized via 98th-percentile of entry length inside
-  // calcAutoFitWidth, so callers no longer need to skip it.
+  // calcAutoFitWidth handles every column, including message (capped at
+  // MAX_AUTOFIT_WIDTH for outlier protection). Triggered by double-click
+  // on the column header or the Fit-all button in the severity column.
   const handleHeaderDoubleClick = useCallback(
     (colId: ColumnId) => {
       const def = getColumnDef(colId);
@@ -829,6 +830,15 @@ function HeaderCell({
       onDragOver={(e) => onDragOver(index, e)}
       onDrop={onDrop}
       onDragEnd={onDragEnd}
+      onDoubleClick={(e) => {
+        // Auto-fit on double-click anywhere on the header. The 10px resize
+        // handle on the right edge is too small a target for users to find;
+        // letting the whole header trigger fit is far more discoverable.
+        e.preventDefault();
+        e.stopPropagation();
+        onDoubleClick(col.id);
+      }}
+      title="Double-click to auto-fit this column"
       style={{
         position: "relative",
         ...(col.isFlex ? { minWidth: 0 } : {}),

--- a/src/components/log-view/LogRow.tsx
+++ b/src/components/log-view/LogRow.tsx
@@ -27,8 +27,10 @@ interface LogRowProps {
   correlationColor?: string | null;
   sectionBandColor?: string | null;
   marker?: Marker | null;
-  onToggleMarker?: (lineId: number) => void;
-  onSetMarkerCategory?: (lineId: number, category: string) => void;
+  /** Receives the entry's filePath so callers can scope markers to the
+   * correct file in aggregate-folder mode. */
+  onToggleMarker?: (filePath: string, lineId: number) => void;
+  onSetMarkerCategory?: (filePath: string, lineId: number, category: string) => void;
   markerCategories?: MarkerCategory[];
 }
 
@@ -353,7 +355,7 @@ export const LogRow = memo(function LogRow({
         }}
         onClick={(e) => {
           e.stopPropagation();
-          onToggleMarker?.(entry.id);
+          onToggleMarker?.(entry.filePath, entry.id);
         }}
         onContextMenu={handleGutterContextMenu}
       >
@@ -410,9 +412,9 @@ export const LogRow = memo(function LogRow({
                 e.stopPropagation();
                 if (!marker) {
                   // First toggle it on, then set category
-                  onToggleMarker?.(entry.id);
+                  onToggleMarker?.(entry.filePath, entry.id);
                 }
-                onSetMarkerCategory?.(entry.id, cat.id);
+                onSetMarkerCategory?.(entry.filePath, entry.id, cat.id);
                 closeGutterMenu();
               }}
             >
@@ -454,7 +456,7 @@ export const LogRow = memo(function LogRow({
                 }}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onToggleMarker?.(entry.id);
+                  onToggleMarker?.(entry.filePath, entry.id);
                   closeGutterMenu();
                 }}
               >

--- a/src/hooks/use-parse-progress-listener.ts
+++ b/src/hooks/use-parse-progress-listener.ts
@@ -29,21 +29,22 @@ interface ParseProgressPayload {
  * from a previous load can never bleed into the next one.
  */
 export function useParseProgressListener() {
-  const folderLoadProgress = useLogStore((state) => state.folderLoadProgress);
+  // Subscribe to a derived boolean so this hook re-renders only on the
+  // null ↔ non-null transition instead of on every progress tick during
+  // a large folder load.
+  const isFolderLoading = useLogStore((state) => state.folderLoadProgress !== null);
   const globalCompletedRef = useRef(0);
   const prevBatchCompletedRef = useRef(0);
   const wasLoadingRef = useRef(false);
 
   useEffect(() => {
-    const isLoading = folderLoadProgress !== null;
-
-    if (isLoading && !wasLoadingRef.current) {
+    if (isFolderLoading && !wasLoadingRef.current) {
       globalCompletedRef.current = 0;
       prevBatchCompletedRef.current = 0;
     }
 
-    wasLoadingRef.current = isLoading;
-  }, [folderLoadProgress]);
+    wasLoadingRef.current = isFolderLoading;
+  }, [isFolderLoading]);
 
   useEffect(() => {
     const unlisten = listen<ParseProgressPayload>(

--- a/src/hooks/use-parse-progress-listener.ts
+++ b/src/hooks/use-parse-progress-listener.ts
@@ -23,9 +23,10 @@ interface ParseProgressPayload {
  * per-file progress instead of only updating between batches.
  *
  * The Rust side emits per-batch counters, but the UI needs a global
- * count across all batches.  We maintain a running offset that resets
- * when a new folder load begins (folderLoadProgress transitions from
- * null → non-null).
+ * count across all batches.  We maintain a running offset that is
+ * reset by an effect each time a new folder load begins
+ * (folderLoadProgress transitions from null → non-null), so progress
+ * from a previous load can never bleed into the next one.
  */
 export function useParseProgressListener() {
   const folderLoadProgress = useLogStore((state) => state.folderLoadProgress);
@@ -51,11 +52,10 @@ export function useParseProgressListener() {
         const p = event.payload;
         const state = useLogStore.getState();
 
-        // Only update if a folder load is currently in progress.
+        // Only update if a folder load is currently in progress. The reset
+        // for the next load is handled by the effect above on the
+        // null → non-null transition.
         if (state.folderLoadProgress === null) {
-          // Reset counters for the next load
-          globalCompletedRef.current = 0;
-          prevBatchCompletedRef.current = 0;
           return;
         }
 

--- a/src/hooks/use-parse-progress-listener.ts
+++ b/src/hooks/use-parse-progress-listener.ts
@@ -28,8 +28,21 @@ interface ParseProgressPayload {
  * null → non-null).
  */
 export function useParseProgressListener() {
+  const folderLoadProgress = useLogStore((state) => state.folderLoadProgress);
   const globalCompletedRef = useRef(0);
   const prevBatchCompletedRef = useRef(0);
+  const wasLoadingRef = useRef(false);
+
+  useEffect(() => {
+    const isLoading = folderLoadProgress !== null;
+
+    if (isLoading && !wasLoadingRef.current) {
+      globalCompletedRef.current = 0;
+      prevBatchCompletedRef.current = 0;
+    }
+
+    wasLoadingRef.current = isLoading;
+  }, [folderLoadProgress]);
 
   useEffect(() => {
     const unlisten = listen<ParseProgressPayload>(

--- a/src/lib/column-config.ts
+++ b/src/lib/column-config.ts
@@ -438,6 +438,11 @@ const MAX_AUTOFIT_WIDTH = 1200;
  * Calculate the auto-fit width for a column given the current display entries.
  * - severity: returns defaultWidth (renders a colored dot, not text)
  * - dateTime: uses a fixed representative timestamp string (view layer formats it)
+ * - message: sized to the 98th-percentile entry length so a single
+ *   stack-trace / JSON-blob outlier doesn't blow the column out to the
+ *   MAX_AUTOFIT_WIDTH cap; still capped at MAX_AUTOFIT_WIDTH overall.
+ *   Percentile-based sizing gives sensible widths on logs whose only
+ *   meaningful content is the message column (e.g. macOS install.log).
  * - all others: two-pass approach —
  *     Pass 1 (O(n), no canvas): find the max string length across ALL entries
  *     Pass 2 (O(k), canvas): measure only strings within 90% of the max length
@@ -452,10 +457,6 @@ export function calcAutoFitWidth(
 ): number {
   if (col.id === "severity") return col.defaultWidth;
 
-  // The message column contains arbitrarily long content (JSON blobs, stack traces, etc.).
-  // Auto-fitting it just pushes everything off-screen — keep its current/default width.
-  if (col.id === "message") return col.defaultWidth;
-
   if (col.id === "dateTime") {
     // Representative sample matching the widest output of formatLogEntryTimestamp().
     // Update this if the display format changes (see src/lib/date-time-format.ts).
@@ -464,6 +465,10 @@ export function calcAutoFitWidth(
   }
 
   const headerW = measureTextWidth(col.label, headerFont) + HEADER_PAD;
+
+  if (col.id === "message") {
+    return calcMessagePercentileWidth(entries, contentFont, headerW, col);
+  }
 
   // Pass 1: find the longest string length (cheap — no canvas)
   let maxLen = 0;
@@ -485,6 +490,48 @@ export function calcAutoFitWidth(
     if (val == null) continue;
     const text = String(val);
     if (text.length < threshold) continue;
+    const w = measureTextWidth(text, contentFont);
+    if (w > maxContent) maxContent = w;
+  }
+
+  return Math.min(
+    MAX_AUTOFIT_WIDTH,
+    Math.ceil(Math.max(headerW, maxContent + CELL_PAD, col.minWidth)),
+  );
+}
+
+const MESSAGE_AUTOFIT_PERCENTILE = 0.98;
+
+/**
+ * Size the message column to the 98th-percentile entry length. Pass 1
+ * collects lengths; pass 2 canvas-measures every entry whose length
+ * lands in the top 2% of the distribution and returns the widest among
+ * them. Outliers above the percentile are ignored.
+ */
+function calcMessagePercentileWidth(
+  entries: readonly LogEntry[],
+  contentFont: string,
+  headerW: number,
+  col: ColumnDefinition,
+): number {
+  const lengths: number[] = [];
+  for (const entry of entries) {
+    if (entry.message) lengths.push(entry.message.length);
+  }
+  if (lengths.length === 0) return Math.ceil(Math.max(headerW, col.defaultWidth));
+
+  lengths.sort((a, b) => a - b);
+  const targetLen = lengths[Math.floor(MESSAGE_AUTOFIT_PERCENTILE * (lengths.length - 1))];
+
+  // Measure entries near the percentile target. Lower bound at 95% of
+  // target so canvas-measure cost stays bounded; upper bound at the
+  // target itself so a 5000-char outlier doesn't widen the column.
+  const lowerThreshold = targetLen * 0.95;
+  let maxContent = 0;
+  for (const entry of entries) {
+    const text = entry.message;
+    if (!text) continue;
+    if (text.length < lowerThreshold || text.length > targetLen) continue;
     const w = measureTextWidth(text, contentFont);
     if (w > maxContent) maxContent = w;
   }

--- a/src/lib/column-config.ts
+++ b/src/lib/column-config.ts
@@ -438,16 +438,12 @@ const MAX_AUTOFIT_WIDTH = 1200;
  * Calculate the auto-fit width for a column given the current display entries.
  * - severity: returns defaultWidth (renders a colored dot, not text)
  * - dateTime: uses a fixed representative timestamp string (view layer formats it)
- * - message: sized to the 98th-percentile entry length so a single
- *   stack-trace / JSON-blob outlier doesn't blow the column out to the
- *   MAX_AUTOFIT_WIDTH cap; still capped at MAX_AUTOFIT_WIDTH overall.
- *   Percentile-based sizing gives sensible widths on logs whose only
- *   meaningful content is the message column (e.g. macOS install.log).
- * - all others: two-pass approach —
+ * - all others (including message): two-pass approach —
  *     Pass 1 (O(n), no canvas): find the max string length across ALL entries
  *     Pass 2 (O(k), canvas): measure only strings within 90% of the max length
- *   This ensures the widest entry is always found regardless of how large the log is,
- *   while keeping canvas calls to a minimum.
+ *   The widest entry's pixel width sets the column, then `MAX_AUTOFIT_WIDTH`
+ *   caps the result so a single stack-trace / JSON-blob outlier can grow
+ *   the column at most to that cap (1200px), not arbitrarily wide.
  */
 export function calcAutoFitWidth(
   col: ColumnDefinition,
@@ -465,10 +461,6 @@ export function calcAutoFitWidth(
   }
 
   const headerW = measureTextWidth(col.label, headerFont) + HEADER_PAD;
-
-  if (col.id === "message") {
-    return calcMessagePercentileWidth(entries, contentFont, headerW, col);
-  }
 
   // Pass 1: find the longest string length (cheap — no canvas)
   let maxLen = 0;
@@ -490,48 +482,6 @@ export function calcAutoFitWidth(
     if (val == null) continue;
     const text = String(val);
     if (text.length < threshold) continue;
-    const w = measureTextWidth(text, contentFont);
-    if (w > maxContent) maxContent = w;
-  }
-
-  return Math.min(
-    MAX_AUTOFIT_WIDTH,
-    Math.ceil(Math.max(headerW, maxContent + CELL_PAD, col.minWidth)),
-  );
-}
-
-const MESSAGE_AUTOFIT_PERCENTILE = 0.98;
-
-/**
- * Size the message column to the 98th-percentile entry length. Pass 1
- * collects lengths; pass 2 canvas-measures every entry whose length
- * lands in the top 2% of the distribution and returns the widest among
- * them. Outliers above the percentile are ignored.
- */
-function calcMessagePercentileWidth(
-  entries: readonly LogEntry[],
-  contentFont: string,
-  headerW: number,
-  col: ColumnDefinition,
-): number {
-  const lengths: number[] = [];
-  for (const entry of entries) {
-    if (entry.message) lengths.push(entry.message.length);
-  }
-  if (lengths.length === 0) return Math.ceil(Math.max(headerW, col.defaultWidth));
-
-  lengths.sort((a, b) => a - b);
-  const targetLen = lengths[Math.floor(MESSAGE_AUTOFIT_PERCENTILE * (lengths.length - 1))];
-
-  // Measure entries near the percentile target. Lower bound at 95% of
-  // target so canvas-measure cost stays bounded; upper bound at the
-  // target itself so a 5000-char outlier doesn't widen the column.
-  const lowerThreshold = targetLen * 0.95;
-  let maxContent = 0;
-  for (const entry of entries) {
-    const text = entry.message;
-    if (!text) continue;
-    if (text.length < lowerThreshold || text.length > targetLen) continue;
     const w = measureTextWidth(text, contentFont);
     if (w > maxContent) maxContent = w;
   }

--- a/src/lib/session-restore.ts
+++ b/src/lib/session-restore.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { readTextFile } from "@tauri-apps/plugin-fs";
-import { clearAllTabSnapshots, useLogStore } from "../stores/log-store";
+import { useLogStore } from "../stores/log-store";
 import { useUiStore } from "../stores/ui-store";
 import { loadPathAsLogSource, loadFilesAsLogSource } from "./log-source";
 import { validateSession, type FileChangeWarning } from "./session";
@@ -93,11 +93,7 @@ export async function restoreSession(sessionPath: string): Promise<string | null
 
   // Clear current state
   useLogStore.getState().clear();
-  clearAllTabSnapshots();
-  useUiStore.setState({
-    openTabs: [],
-    activeTabIndex: -1,
-  });
+  useUiStore.getState().clearTabs();
 
   // Set workspace
   const uiStore = useUiStore.getState();
@@ -108,23 +104,26 @@ export async function restoreSession(sessionPath: string): Promise<string | null
   // Add to recent sessions
   uiStore.addRecentSession(sessionPath);
 
-  // Load each file individually to create proper per-file tabs
+  // Load each file individually to create proper per-file tabs.
+  // If every file fails, fall back to the aggregate load path so the user
+  // isn't left with empty tabs after the pre-clear above.
   const filePaths = validTabs.map((t) => t.filePath);
-  try {
-    for (const tab of validTabs) {
-      try {
-        await loadPathAsLogSource(tab.filePath, { fallbackToFolder: false });
-      } catch (error) {
-        console.warn("[session] failed to load file during restore", { filePath: tab.filePath, error });
-      }
+  let loadedAny = false;
+  for (const tab of validTabs) {
+    try {
+      await loadPathAsLogSource(tab.filePath, { fallbackToFolder: false });
+      loadedAny = true;
+    } catch (error) {
+      console.warn("[session] failed to load file during restore", { filePath: tab.filePath, error });
     }
-  } catch (error) {
-    console.error("[session] failed to import log-source during restore", error);
-    // Fallback: try the aggregate load path
+  }
+
+  if (!loadedAny && filePaths.length > 0) {
     try {
       await loadFilesAsLogSource(filePaths);
+      loadedAny = true;
     } catch (fallbackError) {
-      console.error("[session] fallback aggregate load also failed", fallbackError);
+      console.error("[session] aggregate fallback load failed", fallbackError);
     }
   }
 

--- a/src/lib/session-restore.ts
+++ b/src/lib/session-restore.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { readTextFile } from "@tauri-apps/plugin-fs";
-import { useLogStore } from "../stores/log-store";
+import { clearAllTabSnapshots, useLogStore } from "../stores/log-store";
 import { useUiStore } from "../stores/ui-store";
 import { loadPathAsLogSource, loadFilesAsLogSource } from "./log-source";
 import { validateSession, type FileChangeWarning } from "./session";
@@ -93,6 +93,11 @@ export async function restoreSession(sessionPath: string): Promise<string | null
 
   // Clear current state
   useLogStore.getState().clear();
+  clearAllTabSnapshots();
+  useUiStore.setState({
+    openTabs: [],
+    activeTabIndex: -1,
+  });
 
   // Set workspace
   const uiStore = useUiStore.getState();

--- a/src/lib/session-restore.ts
+++ b/src/lib/session-restore.ts
@@ -107,37 +107,49 @@ export async function restoreSession(sessionPath: string): Promise<string | null
   // Load each file individually to create proper per-file tabs.
   // If every file fails, fall back to the aggregate load path so the user
   // isn't left with empty tabs after the pre-clear above.
+  // Track which paths actually opened so the index/scroll restore below
+  // targets the right tab even when some files failed to load.
   const filePaths = validTabs.map((t) => t.filePath);
-  let loadedAny = false;
+  const loadedTabsByPath = new Map<string, (typeof validTabs)[number]>();
   for (const tab of validTabs) {
     try {
       await loadPathAsLogSource(tab.filePath, { fallbackToFolder: false });
-      loadedAny = true;
+      loadedTabsByPath.set(tab.filePath, tab);
     } catch (error) {
       console.warn("[session] failed to load file during restore", { filePath: tab.filePath, error });
     }
   }
 
-  if (!loadedAny && filePaths.length > 0) {
+  if (loadedTabsByPath.size === 0 && filePaths.length > 0) {
     try {
       await loadFilesAsLogSource(filePaths);
-      loadedAny = true;
+      // Aggregate load opens one tab per file in the same order.
+      for (const tab of validTabs) loadedTabsByPath.set(tab.filePath, tab);
     } catch (fallbackError) {
       console.error("[session] aggregate fallback load failed", fallbackError);
     }
   }
 
-  // Restore active tab index after all tabs are opened
-  const activeIndex = Math.min(session.activeTabIndex, validTabs.length - 1);
-  if (activeIndex >= 0) {
-    uiStore.switchTab(activeIndex);
+  // Restore index / scroll using the actual openTabs list; openTab in
+  // ui-store may dedupe, reorder, or skip based on existing state, so
+  // session indices aren't trustworthy after partial failures.
+  const openTabs = useUiStore.getState().openTabs;
+  const activeSessionTab = validTabs[session.activeTabIndex];
+  if (activeSessionTab) {
+    const liveIndex = openTabs.findIndex((t) => t.filePath === activeSessionTab.filePath);
+    if (liveIndex >= 0) {
+      uiStore.switchTab(liveIndex);
+    }
   }
 
-  // Restore per-tab scroll positions and selected lines
-  for (let i = 0; i < validTabs.length; i++) {
-    const tab = validTabs[i];
-    if (tab.scrollPosition != null || tab.selectedId != null) {
-      uiStore.saveTabScrollState(i, tab.scrollPosition ?? 0, tab.selectedId ?? null);
+  for (const [filePath, savedTab] of loadedTabsByPath) {
+    const liveIndex = openTabs.findIndex((t) => t.filePath === filePath);
+    if (liveIndex >= 0 && (savedTab.scrollPosition != null || savedTab.selectedId != null)) {
+      uiStore.saveTabScrollState(
+        liveIndex,
+        savedTab.scrollPosition ?? 0,
+        savedTab.selectedId ?? null,
+      );
     }
   }
 

--- a/src/lib/tab-snapshot-cache.ts
+++ b/src/lib/tab-snapshot-cache.ts
@@ -1,0 +1,55 @@
+import type { LogEntry, LogFormat, ParserSelectionInfo } from "../types/log";
+import type { ColumnId } from "./column-config";
+
+/**
+ * Module-level in-memory cache of parsed tab state. Lives outside Zustand
+ * so storing/retrieving snapshots doesn't trigger re-renders.
+ *
+ * Extracted into its own module so both `log-store` and `ui-store` can
+ * import the helpers without going through each other (the two stores
+ * already cross-import for other reasons; keeping the snapshot cache
+ * standalone trims one source of cyclic-init risk).
+ */
+
+export type SourceOpenMode =
+  | "single-file"
+  | "aggregate-folder"
+  | "merged"
+  | "diff"
+  | null;
+
+/** Snapshot of parsed file state cached for instant tab restoration. */
+export interface TabEntrySnapshot {
+  entries: LogEntry[];
+  formatDetected: LogFormat | null;
+  parserSelection: ParserSelectionInfo | null;
+  totalLines: number;
+  byteOffset: number;
+  selectedSourceFilePath: string | null;
+  sourceOpenMode: SourceOpenMode;
+  activeColumns: ColumnId[];
+}
+
+const TAB_CACHE_MAX_SIZE = 30;
+
+const tabEntryCache = new Map<string, TabEntrySnapshot>();
+
+export function getCachedTabSnapshot(filePath: string): TabEntrySnapshot | undefined {
+  return tabEntryCache.get(filePath);
+}
+
+export function setCachedTabSnapshot(filePath: string, snapshot: TabEntrySnapshot): void {
+  if (tabEntryCache.size >= TAB_CACHE_MAX_SIZE && !tabEntryCache.has(filePath)) {
+    const oldestKey = tabEntryCache.keys().next().value;
+    if (oldestKey) tabEntryCache.delete(oldestKey);
+  }
+  tabEntryCache.set(filePath, snapshot);
+}
+
+export function clearCachedTabSnapshot(filePath: string): void {
+  tabEntryCache.delete(filePath);
+}
+
+export function clearAllTabSnapshots(): void {
+  tabEntryCache.clear();
+}

--- a/src/stores/log-store.ts
+++ b/src/stores/log-store.ts
@@ -38,47 +38,23 @@ import {
 
 export type { MergedTabState, CorrelatedEntry };
 export type { DiffState, DiffSource };
-
-/**
- * Snapshot of parsed file state — cached in memory so tab switches
- * can restore instantly without re-reading / re-parsing the file.
- */
-export interface TabEntrySnapshot {
-  entries: LogEntry[];
-  formatDetected: LogFormat | null;
-  parserSelection: ParserSelectionInfo | null;
-  totalLines: number;
-  byteOffset: number;
-  selectedSourceFilePath: string | null;
-  sourceOpenMode: SourceOpenMode;
-  activeColumns: ColumnId[];
-}
-
-/** Module-level cache: filePath → parsed snapshot. Lives outside Zustand to avoid triggering re-renders. */
-const tabEntryCache = new Map<string, TabEntrySnapshot>();
-
-const TAB_CACHE_MAX_SIZE = 30;
-
-export function getCachedTabSnapshot(filePath: string): TabEntrySnapshot | undefined {
-  return tabEntryCache.get(filePath);
-}
-
-export function setCachedTabSnapshot(filePath: string, snapshot: TabEntrySnapshot): void {
-  // Evict oldest if at capacity
-  if (tabEntryCache.size >= TAB_CACHE_MAX_SIZE && !tabEntryCache.has(filePath)) {
-    const oldestKey = tabEntryCache.keys().next().value;
-    if (oldestKey) tabEntryCache.delete(oldestKey);
-  }
-  tabEntryCache.set(filePath, snapshot);
-}
-
-export function clearCachedTabSnapshot(filePath: string): void {
-  tabEntryCache.delete(filePath);
-}
-
-export function clearAllTabSnapshots(): void {
-  tabEntryCache.clear();
-}
+// The tab-snapshot cache lives in `lib/tab-snapshot-cache` so ui-store
+// can import its helpers without going through log-store. Re-exported
+// here for backward compat with existing call sites.
+import {
+  getCachedTabSnapshot,
+  setCachedTabSnapshot,
+  clearCachedTabSnapshot,
+  clearAllTabSnapshots,
+} from "../lib/tab-snapshot-cache";
+import type { SourceOpenMode } from "../lib/tab-snapshot-cache";
+export type { TabEntrySnapshot, SourceOpenMode } from "../lib/tab-snapshot-cache";
+export {
+  getCachedTabSnapshot,
+  setCachedTabSnapshot,
+  clearCachedTabSnapshot,
+  clearAllTabSnapshots,
+};
 
 export type SourceStatusKind =
   | "idle"
@@ -109,9 +85,6 @@ export interface ParserSelectionDisplay {
   framingLabel: string;
   dateOrderLabel: string | null;
 }
-
-export type SourceOpenMode = "single-file" | "aggregate-folder" | "merged" | "diff" | null;
-
 
 const UNGROUPED_TOOLBAR_GROUP_ID = "ungrouped";
 const UNGROUPED_TOOLBAR_GROUP_LABEL = "Other Sources";

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -8,7 +8,8 @@ import {
 } from "../lib/log-accessibility";
 import type { ThemeId } from "../lib/themes/types";
 import { DEFAULT_THEME_ID } from "../lib/themes";
-import { clearAllTabSnapshots, clearCachedTabSnapshot, useLogStore } from "./log-store";
+import { useLogStore } from "./log-store";
+import { clearAllTabSnapshots, clearCachedTabSnapshot } from "../lib/tab-snapshot-cache";
 import { useFilterStore } from "./filter-store";
 import type { ColumnId } from "../lib/column-config";
 import type { CollectionResult } from "../lib/commands";
@@ -559,7 +560,12 @@ export const useUiStore = create<UiState>()(
       },
 
       clearTabs: () => {
+        // Mirror closeTab's last-tab path: when no tabs remain, the active
+        // log content and filter must go too, otherwise callers can leave
+        // the app showing stale entries with no tab to attribute them to.
         clearAllTabSnapshots();
+        useLogStore.getState().clearActiveFile();
+        useFilterStore.getState().clearFilter();
         set({ openTabs: [], activeTabIndex: -1 });
       },
 

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -8,7 +8,7 @@ import {
 } from "../lib/log-accessibility";
 import type { ThemeId } from "../lib/themes/types";
 import { DEFAULT_THEME_ID } from "../lib/themes";
-import { clearCachedTabSnapshot, useLogStore } from "./log-store";
+import { clearAllTabSnapshots, clearCachedTabSnapshot, useLogStore } from "./log-store";
 import { useFilterStore } from "./filter-store";
 import type { ColumnId } from "../lib/column-config";
 import type { CollectionResult } from "../lib/commands";
@@ -204,6 +204,7 @@ interface UiState {
   resetColumns: () => void;
   openTab: (filePath: string, fileName: string, sourceContext?: TabSourceContext | null, fileKind?: TabFileKind) => void;
   closeTab: (index: number) => void;
+  clearTabs: () => void;
   switchTab: (index: number) => void;
   saveTabScrollState: (index: number, scrollPosition: number, selectedLineId: number | null) => void;
   setCollectionProgress: (progress: CollectionProgressState | null) => void;
@@ -555,6 +556,11 @@ export const useUiStore = create<UiState>()(
           return;
         }
         set({ activeTabIndex: index });
+      },
+
+      clearTabs: () => {
+        clearAllTabSnapshots();
+        set({ openTabs: [], activeTabIndex: -1 });
       },
 
       saveTabScrollState: (index, scrollPosition, selectedLineId) => {


### PR DESCRIPTION
## Summary
- Fix tail partial-record buffering so incomplete trailing records are not duplicated on the next read.
- Make frontend filter memoization source-aware so filters refresh across file/tab changes.
- Reset tab state before session restore to avoid mixing old and restored tabs.
- Validate and parse date/time filter values instead of silently matching all rows.
- Reset folder parse progress counters at the start of each new load.

## Follow-up review fixes
- `parse_filter_timestamp_millis` now also accepts whole-second datetimes (`2026-04-01 12:30:00`, `2026-04-01T12:30:00`, `04/01/2026 12:30:00`); chrono's `%.f` requires the leading dot, so the original list silently rejected these (Copilot review comment).
- Naive datetime filter inputs are interpreted as **local time** (`chrono::Local::from_local_datetime`) instead of UTC, matching the frontend's local-time display.
- `apply_filter` compiles clauses once before the per-entry loop (pre-parses timestamp targets and lower-cases string needles), avoiding O(entries) repeat work on large logs.
- `match_timestamp` is a single exhaustive match — the previously-dead `Contains | NotContains` arm after the early return is gone; each comparison op parses lazily.
- `useParseProgressListener` subscribes to a derived `isFolderLoading` boolean instead of the raw `folderLoadProgress` number, eliminating per-progress-tick re-renders during folder parses.
- New `useUiStore.clearTabs()` action replaces a raw `setState` shallow-merge in `restoreSession`, also clears active log + filter state to mirror `closeTab`'s last-tab path, and the per-file restore now falls back to the aggregate loader only when every individual file failed.
- `restoreSession` resolves `activeTabIndex` and per-tab scroll restoration against the live `useUiStore.openTabs` list, so partial load failures don't misalign the index.
- Extracted `lib/tab-snapshot-cache.ts` (`TabEntrySnapshot`, `SourceOpenMode`, `get/set/clear/clearAll` helpers); `ui-store` imports directly from there instead of going through `log-store`, breaking that piece of the store-to-store cycle.

## Marker-key fix (out-of-scope but caught during review)
- Marker context-menu had been writing under `entry.filePath` since #126, but `LogListView` still keyed reads off a tab-level `activeFilePath`. In aggregate-folder mode markers were saved correctly but never displayed for rows whose source file wasn't `entries[0].filePath`, so "Mark as Bug" / "Mark as Confirmed" appeared to do nothing.
- LogRow callbacks now take `(filePath, lineId)`; LogListView resolves markers per row via `markersByFile.get(entry.filePath)?.get(entry.id)`, loads markers for every unique `filePath` in `displayEntries`, and tracks a per-file dirty set for the debounced save.

## Column auto-fit (out-of-scope but caught during review)
- The `message` column was excluded from auto-fit entirely, so on logs where Log Text is the dominant column (macOS install.log, generic timestamped logs) the Fit-All button and the divider double-click appeared to be no-ops. Message now uses the same max-content-width logic as every other column, capped at the existing `MAX_AUTOFIT_WIDTH` (1200px).
- Double-click now fits the column when fired anywhere on the header, not only the 10px resize handle on the right edge — the affordance was undiscoverable. Verified end-to-end against real `CcmExec.log` data via Playwright (1200px cap reached on long messages).

## Verification
- npx tsc --noEmit
- npm test (104 tests pass)
- cargo check
- cargo test (incl. new `timestamp_filter_accepts_whole_second_datetimes`, `timestamp_filter_naive_input_is_local_time`, `compile_clauses_*`)
- cargo clippy -- -D warnings

Notes: no ESLint config was present in the repository.