### PR TITLE
fix(tail): reset the view when a tailed log is truncated/rotated (#234)

### DIFF
--- a/src-tauri/src/commands/parsing.rs
+++ b/src-tauri/src/commands/parsing.rs
@@ -13,6 +13,10 @@ use crate::watcher::tail;
 pub struct TailPayload {
     pub entries: Vec<LogEntry>,
     pub file_path: String,
+    /// True when the tailed file was truncated/rotated: `entries` are a fresh
+    /// read from the start of the file and the frontend must replace, not
+    /// append to, its existing view for this file.
+    pub reset: bool,
 }
 
 /// Start tailing a file for new log entries.
@@ -53,10 +57,11 @@ pub fn start_tail(
         parser_selection,
         next_id,
         next_line,
-        move |entries| {
+        move |batch| {
             let payload = TailPayload {
-                entries,
+                entries: batch.entries,
                 file_path: file_path_for_event.clone(),
+                reset: batch.reset,
             };
             if let Err(e) = app.emit("tail-new-entries", &payload) {
                 log::error!("Failed to emit tail entries: {}", e);

--- a/src-tauri/src/watcher/tail.rs
+++ b/src-tauri/src/watcher/tail.rs
@@ -11,6 +11,21 @@ use crate::parser::{self, FileEncoding, ResolvedParser};
 const IME_RECORD_START: &str = "<![LOG[";
 const IME_RECORD_ATTRS_START: &str = "]LOG]!><";
 
+/// The result of reading new content from a tailed file.
+pub struct TailBatch {
+    /// Complete log records parsed since the last read.
+    pub entries: Vec<LogEntry>,
+    /// True when the file was detected as truncated/rotated during this read.
+    ///
+    /// On truncation the reader rewinds to the start of the file, so `entries`
+    /// (when non-empty) represent a fresh read from byte 0 and any entries
+    /// previously emitted for this file are now stale. Consumers must replace,
+    /// not append, their existing view for this file. A reset can also arrive
+    /// with an empty `entries` list (file truncated to empty), which still
+    /// means the prior view should be cleared.
+    pub reset: bool,
+}
+
 /// Manages incremental reading of a log file from a tracked byte offset.
 pub struct TailReader {
     path: PathBuf,
@@ -53,24 +68,33 @@ impl TailReader {
     }
 
     /// Read new content from the file since last read, parse into entries.
-    /// Returns new entries and updates internal byte_offset.
-    pub fn read_new_entries(&mut self) -> Result<Vec<LogEntry>, crate::error::AppError> {
+    /// Returns the new entries plus a `reset` flag and updates internal byte_offset.
+    pub fn read_new_entries(&mut self) -> Result<TailBatch, crate::error::AppError> {
         let mut file = std::fs::File::open(&self.path).map_err(crate::error::AppError::Io)?;
 
         let metadata = file.metadata().map_err(crate::error::AppError::Io)?;
 
         let file_size = metadata.len();
 
-        // File was truncated (e.g. log rotation) — reset to beginning
+        // File was truncated (e.g. log rotation) — rewind to the beginning and
+        // signal a reset so the frontend replaces (not appends) its stale view.
+        // Line numbers restart at 1 to match the new file generation; ids stay
+        // monotonic so they remain unique across the reset.
+        let mut reset = false;
         if file_size < self.byte_offset {
             self.byte_offset = 0;
             self.pending_fragment.clear();
             self.pending_byte = None;
+            self.next_line = 1;
+            reset = true;
         }
 
         // No new data
         if file_size == self.byte_offset {
-            return Ok(vec![]);
+            return Ok(TailBatch {
+                entries: vec![],
+                reset,
+            });
         }
 
         // Seek to our byte offset
@@ -133,7 +157,10 @@ impl TailReader {
 
         if lines.is_empty() {
             self.byte_offset = file_size;
-            return Ok(vec![]);
+            return Ok(TailBatch {
+                entries: vec![],
+                reset,
+            });
         }
 
         // Parse the new complete records through the same dispatch path as initial parsing.
@@ -153,7 +180,7 @@ impl TailReader {
         // actual file size so the same bytes are not read and prepended again.
         self.byte_offset = file_size;
 
-        Ok(entries)
+        Ok(TailBatch { entries, reset })
     }
 }
 
@@ -247,7 +274,7 @@ pub fn start_tail_session<F>(
     on_new_entries: F,
 ) -> Result<TailSession, crate::error::AppError>
 where
-    F: Fn(Vec<LogEntry>) + Send + 'static,
+    F: Fn(TailBatch) + Send + 'static,
 {
     let stop_flag = Arc::new(AtomicBool::new(false));
     let paused = Arc::new(AtomicBool::new(false));
@@ -300,9 +327,9 @@ where
                             if event.paths.iter().any(|p| p == &watch_path)
                                 && !paused_clone.load(Ordering::Relaxed) =>
                         {
-                            if let Ok(entries) = tail_reader.read_new_entries() {
-                                if !entries.is_empty() {
-                                    on_new_entries(entries);
+                            if let Ok(batch) = tail_reader.read_new_entries() {
+                                if batch.reset || !batch.entries.is_empty() {
+                                    on_new_entries(batch);
                                 }
                             }
                         }
@@ -315,9 +342,9 @@ where
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                     // Periodic poll — check for changes even without FS event
                     if !paused_clone.load(Ordering::Relaxed) {
-                        if let Ok(entries) = tail_reader.read_new_entries() {
-                            if !entries.is_empty() {
-                                on_new_entries(entries);
+                        if let Ok(batch) = tail_reader.read_new_entries() {
+                            if batch.reset || !batch.entries.is_empty() {
+                                on_new_entries(batch);
                             }
                         }
                     }
@@ -418,7 +445,7 @@ mod tests {
         writeln!(file, "16/01/2024 09:30:00 Follow-up entry").expect("should append log line");
         drop(file);
 
-        let entries = reader.read_new_entries().expect("tail read should succeed");
+        let entries = reader.read_new_entries().expect("tail read should succeed").entries;
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].format, LogFormat::Timestamped);
@@ -456,7 +483,8 @@ mod tests {
 
         let first_entries = reader
             .read_new_entries()
-            .expect("first tail read should succeed");
+            .expect("first tail read should succeed")
+            .entries;
         assert_eq!(first_entries.len(), 1);
         assert_eq!(first_entries[0].message, "complete");
 
@@ -469,7 +497,8 @@ mod tests {
 
         let second_entries = reader
             .read_new_entries()
-            .expect("second tail read should succeed");
+            .expect("second tail read should succeed")
+            .entries;
         assert_eq!(second_entries.len(), 1);
         assert_eq!(second_entries[0].message, "partial done");
 
@@ -540,7 +569,10 @@ mod tests {
             write!(file, "{}", appended).expect("should append trailing fixture chunk");
             drop(file);
 
-            let tail_entries = reader.read_new_entries().expect("tail read should succeed");
+            let tail_entries = reader
+                .read_new_entries()
+                .expect("tail read should succeed")
+                .entries;
             let (full_result, _) =
                 parser::parse_file(&path_str).expect("full fixture should parse");
             let expected_entries = &full_result.entries[initial_result.entries.len()..];
@@ -601,7 +633,8 @@ mod tests {
 
         let partial_entries = reader
             .read_new_entries()
-            .expect("partial IME tail read should succeed");
+            .expect("partial IME tail read should succeed")
+            .entries;
 
         assert!(partial_entries.is_empty());
 
@@ -618,7 +651,8 @@ mod tests {
 
         let tail_entries = reader
             .read_new_entries()
-            .expect("complete IME tail read should succeed");
+            .expect("complete IME tail read should succeed")
+            .entries;
         let (full_result, _) = parser::parse_file(&path_str).expect("full fixture should parse");
 
         assert_eq!(tail_entries.len(), 1);
@@ -626,9 +660,58 @@ mod tests {
 
         let repeat_entries = reader
             .read_new_entries()
-            .expect("subsequent IME tail read should succeed");
+            .expect("subsequent IME tail read should succeed")
+            .entries;
         assert!(repeat_entries.is_empty());
 
         fs::remove_dir_all(root).expect("should clean up temp IME fixture");
+    }
+
+    #[test]
+    fn test_tail_reader_signals_reset_and_rewinds_on_truncation() {
+        let path = unique_test_path("tail-reader-truncation");
+        fs::write(
+            &path,
+            "15/01/2024 08:00:00 First entry\n15/01/2024 08:00:01 Second entry\n",
+        )
+        .expect("should write initial file");
+
+        let byte_offset = fs::metadata(&path).expect("metadata should exist").len();
+        let selection = ResolvedParser::generic_timestamped(DateOrder::DayFirst);
+        let mut reader = TailReader::new(path.clone(), byte_offset, selection, 2, 3);
+
+        // Normal append — should NOT signal a reset.
+        let mut file = OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("should reopen temp file");
+        writeln!(file, "15/01/2024 08:00:02 Third entry").expect("should append log line");
+        drop(file);
+
+        let batch = reader
+            .read_new_entries()
+            .expect("append tail read should succeed");
+        assert!(!batch.reset, "appending must not signal a reset");
+        assert_eq!(batch.entries.len(), 1);
+        assert_eq!(batch.entries[0].id, 2);
+        assert_eq!(batch.entries[0].line_number, 3);
+
+        // Truncate to a smaller size (log rotation) and write fresh content.
+        fs::write(&path, "16/01/2024 09:00:00 Rotated entry\n").expect("should truncate file");
+
+        let batch = reader
+            .read_new_entries()
+            .expect("truncated tail read should succeed");
+        assert!(
+            batch.reset,
+            "truncation must signal a reset so the UI can drop stale entries"
+        );
+        assert_eq!(batch.entries.len(), 1);
+        assert!(batch.entries[0].message.contains("Rotated entry"));
+        // Line numbers restart at 1 for the new file generation; ids stay monotonic.
+        assert_eq!(batch.entries[0].line_number, 1);
+        assert_eq!(batch.entries[0].id, 3);
+
+        fs::remove_file(path).expect("should clean up temp file");
     }
 }

--- a/src/hooks/use-file-watcher.ts
+++ b/src/hooks/use-file-watcher.ts
@@ -19,6 +19,8 @@ export function useFileWatcher() {
   const isPaused = useLogStore((s) => s.isPaused);
   const appendEntries = useLogStore((s) => s.appendEntries);
   const appendAggregateEntries = useLogStore((s) => s.appendAggregateEntries);
+  const resetEntries = useLogStore((s) => s.resetEntries);
+  const resetAggregateEntries = useLogStore((s) => s.resetAggregateEntries);
   const setParserSelection = useLogStore((s) => s.setParserSelection);
 
   // Start/stop tailing when file changes
@@ -101,13 +103,24 @@ export function useFileWatcher() {
   // Listen for new tail entries from the Rust backend
   useEffect(() => {
     const unlisten = listen<TailPayload>("tail-new-entries", (event) => {
-      const { entries: newEntries, filePath, parserSelection } = event.payload;
+      const { entries: newEntries, filePath, parserSelection, reset } = event.payload;
       const state = useLogStore.getState();
 
       if (state.sourceOpenMode === "aggregate-folder") {
         const isTrackedFile = state.aggregateFiles.some((file) => file.filePath === filePath);
 
-        if (!isTrackedFile || newEntries.length === 0) {
+        if (!isTrackedFile) {
+          return;
+        }
+
+        // A truncation reset must clear stale entries even when the fresh read
+        // is empty, so it cannot be gated behind the empty-batch guard below.
+        if (reset) {
+          resetAggregateEntries(filePath, newEntries);
+          return;
+        }
+
+        if (newEntries.length === 0) {
           return;
         }
 
@@ -117,12 +130,21 @@ export function useFileWatcher() {
 
       const currentPath = state.openFilePath;
 
-      if (!currentPath || currentPath !== filePath || newEntries.length === 0) {
+      if (!currentPath || currentPath !== filePath) {
         return;
       }
 
       if (parserSelection) {
         setParserSelection(parserSelection);
+      }
+
+      if (reset) {
+        resetEntries(newEntries);
+        return;
+      }
+
+      if (newEntries.length === 0) {
+        return;
       }
 
       appendEntries(newEntries);
@@ -131,5 +153,11 @@ export function useFileWatcher() {
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, [appendAggregateEntries, appendEntries, setParserSelection]);
+  }, [
+    appendAggregateEntries,
+    appendEntries,
+    resetAggregateEntries,
+    resetEntries,
+    setParserSelection,
+  ]);
 }

--- a/src/stores/log-store.test.ts
+++ b/src/stores/log-store.test.ts
@@ -65,6 +65,61 @@ describe("log-store", () => {
     });
   });
 
+  describe("resetEntries (tail truncation)", () => {
+    it("replaces the whole view with the fresh read and resets totalLines", () => {
+      useLogStore.getState().setEntries([makeEntry({ id: 1 }), makeEntry({ id: 2 })]);
+      useLogStore.getState().setTotalLines(2);
+      useLogStore.getState().appendEntries([makeEntry({ id: 3 })]);
+      expect(useLogStore.getState().entries).toHaveLength(3);
+
+      // The tailed file was truncated: the fresh read is a single new entry.
+      useLogStore.getState().resetEntries([makeEntry({ id: 4, message: "rotated" })]);
+
+      expect(useLogStore.getState().entries).toHaveLength(1);
+      expect(useLogStore.getState().entries[0].message).toBe("rotated");
+      expect(useLogStore.getState().totalLines).toBe(1);
+    });
+
+    it("clears selectedId when the selected entry is gone after reset", () => {
+      useLogStore.getState().setEntries([makeEntry({ id: 1 }), makeEntry({ id: 2 })]);
+      useLogStore.getState().selectEntry(2);
+      useLogStore.getState().resetEntries([makeEntry({ id: 5 })]);
+      expect(useLogStore.getState().selectedId).toBeNull();
+    });
+
+    it("handles an empty fresh read when the file is truncated to empty", () => {
+      useLogStore.getState().setEntries([makeEntry({ id: 1 })]);
+      useLogStore.getState().setTotalLines(1);
+      useLogStore.getState().resetEntries([]);
+      expect(useLogStore.getState().entries).toHaveLength(0);
+      expect(useLogStore.getState().totalLines).toBe(0);
+    });
+  });
+
+  describe("resetAggregateEntries (tail truncation)", () => {
+    it("replaces only the truncated file's entries and preserves the others", () => {
+      useLogStore.getState().setEntries([
+        makeEntry({ id: 1, filePath: "/a.log", timestamp: 100 }),
+        makeEntry({ id: 2, filePath: "/b.log", timestamp: 200 }),
+      ]);
+
+      useLogStore
+        .getState()
+        .resetAggregateEntries("/a.log", [
+          makeEntry({ id: 99, filePath: "/a.log", message: "rotated-a", timestamp: 50 }),
+        ]);
+
+      const entries = useLogStore.getState().entries;
+      const aEntries = entries.filter((e) => e.filePath === "/a.log");
+      const bEntries = entries.filter((e) => e.filePath === "/b.log");
+
+      expect(bEntries).toHaveLength(1);
+      expect(aEntries).toHaveLength(1);
+      expect(aEntries[0].message).toBe("rotated-a");
+      expect(useLogStore.getState().totalLines).toBe(2);
+    });
+  });
+
   describe("selectEntry", () => {
     it("sets and clears selection", () => {
       useLogStore.getState().selectEntry(5);

--- a/src/stores/log-store.ts
+++ b/src/stores/log-store.ts
@@ -558,6 +558,8 @@ interface LogState {
   hasFindSession: () => boolean;
   setEntries: (entries: LogEntry[]) => void;
   appendEntries: (entries: LogEntry[]) => void;
+  /** Replace the single-file view after a tailed file was truncated/rotated. */
+  resetEntries: (entries: LogEntry[]) => void;
   selectEntry: (id: number | null) => void;
   togglePause: () => void;
   setLoading: (loading: boolean) => void;
@@ -583,6 +585,8 @@ interface LogState {
   setFindUseRegex: (useRegex: boolean) => void;
   recomputeFindMatches: () => void;
   appendAggregateEntries: (filePath: string, entries: LogEntry[]) => void;
+  /** Replace one file's entries in an aggregate stream after it was truncated/rotated. */
+  resetAggregateEntries: (filePath: string, entries: LogEntry[]) => void;
   findNext: (trigger: string) => void;
   findPrevious: (trigger: string) => void;
   clearFind: () => void;
@@ -759,6 +763,22 @@ export const useLogStore = create<LogState>((set, get) => ({
     }));
     recomputeAndSetMatches();
   },
+  resetEntries: (newEntries) => {
+    // The tailed file was truncated/rotated: `newEntries` are a fresh read from
+    // the start of the file, so replace the whole view instead of appending.
+    // Without this, rotated logs accumulate forever and eventually OOM.
+    set((state) => ({
+      entries: newEntries,
+      totalLines: newEntries.length,
+      guidNameMap: buildGuidNameMap(newEntries),
+      selectedId:
+        state.selectedId !== null &&
+        !newEntries.some((entry) => entry.id === state.selectedId)
+          ? null
+          : state.selectedId,
+    }));
+    recomputeAndSetMatches();
+  },
   appendAggregateEntries: (filePath, newEntries) => {
     set((state) => {
       const nextId = state.entries.reduce(
@@ -779,6 +799,38 @@ export const useLogStore = create<LogState>((set, get) => ({
         entries,
         totalLines: state.totalLines + entriesWithIds.length,
         guidNameMap: mergeGuidNameMap(state.guidNameMap, newEntries),
+      };
+    });
+    recomputeAndSetMatches();
+  },
+  resetAggregateEntries: (filePath, newEntries) => {
+    // One file in the aggregate stream was truncated/rotated: drop its stale
+    // entries and re-insert the fresh read, keeping the merged sort order.
+    set((state) => {
+      const remaining = state.entries.filter((entry) => entry.filePath !== filePath);
+      const nextId = remaining.reduce(
+        (maxId, entry) => Math.max(maxId, entry.id),
+        -1
+      ) + 1;
+      const entriesWithIds = newEntries.map((entry, index) => ({
+        ...entry,
+        filePath,
+        id: nextId + index,
+      }));
+      const fileOrder = buildAggregateFileOrder(state.aggregateFiles);
+      const entries = [...remaining, ...entriesWithIds].sort((left, right) =>
+        compareMergedLogEntries(left, right, fileOrder)
+      );
+
+      return {
+        entries,
+        totalLines: entries.length,
+        guidNameMap: buildGuidNameMap(entries),
+        selectedId:
+          state.selectedId !== null &&
+          !entries.some((entry) => entry.id === state.selectedId)
+            ? null
+            : state.selectedId,
       };
     });
     recomputeAndSetMatches();

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -244,4 +244,10 @@ export interface TailPayload {
   entries: LogEntry[];
   filePath: string;
   parserSelection?: ParserSelectionInfo;
+  /**
+   * True when the tailed file was truncated/rotated: `entries` are a fresh read
+   * from the start of the file and any previously received entries for this file
+   * are now stale. Consumers must replace, not append, their existing view.
+   */
+  reset: boolean;
 }


### PR DESCRIPTION
Closes #234.

## Problem
During live tailing, when the log file was truncated or rotated (e.g. WSUS `softwaredistribution.log` during an initial sync), the backend correctly re-read the file from the start — but the frontend blindly **appended** those re-read lines on top of the stale ones. The in-memory entry array grew without bound (the reporter hit ~250k entries), which is almost certainly the same unbounded growth behind the out-of-memory crash in #193.

## Fix
Thread a truncation signal end to end:
- `TailReader::read_new_entries` now returns `TailBatch { entries, reset }`. On truncation it rewinds to byte 0 and sets `reset` (line numbers restart at 1; ids stay monotonic so they remain unique across the reset).
- The watch loop forwards the batch to the callback even when it's empty-but-reset (so a truncate-to-empty still clears the UI).
- `TailPayload` carries `reset` to the frontend.
- The frontend **replaces** the file's entries instead of appending when `reset` is set — `resetEntries` (single file) / `resetAggregateEntries` (aggregate stream) — bounding memory to the current file contents.

## Tests
- New Rust test `test_tail_reader_signals_reset_and_rewinds_on_truncation` (append does not reset; truncation does, with line numbers restarting at 1).
- New store tests for `resetEntries` / `resetAggregateEntries` (replace, reset `totalLines`, clear stale selection, handle truncate-to-empty, preserve other files in aggregate mode).
- All existing tail tests updated for the new return type and still pass.

Thanks @PraveenGururaj for the clear repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)