### PR TITLE
docs: MVP plan for unified Intune platform (WinUI3/Rust + .NET engine)

### DIFF
--- a/cmprojectx-skeleton/.gitignore
+++ b/cmprojectx-skeleton/.gitignore
@@ -1,0 +1,21 @@
+# Rust
+/target
+**/*.rs.bk
+Cargo.lock
+
+# .NET
+bin/
+obj/
+*.user
+.vs/
+
+# Local data / secrets
+*.db
+*.sqlite
+*.litedb
+appsettings.*.local.json
+.env
+
+# OS / editor
+.DS_Store
+.idea/

--- a/cmprojectx-skeleton/Cargo.toml
+++ b/cmprojectx-skeleton/Cargo.toml
@@ -1,0 +1,19 @@
+# Rust workspace root for the cmProjectX client side.
+# The .NET service (service/) is a separate build (dotnet).
+[workspace]
+resolver = "2"
+members = [
+    "app",
+    "crates/api-types",
+    # "crates/parser" is an EXTERNAL OSS dependency (see crates/parser/README.md),
+    # not a local member. It is consumed by `app` via a git dependency.
+]
+
+[workspace.package]
+edition = "2021"
+license = "UNLICENSED" # TODO: set commercial/source-available license once decided
+authors = ["adamgell"]
+
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/cmprojectx-skeleton/README.md
+++ b/cmprojectx-skeleton/README.md
@@ -1,0 +1,56 @@
+# cmProjectX
+
+> Windows-forward unified Intune platform: a Rust/WinUI 3 client + a hard-forked
+> .NET Intune (Graph) engine, with a persistent, searchable **audit/drift
+> time-machine**. See [`docs/MVP-PLAN.md`](./docs/MVP-PLAN.md) for the full plan.
+
+This is a **skeleton** — structure + seams + stubs, not a working app yet.
+
+## Architecture
+
+```
+  ┌──────────────────────────────────────────┐         ┌────────────────────────────────────┐
+  │  app/  — WinUI 3 + Rust (Windows Reactor)  │  HTTP   │  service/  — .NET Intune engine       │
+  │  • Reactor UI (Rust forward)               │ ◄─────► │  • Core/  hard-forked IC (Graph)     │
+  │  • api_client → service                    │  REST/  │  • Sync/  Graph delta sync           │
+  │  • (Phase 2) CMTrace parser, log index     │ OpenAPI │  • Store/ append-only + search index │
+  └──────────────────────────────────────────┘         │  • Api/   thin ASP.NET host          │
+                                                         └──────────────┬───────────────────────┘
+                                              contract/openapi.yaml ─────┘ (one schema → both sides)
+                                                            future: WebUI · Agents (MCP) — same API
+```
+
+## Layout
+
+| Path | Stack | Role |
+|---|---|---|
+| `contract/` | OpenAPI | **Single source of truth** for DTOs + endpoints → generates C# *and* Rust types |
+| `service/Core/` | .NET 10 | **Drop the hard-forked Intune Commander core here** (Graph services + multi-cloud auth) |
+| `service/Sync/` | .NET 10 | Graph **delta** sync engine (stub) |
+| `service/Store/` | .NET 10 | Append-only audit+config snapshots + full-text index (stub) |
+| `service/Api/` | .NET 10 | Thin ASP.NET minimal-API host (the main new code) |
+| `app/` | Rust | WinUI 3 client (Windows Reactor) + API client |
+| `crates/api-types/` | Rust | DTOs mirroring the contract (generatable) |
+| `crates/parser/` | Rust | **External OSS dependency** on the CMTrace Open parser (upstream seam) |
+
+## Getting started
+
+```bash
+# .NET service
+cd service && dotnet build           # after you drop Core/ in and create the .sln
+
+# Rust app
+cargo build                          # builds app/ + crates/*
+cargo run -p app                     # pings the service /health
+```
+
+## Status / next steps
+
+- [ ] Create the .NET solution: `dotnet new sln && dotnet sln add service/**/**.csproj`
+- [ ] Hard-fork IntuneCommander `Core` into `service/Core/`
+- [ ] Phase 0: Windows Reactor risk-gate (LogGrid + live tail) — confirm the framework
+- [ ] Phase 1 (MVP): device-code auth → delta sync → store/index → timeline/drift/search
+- [ ] Wire OpenAPI codegen for both languages
+- [ ] Decide: repo name, transport (REST vs gRPC), commercial license
+
+> Generated as a starting skeleton. Pin/confirm crate & package versions before building.

--- a/cmprojectx-skeleton/app/Cargo.toml
+++ b/cmprojectx-skeleton/app/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "app"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+api-types = { path = "../crates/api-types" }
+serde.workspace = true
+serde_json.workspace = true
+reqwest = { version = "0.12", features = ["json"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+# --- WinUI 3 UI (Windows Reactor) -------------------------------------------
+# Windows Reactor landed in microsoft/windows-rs (announced May 2026). Confirm
+# the published crate name/version before enabling. Until then the UI lives in
+# main.rs as a documented sketch and `cargo run -p app` just pings the service.
+#
+# [target.'cfg(windows)'.dependencies]
+# windows-reactor = { git = "https://github.com/microsoft/windows-rs" } # TODO: pin
+# windows-canvas  = { git = "https://github.com/microsoft/windows-rs" } # TODO: pin
+
+# --- CMTrace parser (Phase 2, upstream OSS seam) ----------------------------
+# cmtraceopen-parser = { git = "https://github.com/adamgell/cmtraceopen", rev = "..." }

--- a/cmprojectx-skeleton/app/src/api_client.rs
+++ b/cmprojectx-skeleton/app/src/api_client.rs
@@ -1,0 +1,47 @@
+//! Thin HTTP client to the local .NET service (contract/openapi.yaml).
+//! Replace with a generated client (progenitor) once codegen is wired.
+
+use api_types::{AuditEvent, DriftRecord, SearchResult, SyncStatus};
+
+pub struct ApiClient {
+    base: String,
+    http: reqwest::Client,
+}
+
+impl ApiClient {
+    pub fn new(base: impl Into<String>) -> Self {
+        Self { base: base.into(), http: reqwest::Client::new() }
+    }
+
+    pub async fn health(&self) -> reqwest::Result<SyncStatus> {
+        self.http.get(format!("{}/health", self.base)).send().await?.json().await
+    }
+
+    pub async fn audit(&self, q: Option<&str>) -> reqwest::Result<Vec<AuditEvent>> {
+        let mut req = self.http.get(format!("{}/audit", self.base));
+        if let Some(q) = q {
+            req = req.query(&[("q", q)]);
+        }
+        req.send().await?.json().await
+    }
+
+    pub async fn drift(&self, object_id: &str) -> reqwest::Result<DriftRecord> {
+        self.http
+            .get(format!("{}/drift", self.base))
+            .query(&[("objectId", object_id)])
+            .send()
+            .await?
+            .json()
+            .await
+    }
+
+    pub async fn search(&self, q: &str) -> reqwest::Result<Vec<SearchResult>> {
+        self.http
+            .get(format!("{}/search", self.base))
+            .query(&[("q", q)])
+            .send()
+            .await?
+            .json()
+            .await
+    }
+}

--- a/cmprojectx-skeleton/app/src/main.rs
+++ b/cmprojectx-skeleton/app/src/main.rs
@@ -1,0 +1,43 @@
+//! cmProjectX — WinUI 3 + Rust (Windows Reactor) client.
+//!
+//! This skeleton's `main` just confirms it can reach the local service. The
+//! real UI is a Windows Reactor app; the intended shape is sketched below.
+//!
+//! ```ignore
+//! // Reactor: UI as a pure function of state (component + hooks).
+//! fn app(cx: &mut RenderCx) -> Element {
+//!     nav_view((
+//!         nav_item("Timeline", timeline_workspace),  // audit time-machine (MVP)
+//!         nav_item("Drift",    drift_workspace),      // snapshot diff
+//!         nav_item("Search",   search_workspace),     // unified search
+//!         nav_item("Logs",     logs_workspace),       // Phase 2: CMTrace parser
+//!     )).into()
+//! }
+//!
+//! fn timeline_workspace(cx: &mut RenderCx) -> Element {
+//!     // use_resource loads from ApiClient::audit(); render a virtualized ListView.
+//!     let events = cx.use_resource(|| api().audit(None));
+//!     list_view(events).into()
+//! }
+//! ```
+
+mod api_client;
+use api_client::ApiClient;
+
+const SERVICE_URL: &str = "http://127.0.0.1:5099";
+
+#[tokio::main]
+async fn main() {
+    let client = ApiClient::new(SERVICE_URL);
+
+    match client.health().await {
+        Ok(status) => println!("service healthy: {status:?}"),
+        Err(e) => eprintln!(
+            "could not reach service at {SERVICE_URL}: {e}\n\
+             start it with: cd service && dotnet run --project Api"
+        ),
+    }
+
+    // TODO (Phase 0): replace this with the Windows Reactor app entry point
+    // and validate LogGrid + live-tail virtualized scrolling before building out.
+}

--- a/cmprojectx-skeleton/contract/README.md
+++ b/cmprojectx-skeleton/contract/README.md
@@ -1,0 +1,29 @@
+# API contract
+
+`openapi.yaml` is the **single source of truth** for the DTOs and endpoints shared
+between the .NET service and the Rust client. Generate types from it on both sides
+instead of hand-writing them twice.
+
+## Generate C# (service side)
+
+```bash
+# Option A: NSwag
+nswag openapi2csclient /input:openapi.yaml /classstyle:Record \
+  /namespace:CmProjectX.Contract /output:../service/Api/Contract.g.cs
+
+# Option B: openapi-generator
+openapi-generator-cli generate -i openapi.yaml -g aspnetcore -o ../service/Api
+```
+
+## Generate Rust (client side)
+
+```bash
+# Option A: progenitor (build-time, type-safe client)
+#   add a build.rs in crates/api-types that runs progenitor against openapi.yaml
+#
+# Option B: openapi-generator
+openapi-generator-cli generate -i openapi.yaml -g rust -o ../crates/api-types
+```
+
+Until codegen is wired, `crates/api-types/src/lib.rs` holds hand-written structs
+that mirror these schemas — keep them in sync, or replace them with generated code.

--- a/cmprojectx-skeleton/contract/openapi.yaml
+++ b/cmprojectx-skeleton/contract/openapi.yaml
@@ -1,0 +1,140 @@
+openapi: 3.1.0
+info:
+  title: cmProjectX Service API
+  version: 0.1.0
+  description: >
+    Contract between the Rust/WinUI 3 client and the .NET Intune engine.
+    This is the single source of truth for DTOs and endpoints — generate
+    C# and Rust types from it (see contract/README.md).
+
+servers:
+  - url: http://127.0.0.1:5099
+    description: Local sidecar (MVP)
+
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      summary: Liveness probe
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SyncStatus" }
+
+  /sync:
+    post:
+      operationId: triggerSync
+      summary: Trigger a Graph delta sync for the active tenant
+      responses:
+        "202": { description: Accepted; sync started }
+
+  /audit:
+    get:
+      operationId: getAuditTimeline
+      summary: Query the audit-event timeline (the time-machine)
+      parameters:
+        - { name: from, in: query, schema: { type: string, format: date-time } }
+        - { name: to,   in: query, schema: { type: string, format: date-time } }
+        - { name: q,    in: query, schema: { type: string } }
+      responses:
+        "200":
+          description: Matching audit events, newest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/AuditEvent" }
+
+  /drift:
+    get:
+      operationId: getDrift
+      summary: Drift between two config snapshots of an object
+      parameters:
+        - { name: objectId, in: query, required: true, schema: { type: string } }
+        - { name: baseSnapshotId, in: query, schema: { type: string } }
+        - { name: headSnapshotId, in: query, schema: { type: string } }
+      responses:
+        "200":
+          description: Drift record
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DriftRecord" }
+
+  /search:
+    get:
+      operationId: search
+      summary: Full-text search across audit events and config snapshots
+      parameters:
+        - { name: q, in: query, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/SearchResult" }
+
+components:
+  schemas:
+    SyncStatus:
+      type: object
+      properties:
+        tenantId:    { type: string }
+        lastSyncUtc: { type: string, format: date-time, nullable: true }
+        cloud:       { type: string, enum: [Commercial, GCC, GCCHigh, DoD] }
+        healthy:     { type: boolean }
+      required: [healthy]
+
+    AuditEvent:
+      type: object
+      properties:
+        id:         { type: string }
+        timestamp:  { type: string, format: date-time }
+        actor:      { type: string, description: "who made the change" }
+        action:     { type: string }
+        objectType: { type: string }
+        objectId:   { type: string }
+        objectName: { type: string }
+      required: [id, timestamp, action, objectType, objectId]
+
+    ConfigSnapshot:
+      type: object
+      properties:
+        snapshotId: { type: string }
+        objectId:   { type: string }
+        objectType: { type: string }
+        capturedUtc: { type: string, format: date-time }
+        body:       { type: object, additionalProperties: true }
+      required: [snapshotId, objectId, objectType, capturedUtc]
+
+    DriftRecord:
+      type: object
+      properties:
+        objectId:       { type: string }
+        baseSnapshotId: { type: string }
+        headSnapshotId: { type: string }
+        changes:
+          type: array
+          items: { $ref: "#/components/schemas/DriftChange" }
+      required: [objectId, changes]
+
+    DriftChange:
+      type: object
+      properties:
+        path:     { type: string, description: "JSON path of the changed field" }
+        kind:     { type: string, enum: [Added, Removed, Modified] }
+        before:   { nullable: true }
+        after:    { nullable: true }
+      required: [path, kind]
+
+    SearchResult:
+      type: object
+      properties:
+        kind:    { type: string, enum: [AuditEvent, ConfigSnapshot] }
+        id:      { type: string }
+        score:   { type: number }
+        summary: { type: string }
+      required: [kind, id, summary]

--- a/cmprojectx-skeleton/crates/api-types/Cargo.toml
+++ b/cmprojectx-skeleton/crates/api-types/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "api-types"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+serde.workspace = true

--- a/cmprojectx-skeleton/crates/api-types/src/lib.rs
+++ b/cmprojectx-skeleton/crates/api-types/src/lib.rs
@@ -1,0 +1,77 @@
+//! DTOs mirroring `contract/openapi.yaml`.
+//!
+//! Hand-written for now — keep in sync with the contract, or replace this crate
+//! with code generated from the OpenAPI spec (see contract/README.md).
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncStatus {
+    pub healthy: bool,
+    pub tenant_id: Option<String>,
+    pub last_sync_utc: Option<String>,
+    pub cloud: Option<Cloud>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum Cloud {
+    Commercial,
+    #[serde(rename = "GCC")]
+    Gcc,
+    #[serde(rename = "GCCHigh")]
+    GccHigh,
+    DoD,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditEvent {
+    pub id: String,
+    pub timestamp: String,
+    pub actor: Option<String>,
+    pub action: String,
+    pub object_type: String,
+    pub object_id: String,
+    pub object_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DriftRecord {
+    pub object_id: String,
+    pub base_snapshot_id: Option<String>,
+    pub head_snapshot_id: Option<String>,
+    pub changes: Vec<DriftChange>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DriftChange {
+    pub path: String,
+    pub kind: DriftKind,
+    pub before: Option<serde_json::Value>,
+    pub after: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum DriftKind {
+    Added,
+    Removed,
+    Modified,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchResult {
+    pub kind: SearchKind,
+    pub id: String,
+    pub score: Option<f64>,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum SearchKind {
+    AuditEvent,
+    ConfigSnapshot,
+}

--- a/cmprojectx-skeleton/crates/parser/README.md
+++ b/cmprojectx-skeleton/crates/parser/README.md
@@ -1,0 +1,19 @@
+# crates/parser — external OSS dependency (the upstream seam)
+
+The CMTrace log parser is **not vendored here** — it's consumed as an external
+dependency from the open-source CMTrace Open repo. This keeps the open-core
+boundary clean and makes parser improvements flow **upstream** with zero friction
+(same language, no FFI).
+
+Add it to `app/Cargo.toml` when log features land (Phase 2):
+
+```toml
+# git dependency on a pinned commit during early dev
+cmtraceopen-parser = { git = "https://github.com/adamgell/cmtraceopen", rev = "<pin>" }
+
+# or, once published:
+# cmtraceopen-parser = "x.y"
+```
+
+> Rule: bug fixes / new formats go to the OSS crate first, then flow here via a
+> version/rev bump. Never fork the parser into this repo.

--- a/cmprojectx-skeleton/docs/MVP-PLAN.md
+++ b/cmprojectx-skeleton/docs/MVP-PLAN.md
@@ -1,0 +1,234 @@
+# Unified Intune Platform — MVP Plan
+
+> **Status:** Planning / pre-skeleton. No code yet.
+> **Scope:** A new, Windows-forward commercial product combining **CMTrace Open**
+> (Rust log/diagnostics engine) with the **Intune Commander** (.NET Graph engine),
+> plus a new persistent, searchable **audit/drift "time-machine."**
+> **Destination:** This doc lives in the `cmtraceopen` repo for now; it will be
+> migrated into a new **private mono-repo** that the owner is creating.
+
+---
+
+## 1. Product thesis
+
+Two existing apps sit on opposite sides of the same workflow:
+
+- **CMTrace Open** — the *device / read* side. What **actually happened** on a
+  machine: IME logs, app/workload/script deployment outcomes, error codes, GUIDs,
+  dsregcmd, EVTX, timeline. (Rust backend + React/Fluent UI on Tauri.)
+- **Intune Commander** — the *tenant / manage* side. What was **supposed to
+  happen**: Graph API coverage for 30+ Intune object types, config export/import,
+  drift detection, baseline comparison, multi-cloud (Commercial/GCC/GCC-High/DoD).
+  (.NET 10 core + CLI + React UI.)
+
+**The unique value of combining them is correlation across the gap between
+*intended* and *actual* state, retained over time:**
+
+> **who changed it** (audit event) → **what it became** (config drift snapshot) →
+> **what broke** (device log outcome) — on one timeline, searchable, and retained
+> longer than Microsoft keeps it.
+
+Intune's native audit retention is limited (~1 year), so a persistent local index
+meaningfully **extends the forensic/audit window** and enables longitudinal drift
+analysis. No single existing tool does this.
+
+---
+
+## 2. Decisions locked in
+
+| Decision | Choice | Notes |
+|---|---|---|
+| Platform priority | **Windows-forward** | macOS de-prioritized for this product. |
+| New app UI stack | **WinUI 3 + Rust (Windows Reactor)** | "Rust forward." Native Fluent. |
+| Intune/Graph engine | **Hard-fork the .NET IC core; keep it** | Do **not** rewrite Graph in Rust. |
+| Topology | **Polyglot, API-first** | Rust/WinUI3 client ↔ HTTP API ↔ .NET service. |
+| Repo | **Mono-repo** | Both stacks + the API contract in one place. |
+| MVP slice | **Audit/drift time-machine** | Pure Intune data; no logs on critical path. |
+| Data residency (MVP) | **Local desktop** | .NET service runs as a **local sidecar** on localhost. |
+| System-of-record / index | **In the .NET service** | Shared store reachable by desktop now, webui/agents later. |
+| Parser | **Stays native Rust, external OSS crate** | Keeps upstream contributions friction-free. |
+| Transport | **REST + OpenAPI** (proposed) | Works for the Reactor client now and the webui later. |
+| Commercial license | **TBD** (decide later) | Structure supports proprietary or source-available. |
+
+### Why keep the .NET engine (correction from an earlier "all-Rust" idea)
+
+- IC's **Core library is already UI-decoupled** and driven headlessly by its CLI,
+  so exposing it via an API host is a **thin add, not a rewrite**.
+- Avoids re-implementing 30+ Graph object types + multi-cloud auth in Rust
+  (months of work + regression risk).
+- Putting the **system-of-record + index in the .NET service** means the future
+  **webui and agents share the same store** natively (solves the
+  "desktop-local index can't be served" problem).
+- Running it as a **local sidecar** keeps the MVP a single-machine desktop
+  experience, while the *same* service hosts remotely later — no re-architecture.
+
+---
+
+## 3. Target architecture
+
+```
+  ┌──────────────────────────────────────────┐         ┌────────────────────────────────────┐
+  │  NEW APP — WinUI 3 + Rust (Reactor)        │  HTTP   │  .NET IC core (hard-forked)          │
+  │  • Reactor UI (Rust forward)               │ ◄─────► │  • 30+ Graph services (AS-IS)        │
+  │  • CMTrace parser (native Rust, upstream)  │  REST/  │  • Multi-cloud Entra auth (AS-IS)    │
+  │  • Local log index (Tantivy)               │ OpenAPI │  • Drift / export (AS-IS)            │
+  │  • Log diagnostics + correlation UI        │         │  • NEW: audit+config store + index   │
+  └──────────────────────────────────────────┘         │  • NEW: thin API host (the only add)  │
+                                                         └──────────────┬───────────────────────┘
+                                                            future: WebUI · Agents (MCP) — same API
+```
+
+**Data ownership**
+
+- **.NET service:** Intune system-of-record — audit events + config snapshots
+  (append-only) + full-text index (Lucene.NET) + drift. Shared by all clients.
+- **Rust app:** log parsing + local log index (Tantivy) + UI. Logs are
+  device-local anyway.
+- **Correlation:** join across the two (a failing log line → the policy/app/script
+  in the .NET store), via API.
+
+**Two seams that keep future-you sane**
+
+1. The **parser stays an external OSS crate** → improvements flow upstream to
+   CMTrace Open.
+2. The **`contract/` OpenAPI schema is the single source of truth** for DTOs →
+   generates both C# and Rust types so the two-language split can't drift.
+
+---
+
+## 4. Mono-repo structure (proposed skeleton)
+
+```
+new-repo/
+├─ service/            ← hard-forked .NET IC
+│  ├─ Core/            (30+ Graph services, multi-cloud auth — AS-IS)
+│  ├─ Store/           (NEW: append-only audit+config snapshots + Lucene.NET index)
+│  ├─ Sync/            (NEW: Graph delta sync engine)
+│  └─ Api/             (NEW: thin ASP.NET host — the main new code)
+├─ app/                ← WinUI 3 + Rust (windows-reactor + windows-canvas)
+├─ crates/parser/      ← OSS cmtraceopen-parser dependency (Phase 2; upstream seam)
+├─ contract/           ← OpenAPI schema → generates C# + Rust types (shared component)
+└─ docs/               ← this plan, ADRs
+```
+
+---
+
+## 5. "Best of both" — what carries over
+
+| Asset | From | Fate in new app |
+|---|---|---|
+| Rust parser engine (multi-format, auto-detect) | CMTrace | ✅ Direct crate reuse, no FFI (Phase 2). Crown jewel. |
+| Watcher / live tail, error_db, IME/dsregcmd/sysmon/evtx analyzers | CMTrace | ✅ Reuse — already Rust (Phase 2). |
+| React UI + Fluent components | both | ⚠️ Rewritten as Reactor components; design language carries 1:1. |
+| 30+ Graph services / multi-cloud auth / drift / export | Intune Commander | ✅ Hard-fork, kept AS-IS behind the API. |
+| LiteDB cache | Intune Commander | ✅ Keep as Graph accelerator behind the API. |
+| Audit/drift durable store + index | — | 🆕 New, in the .NET service. |
+
+---
+
+## 6. Shared components (three senses)
+
+1. **Open-core shared code (OSS ↔ commercial):** the `cmtraceopen-parser` crate
+   (+ log models, error_db), consumed by both the OSS app and this product.
+2. **Cross-service contract (Rust ↔ .NET):** the OpenAPI schema in `contract/`,
+   generating types for both languages.
+3. **In-app Reactor component library:** `LogGrid` (virtualized + live-tail),
+   `DriftDiffView`, `FactGroupCard`, `StatusBanner`, `TimelineCanvas`
+   (on `windows-canvas`/Direct2D), `SearchBar`/`ResultsList`, `NavShell`.
+
+---
+
+## 7. MVP plan (audit/drift time-machine)
+
+The MVP is **pure Intune data** — no logs on the critical path — so the work
+splits cleanly:
+
+- **.NET service (most of the value, mostly existing code):** hard-fork core →
+  add audit+config **append-only store + index** (Lucene.NET) → add **Graph delta
+  sync** → expose **drift + timeline + search** over HTTP.
+- **Rust/WinUI3 Reactor app (the new, Rust-forward client):** thin client
+  rendering **timeline + drift-diff + search** from the API.
+
+### Phasing
+
+- **Phase 0 — Reactor risk-gate (small, throwaway).** Windows Reactor is brand new
+  (landed in `microsoft/windows-rs`, May 2026). Build *just* `LogGrid` + live tail
+  against the real parser crate. Green-light only if virtualized scrolling +
+  streaming appends hold up on a large file. Days, not months.
+- **Phase 1 — MVP.** Single tenant, **device-code Entra auth** → pull **audit
+  events + a handful of config object types** via Graph (delta) → **append-only
+  store + index** → UI: **audit timeline + drift-diff + unified search**.
+- **Phase 2.** Bring in the **CMTrace parser + log viewer** (native Rust) and the
+  **log↔policy correlation** workflow. Broaden Graph object-type coverage.
+- **Phase 3.** Host the .NET service remotely → **WebUI** (React) + **app-only
+  Entra auth** for unattended sync. Then **agents** (MCP server over the API).
+
+---
+
+## 8. Engineering realities to design around
+
+- **Sync scale:** "pull in all logs and info" is a sync-scale problem. Rely on
+  **Graph delta queries**, throttling/backoff, and a background sync engine — not
+  naive full pulls.
+- **Cache ≠ system of record:** IC's LiteDB cache (24h TTL) is a *read
+  accelerator*. The time-machine needs a *separate, durable, append-only* store
+  that never expires. Keep them distinct.
+- **Reactor maturity:** first-party-*authored* (Kenny Kerr) but new and not
+  declared production-ready. Hence the Phase 0 gate.
+- **Packaging:** Windows-forward. Reactor app (~3 MB + Windows App SDK 2.0.1+
+  runtime) + self-contained .NET service sidecar. MSIX is the blessed path.
+
+---
+
+## 9. Licensing posture (decide later)
+
+- Both source apps are **MIT**, owner holds copyright → free to build a closed
+  product on them.
+- **MIT is irrevocable for already-public code** → the commercial moat is the
+  **new** parts (audit/drift platform, webui, agents), not the already-open parts.
+- Before taking money: **dependency license audit** (`cargo-deny`, `nuget-license`,
+  `license-checker`); confirm the Intune Commander → `Micke-K/IntuneManagement`
+  lineage copied no copyleft code (formats aren't copyrightable; clean reimpl is
+  fine); add a **DCO/CLA** going forward.
+- **Open-core split:** parser stays MIT/external; the app repo can go proprietary
+  or source-available (BUSL / Elastic v2 / PolyForm worth considering for an
+  audit tool, where source visibility is a selling point).
+- *This is engineering guidance, not legal advice — get a short IP-attorney pass
+  before commercial launch.*
+
+---
+
+## 10. Open decisions / TBD
+
+- [ ] Repo name (`intune-forge` / `intune-time-machine` / `driftwatch` / …).
+- [ ] Confirm transport = **REST + OpenAPI** (vs gRPC).
+- [ ] How the parser is consumed early: **git dependency on a pinned commit**
+  (proposed) vs submodule vs published crate.
+- [ ] "Agents" meaning: **AI/LLM agents** querying the platform (MCP) vs
+  **device-side log-collection agents**. Very different builds.
+- [ ] Commercial license flavor (proprietary EULA vs source-available).
+
+---
+
+## Appendix — WinUI 3 + Rust foundation (research summary)
+
+- **Windows Reactor** — a React-inspired, declarative UI framework for native
+  **WinUI 3 in pure Rust**, by **Kenny Kerr** (creator of C++/WinRT and the
+  `windows` crate), landed in `microsoft/windows-rs` (announced **May 2026**).
+  Function components + typed props, hooks (`use_state`, `use_reducer`,
+  `use_effect`, `use_context`, `use_memo`, `use_callback`, `use_resource`,
+  `use_mutation`), 55+ widgets incl. virtualized `ListView`/`GridView`/`FlipView`,
+  builder DSL + tuple children (no macros), runtime theming, accessibility.
+  Companion `windows-canvas` (Direct2D). ~3 MB binary; needs Windows App SDK
+  2.0.1+ runtime.
+- **No XAML** on any Rust path — UI is built in code (the React/hooks model
+  replaces XAML + x:Bind + MVVM). XAML/designer/MVVM exist only on the C# path.
+- **Caveat:** new and not declared production-ready → Phase 0 risk-gate.
+
+Sources:
+- <https://github.com/microsoft/windows-rs>
+- <https://github.com/microsoft/windows-rs/issues/4483> (Rust for Windows — May 2026)
+- <https://github.com/microsoft/windows-rs/pull/4479> (Windows Reactor)
+- <https://github.com/adamgell/IntuneCommander>
+- <https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/downloads>
+- <https://learn.microsoft.com/en-us/windows/apps/winui/winui3/>

--- a/cmprojectx-skeleton/service/Api/Api.csproj
+++ b/cmprojectx-skeleton/service/Api/Api.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>CmProjectX.Api</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Store\Store.csproj" />
+    <ProjectReference Include="..\Sync\Sync.csproj" />
+    <!-- <ProjectReference Include="..\Core\Core.csproj" /> TODO: after hard-fork -->
+  </ItemGroup>
+
+</Project>

--- a/cmprojectx-skeleton/service/Api/Program.cs
+++ b/cmprojectx-skeleton/service/Api/Program.cs
@@ -1,0 +1,57 @@
+// cmProjectX service — thin ASP.NET host in front of the hard-forked IC core.
+// Endpoints mirror contract/openapi.yaml. All handlers are stubs (501) for now.
+//
+// Run as a LOCAL SIDECAR for the MVP (the Rust app launches it on 127.0.0.1).
+
+using CmProjectX.Store;
+using CmProjectX.Sync;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<ISnapshotStore, SnapshotStore>();
+builder.Services.AddSingleton<GraphDeltaSync>();
+
+var app = builder.Build();
+
+// GET /health
+app.MapGet("/health", () => Results.Ok(new
+{
+    healthy = true,
+    tenantId = (string?)null,
+    lastSyncUtc = (DateTime?)null,
+    cloud = "Commercial",
+}));
+
+// POST /sync — trigger a Graph delta sync
+app.MapPost("/sync", (GraphDeltaSync sync) =>
+{
+    // TODO: kick off background delta sync using the hard-forked IC Graph services.
+    _ = sync;
+    return Results.Accepted();
+});
+
+// GET /audit — the audit-event timeline (time-machine)
+app.MapGet("/audit", (DateTime? from, DateTime? to, string? q, ISnapshotStore store) =>
+{
+    // TODO: query the append-only audit store.
+    _ = (from, to, q, store);
+    return Results.StatusCode(StatusCodes.Status501NotImplemented);
+});
+
+// GET /drift — drift between two config snapshots
+app.MapGet("/drift", (string objectId, string? baseSnapshotId, string? headSnapshotId, ISnapshotStore store) =>
+{
+    // TODO: diff snapshots → DriftRecord.
+    _ = (objectId, baseSnapshotId, headSnapshotId, store);
+    return Results.StatusCode(StatusCodes.Status501NotImplemented);
+});
+
+// GET /search — full-text across audit + snapshots
+app.MapGet("/search", (string q, ISnapshotStore store) =>
+{
+    // TODO: query the full-text index (Lucene.NET).
+    _ = (q, store);
+    return Results.StatusCode(StatusCodes.Status501NotImplemented);
+});
+
+app.Run("http://127.0.0.1:5099");

--- a/cmprojectx-skeleton/service/Core/README.md
+++ b/cmprojectx-skeleton/service/Core/README.md
@@ -1,0 +1,21 @@
+# service/Core — hard-forked Intune Commander core
+
+**Drop the hard-forked IntuneCommander `Core` library here.**
+
+It already provides (per IntuneCommander docs):
+- Graph API service coverage for **30+ Intune object types** (built & tested)
+- Multi-cloud auth + endpoints (**Commercial / GCC / GCC-High / DoD**)
+- Drift detection, export/import, baseline comparison
+- LiteDB-backed encrypted cache (keep as a Graph *accelerator*)
+
+It is already **UI-decoupled** (the IC CLI drives it headlessly), so `Api/`,
+`Sync/`, and `Store/` just reference it as a project/package.
+
+## Steps
+1. Copy IntuneCommander's `Core` project into this folder.
+2. `dotnet sln ../CmProjectX.sln add Core/Core.csproj`
+3. Reference it from `Api`, `Sync`, `Store`.
+4. Trim anything tied to the old desktop/WPF UI.
+
+> Reuse, don't rewrite. The commercial value is the *new* time-machine layer
+> (Sync + Store + Api), not re-implementing Graph.

--- a/cmprojectx-skeleton/service/Store/SnapshotStore.cs
+++ b/cmprojectx-skeleton/service/Store/SnapshotStore.cs
@@ -1,0 +1,47 @@
+namespace CmProjectX.Store;
+
+// The DURABLE system-of-record for the audit/drift time-machine.
+// IMPORTANT: this is NOT the IC LiteDB cache (that 24h-TTL cache is a Graph
+// accelerator). This store is APPEND-ONLY and never expires — that permanence
+// is the whole value prop (outliving Microsoft's audit retention).
+//
+// MVP target: SQLite for snapshots/audit + Lucene.NET for full-text search.
+
+public interface ISnapshotStore
+{
+    // Append-only writes (never mutate/delete history).
+    Task AppendAuditEventAsync(AuditEventRecord evt, CancellationToken ct = default);
+    Task AppendSnapshotAsync(ConfigSnapshotRecord snapshot, CancellationToken ct = default);
+
+    // Reads for the timeline / drift / search surfaces.
+    Task<IReadOnlyList<AuditEventRecord>> QueryAuditAsync(
+        DateTime? from, DateTime? to, string? q, CancellationToken ct = default);
+
+    Task<ConfigSnapshotRecord?> GetSnapshotAsync(string snapshotId, CancellationToken ct = default);
+}
+
+// Placeholder records — replace with types generated from contract/openapi.yaml.
+public sealed record AuditEventRecord(
+    string Id, DateTime Timestamp, string? Actor, string Action,
+    string ObjectType, string ObjectId, string? ObjectName);
+
+public sealed record ConfigSnapshotRecord(
+    string SnapshotId, string ObjectId, string ObjectType,
+    DateTime CapturedUtc, string BodyJson);
+
+// TODO: SQLite + Lucene.NET implementation.
+public sealed class SnapshotStore : ISnapshotStore
+{
+    public Task AppendAuditEventAsync(AuditEventRecord evt, CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task AppendSnapshotAsync(ConfigSnapshotRecord snapshot, CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<IReadOnlyList<AuditEventRecord>> QueryAuditAsync(
+        DateTime? from, DateTime? to, string? q, CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<ConfigSnapshotRecord?> GetSnapshotAsync(string snapshotId, CancellationToken ct = default)
+        => throw new NotImplementedException();
+}

--- a/cmprojectx-skeleton/service/Store/Store.csproj
+++ b/cmprojectx-skeleton/service/Store/Store.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>CmProjectX.Store</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- TODO: durable store + full-text index -->
+    <!-- <PackageReference Include="Microsoft.Data.Sqlite" Version="*" /> -->
+    <!-- <PackageReference Include="Lucene.Net" Version="*" /> -->
+  </ItemGroup>
+
+</Project>

--- a/cmprojectx-skeleton/service/Sync/GraphDeltaSync.cs
+++ b/cmprojectx-skeleton/service/Sync/GraphDeltaSync.cs
@@ -1,0 +1,26 @@
+using CmProjectX.Store;
+
+namespace CmProjectX.Sync;
+
+// Incremental sync engine. Pulls Intune audit events + config object snapshots
+// via Microsoft Graph and appends them to the durable store.
+//
+// MUST use Graph DELTA queries (track deltaLink per object type) + throttling/
+// backoff — never naive full pulls. Reuse the hard-forked IC Graph services.
+public sealed class GraphDeltaSync
+{
+    private readonly ISnapshotStore _store;
+
+    public GraphDeltaSync(ISnapshotStore store) => _store = store;
+
+    public Task RunAsync(CancellationToken ct = default)
+    {
+        // TODO:
+        //  1. For each tracked object type, call IC Graph service with its delta token.
+        //  2. Append new ConfigSnapshotRecord per changed object (append-only).
+        //  3. Pull deviceManagement audit events; append AuditEventRecord.
+        //  4. Persist updated delta tokens; honor Retry-After throttling.
+        _ = _store;
+        throw new NotImplementedException();
+    }
+}

--- a/cmprojectx-skeleton/service/Sync/Sync.csproj
+++ b/cmprojectx-skeleton/service/Sync/Sync.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>CmProjectX.Sync</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Store\Store.csproj" />
+    <!-- <ProjectReference Include="..\Core\Core.csproj" /> TODO: after hard-fork -->
+  </ItemGroup>
+
+</Project>

--- a/docs/MVP-PLAN.md
+++ b/docs/MVP-PLAN.md
@@ -1,0 +1,234 @@
+# Unified Intune Platform — MVP Plan
+
+> **Status:** Planning / pre-skeleton. No code yet.
+> **Scope:** A new, Windows-forward commercial product combining **CMTrace Open**
+> (Rust log/diagnostics engine) with the **Intune Commander** (.NET Graph engine),
+> plus a new persistent, searchable **audit/drift "time-machine."**
+> **Destination:** This doc lives in the `cmtraceopen` repo for now; it will be
+> migrated into a new **private mono-repo** that the owner is creating.
+
+---
+
+## 1. Product thesis
+
+Two existing apps sit on opposite sides of the same workflow:
+
+- **CMTrace Open** — the *device / read* side. What **actually happened** on a
+  machine: IME logs, app/workload/script deployment outcomes, error codes, GUIDs,
+  dsregcmd, EVTX, timeline. (Rust backend + React/Fluent UI on Tauri.)
+- **Intune Commander** — the *tenant / manage* side. What was **supposed to
+  happen**: Graph API coverage for 30+ Intune object types, config export/import,
+  drift detection, baseline comparison, multi-cloud (Commercial/GCC/GCC-High/DoD).
+  (.NET 10 core + CLI + React UI.)
+
+**The unique value of combining them is correlation across the gap between
+*intended* and *actual* state, retained over time:**
+
+> **who changed it** (audit event) → **what it became** (config drift snapshot) →
+> **what broke** (device log outcome) — on one timeline, searchable, and retained
+> longer than Microsoft keeps it.
+
+Intune's native audit retention is limited (~1 year), so a persistent local index
+meaningfully **extends the forensic/audit window** and enables longitudinal drift
+analysis. No single existing tool does this.
+
+---
+
+## 2. Decisions locked in
+
+| Decision | Choice | Notes |
+|---|---|---|
+| Platform priority | **Windows-forward** | macOS de-prioritized for this product. |
+| New app UI stack | **WinUI 3 + Rust (Windows Reactor)** | "Rust forward." Native Fluent. |
+| Intune/Graph engine | **Hard-fork the .NET IC core; keep it** | Do **not** rewrite Graph in Rust. |
+| Topology | **Polyglot, API-first** | Rust/WinUI3 client ↔ HTTP API ↔ .NET service. |
+| Repo | **Mono-repo** | Both stacks + the API contract in one place. |
+| MVP slice | **Audit/drift time-machine** | Pure Intune data; no logs on critical path. |
+| Data residency (MVP) | **Local desktop** | .NET service runs as a **local sidecar** on localhost. |
+| System-of-record / index | **In the .NET service** | Shared store reachable by desktop now, webui/agents later. |
+| Parser | **Stays native Rust, external OSS crate** | Keeps upstream contributions friction-free. |
+| Transport | **REST + OpenAPI** (proposed) | Works for the Reactor client now and the webui later. |
+| Commercial license | **TBD** (decide later) | Structure supports proprietary or source-available. |
+
+### Why keep the .NET engine (correction from an earlier "all-Rust" idea)
+
+- IC's **Core library is already UI-decoupled** and driven headlessly by its CLI,
+  so exposing it via an API host is a **thin add, not a rewrite**.
+- Avoids re-implementing 30+ Graph object types + multi-cloud auth in Rust
+  (months of work + regression risk).
+- Putting the **system-of-record + index in the .NET service** means the future
+  **webui and agents share the same store** natively (solves the
+  "desktop-local index can't be served" problem).
+- Running it as a **local sidecar** keeps the MVP a single-machine desktop
+  experience, while the *same* service hosts remotely later — no re-architecture.
+
+---
+
+## 3. Target architecture
+
+```
+  ┌──────────────────────────────────────────┐         ┌────────────────────────────────────┐
+  │  NEW APP — WinUI 3 + Rust (Reactor)        │  HTTP   │  .NET IC core (hard-forked)          │
+  │  • Reactor UI (Rust forward)               │ ◄─────► │  • 30+ Graph services (AS-IS)        │
+  │  • CMTrace parser (native Rust, upstream)  │  REST/  │  • Multi-cloud Entra auth (AS-IS)    │
+  │  • Local log index (Tantivy)               │ OpenAPI │  • Drift / export (AS-IS)            │
+  │  • Log diagnostics + correlation UI        │         │  • NEW: audit+config store + index   │
+  └──────────────────────────────────────────┘         │  • NEW: thin API host (the only add)  │
+                                                         └──────────────┬───────────────────────┘
+                                                            future: WebUI · Agents (MCP) — same API
+```
+
+**Data ownership**
+
+- **.NET service:** Intune system-of-record — audit events + config snapshots
+  (append-only) + full-text index (Lucene.NET) + drift. Shared by all clients.
+- **Rust app:** log parsing + local log index (Tantivy) + UI. Logs are
+  device-local anyway.
+- **Correlation:** join across the two (a failing log line → the policy/app/script
+  in the .NET store), via API.
+
+**Two seams that keep future-you sane**
+
+1. The **parser stays an external OSS crate** → improvements flow upstream to
+   CMTrace Open.
+2. The **`contract/` OpenAPI schema is the single source of truth** for DTOs →
+   generates both C# and Rust types so the two-language split can't drift.
+
+---
+
+## 4. Mono-repo structure (proposed skeleton)
+
+```
+new-repo/
+├─ service/            ← hard-forked .NET IC
+│  ├─ Core/            (30+ Graph services, multi-cloud auth — AS-IS)
+│  ├─ Store/           (NEW: append-only audit+config snapshots + Lucene.NET index)
+│  ├─ Sync/            (NEW: Graph delta sync engine)
+│  └─ Api/             (NEW: thin ASP.NET host — the main new code)
+├─ app/                ← WinUI 3 + Rust (windows-reactor + windows-canvas)
+├─ crates/parser/      ← OSS cmtraceopen-parser dependency (Phase 2; upstream seam)
+├─ contract/           ← OpenAPI schema → generates C# + Rust types (shared component)
+└─ docs/               ← this plan, ADRs
+```
+
+---
+
+## 5. "Best of both" — what carries over
+
+| Asset | From | Fate in new app |
+|---|---|---|
+| Rust parser engine (multi-format, auto-detect) | CMTrace | ✅ Direct crate reuse, no FFI (Phase 2). Crown jewel. |
+| Watcher / live tail, error_db, IME/dsregcmd/sysmon/evtx analyzers | CMTrace | ✅ Reuse — already Rust (Phase 2). |
+| React UI + Fluent components | both | ⚠️ Rewritten as Reactor components; design language carries 1:1. |
+| 30+ Graph services / multi-cloud auth / drift / export | Intune Commander | ✅ Hard-fork, kept AS-IS behind the API. |
+| LiteDB cache | Intune Commander | ✅ Keep as Graph accelerator behind the API. |
+| Audit/drift durable store + index | — | 🆕 New, in the .NET service. |
+
+---
+
+## 6. Shared components (three senses)
+
+1. **Open-core shared code (OSS ↔ commercial):** the `cmtraceopen-parser` crate
+   (+ log models, error_db), consumed by both the OSS app and this product.
+2. **Cross-service contract (Rust ↔ .NET):** the OpenAPI schema in `contract/`,
+   generating types for both languages.
+3. **In-app Reactor component library:** `LogGrid` (virtualized + live-tail),
+   `DriftDiffView`, `FactGroupCard`, `StatusBanner`, `TimelineCanvas`
+   (on `windows-canvas`/Direct2D), `SearchBar`/`ResultsList`, `NavShell`.
+
+---
+
+## 7. MVP plan (audit/drift time-machine)
+
+The MVP is **pure Intune data** — no logs on the critical path — so the work
+splits cleanly:
+
+- **.NET service (most of the value, mostly existing code):** hard-fork core →
+  add audit+config **append-only store + index** (Lucene.NET) → add **Graph delta
+  sync** → expose **drift + timeline + search** over HTTP.
+- **Rust/WinUI3 Reactor app (the new, Rust-forward client):** thin client
+  rendering **timeline + drift-diff + search** from the API.
+
+### Phasing
+
+- **Phase 0 — Reactor risk-gate (small, throwaway).** Windows Reactor is brand new
+  (landed in `microsoft/windows-rs`, May 2026). Build *just* `LogGrid` + live tail
+  against the real parser crate. Green-light only if virtualized scrolling +
+  streaming appends hold up on a large file. Days, not months.
+- **Phase 1 — MVP.** Single tenant, **device-code Entra auth** → pull **audit
+  events + a handful of config object types** via Graph (delta) → **append-only
+  store + index** → UI: **audit timeline + drift-diff + unified search**.
+- **Phase 2.** Bring in the **CMTrace parser + log viewer** (native Rust) and the
+  **log↔policy correlation** workflow. Broaden Graph object-type coverage.
+- **Phase 3.** Host the .NET service remotely → **WebUI** (React) + **app-only
+  Entra auth** for unattended sync. Then **agents** (MCP server over the API).
+
+---
+
+## 8. Engineering realities to design around
+
+- **Sync scale:** "pull in all logs and info" is a sync-scale problem. Rely on
+  **Graph delta queries**, throttling/backoff, and a background sync engine — not
+  naive full pulls.
+- **Cache ≠ system of record:** IC's LiteDB cache (24h TTL) is a *read
+  accelerator*. The time-machine needs a *separate, durable, append-only* store
+  that never expires. Keep them distinct.
+- **Reactor maturity:** first-party-*authored* (Kenny Kerr) but new and not
+  declared production-ready. Hence the Phase 0 gate.
+- **Packaging:** Windows-forward. Reactor app (~3 MB + Windows App SDK 2.0.1+
+  runtime) + self-contained .NET service sidecar. MSIX is the blessed path.
+
+---
+
+## 9. Licensing posture (decide later)
+
+- Both source apps are **MIT**, owner holds copyright → free to build a closed
+  product on them.
+- **MIT is irrevocable for already-public code** → the commercial moat is the
+  **new** parts (audit/drift platform, webui, agents), not the already-open parts.
+- Before taking money: **dependency license audit** (`cargo-deny`, `nuget-license`,
+  `license-checker`); confirm the Intune Commander → `Micke-K/IntuneManagement`
+  lineage copied no copyleft code (formats aren't copyrightable; clean reimpl is
+  fine); add a **DCO/CLA** going forward.
+- **Open-core split:** parser stays MIT/external; the app repo can go proprietary
+  or source-available (BUSL / Elastic v2 / PolyForm worth considering for an
+  audit tool, where source visibility is a selling point).
+- *This is engineering guidance, not legal advice — get a short IP-attorney pass
+  before commercial launch.*
+
+---
+
+## 10. Open decisions / TBD
+
+- [ ] Repo name (`intune-forge` / `intune-time-machine` / `driftwatch` / …).
+- [ ] Confirm transport = **REST + OpenAPI** (vs gRPC).
+- [ ] How the parser is consumed early: **git dependency on a pinned commit**
+  (proposed) vs submodule vs published crate.
+- [ ] "Agents" meaning: **AI/LLM agents** querying the platform (MCP) vs
+  **device-side log-collection agents**. Very different builds.
+- [ ] Commercial license flavor (proprietary EULA vs source-available).
+
+---
+
+## Appendix — WinUI 3 + Rust foundation (research summary)
+
+- **Windows Reactor** — a React-inspired, declarative UI framework for native
+  **WinUI 3 in pure Rust**, by **Kenny Kerr** (creator of C++/WinRT and the
+  `windows` crate), landed in `microsoft/windows-rs` (announced **May 2026**).
+  Function components + typed props, hooks (`use_state`, `use_reducer`,
+  `use_effect`, `use_context`, `use_memo`, `use_callback`, `use_resource`,
+  `use_mutation`), 55+ widgets incl. virtualized `ListView`/`GridView`/`FlipView`,
+  builder DSL + tuple children (no macros), runtime theming, accessibility.
+  Companion `windows-canvas` (Direct2D). ~3 MB binary; needs Windows App SDK
+  2.0.1+ runtime.
+- **No XAML** on any Rust path — UI is built in code (the React/hooks model
+  replaces XAML + x:Bind + MVVM). XAML/designer/MVVM exist only on the C# path.
+- **Caveat:** new and not declared production-ready → Phase 0 risk-gate.
+
+Sources:
+- <https://github.com/microsoft/windows-rs>
+- <https://github.com/microsoft/windows-rs/issues/4483> (Rust for Windows — May 2026)
+- <https://github.com/microsoft/windows-rs/pull/4479> (Windows Reactor)
+- <https://github.com/adamgell/IntuneCommander>
+- <https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/downloads>
+- <https://learn.microsoft.com/en-us/windows/apps/winui/winui3/>


### PR DESCRIPTION
## What

Adds `docs/MVP-PLAN.md` — a planning document (no code) for a new **Windows-forward commercial product** that combines:

- **CMTrace Open** — the Rust log/diagnostics engine (device / *actual* state)
- **Intune Commander** (.NET) — the Graph engine (tenant / *intended* state)
- a new persistent, searchable **audit/drift "time-machine"**

This doc is parked here for safekeeping; it will be migrated into a new **private mono-repo** that the owner is creating.

## Key decisions captured

- **WinUI 3 + Rust (Windows Reactor)** for the new app UI ("Rust forward").
- **Hard-fork the .NET Intune Commander core and keep it** as the living Graph engine (do *not* rewrite Graph in Rust) — exposed via a thin **REST/OpenAPI** host, run as a **local sidecar** for the MVP.
- **Mono-repo**, polyglot, API-first. System-of-record + index live in the .NET service so future **webui/agents** share the same store.
- **MVP = audit/drift time-machine** (pure Intune data; logs/correlation in Phase 2).
- Parser stays an **external OSS crate** to keep upstream contributions friction-free.
- Commercial license **TBD**; open-core split keeps the option open.

## Open items (tracked in the doc)

Repo name · transport confirm (REST vs gRPC) · parser dependency mechanism · "agents" meaning (AI/MCP vs device-side) · commercial license flavor.

> Note: `docs/` is gitignored in this repo; the file was force-added following the existing convention (e.g. `docs/design-system/*`, `docs/superpowers/plans/*` are tracked the same way).

https://claude.ai/code/session_016YDGisKmGGVDw3xAXmdyNt

---
_Generated by [Claude Code](https://claude.ai/code/session_016YDGisKmGGVDw3xAXmdyNt)_