### PR TITLE
docs(changelog): note the re-issued code-signing certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- **Re-issued code-signing certificate**: Windows builds are now signed with a re-issued Azure Trusted Signing certificate. The signature is still a valid Microsoft Public Trust certificate, and macOS builds remain signed and notarized — but because the underlying signing identity was renewed, Windows SmartScreen reputation is rebuilding. Fresh installs may briefly show an "unrecognized app" / unknown-publisher prompt until reputation re-establishes over the following weeks. The installers are validly signed; choosing **More info → Run anyway** is safe.
+
 ## [1.3.2] - 2026-05-11
 
 ### Added


### PR DESCRIPTION
## What
Adds an `## [Unreleased]` entry to `CHANGELOG.md` documenting the re-issued Windows code-signing certificate and the temporary SmartScreen reputation rebuild.

## Why
The signing identity was renewed (Azure Trusted Signing was rebuilt after a subscription tenant move), so fresh installs may briefly show an "unrecognized app" / unknown-publisher prompt until reputation re-establishes. The entry reassures users the builds are validly signed (Microsoft Public Trust; macOS still notarized) and that **More info → Run anyway** is safe. Framed around user impact rather than the infrastructure details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)