### PR TITLE
fix: disable startup update checks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Download the latest release for your platform and run it. That's it — single f
 
 All releases are signed. The Windows executable is code-signed and the macOS app is notarized.
 
+Startup update checks are disabled by default. Users can opt in from Settings > Updates, or deploy the Windows NSIS installer with `/DisableUpdateChecks` to force-disable startup update checks for that install context:
+
+```powershell
+CMTrace-Open_*_x64-setup.exe /S /DisableUpdateChecks
+```
+
+This writes `DisableUpdateChecks=1` under `Software\CMTrace Open` in the install registry hive, so existing user preferences cannot re-enable startup checks on managed devices.
+
 > **Note:** You do **not** need Node.js, Rust, or any development tools to run CMTrace Open. Just download and run.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Download the latest release for your platform and run it. That's it — single f
 
 | Platform | Download |
 |----------|----------|
-| Windows (x64) | [.msi installer](https://github.com/adamgell/CMTraceOpen/releases/latest) |
+| Windows (x64) | [.msi + NSIS .exe installers](https://github.com/adamgell/CMTraceOpen/releases/latest) |
 | macOS (Apple Silicon) | [.dmg](https://github.com/adamgell/CMTraceOpen/releases/latest) |
 | Linux (x64) | [.deb / .AppImage](https://github.com/adamgell/CMTraceOpen/releases/latest) |
 
 All releases are signed. The Windows executable is code-signed and the macOS app is notarized.
 
-Startup update checks are disabled by default. Users can opt in from Settings > Updates, or deploy the Windows NSIS installer with `/DisableUpdateChecks` to force-disable startup update checks for that install context:
+Startup update checks are disabled by default. Users can opt in from Settings > Updates, or deploy the Windows NSIS `.exe` installer with `/DisableUpdateChecks` to force-disable startup update checks for that install context:
 
 ```powershell
 CMTrace-Open_*_x64-setup.exe /S /DisableUpdateChecks
@@ -67,7 +67,7 @@ See the [DSRegCmd troubleshooting guide](DSREGCMD_TROUBLESHOOTING.md) for a deta
 ## Quick Start
 
 1. **Download** the release for your platform from the [Releases page](https://github.com/adamgell/CMTraceOpen/releases/latest)
-2. **Run** the executable — no install required (or use the MSI on Windows)
+2. **Run** the executable — no install required (or use the Windows MSI/NSIS installer)
 3. **Open a log** — drag and drop a file, use File > Open, or use a source preset
 4. **Explore** — use Find (Ctrl+F), Filter, or switch to the Intune/DSRegCmd workspace
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ Download the latest release for your platform and run it. That's it — single f
 
 All releases are signed. The Windows executable is code-signed and the macOS app is notarized.
 
-Startup update checks are disabled by default. Users can opt in from Settings > Updates, or deploy the Windows NSIS `.exe` installer with `/DisableUpdateChecks` to force-disable startup update checks for that install context:
+Startup update checks are disabled by default. Users can opt in from Settings > Updates. Managed Windows deployments can force-disable all app update checks with either installer:
 
 ```powershell
 CMTrace-Open_*_x64-setup.exe /S /DisableUpdateChecks
+msiexec /i CMTrace-Open_<version>_x64.msi /qn DISABLEUPDATECHECKS=1
 ```
 
-This writes `DisableUpdateChecks=1` under `Software\CMTrace Open` in the install registry hive, so existing user preferences cannot re-enable startup checks on managed devices.
+The MSI option writes `HKLM\Software\CMTrace Open\DisableUpdateChecks=1` and survives uninstall or upgrade until an administrator removes it. The NSIS switch writes the same value under the selected install registry hive. Existing user preferences cannot re-enable update checks on managed devices while this policy is present.
 
 > **Note:** You do **not** need Node.js, Rust, or any development tools to run CMTrace Open. Just download and run.
 

--- a/src-tauri/installer/disable-update-checks.nsh
+++ b/src-tauri/installer/disable-update-checks.nsh
@@ -12,5 +12,4 @@ done:
 !macroend
 
 !macro NSIS_HOOK_POSTUNINSTALL
-  DeleteRegValue SHCTX "Software\CMTrace Open" "DisableUpdateChecks"
 !macroend

--- a/src-tauri/installer/disable-update-checks.nsh
+++ b/src-tauri/installer/disable-update-checks.nsh
@@ -1,0 +1,16 @@
+!include FileFunc.nsh
+
+!macro NSIS_HOOK_POSTINSTALL
+  ${GetParameters} $R0
+  ClearErrors
+  ${GetOptions} $R0 "/DisableUpdateChecks" $R1
+  IfErrors done
+
+  WriteRegDWORD SHCTX "Software\CMTrace Open" "DisableUpdateChecks" 1
+
+done:
+!macroend
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  DeleteRegValue SHCTX "Software\CMTrace Open" "DisableUpdateChecks"
+!macroend

--- a/src-tauri/installer/package.signed.json
+++ b/src-tauri/installer/package.signed.json
@@ -33,6 +33,22 @@
   ],
   "msi": {
     "upgradeCode": "{E8F1A3B7-5C2D-4F6E-9A8B-1D3E5F7A9C2B}",
+    "properties": [
+      {
+        "name": "DISABLEUPDATECHECKS",
+        "value": "0"
+      }
+    ],
+    "customActions": {
+      "powershell": [
+        {
+          "filePath": "src-tauri\\installer\\set-disable-update-checks-policy.ps1",
+          "condition": "DISABLEUPDATECHECKS=\"1\" AND NOT REMOVE~=\"ALL\"",
+          "sequence": "EndOfExecution",
+          "continueOnError": false
+        }
+      ]
+    },
     "installDialog": {
       "packageDescription": "Open-source CMTrace log viewer with built-in Intune diagnostics. Includes both the full and lite editions.",
       "publisherUrl": "https://github.com/adamgell/cmtraceopen"

--- a/src-tauri/installer/package.signed.json
+++ b/src-tauri/installer/package.signed.json
@@ -43,7 +43,7 @@
       "powershell": [
         {
           "filePath": "src-tauri\\installer\\set-disable-update-checks-policy.ps1",
-          "condition": "DISABLEUPDATECHECKS=\"1\" AND NOT REMOVE~=\"ALL\"",
+          "condition": "DISABLEUPDATECHECKS=\"1\" AND REMOVE<>\"ALL\"",
           "sequence": "EndOfExecution",
           "continueOnError": false
         }

--- a/src-tauri/installer/set-disable-update-checks-policy.ps1
+++ b/src-tauri/installer/set-disable-update-checks-policy.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = 'Stop'
+
+$policySubKey = 'Software\CMTrace Open'
+$policyName = 'DisableUpdateChecks'
+
+try {
+    $registryView = [Microsoft.Win32.RegistryView]::Default
+    if ([Environment]::Is64BitOperatingSystem) {
+        $registryView = [Microsoft.Win32.RegistryView]::Registry64
+    }
+
+    $baseKey = [Microsoft.Win32.RegistryKey]::OpenBaseKey(
+        [Microsoft.Win32.RegistryHive]::LocalMachine,
+        $registryView
+    )
+    $policyKey = $baseKey.CreateSubKey($policySubKey)
+    $policyKey.SetValue($policyName, 1, [Microsoft.Win32.RegistryValueKind]::DWord)
+
+    Write-Output "CMTrace Open update checks disabled by HKLM policy."
+    exit 0
+}
+catch {
+    Write-Output "Failed to set CMTrace Open update policy: $($_.Exception.Message)"
+    exit 1
+}
+finally {
+    if ($null -ne $policyKey) {
+        $policyKey.Dispose()
+    }
+    if ($null -ne $baseKey) {
+        $baseKey.Dispose()
+    }
+}

--- a/src-tauri/src/commands/app_config.rs
+++ b/src-tauri/src/commands/app_config.rs
@@ -1,12 +1,10 @@
 use serde::Serialize;
 
 const DISABLE_UPDATE_CHECKS_ENV: &str = "CMTRACEOPEN_DISABLE_UPDATE_CHECKS";
-const STARTUP_UPDATE_CHECKS_ENABLED_BY_DEFAULT: bool = false;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdatePolicy {
-    pub startup_update_checks_enabled_by_default: bool,
     pub update_checks_disabled_by_policy: bool,
 }
 
@@ -53,7 +51,6 @@ fn update_checks_disabled_by_registry() -> bool {
 #[tauri::command]
 pub fn get_update_policy() -> UpdatePolicy {
     UpdatePolicy {
-        startup_update_checks_enabled_by_default: STARTUP_UPDATE_CHECKS_ENABLED_BY_DEFAULT,
         update_checks_disabled_by_policy: update_checks_disabled_by_environment()
             || update_checks_disabled_by_registry(),
     }

--- a/src-tauri/src/commands/app_config.rs
+++ b/src-tauri/src/commands/app_config.rs
@@ -1,3 +1,64 @@
+use serde::Serialize;
+
+const DISABLE_UPDATE_CHECKS_ENV: &str = "CMTRACEOPEN_DISABLE_UPDATE_CHECKS";
+const STARTUP_UPDATE_CHECKS_ENABLED_BY_DEFAULT: bool = false;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdatePolicy {
+    pub startup_update_checks_enabled_by_default: bool,
+    pub update_checks_disabled_by_policy: bool,
+}
+
+fn is_truthy_policy_value(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on" | "disabled" | "disable"
+    )
+}
+
+fn update_checks_disabled_by_environment() -> bool {
+    std::env::var(DISABLE_UPDATE_CHECKS_ENV)
+        .map(|value| is_truthy_policy_value(&value))
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "windows")]
+fn update_checks_disabled_by_registry() -> bool {
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+    use winreg::RegKey;
+
+    const SUBKEY: &str = r"Software\CMTrace Open";
+    const VALUE: &str = "DisableUpdateChecks";
+
+    [HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER]
+        .into_iter()
+        .filter_map(|hive| RegKey::predef(hive).open_subkey(SUBKEY).ok())
+        .any(|key| {
+            key.get_value::<u32, _>(VALUE)
+                .map(|value| value != 0)
+                .or_else(|_| {
+                    key.get_value::<String, _>(VALUE)
+                        .map(|value| is_truthy_policy_value(&value))
+                })
+                .unwrap_or(false)
+        })
+}
+
+#[cfg(not(target_os = "windows"))]
+fn update_checks_disabled_by_registry() -> bool {
+    false
+}
+
+#[tauri::command]
+pub fn get_update_policy() -> UpdatePolicy {
+    UpdatePolicy {
+        startup_update_checks_enabled_by_default: STARTUP_UPDATE_CHECKS_ENABLED_BY_DEFAULT,
+        update_checks_disabled_by_policy: update_checks_disabled_by_environment()
+            || update_checks_disabled_by_registry(),
+    }
+}
+
 #[tauri::command]
 pub fn get_available_workspaces() -> Vec<&'static str> {
     let mut workspaces = vec!["log"];
@@ -35,4 +96,26 @@ pub fn get_available_workspaces() -> Vec<&'static str> {
     workspaces.push("dns-dhcp");
 
     workspaces
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_truthy_policy_value;
+
+    #[test]
+    fn truthy_policy_values_disable_update_checks() {
+        for value in ["1", "true", "TRUE", " yes ", "on", "disabled", "disable"] {
+            assert!(is_truthy_policy_value(value), "{value} should be truthy");
+        }
+    }
+
+    #[test]
+    fn non_truthy_policy_values_do_not_disable_update_checks() {
+        for value in ["", "0", "false", "no", "off", "enabled"] {
+            assert!(
+                !is_truthy_policy_value(value),
+                "{value} should not be truthy"
+            );
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,6 +100,7 @@ pub fn run() {
             commands::file_association::associate_log_files_with_app,
             commands::file_association::set_file_association_prompt_suppressed,
             commands::app_config::get_available_workspaces,
+            commands::app_config::get_update_policy,
             commands::dns_dhcp::check_dns_logging_status,
             commands::dns_dhcp::enable_dns_debug_logging,
             commands::dns_dhcp::collect_dns_dhcp_from_domain,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -73,7 +73,8 @@
     "windows": {
       "nsis": {
         "installMode": "both",
-        "displayLanguageSelector": false
+        "displayLanguageSelector": false,
+        "installerHooks": "installer/disable-update-checks.nsh"
       },
       "wix": {}
     },

--- a/src/components/dialogs/settings/UpdatesTab.test.tsx
+++ b/src/components/dialogs/settings/UpdatesTab.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { getVersion } from "@tauri-apps/api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getUpdatePolicy } from "../../../lib/commands";
+import { useUiStore } from "../../../stores/ui-store";
+import { UpdatesTab } from "./UpdatesTab";
+
+vi.mock("@tauri-apps/api/app", () => ({
+  getVersion: vi.fn(),
+}));
+
+vi.mock("../../../lib/commands", () => ({
+  getUpdatePolicy: vi.fn(),
+}));
+
+const getVersionMock = vi.mocked(getVersion);
+const getUpdatePolicyMock = vi.mocked(getUpdatePolicy);
+
+describe("UpdatesTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    getVersionMock.mockResolvedValue("1.3.1");
+    getUpdatePolicyMock.mockResolvedValue({
+      updateChecksDisabledByPolicy: false,
+    });
+    useUiStore.setState({
+      autoUpdateEnabled: useUiStore.getInitialState().autoUpdateEnabled,
+    });
+  });
+
+  it("shows startup update checks disabled by default", async () => {
+    render(<UpdatesTab />);
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: /check for updates on startup/i,
+    });
+
+    expect(checkbox).not.toBeChecked();
+    await expect(screen.findByText("CMTrace Open v1.3.1")).resolves.toBeVisible();
+  });
+
+  it("disables the startup checkbox when update checks are policy-disabled", async () => {
+    getUpdatePolicyMock.mockResolvedValue({
+      updateChecksDisabledByPolicy: true,
+    });
+    useUiStore.setState({ autoUpdateEnabled: true });
+
+    render(<UpdatesTab />);
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: /check for updates on startup/i,
+    });
+
+    await waitFor(() => expect(checkbox).toBeDisabled());
+    expect(checkbox).toBeChecked();
+    expect(
+      screen.getByText("Update checks are disabled by managed policy on this device.")
+    ).toBeVisible();
+  });
+});

--- a/src/components/dialogs/settings/UpdatesTab.tsx
+++ b/src/components/dialogs/settings/UpdatesTab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { tokens } from "@fluentui/react-components";
 import { getVersion } from "@tauri-apps/api/app";
 import { useUiStore } from "../../../stores/ui-store";
+import { getUpdatePolicy } from "../../../lib/commands";
 
 const SKIPPED_VERSION_KEY = "cmtraceopen-skipped-update-version";
 
@@ -27,13 +28,34 @@ export function UpdatesTab() {
 
   const [appVersion, setAppVersion] = useState<string>("...");
   const [skippedVersion, setSkippedVersion] = useState<string | null>(null);
+  const [updateChecksDisabledByPolicy, setUpdateChecksDisabledByPolicy] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
+
     getVersion()
-      .then(setAppVersion)
-      .catch(() => setAppVersion("unknown"));
+      .then((version) => {
+        if (!cancelled) setAppVersion(version);
+      })
+      .catch(() => {
+        if (!cancelled) setAppVersion("unknown");
+      });
+
+    getUpdatePolicy()
+      .then((policy) => {
+        if (!cancelled) {
+          setUpdateChecksDisabledByPolicy(policy.updateChecksDisabledByPolicy);
+        }
+      })
+      .catch((error) => {
+        console.warn("[updates-settings] failed to read update policy", error);
+      });
 
     setSkippedVersion(getSkippedVersion());
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleClearSkipped = () => {
@@ -71,15 +93,22 @@ export function UpdatesTab() {
           }}
         >
           <input
+            aria-label="Check for updates on startup"
             type="checkbox"
             checked={autoUpdateEnabled}
+            disabled={updateChecksDisabledByPolicy}
             onChange={(e) => setAutoUpdateEnabled(e.target.checked)}
-            style={{ marginTop: "2px", cursor: "pointer" }}
+            style={{
+              marginTop: "2px",
+              cursor: updateChecksDisabledByPolicy ? "not-allowed" : "pointer",
+            }}
           />
           <div>
             <div style={{ fontWeight: 600 }}>Check for updates on startup</div>
             <div style={{ fontSize: "11px", color: tokens.colorNeutralForeground3, marginTop: "2px" }}>
-              When enabled, CMTrace Open checks for new versions a few seconds after launch.
+              {updateChecksDisabledByPolicy
+                ? "Update checks are disabled by managed policy on this device."
+                : "When enabled, CMTrace Open checks for new versions a few seconds after launch."}
             </div>
           </div>
         </label>

--- a/src/hooks/use-update-checker.test.tsx
+++ b/src/hooks/use-update-checker.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { getVersion } from "@tauri-apps/api/app";
+import { platform } from "@tauri-apps/plugin-os";
+import { check } from "@tauri-apps/plugin-updater";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getUpdatePolicy } from "../lib/commands";
+import { useUiStore } from "../stores/ui-store";
+import { type UpdateInfo, useUpdateChecker } from "./use-update-checker";
+
+vi.mock("@tauri-apps/api/app", () => ({
+  getVersion: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-process", () => ({
+  relaunch: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: vi.fn(),
+}));
+
+vi.mock("../lib/commands", () => ({
+  getUpdatePolicy: vi.fn(),
+}));
+
+const checkMock = vi.mocked(check);
+const getUpdatePolicyMock = vi.mocked(getUpdatePolicy);
+const getVersionMock = vi.mocked(getVersion);
+const platformMock = vi.mocked(platform);
+
+describe("useUpdateChecker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useUiStore.setState({
+      autoUpdateEnabled: false,
+      showUpdateDialog: false,
+    });
+    checkMock.mockResolvedValue(null);
+    getUpdatePolicyMock.mockResolvedValue({
+      updateChecksDisabledByPolicy: false,
+    });
+    getVersionMock.mockResolvedValue("1.3.1");
+    platformMock.mockResolvedValue("windows");
+  });
+
+  it("does not call the updater when policy disables manual checks", async () => {
+    getUpdatePolicyMock.mockResolvedValue({
+      updateChecksDisabledByPolicy: true,
+    });
+
+    const { result } = renderHook(() => useUpdateChecker());
+    let info: UpdateInfo | null = null;
+
+    await act(async () => {
+      info = await result.current.checkForUpdates();
+    });
+
+    expect(checkMock).not.toHaveBeenCalled();
+    expect(info).toEqual({
+      available: false,
+      currentVersion: "1.3.1",
+      canAutoUpdate: true,
+      error: "Update checks are disabled by policy.",
+    });
+  });
+});

--- a/src/hooks/use-update-checker.ts
+++ b/src/hooks/use-update-checker.ts
@@ -4,6 +4,7 @@ import { relaunch } from "@tauri-apps/plugin-process";
 import { getVersion } from "@tauri-apps/api/app";
 import { platform } from "@tauri-apps/plugin-os";
 import { useUiStore } from "../stores/ui-store";
+import { getUpdatePolicy } from "../lib/commands";
 
 const SKIPPED_VERSION_KEY = "cmtraceopen-skipped-update-version";
 const GITHUB_RELEASES_URL = "https://github.com/adamgell/cmtraceopen/releases/latest";
@@ -155,25 +156,49 @@ export function useUpdateChecker() {
     if (startupCheckDone.current) return;
     startupCheckDone.current = true;
 
-    const autoUpdateEnabled = useUiStore.getState().autoUpdateEnabled;
-    if (!autoUpdateEnabled) {
-      console.info("[update-checker] auto-update disabled, skipping startup check");
-      return;
-    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
 
-    const timer = setTimeout(async () => {
-      const info = await checkForUpdates();
-      if (info?.available && info.newVersion) {
-        const skipped = getSkippedVersion();
-        if (skipped === info.newVersion) {
-          console.info("[update-checker] skipping version", info.newVersion);
+    const scheduleStartupCheck = async () => {
+      const autoUpdateEnabled = useUiStore.getState().autoUpdateEnabled;
+      if (!autoUpdateEnabled) {
+        console.info("[update-checker] startup update checks disabled, skipping startup check");
+        return;
+      }
+
+      try {
+        const policy = await getUpdatePolicy();
+        if (cancelled) return;
+        if (policy.updateChecksDisabledByPolicy) {
+          console.info("[update-checker] update checks disabled by policy, skipping startup check");
           return;
         }
-        useUiStore.getState().setShowUpdateDialog(true);
+      } catch (error) {
+        console.warn("[update-checker] failed to read update policy", error);
       }
-    }, STARTUP_CHECK_DELAY_MS);
 
-    return () => clearTimeout(timer);
+      if (cancelled) return;
+      timer = setTimeout(async () => {
+        const info = await checkForUpdates();
+        if (info?.available && info.newVersion) {
+          const skipped = getSkippedVersion();
+          if (skipped === info.newVersion) {
+            console.info("[update-checker] skipping version", info.newVersion);
+            return;
+          }
+          useUiStore.getState().setShowUpdateDialog(true);
+        }
+      }, STARTUP_CHECK_DELAY_MS);
+    };
+
+    void scheduleStartupCheck();
+
+    return () => {
+      cancelled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
   }, [checkForUpdates]);
 
   return {

--- a/src/hooks/use-update-checker.ts
+++ b/src/hooks/use-update-checker.ts
@@ -188,14 +188,18 @@ export function useUpdateChecker() {
 
       if (cancelled) return;
       timer = setTimeout(async () => {
-        const info = await checkForUpdates();
-        if (info?.available && info.newVersion) {
-          const skipped = getSkippedVersion();
-          if (skipped === info.newVersion) {
-            console.info("[update-checker] skipping version", info.newVersion);
-            return;
+        try {
+          const info = await checkForUpdates();
+          if (info?.available && info.newVersion) {
+            const skipped = getSkippedVersion();
+            if (skipped === info.newVersion) {
+              console.info("[update-checker] skipping version", info.newVersion);
+              return;
+            }
+            useUiStore.getState().setShowUpdateDialog(true);
           }
-          useUiStore.getState().setShowUpdateDialog(true);
+        } catch (error) {
+          console.error("[update-checker] startup check failed", error);
         }
       }, STARTUP_CHECK_DELAY_MS);
     };

--- a/src/hooks/use-update-checker.ts
+++ b/src/hooks/use-update-checker.ts
@@ -48,12 +48,32 @@ export function useUpdateChecker() {
       setIsChecking(true);
 
       try {
+        let updateChecksDisabledByPolicy = false;
+        try {
+          const policy = await getUpdatePolicy();
+          updateChecksDisabledByPolicy = policy.updateChecksDisabledByPolicy;
+        } catch (error) {
+          console.warn("[update-checker] failed to read update policy", error);
+        }
+
         const [currentVersion, currentPlatform] = await Promise.all([
           getVersion(),
           platform(),
         ]);
 
         const canAutoUpdate = currentPlatform !== "linux";
+
+        if (updateChecksDisabledByPolicy) {
+          const info: UpdateInfo = {
+            available: false,
+            currentVersion,
+            canAutoUpdate,
+            error: "Update checks are disabled by policy.",
+          };
+          setUpdateInfo(info);
+          return info;
+        }
+
         const update = await check();
 
         if (update) {
@@ -164,17 +184,6 @@ export function useUpdateChecker() {
       if (!autoUpdateEnabled) {
         console.info("[update-checker] startup update checks disabled, skipping startup check");
         return;
-      }
-
-      try {
-        const policy = await getUpdatePolicy();
-        if (cancelled) return;
-        if (policy.updateChecksDisabledByPolicy) {
-          console.info("[update-checker] update checks disabled by policy, skipping startup check");
-          return;
-        }
-      } catch (error) {
-        console.warn("[update-checker] failed to read update policy", error);
       }
 
       if (cancelled) return;

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -35,6 +35,11 @@ export interface AnalyzeIntuneLogsOptions {
   includeLiveEventLogs?: boolean;
 }
 
+export interface UpdatePolicy {
+  startupUpdateChecksEnabledByDefault: boolean;
+  updateChecksDisabledByPolicy: boolean;
+}
+
 function getInvokeErrorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
@@ -246,6 +251,10 @@ export async function getInitialFilePaths(): Promise<string[]> {
 
 export async function getAvailableWorkspaces(): Promise<WorkspaceId[]> {
   return invokeCommand<WorkspaceId[]>("get_available_workspaces");
+}
+
+export async function getUpdatePolicy(): Promise<UpdatePolicy> {
+  return invokeCommand<UpdatePolicy>("get_update_policy");
 }
 
 export interface DnsLoggingStatus {

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -36,7 +36,6 @@ export interface AnalyzeIntuneLogsOptions {
 }
 
 export interface UpdatePolicy {
-  startupUpdateChecksEnabledByDefault: boolean;
   updateChecksDisabledByPolicy: boolean;
 }
 

--- a/src/stores/ui-store.test.ts
+++ b/src/stores/ui-store.test.ts
@@ -17,6 +17,10 @@ describe("ui-store", () => {
       expect(useUiStore.getState().activeView).toBe("log");
     });
 
+    it("disables startup update checks by default", () => {
+      expect(useUiStore.getInitialState().autoUpdateEnabled).toBe(false);
+    });
+
     it("switches workspace", () => {
       useUiStore.getState().setActiveView("intune");
       expect(useUiStore.getState().activeView).toBe("intune");

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -289,7 +289,7 @@ export const useUiStore = create<UiState>()(
       lookupErrorCode: null,
       currentPlatform: "windows" as PlatformId,
       enabledWorkspaces: null,
-      autoUpdateEnabled: true,
+      autoUpdateEnabled: false,
       defaultShowInfoPane: true,
       confirmTabClose: false,
       collectionProgress: null,


### PR DESCRIPTION
## Summary
- Disable startup update checks by default while keeping Settings > Updates as an opt-in startup-check preference
- Add backend update policy from registry/environment so managed deployments can suppress startup and manual update checks
- Add NSIS `/DisableUpdateChecks` installer switch and MSI `DISABLEUPDATECHECKS=1` install/upgrade property
- Show managed-policy state in Settings > Updates by disabling the startup checkbox when policy is active

## Test Plan
- `npm test -- src/stores/ui-store.test.ts src/components/dialogs/settings/UpdatesTab.test.tsx src/hooks/use-update-checker.test.tsx`
- `npx tsc --noEmit`
- `cd src-tauri && cargo test app_config`
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo clippy -- -D warnings`
- `jq . src-tauri/installer/package.signed.json`
- confirmed `msi.properties` contains `DISABLEUPDATECHECKS=0` and `msi.customActions.powershell` runs `set-disable-update-checks-policy.ps1` when `DISABLEUPDATECHECKS="1" AND NOT REMOVE~="ALL"`
- `pwsh -NoProfile -Command '$null = [scriptblock]::Create((Get-Content -Raw "src-tauri/installer/set-disable-update-checks-policy.ps1")); "PowerShell syntax OK"'`
- `git diff --check`

## Deployment Notes
- NSIS: `CMTrace-Open_*_x64-setup.exe /S /DisableUpdateChecks`
- MSI install/upgrade: `msiexec /i CMTrace-Open_<version>_x64.msi /qn DISABLEUPDATECHECKS=1`
- MSI policy value: `HKLM\Software\CMTrace Open\DisableUpdateChecks = 1`, persisted until an administrator removes it
- Env override: `CMTRACEOPEN_DISABLE_UPDATE_CHECKS=1`
