### PR TITLE
fix(log-view): replace raw NUL byte in marker key with \x00 escape

### DIFF
--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -244,7 +244,7 @@ export function LogListView({ dataSource }: { dataSource?: LogListDataSource } =
   }, [displayEntries, isMerged]);
   // Stable JSON key so loadMarkers fires on set membership change, not on
   // every new array reference.
-  const markerFilePathsKey = markerFilePaths.join(" ");
+  const markerFilePathsKey = markerFilePaths.join("\x00");
 
   useEffect(() => {
     if (isMerged) return;


### PR DESCRIPTION
### What
`LogListView.tsx` contained a **raw NUL (0x00) control character** embedded directly in a string literal:

```js
const markerFilePathsKey = markerFilePaths.join("<NUL>");  // one literal 0x00 byte
```

Replaced with the escape sequence — **byte-for-byte identical at runtime**:

```js
const markerFilePathsKey = markerFilePaths.join("\x00");
```

### Why
A lone NUL byte makes tooling treat the whole file as **binary**:
- `file` reports it as `data`, not text.
- ugrep / ripgrep skip it under `-I` (ignore-binary), so `grep` silently finds **nothing** in this file — it returns no matches even for tokens that exist.
- Some editors and diff/review viewers mishandle embedded NULs.

Using the `"\x00"` escape keeps the delimiter semantics (NUL is the right choice — it's the one character a filesystem path can't contain) while keeping the source plain ASCII. After the change, `file` reports UTF-8 text and grep works normally.

### Scope / history
Pre-existing since 2026-05-01 (`0dafdb8`), unrelated to any recent feature — surfaced while diagnosing why `grep` returned nothing for this file.

### Verification
- `npx tsc --noEmit` — clean
- `npx vitest run` — 138 passed (no behavior change; `"\x00"` produces the same 1-char NUL string)
- `file` now reports UTF-8 text; wrapped `grep` finds `getCanvasFont`, `markerFilePathsKey`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)