### PR TITLE
fix(collector): collect new Teams (MSIX) client logs (#205)

### DIFF
--- a/crates/cmtraceopen-parser/src/collector/profile.rs
+++ b/crates/cmtraceopen-parser/src/collector/profile.rs
@@ -83,4 +83,23 @@ mod tests {
         profile.filter_by_families(&[]);
         assert_eq!(profile.total_items(), 0);
     }
+
+    #[test]
+    fn embedded_profile_includes_new_teams_msix_logs() {
+        // Regression guard for issue #205: the new Teams (MSIX) client writes
+        // logs under %LOCALAPPDATA%\Packages\MSTeams_8wekyb3d8bbwe\..., which the
+        // classic-Teams manifest rows do not cover.
+        let profile = CollectionProfile::embedded();
+        let item = profile
+            .logs
+            .iter()
+            .find(|i| i.id == "teams-msix-logs")
+            .expect("profile must contain the new Teams MSIX log source");
+        assert_eq!(item.family, "teams");
+        assert!(
+            item.source_pattern.contains("MSTeams_8wekyb3d8bbwe"),
+            "unexpected source pattern: {}",
+            item.source_pattern
+        );
+    }
 }

--- a/crates/cmtraceopen-parser/src/collector/profile_data.json
+++ b/crates/cmtraceopen-parser/src/collector/profile_data.json
@@ -213,6 +213,13 @@
             "notes": "Teams Squirrel installer log."
         },
         {
+            "id": "teams-msix-logs",
+            "family": "teams",
+            "sourcePattern": "%LOCALAPPDATA%\\Packages\\MSTeams_8wekyb3d8bbwe\\LocalCache\\Microsoft\\MSTeams\\Logs\\*",
+            "destinationFolder": "logs/teams",
+            "notes": "New Microsoft Teams (MSIX package MSTeams_8wekyb3d8bbwe) client logs."
+        },
+        {
             "id": "winget-state",
             "family": "wpm",
             "sourcePattern": "%TEMP%\\winget\\defaultState\\WPM-*.txt",


### PR DESCRIPTION
Closes #205.

The diagnostic log collector only targeted the classic Electron Teams client (`%APPDATA%\Microsoft\Teams\*.txt` and the Squirrel installer log). The new Teams client ships as an MSIX package and writes its logs elsewhere, so the Teams folder in the evidence bundle came up empty.

## Change
Add the new Teams (MSIX) log path to the embedded collection manifest (`crates/cmtraceopen-parser/src/collector/profile_data.json`):

```
%LOCALAPPDATA%\Packages\MSTeams_8wekyb3d8bbwe\LocalCache\Microsoft\MSTeams\Logs\*
```

- Reuses the existing `teams` family, so it's already selectable in the Collect Diagnostics UI (no frontend change).
- Mirrors the existing Company Portal MSIX entry's idiom (`%LOCALAPPDATA%\Packages\<pkg>_8wekyb3d8bbwe\...`).
- `%LOCALAPPDATA%` is expanded the same way as the sibling entries.

## Test
Adds `embedded_profile_includes_new_teams_msix_logs` to pin the row so it can't be silently dropped again. `cargo test -p cmtraceopen-parser collector` passes (including `embedded_profile_deserializes`, which validates the JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)