### PR TITLE
fix(ci): ignore quick-xml RUSTSEC-2026-0194/0195 to unblock cargo-deny

### DIFF
--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -22,6 +22,8 @@ ignore = [
     "RUSTSEC-2025-0081", # gtk-related (Tauri Linux)
     "RUSTSEC-2025-0098", # gtk-related (Tauri Linux)
     "RUSTSEC-2025-0100", # gtk-related (Tauri Linux)
+    "RUSTSEC-2026-0194", # quick-xml: quadratic runtime on duplicate attrs (via wayland-scanner, Tauri Linux clipboard)
+    "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-declaration alloc (via wayland-scanner, Tauri Linux clipboard)
 ]
 
 [licenses]


### PR DESCRIPTION
## Problem

`cargo deny check advisories` (part of the required **Check & Test (Rust)** gate) fails on every run right now, turning CI red repo-wide and breaking the nightly build. Two newly-published advisories are the cause:

- `RUSTSEC-2026-0194` — quick-xml: quadratic run time checking a start tag for duplicate attribute names
- `RUSTSEC-2026-0195` — quick-xml: unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS)

This is why even pure-docs PRs (e.g. #238) show a failing Rust check.

## Why ignore rather than upgrade

`quick-xml` is not a direct dependency. It enters only transitively on **Linux** via:

```
wayland-scanner -> wayland-client -> ... -> arboard -> tauri-plugin-clipboard-manager
```

It cannot be bumped to the fixed >=0.41.0 without an upstream Tauri/wayland update. This matches the existing policy in `deny.toml`, which already ignores the rest of the Tauri Linux transitive advisory tree.

## Change

Add both advisories to the `[advisories] ignore` list. Verified locally: `cargo deny check advisories` -> `advisories ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)