### PR TITLE
chore: pin remaining floating action refs and fix dependabot cargo directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,9 @@ updates:
         dependency-type: "production"
     open-pull-requests-limit: 10
 
-  # Rust crate dependencies
+  # Rust crate dependencies — the workspace Cargo.lock lives at the repo root
   - package-ecosystem: "cargo"
-    directory: "/src-tauri"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/download-metrics.yml
+++ b/.github/workflows/download-metrics.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out collector source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Build & CI
+
+- **Pin the last floating action refs (#274)**: `download-metrics.yml` was the only workflow still referencing actions by mutable tag (`actions/checkout@v7`, `actions/setup-node@v7`); every other call site in the repo is SHA-pinned with a `# vX.Y.Z` trailer, and `.github/dependabot.yml` documents the github-actions ecosystem as "proposes SHA pin updates when new versions release". It is also the least safe place to keep a floating ref rather than the most harmless: the workflow runs unattended on a `17 0 * * *` cron with `permissions: contents: write`, passes `GITHUB_TOKEN` into the collector, and pushes commits to the `download-metrics` branch — and it is covered by no required status check, so a failure surfaces silently. Both steps are now pinned to the same SHAs the rest of the repo uses. These two tags were also the sole reason Dependabot titled the recent action bumps "from 4 to 7" (it reports the lowest version present in the repo).
+- **Point Dependabot's cargo ecosystem at the workspace root (#274)**: The cargo entry in `.github/dependabot.yml` was still set to `directory: "/src-tauri"`, but #240 moved the workspace lockfile to the repo root — there is no `src-tauri/Cargo.lock`. As a result Dependabot had opened no cargo pull requests since that move, so Rust dependencies never self-healed while npm-side bumps kept arriving weekly. Now set to `/`.
+
+### Dependencies
+
+- **Rust**: `tauri-plugin-dialog` 2.7.1 → 2.7.2 (#274), realigning the Rust half with the npm half bumped in #272. 2.7.2 is an Android-only fix (`MaterialAlertDialogBuilder`) with no effect on this app's targets, but the two halves are kept in lockstep by convention — and the frontend suite cannot detect plugin drift at all, since `src/test-setup.ts` mocks `@tauri-apps/plugin-dialog` wholesale.
+- **Frontend (production)**: `@fluentui/react-components` 9.74.3 → 9.74.4, `@fluentui/react-charts` 9.3.21 → 9.3.22, `@tanstack/react-virtual` 3.14.6 → 3.14.7, `@tauri-apps/plugin-dialog` 2.7.1 → 2.7.2 (#272). The only functional change in the group is `@tanstack/virtual-core` 3.17.4 → 3.17.5, which clamps `scrollOffset` at a lower bound of 0 and resets the deferred iOS scroll adjustment inside `scrollToOffset`/`scrollToIndex` (upstream TanStack/virtual #1229, #1233) — an upstream bugfix that lands in the log list's tail-follow and jump-to-entry paths.
+- **Frontend (dev)**: `@testing-library/jest-dom` 6.9.1 → 7.0.0 and `vite` 8.1.4 → 8.1.5 (#271). jest-dom 7 promotes `@testing-library/dom` to a required peer (satisfied at 10.4.1) and raises its declared minimum Node to 22, while CI pins Node 20; the published bundle uses no Node 22-only APIs and the full suite passes, so this is a supportability note rather than a break.
+- **GitHub Actions**: `actions/setup-node` 6.4.0 → 7.0.0 (#270), `actions/checkout` 7.0.0 → 7.0.1 (#268), `taiki-e/install-action` 2.83.2 → 2.84.0 (#269). Despite Dependabot's "from 4 to 7" titles, `main` was already SHA-pinned to checkout v7.0.0 everywhere except `download-metrics.yml`, so the checkout change is a patch across ten steps: v7.0.1 escapes the credentials-file path before `git config --unset` (actions/checkout #2530), which matters on the Windows signing jobs where that path contains backslashes. Neither major alters any action input — the entire `action.yml` delta from checkout v4 to v7.0.1 is `using: node20` → `node24` — and the v7.0.0 fork-PR restriction does not apply, as no workflow here triggers on `pull_request_target` or `workflow_run`.
+
 ## [1.4.0] - 2026-07-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,9 +4931,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
 dependencies = [
  "log",
  "raw-window-handle",


### PR DESCRIPTION
Follow-ups surfaced while reviewing and merging the 2026-07-20 dependabot batch (#268, #269, #270, #271, #272). All three are defects those PRs exposed but could not fix themselves.

## 1. Pin `download-metrics.yml` to SHAs

It was the **only** workflow left using mutable tag refs (`actions/checkout@v7`, `actions/setup-node@v7`); every other call site in the repo is SHA-pinned with a `# vX.Y.Z` trailer, and `.github/dependabot.yml` documents the github-actions ecosystem as "proposes SHA pin updates when new versions release".

It is also the worst place to keep a floating ref rather than the most harmless:

- `permissions: contents: write` (`:8-9`)
- passes `GITHUB_TOKEN: ${{ github.token }}` into `npm run collect` (`:55`)
- runs `git -C metrics-worktree push origin HEAD:download-metrics` (`:74`)
- fires unattended on cron `17 0 * * *` (`:5`) and is covered by **no** required status check

A re-pointed upstream tag would execute with a token that can push commits, nightly, with nobody watching. Pinned to the same SHAs the rest of the repo now uses.

> Side note: these two floating tags are also *why* dependabot titled the recent bumps "from 4 to 7". It reports the lowest version present in the repo — `main` was already on SHA-pinned checkout v7.0.0 everywhere else, so 10 of those 11 steps were really a v7.0.0 → v7.0.1 patch.

## 2. Point the dependabot cargo ecosystem at `/`

It was set to `directory: "/src-tauri"`, but PR #240 moved the workspace lockfile to the repo root — there is no `src-tauri/Cargo.lock`. Consequence: dependabot has opened **zero** cargo PRs since that move, so the Rust dependency half never self-heals while npm-side bumps keep arriving weekly.

## 3. Align `tauri-plugin-dialog` Rust half to 2.7.2

Direct fallout from #2: #272 took the npm half to 2.7.2 while the Rust half stayed at 2.7.1.

No functional impact today — 2.7.2 is an Android-only fix, and the npm tarballs for 2.7.1/2.7.2 differ only in the `version` field — but this repo keeps the halves aligned by convention, and the frontend suite cannot catch plugin drift at all (`src/test-setup.ts` mocks `@tauri-apps/plugin-dialog` wholesale).

Edited **surgically** rather than via `cargo update -p tauri-plugin-dialog --precise 2.7.2`, which additionally unified `windows-sys` to 0.61.2 across ~15 crates and bumped `getrandom` 0.3.4 → 0.4.2 — unrelated churn on the Windows build surface.

## Verification

- Dependency sets for 2.7.1 vs 2.7.2 are identical (`log`'s req tightens to `^0.4.21`; resolved `log` is 0.4.29)
- 2.7.2 checksum confirmed independently against the crates.io API; not yanked
- `cargo metadata --locked` exits 0
- `cargo check --locked --workspace` passes, compiling `tauri-plugin-dialog v2.7.2`
- Cargo lockfile stays at exactly 2 changed lines — cargo does not rewrite it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nQJNW7RKRuRRfzfdvtQYR