### PR TITLE
fix(#193): restore saved filter on Open Session + add persistent error logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,17 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -43,6 +54,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -147,6 +175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +258,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +285,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -267,6 +337,40 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a813de7f2bbedb7dce265b64f1cf5908ebe4d56281ece8d847e98113788b9b0"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.2.1",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta 0.1.4",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytecount"
@@ -539,6 +643,7 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-log",
  "tauri-plugin-os",
  "tauri-plugin-process",
  "tauri-plugin-updater",
@@ -1208,6 +1313,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,7 +1370,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a186db904e8dbf437db134e759e52482bdb39998a32c560f12fda986ed1ea2"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "anyhow",
  "bitflags 2.11.1",
  "bumpalo",
@@ -1295,7 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca7d44d22004409a61c393afb3369c8f7bb74abcae49fe249ee01dcc3002113"
 dependencies = [
  "bytes",
- "rkyv",
+ "rkyv 0.8.15",
  "serde",
  "simdutf8",
 ]
@@ -1327,6 +1442,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1476,6 +1600,12 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -1878,6 +2008,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2585,6 +2718,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "markup5ever"
@@ -3364,6 +3500,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,11 +3588,31 @@ dependencies = [
 
 [[package]]
 name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive 0.1.4",
+]
+
+[[package]]
+name = "ptr_meta"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
 dependencies = [
- "ptr_meta_derive",
+ "ptr_meta_derive 0.3.1",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3524,12 +3689,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rancor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
 dependencies = [
- "ptr_meta",
+ "ptr_meta 0.3.1",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3638,6 +3839,15 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rend"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
@@ -3721,6 +3931,24 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta 0.1.4",
+ "rend 0.4.2",
+ "rkyv_derive 0.7.46",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
@@ -3729,12 +3957,23 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "munge",
- "ptr_meta",
+ "ptr_meta 0.3.1",
  "rancor",
- "rend",
- "rkyv_derive",
+ "rend 0.5.3",
+ "rkyv_derive 0.8.15",
  "tinyvec",
  "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3746,6 +3985,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand",
+ "rkyv 0.7.46",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3950,6 +4206,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -4287,7 +4549,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bumpalo",
  "bytes",
  "cfg-if",
@@ -4506,6 +4768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4709,6 +4977,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-log"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+dependencies = [
+ "android_logger",
+ "byte-unit",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "tauri-plugin-os"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4851,7 +5141,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -5442,6 +5732,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "159a7cadce548703edd50d24069bc294c5415ecab0a480e0cd1ca06d112dc94a"
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5470,6 +5766,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "version-compare"
@@ -6559,6 +6861,15 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ tauri-plugin-clipboard-manager = "2"
 tauri-plugin-os = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-log = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,7 +52,33 @@ fn get_initial_file_paths_from_args() -> Vec<String> {
 pub fn run() {
     let initial_file_paths = get_initial_file_paths_from_args();
 
+    // Route panics to the persistent log so a hard crash (e.g. the reported
+    // out-of-memory failure) leaves a line users can attach to a report.
+    // Chained after the default hook so the standard abort message is kept.
+    let default_panic_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        log::error!("panic: {info}");
+        default_panic_hook(info);
+    }));
+
     tauri::Builder::default()
+        // Persistent file logging (issue #193): the backend already uses the
+        // `log` facade throughout, but no logger backend was ever registered so
+        // those messages went nowhere. Write to the OS app-log dir with a size
+        // cap + rotation, and keep stderr for `npm run app:dev`.
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .targets([
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {
+                        file_name: Some("cmtrace-open".into()),
+                    }),
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stderr),
+                ])
+                .level(log::LevelFilter::Info)
+                .max_file_size(5_000_000)
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepOne)
+                .build(),
+        )
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_clipboard_manager::init())

--- a/src/lib/session-restore.test.ts
+++ b/src/lib/session-restore.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { readTextFile } from "@tauri-apps/plugin-fs";
+import { restoreSession } from "./session-restore";
+import { useFilterStore } from "../stores/filter-store";
+
+// Keep restore off the real backend/file loaders — we only care that the saved
+// filter clauses end up in the filter store (issue #193).
+vi.mock("./log-source", () => ({
+  loadPathAsLogSource: vi.fn().mockResolvedValue(undefined),
+  loadFilesAsLogSource: vi.fn().mockResolvedValue(undefined),
+}));
+
+function sessionJson(clauses: unknown[]): string {
+  return JSON.stringify({
+    version: 1,
+    savedAt: "2026-01-01T00:00:00Z",
+    workspace: "log",
+    tabs: [
+      {
+        filePath: "/tmp/app.log",
+        fileHash: "abc",
+        fileSize: 100,
+        selectedId: null,
+        scrollPosition: null,
+        activeColumns: [],
+      },
+    ],
+    activeTabIndex: 0,
+    mergedTabState: null,
+    filters: {
+      clauses,
+      findQuery: "",
+      findCaseSensitive: false,
+      findUseRegex: false,
+      highlightText: "",
+    },
+    workspaceState: { type: "log" },
+  });
+}
+
+describe("restoreSession filter restore (issue #193)", () => {
+  beforeEach(() => {
+    // compute_file_hash returns a matching hash so the tab is considered valid.
+    vi.mocked(invoke).mockResolvedValue({ hash: "abc", sizeBytes: 100 });
+    useFilterStore.getState().clearFilter();
+  });
+
+  it("writes the saved filter clauses back into the filter store", async () => {
+    vi.mocked(readTextFile).mockResolvedValue(
+      sessionJson([{ field: "Message", op: "Contains", value: "error" }])
+    );
+
+    expect(useFilterStore.getState().clauses).toHaveLength(0);
+
+    await restoreSession("/tmp/session.cmtrace");
+
+    const clauses = useFilterStore.getState().clauses;
+    expect(clauses).toEqual([{ field: "Message", op: "Contains", value: "error" }]);
+  });
+
+  it("leaves the filter cleared when the session had no clauses", async () => {
+    vi.mocked(readTextFile).mockResolvedValue(sessionJson([]));
+
+    await restoreSession("/tmp/session.cmtrace");
+
+    expect(useFilterStore.getState().clauses).toHaveLength(0);
+  });
+});

--- a/src/lib/session-restore.ts
+++ b/src/lib/session-restore.ts
@@ -3,6 +3,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { readTextFile } from "@tauri-apps/plugin-fs";
 import { useLogStore } from "../stores/log-store";
 import { useUiStore } from "../stores/ui-store";
+import { useFilterStore } from "../stores/filter-store";
 import { loadPathAsLogSource, loadFilesAsLogSource } from "./log-source";
 import { validateSession, type FileChangeWarning } from "./session";
 
@@ -153,13 +154,21 @@ export async function restoreSession(sessionPath: string): Promise<string | null
     }
   }
 
-  // Restore filters AFTER files are loaded so find/highlight operate on the loaded entries
+  // Restore filters AFTER files are loaded so find/highlight/filter operate on
+  // the loaded entries. This runs after clearTabs() above (which clears the
+  // filter store), so it must repopulate the filter clauses too — otherwise
+  // Open Session silently drops the saved filter (issue #193).
   const logStore = useLogStore.getState();
   if (session.filters) {
     logStore.setHighlightText(session.filters.highlightText || "");
     logStore.setFindQuery(session.filters.findQuery || "");
     logStore.setFindCaseSensitive(session.filters.findCaseSensitive ?? false);
     logStore.setFindUseRegex(session.filters.findUseRegex ?? false);
+    if (session.filters.clauses.length > 0) {
+      // Writing the store re-applies the filter to the loaded entries and
+      // refreshes the toolbar badge, status bar, and Filter dialog.
+      useFilterStore.getState().setClauses(session.filters.clauses);
+    }
   }
 
   return sessionPath;

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { validateSession, createEmptySession } from "./session";
+
+function sessionWith(clauses: unknown[]): Record<string, unknown> {
+  return {
+    version: 1,
+    savedAt: "2026-01-01T00:00:00Z",
+    workspace: "log",
+    tabs: [],
+    activeTabIndex: 0,
+    mergedTabState: null,
+    filters: {
+      clauses,
+      findQuery: "",
+      findCaseSensitive: false,
+      findUseRegex: false,
+      highlightText: "",
+    },
+    workspaceState: { type: "log" },
+  };
+}
+
+describe("validateSession filter clauses", () => {
+  it("keeps well-formed clauses", () => {
+    const session = validateSession(
+      sessionWith([{ field: "Message", op: "Contains", value: "error" }])
+    );
+    expect(session).not.toBeNull();
+    expect(session!.filters.clauses).toEqual([
+      { field: "Message", op: "Contains", value: "error" },
+    ]);
+  });
+
+  it("drops malformed clauses but keeps valid ones", () => {
+    const session = validateSession(
+      sessionWith([
+        { field: "Message", op: "Contains", value: "error" }, // valid
+        { field: "Bogus", op: "Contains", value: "x" }, // invalid field
+        { field: "Message", op: "Nope", value: "x" }, // invalid op
+        { field: "Message", op: "Contains", value: 42 }, // non-string value
+        "not-an-object",
+        null,
+      ])
+    );
+    expect(session).not.toBeNull();
+    expect(session!.filters.clauses).toEqual([
+      { field: "Message", op: "Contains", value: "error" },
+    ]);
+  });
+
+  it("yields an empty clause list when clauses is missing or not an array", () => {
+    const empty = createEmptySession();
+    expect(empty.filters.clauses).toEqual([]);
+
+    const session = validateSession(sessionWith("nonsense" as unknown as unknown[]));
+    expect(session).not.toBeNull();
+    expect(session!.filters.clauses).toEqual([]);
+  });
+});

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,3 +1,9 @@
+import type {
+  FilterClause,
+  FilterField,
+  FilterOp,
+} from "../components/dialogs/FilterDialog";
+
 export interface SessionFile {
   version: number;
   savedAt: string;
@@ -26,7 +32,7 @@ export interface SessionMergedState {
 }
 
 export interface SessionFilters {
-  clauses: unknown[];
+  clauses: FilterClause[];
   findQuery: string;
   findCaseSensitive: boolean;
   findUseRegex: boolean;
@@ -50,6 +56,42 @@ export type SessionWorkspaceState =
   | { type: string };
 
 const CURRENT_VERSION = 1;
+
+// Valid filter clause fields/ops, mirrored from FilterDialog. Used to sanitize
+// clauses loaded from a session file so a malformed or hand-edited session can
+// never inject a clause that would be replayed to the backend `apply_filter`.
+const FILTER_FIELDS: readonly FilterField[] = [
+  "Message",
+  "Component",
+  "Thread",
+  "Timestamp",
+  "Severity",
+];
+const FILTER_OPS: readonly FilterOp[] = [
+  "Equals",
+  "NotEquals",
+  "Contains",
+  "NotContains",
+  "Before",
+  "After",
+];
+
+/** Keep only well-formed filter clauses from an untrusted session file. */
+function sanitizeClauses(raw: unknown): FilterClause[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((candidate) => {
+    if (typeof candidate !== "object" || candidate === null) return [];
+    const c = candidate as Record<string, unknown>;
+    if (
+      (FILTER_FIELDS as readonly string[]).includes(c.field as string) &&
+      (FILTER_OPS as readonly string[]).includes(c.op as string) &&
+      typeof c.value === "string"
+    ) {
+      return [{ field: c.field as FilterField, op: c.op as FilterOp, value: c.value }];
+    }
+    return [];
+  });
+}
 
 export function createEmptySession(): SessionFile {
   return {
@@ -101,7 +143,7 @@ export function validateSession(data: unknown): SessionFile | null {
     ? obj.filters as Record<string, unknown>
     : {};
   const filters: SessionFilters = {
-    clauses: Array.isArray(rawFilters.clauses) ? rawFilters.clauses : [],
+    clauses: sanitizeClauses(rawFilters.clauses),
     findQuery: typeof rawFilters.findQuery === "string" ? rawFilters.findQuery : "",
     findCaseSensitive: typeof rawFilters.findCaseSensitive === "boolean" ? rawFilters.findCaseSensitive : false,
     findUseRegex: typeof rawFilters.findUseRegex === "boolean" ? rawFilters.findUseRegex : false,


### PR DESCRIPTION
Addresses the three items in #193. Rebased onto current `main` (post #240 workspace/lockfile repair).

## 1. Out of Memory
Root-caused to the log-tailing bug fixed separately in #243 (rotated/truncated logs accumulated entries without bound). The persistent logging added here makes future OOM reports diagnosable.

## 2. Filter not restored on Open Session (fixed here)
**Save Session** persisted the filter clauses, but **Open Session** only re-applied highlight/find text and never wrote the clauses back into the filter store — and `clearTabs()` actively cleared any existing filter during load — so the filter came back empty every time.

- `session-restore.ts` now restores the saved clauses into the filter store after files load, which re-applies the filter to the loaded entries and refreshes the toolbar badge, status bar, and Filter dialog.
- `session.ts` now types and sanitizes `SessionFilters.clauses` as `FilterClause[]`, so a malformed or hand-edited session file can't inject a bogus clause into the backend `apply_filter`.
- New tests: `session.test.ts` (validation drops malformed clauses) and `session-restore.test.ts` (Open Session repopulates the filter store).

## 3. "Does it log errors, and where?" (added here)
Today: **no** — the backend uses the `log` facade throughout but no logger backend was registered, so nothing was written to disk.

This registers `tauri-plugin-log` to write to the OS app-log directory (`cmtrace-open.log`; on Windows `%LOCALAPPDATA%\com.cmtrace.open\logs\`) with a 5 MB cap + single-file rotation, and adds a panic hook so a hard crash leaves a line. Backend-only — no frontend log capability, so no `tauri.conf.json` change is needed. `Cargo.toml` + the root `Cargo.lock` are both updated (additive: `tauri-plugin-log` and its transitive deps).

Closes #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)