### PR TITLE
chore(ci): enforce clippy --all-targets and fix latent test-only lints

### DIFF
--- a/.github/workflows/cmtrace-ci.yml
+++ b/.github/workflows/cmtrace-ci.yml
@@ -64,11 +64,11 @@ jobs:
 
       - name: Rust clippy (lite)
         working-directory: src-tauri
-        run: cargo clippy --no-default-features -- -D warnings
+        run: cargo clippy --no-default-features --all-targets -- -D warnings
 
       - name: Rust clippy
         working-directory: src-tauri
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Install cargo-deny and cargo-audit
         uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6

--- a/src-tauri/src/commands/fonts.rs
+++ b/src-tauri/src/commands/fonts.rs
@@ -38,7 +38,7 @@ mod tests {
     fn test_list_is_sorted() {
         let result = list_system_fonts();
         let mut sorted = result.families.clone();
-        sorted.sort_unstable_by(|a, b| a.to_ascii_lowercase().cmp(&b.to_ascii_lowercase()));
+        sorted.sort_unstable_by_key(|a| a.to_ascii_lowercase());
         assert_eq!(result.families, sorted);
     }
 

--- a/src-tauri/tests/dns_audit_real.rs
+++ b/src-tauri/tests/dns_audit_real.rs
@@ -1,6 +1,7 @@
 //! Integration test against the real DNS audit EVTX fixture.
 //! Skipped if the fixture file is not present.
 //! Requires the `event-log` feature.
+#![cfg(feature = "event-log")]
 
 use std::path::Path;
 
@@ -10,7 +11,6 @@ const FIXTURE_PATH: &str = concat!(
 );
 
 #[test]
-#[cfg(feature = "event-log")]
 fn test_real_dns_audit_evtx() {
     if !Path::new(FIXTURE_PATH).exists() {
         eprintln!("Skipping: real DNS audit EVTX fixture not found at {}", FIXTURE_PATH);


### PR DESCRIPTION
Follow-up to the #234/#193/#205/#227 fixes — addresses the pre-existing clippy lint spotted in passing.

## Problem
CI runs `cargo clippy -- -D warnings` **without** `--all-targets`, so it never compiles test/bench modules and misses lints there. Two such lints were latent:

1. `src-tauri/src/commands/fonts.rs` — `sort_unstable_by(|a, b| a.to_ascii_lowercase().cmp(&b.to_ascii_lowercase()))`, which clippy 1.92+ flags as `clippy::unnecessary_sort_by`.
2. `src-tauri/tests/dns_audit_real.rs` — the file's `use std::path::Path;` and `const FIXTURE_PATH` sat outside the `event-log` `#[cfg]`, so `--no-default-features --all-targets` failed with unused-import / unused-const.

## Change
- fonts.rs: use clippy's suggestion (`sort_unstable_by_key`).
- dns_audit_real.rs: gate the whole file with `#![cfg(feature = "event-log")]` (it already documented that it requires the feature) and drop the now-redundant per-function `#[cfg]`.
- CI: add `--all-targets` to both the full and lite clippy steps so test-only lints are caught going forward.

## Verification
Both pass locally:
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --no-default-features --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)