### PR TITLE
chore: raise Rust MSRV to 1.88 and make sha256 hex formatting sha2-0.11-ready

### DIFF
--- a/.github/workflows/cmtrace-ci.yml
+++ b/.github/workflows/cmtrace-ci.yml
@@ -86,13 +86,13 @@ jobs:
         run: cargo audit
 
   msrv:
-    name: Rust MSRV (1.77.2 / ${{ matrix.os }})
+    name: Rust MSRV (1.88 / ${{ matrix.os }})
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
@@ -105,10 +105,10 @@ jobs:
             librsvg2-dev \
             patchelf
 
-      - name: Setup Rust 1.77.2
+      - name: Setup Rust 1.88
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: "1.77.2"
+          toolchain: "1.88"
 
       - name: Cache Rust dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -118,11 +118,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             src-tauri/target/
-          key: ${{ runner.os }}-cargo-msrv-1.77.2-${{ hashFiles('Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-msrv-1.77.2-
+          key: ${{ runner.os }}-cargo-msrv-1.88-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-msrv-1.88-
 
       - name: Rust MSRV check
-        run: cargo +1.77.2 check --workspace --all-features --locked
+        run: cargo +1.88 check --workspace --all-features --locked
 
   frontend:
     name: TypeScript Check
@@ -157,7 +157,7 @@ jobs:
     name: ESP Diagnostics (Windows)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Format detection (`detect.rs`) samples the first lines of a file to auto-select 
 ## Prerequisites
 
 - Node.js 18+ (v20 LTS recommended)
-- Rust 1.77.2+ (MSVC toolchain on Windows)
+- Rust 1.88+ (MSVC toolchain on Windows)
 - Windows: Visual Studio Build Tools with C++ workload + Windows SDK + WebView2 Runtime
 - Automated Windows setup: `powershell -ExecutionPolicy Bypass -File .\scripts\Install-CMTraceOpenBuildPrereqs.ps1`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing. This guide covers development setup, b
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) v18+ (v20 LTS recommended)
-- [Rust](https://www.rust-lang.org/tools/install) 1.77.2+ (MSVC toolchain on Windows)
+- [Rust](https://www.rust-lang.org/tools/install) 1.88+ (MSVC toolchain on Windows)
 - [Tauri v2 prerequisites](https://v2.tauri.app/start/prerequisites/)
 
 ### Windows-specific

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 members = ["src-tauri", "crates/cmtraceopen-parser"]
 resolver = "2"
 
-# time 0.3.47 fixes RUSTSEC-2026-0009 but requires Rust 1.88. Keep the
-# workspace's Rust 1.77.2 contract with the documented upstream backport.
+# time 0.3.47 fixes RUSTSEC-2026-0009 but requires Rust 1.88, which the old
+# 1.77.2 floor could not meet -- hence this vendored backport. The floor is now
+# 1.88, so this patch (and the `time = "=0.3.36"` pin in src-tauri) is no longer
+# required and can be dropped in favour of upstream 0.3.47 as a follow-up.
 [patch.crates-io]
 time = { path = "vendor/time-0.3.36" }

--- a/crates/cmtraceopen-parser/Cargo.toml
+++ b/crates/cmtraceopen-parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cmtraceopen-parser"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.77.2"
+rust-version = "1.88"
 description = "Pure-Rust log-format parser, error-code database, and entry models for CMTrace Open. Targets native and wasm32."
 license = "MIT"
 

--- a/crates/cmtraceopen-parser/src/esp/redaction.rs
+++ b/crates/cmtraceopen-parser/src/esp/redaction.rs
@@ -384,7 +384,7 @@ fn plain_json_container_end(bytes: &[u8], start: usize) -> usize {
     let mut in_string = false;
 
     for index in start..bytes.len() {
-        if bytes[index] == b'"' && preceding_backslash_count(bytes, index) % 2 == 0 {
+        if bytes[index] == b'"' && preceding_backslash_count(bytes, index).is_multiple_of(2) {
             in_string = !in_string;
             continue;
         }
@@ -444,7 +444,7 @@ fn json_string_end(bytes: &[u8], start: usize) -> usize {
             continue;
         }
         let slash_count = preceding_backslash_count(bytes, index);
-        if slash_count % 2 == 0 {
+        if slash_count.is_multiple_of(2) {
             return index + 1;
         }
     }

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -122,7 +122,7 @@ impl GuidRegistry {
         let dominated = self
             .entries
             .get(&guid)
-            .map_or(true, |existing| source > existing.source);
+            .is_none_or(|existing| source > existing.source);
         if dominated {
             self.entries.insert(guid, GuidEntry { name, source });
         }

--- a/scripts/ci-bundle-outputs.test.mjs
+++ b/scripts/ci-bundle-outputs.test.mjs
@@ -20,6 +20,26 @@ const scriptPath = fileURLToPath(
 const workflowPath = fileURLToPath(
   new URL("../.github/workflows/cmtrace-ci.yml", import.meta.url),
 );
+const appManifestPath = fileURLToPath(
+  new URL("../src-tauri/Cargo.toml", import.meta.url),
+);
+
+/**
+ * The MSRV is declared in src-tauri/Cargo.toml; CI must pin the same version.
+ * Reading it here rather than hardcoding keeps this contract honest across
+ * bumps -- the test asserts manifest/CI agreement, not one frozen number.
+ */
+function declaredMsrv() {
+  const manifest = readFileSync(appManifestPath, "utf8");
+  const match = manifest.match(/^rust-version\s*=\s*"([^"]+)"/m);
+  assert.ok(match, "src-tauri/Cargo.toml must declare rust-version");
+  return match[1];
+}
+
+/** Escape a version string for safe use inside a RegExp. */
+function reEscape(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 function createBundleWorkspace(t) {
   const root = mkdtempSync(join(tmpdir(), "cmtrace-ci-bundle-"));
@@ -255,9 +275,10 @@ function assertMsrvWorkflowContract(workflowText) {
     msrvJob,
     /- name: Install system dependencies\n\s+if: runner\.os == 'Linux'/,
   );
+  const msrv = declaredMsrv();
   const orderedSteps = [
     "- name: Install system dependencies",
-    "- name: Setup Rust 1.77.2",
+    `- name: Setup Rust ${msrv}`,
     "- name: Cache Rust dependencies",
     "- name: Rust MSRV check",
   ];
@@ -269,17 +290,24 @@ function assertMsrvWorkflowContract(workflowText) {
     previousIndex = index;
   }
 
+  const v = reEscape(msrv);
   assert.match(
     msrvJob,
-    /- name: Setup Rust 1\.77\.2[\s\S]*?uses: dtolnay\/rust-toolchain@[0-9a-f]{40}[\s\S]*?toolchain: "1\.77\.2"/,
+    new RegExp(
+      `- name: Setup Rust ${v}[\\s\\S]*?uses: dtolnay/rust-toolchain@[0-9a-f]{40}[\\s\\S]*?toolchain: "${v}"`,
+    ),
   );
   assert.match(
     msrvJob,
-    /- name: Cache Rust dependencies[\s\S]*?src-tauri\/target\/[\s\S]*?key: \$\{\{ runner\.os \}\}-cargo-msrv-1\.77\.2-\$\{\{ hashFiles\('Cargo\.lock'\) \}\}/,
+    new RegExp(
+      `- name: Cache Rust dependencies[\\s\\S]*?src-tauri/target/[\\s\\S]*?key: \\$\\{\\{ runner\\.os \\}\\}-cargo-msrv-${v}-\\$\\{\\{ hashFiles\\('Cargo\\.lock'\\) \\}\\}`,
+    ),
   );
   assert.match(
     msrvJob,
-    /- name: Rust MSRV check\n\s+run: cargo \+1\.77\.2 check --workspace --all-features --locked/,
+    new RegExp(
+      `- name: Rust MSRV check\\n\\s+run: cargo \\+${v} check --workspace --all-features --locked`,
+    ),
   );
 }
 
@@ -293,7 +321,7 @@ test("CI bundle workflow contract accepts CRLF line endings", () => {
   assert.doesNotThrow(() => assertWorkflowContract(workflow));
 });
 
-test("CI enforces the declared Rust 1.77.2 MSRV", () => {
+test("CI enforces the MSRV declared in src-tauri/Cargo.toml", () => {
   assertMsrvWorkflowContract(readFileSync(workflowPath, "utf8"));
 });
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ description = "Open-source CMTrace log viewer with Intune diagnostics"
 authors = ["Adam Gell"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.77.2"
+rust-version = "1.88"
 
 [lib]
 name = "app_lib"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,8 +51,9 @@ notify = "8"
 tokio = { version = "1", features = ["fs", "io-util", "sync", "rt", "net"] }
 rayon = "1.10"
 font-kit = "0.14"
-# evtx 0.12 uses Cargo's 2024 edition, which Cargo 1.77.2 cannot parse.
-# Keep this exact pin aligned with the declared MSRV and its CI check.
+# evtx 0.12 uses Cargo's 2024 edition, which Cargo 1.77.2 could not parse.
+# The MSRV is now 1.88, so this exact pin is no longer MSRV-mandated; it is
+# retained deliberately and can be revisited separately.
 evtx = { version = "=0.8.5", optional = true }
 quick-xml = { version = "0.38", optional = true }
 glob = "0.3"
@@ -63,7 +64,8 @@ anyhow = "1"
 zip = { version = "=2.4.2", default-features = false, features = ["deflate"], optional = true }
 cab = { version = "=0.6.0", optional = true }
 # This exact requirement makes Cargo select the security-backported path patch
-# in the workspace root instead of a newer release that exceeds Rust 1.77.2.
+# in the workspace root. With the MSRV now at 1.88, upstream time 0.3.47 (which
+# carries the real RUSTSEC-2026-0009 fix) is reachable -- see the root Cargo.toml.
 time = { version = "=0.3.36", default-features = false, features = ["parsing"] }
 
 [target.'cfg(unix)'.dependencies]
@@ -74,8 +76,8 @@ plist = { version = "1", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.56"
-# windows 0.62 raises its MSRV to Rust 1.82. Keep the 0.61 line for the
-# application's declared Rust 1.77.2 floor and exercise it in Windows CI.
+# windows 0.62 raises its MSRV to Rust 1.82, which the old 1.77.2 floor barred.
+# The floor is now 1.88; the 0.61 pin is kept for now and exercised in Windows CI.
 windows = { version = "=0.61.3", features = [
     "Win32_Foundation",
     "Win32_NetworkManagement_NetManagement",
@@ -100,8 +102,8 @@ windows = { version = "=0.61.3", features = [
     "Win32_System_WinRT",
 ] }
 windows-future = "=0.2.1"
-# ureq 3.3 uses Cargo's 2024 edition and requires Rust 1.85.
-# Keep this exact pin aligned with the declared Rust 1.77.2 MSRV.
+# ureq 3.3 uses Cargo's 2024 edition and requires Rust 1.85, which the old
+# 1.77.2 floor barred. The floor is now 1.88; this pin is kept for now.
 ureq = "=3.2.0"
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]

--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -529,6 +529,7 @@ pub struct FileHashResult {
 #[tauri::command]
 pub fn compute_file_hash(path: String) -> Result<FileHashResult, crate::error::AppError> {
     use sha2::{Digest, Sha256};
+    use std::fmt::Write as _;
     use std::io::Read;
 
     let mut file = std::fs::File::open(&path).map_err(crate::error::AppError::Io)?;
@@ -546,7 +547,13 @@ pub fn compute_file_hash(path: String) -> Result<FileHashResult, crate::error::A
         hasher.update(&buffer[..bytes_read]);
     }
 
-    let hash = format!("sha256:{:x}", hasher.finalize());
+    // Formatted byte-by-byte rather than with `{:x}`: sha2 0.11 returns a
+    // hybrid-array `Array`, which (unlike generic-array) has no `LowerHex` impl.
+    // Output is byte-identical to the old `{:x}`.
+    let mut hash = String::from("sha256:");
+    for byte in hasher.finalize() {
+        let _ = write!(&mut hash, "{byte:02x}");
+    }
     Ok(FileHashResult { hash, size_bytes })
 }
 

--- a/src-tauri/src/commands/markers.rs
+++ b/src-tauri/src/commands/markers.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::fs;
 
 use serde::{Deserialize, Serialize};
@@ -43,7 +44,16 @@ pub struct MarkerFile {
 fn hash_file_path(file_path: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(file_path.as_bytes());
-    format!("{:x}", hasher.finalize())
+    // Formatted byte-by-byte rather than with `{:x}`: sha2 0.11 returns a
+    // hybrid-array `Array`, which (unlike generic-array) has no `LowerHex` impl.
+    // Output is byte-identical to the old `{:x}`, so existing marker keys survive.
+    hasher
+        .finalize()
+        .iter()
+        .fold(String::with_capacity(64), |mut acc, byte| {
+            let _ = write!(acc, "{byte:02x}");
+            acc
+        })
 }
 
 /// Resolve the path `markers/<hash>.json` inside the app data directory.
@@ -110,4 +120,34 @@ pub fn delete_markers(file_path: String, app: AppHandle) -> Result<(), AppError>
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `hash_file_path` names the on-disk marker file, so its output is a storage
+    /// key: any change to the encoding orphans every marker a user has saved.
+    /// This pins the exact lowercase, zero-padded, 64-char form that `{:x}`
+    /// produced before the sha2 0.11 / hybrid-array migration.
+    #[test]
+    fn hash_file_path_encoding_is_stable() {
+        assert_eq!(
+            hash_file_path(r"C:\logs\test.log"),
+            "2a6f96d670395f2b2072bedc3553e06131f7887b9f943e3971496d0c3f1b1240"
+        );
+    }
+
+    #[test]
+    fn hash_file_path_pads_leading_zero_nibble() {
+        // "marker-5" hashes to a digest whose first byte is 0x0b. Formatting per
+        // byte with `{:x}` instead of `{:02x}` would emit "b" for that byte and
+        // yield a 63-char string, so this pins the zero padding.
+        let hash = hash_file_path("marker-5");
+        assert_eq!(hash.len(), 64);
+        assert_eq!(
+            hash,
+            "0b58d27bafce39bac0c607e45047a13f95f4ff3d443d447472b9c00a23840d64"
+        );
+    }
 }

--- a/src-tauri/src/esp/archive.rs
+++ b/src-tauri/src/esp/archive.rs
@@ -1013,7 +1013,7 @@ fn decode_registry_text(bytes: &[u8]) -> Result<String, ArchiveError> {
 }
 
 fn decode_utf16(bytes: &[u8], little_endian: bool) -> Result<String, ArchiveError> {
-    if bytes.len() % 2 != 0 {
+    if !bytes.len().is_multiple_of(2) {
         return Err(ArchiveError::InvalidEvidence {
             detail: "registry export contains an odd number of UTF-16 bytes".to_string(),
         });

--- a/src-tauri/src/esp/process.rs
+++ b/src-tauri/src/esp/process.rs
@@ -639,7 +639,7 @@ fn find_matching_argument_quote(bytes: &[u8], start: usize, quote: u8) -> Option
             while slash_start > start && bytes[slash_start - 1] == b'\\' {
                 slash_start -= 1;
             }
-            if (cursor - slash_start) % 2 == 0 {
+            if (cursor - slash_start).is_multiple_of(2) {
                 return Some(cursor);
             }
         }
@@ -921,7 +921,7 @@ fn secret_argument_end(
                 index += 1;
             }
             if index < bytes.len() && bytes[index] == b'"' {
-                if !in_single_quotes && (index - slash_start) % 2 == 0 {
+                if !in_single_quotes && (index - slash_start).is_multiple_of(2) {
                     in_double_quotes = !in_double_quotes;
                 }
                 index += 1;

--- a/src-tauri/src/esp/registry.rs
+++ b/src-tauri/src/esp/registry.rs
@@ -1168,7 +1168,7 @@ fn decode_registry_value(value_type: u32, bytes: &[u8]) -> Option<EspObservation
 
 #[cfg(any(target_os = "windows", test))]
 fn decode_utf16_units(bytes: &[u8]) -> Option<Vec<u16>> {
-    if bytes.len() % 2 != 0 {
+    if !bytes.len().is_multiple_of(2) {
         return None;
     }
     Some(

--- a/src-tauri/src/esp/relaunch.rs
+++ b/src-tauri/src/esp/relaunch.rs
@@ -186,15 +186,15 @@ fn quote_windows_argument(argument: &str) -> String {
             continue;
         }
         if character == '"' {
-            quoted.extend(std::iter::repeat('\\').take(backslashes * 2 + 1));
+            quoted.extend(std::iter::repeat_n('\\', backslashes * 2 + 1));
             quoted.push('"');
         } else {
-            quoted.extend(std::iter::repeat('\\').take(backslashes));
+            quoted.extend(std::iter::repeat_n('\\', backslashes));
             quoted.push(character);
         }
         backslashes = 0;
     }
-    quoted.extend(std::iter::repeat('\\').take(backslashes * 2));
+    quoted.extend(std::iter::repeat_n('\\', backslashes * 2));
     quoted.push('"');
     quoted
 }

--- a/src-tauri/src/esp/session.rs
+++ b/src-tauri/src/esp/session.rs
@@ -377,7 +377,7 @@ impl EspSessionManager {
             || control
                 .reservation
                 .as_ref()
-                .map_or(true, |reservation| reservation.session_id != session_id)
+                .is_none_or(|reservation| reservation.session_id != session_id)
         {
             active.cancellation.cancel();
             active.activation.release();
@@ -864,10 +864,10 @@ impl SessionEngine {
         let replacements = replace_artifact_ids.into_iter().collect::<BTreeSet<_>>();
         if !replacements.is_empty() {
             self.tail_records.retain(|record| {
-                record_artifact_id(record.record()).map_or(true, |id| !replacements.contains(id))
+                record_artifact_id(record.record()).is_none_or(|id| !replacements.contains(id))
             });
             self.tail_coverage.retain(|record| {
-                coverage_artifact_id(record.record()).map_or(true, |id| !replacements.contains(id))
+                coverage_artifact_id(record.record()).is_none_or(|id| !replacements.contains(id))
             });
         }
         self.tail_records.extend(reconcile_identified_records(
@@ -931,7 +931,7 @@ fn coherent_utc_timestamp<'a>(
         else {
             continue;
         };
-        if latest.map_or(true, |current| observed > current) {
+        if latest.is_none_or(|current| observed > current) {
             coherent = observed.to_rfc3339_opts(SecondsFormat::AutoSi, true);
             latest = Some(observed);
         }

--- a/src-tauri/src/macos_diag/unified_log.rs
+++ b/src-tauri/src/macos_diag/unified_log.rs
@@ -266,8 +266,7 @@ mod tests {
     fn test_parse_ndjson_log_entries_capped() {
         let line = r#"{"timestamp":"2024-01-01 00:00:00.000000-0000","processImagePath":"/usr/bin/test","messageType":"Info","eventMessage":"msg","processID":1}"#;
         // Create 10 lines
-        let input = std::iter::repeat(line)
-            .take(10)
+        let input = std::iter::repeat_n(line, 10)
             .collect::<Vec<_>>()
             .join("\n");
 

--- a/src-tauri/src/sysmon/evtx_parser.rs
+++ b/src-tauri/src/sysmon/evtx_parser.rs
@@ -261,11 +261,11 @@ pub fn build_summary(
 
         if !event.timestamp.is_empty() {
             if let Some(ms) = event.timestamp_ms {
-                if earliest_ms.map_or(true, |existing| ms < existing) {
+                if earliest_ms.is_none_or(|existing| ms < existing) {
                     earliest_ms = Some(ms);
                     earliest_ts = Some(event.timestamp.clone());
                 }
-                if latest_ms.map_or(true, |existing| ms > existing) {
+                if latest_ms.is_none_or(|existing| ms > existing) {
                     latest_ms = Some(ms);
                     latest_ts = Some(event.timestamp.clone());
                 }
@@ -276,11 +276,11 @@ pub fn build_summary(
                 let ts = event.timestamp.as_str();
                 if earliest_ts
                     .as_deref()
-                    .map_or(true, |existing| ts < existing)
+                    .is_none_or(|existing| ts < existing)
                 {
                     earliest_ts = Some(event.timestamp.clone());
                 }
-                if latest_ts.as_deref().map_or(true, |existing| ts > existing) {
+                if latest_ts.as_deref().is_none_or(|existing| ts > existing) {
                     latest_ts = Some(event.timestamp.clone());
                 }
             }

--- a/src-tauri/tests/esp_diagnostics_sources.rs
+++ b/src-tauri/tests/esp_diagnostics_sources.rs
@@ -7977,7 +7977,7 @@ fn bundle_manifest_reports_missing_and_malformed_artifacts_without_fallback() {
             .provenance
             .file_path
             .as_deref()
-            .map_or(true, |path| !path.ends_with("unlisted.log"))
+            .is_none_or(|path| !path.ends_with("unlisted.log"))
     }));
 }
 
@@ -8043,7 +8043,7 @@ fn bundle_legacy_fallback_is_depth_extension_and_basename_allowlisted() {
         Some("Legacy Profile")
     );
     assert!(snapshot.raw_evidence.iter().all(|record| {
-        record.provenance.file_path.as_deref().map_or(true, |path| {
+        record.provenance.file_path.as_deref().is_none_or(|path| {
             !path.ends_with("arbitrary.json") && !path.ends_with("ignored.exe")
         })
     }));

--- a/vendor/time-0.3.36/CMTRACEOPEN-BACKPORT.md
+++ b/vendor/time-0.3.36/CMTRACEOPEN-BACKPORT.md
@@ -13,7 +13,7 @@ limit from upstream commit
 That commit is the fix released in `time` 0.3.47 for RUSTSEC-2026-0009.
 
 The fixed upstream release requires Rust 1.88.0, while CMTrace Open's locked
-compiler contract is Rust 1.77.2. The root `[patch.crates-io]` override and the
+compiler contract is Rust 1.88 (was 1.77.2 when this backport was created). The root `[patch.crates-io]` override and the
 exact `=0.3.36` requirement preserve that contract without ignoring the
 advisory. `src-tauri/tests/security_dependencies.rs` verifies the upstream
 boundary: 31 nested RFC 2822 comments parse and 32 are rejected.
@@ -25,7 +25,7 @@ of these checks:
 1. Keep the source diff against crates.io 0.3.36 limited to the documented
    upstream backport.
 2. Run `cargo test -p cmtrace-open --test security_dependencies`.
-3. Run `cargo +1.77.2 check --workspace --all-features --locked`.
+3. Run `cargo +1.88 check --workspace --all-features --locked`.
 4. Run `cargo audit` and `cd src-tauri && cargo deny check` to ensure no
    vulnerable registry copy of `time` re-enters the dependency graph.
 


### PR DESCRIPTION
Unblocks four dependabot PRs that are green on every required check but fail the MSRV job #266 added, and prepares the two sha256 call sites for sha2 0.11.

## 1. Raise the Rust floor 1.77.2 → 1.88

| PR | Crate | Requires rustc |
|---|---|---|
| #277 | `plist` 1.8.0 | 1.81 |
| #288 | `serde_with` 3.17.0 | 1.82 |
| #285 | `uuid` 1.24.0 | 1.85 |
| #275 | `sha2` 0.11.0 | 1.85 |

The floor also caps dependabot itself. Because `src-tauri` declares `rust-version`, dependabot proposed `serde_with` **3.17.0** instead of **3.21.0** — and 3.21.0 is the patched version for **GHSA-7gcf-g7xr-8hxj** (`KeyValueMap` panics on empty sequence/map entries), which requires 1.88. So that advisory was unfixable at the old floor. #266's merge additionally reverted `serde_with` on main from 3.18.0 back to 3.16.1, moving it further from the fix.

**Why 1.88 specifically** — it is the smallest floor clearing all of the above. Verified it is sufficient and not excessive: the highest `rust-version` declared anywhere in the resolved graph is `wasip2` at 1.87.0, and nothing requires more than 1.88.

Both workspace crates remain `edition = "2021"`, so only the toolchain floor moves; no source migration.

Updated: both `rust-version` fields, the `msrv` job (name, toolchain, cache keys, `cargo +1.88`), and CLAUDE.md. The README does not pin a Rust version, so it needed no change.

## 2. Format sha256 digests byte-wise instead of `{:x}`

`digest` 0.11 replaced `generic-array` with `hybrid-array`, and hybrid-array's `Array` has no `LowerHex` impl, so `format!("{:x}", hasher.finalize())` fails to compile — the actual error on #275:

```
error[E0277]: the trait bound `Array<u8, UInt<...>>: LowerHex` is not satisfied
  --> src-tauri/src/commands/file_ops.rs:511:39
  --> src-tauri/src/commands/markers.rs:46:21
```

Those are the only two `finalize()` sites in the workspace. Both now format per byte with `{byte:02x}`, which compiles against **both sha2 0.10 and 0.11** — so this lands safely on today's main ahead of the bump, and #275 goes green on rebase.

### Why this needed tests

`hash_file_path` names the on-disk marker file, so its output is a **storage key** — any drift in the encoding orphans every marker a user has saved. Added two regression tests pinning the exact 64-char lowercase form, including an input (`"marker-5"`, digest begins `0x0b`) that would catch a missing zero-pad.

## 3. Two stale action pins

The `msrv` and `windows-esp` jobs #266 added carried `actions/checkout` v7.0.0 — the pin #268 retired. All five checkout call sites in `cmtrace-ci.yml` are now v7.0.1.

## Verification

- `cargo clippy --locked --all-targets -- -D warnings` — passes
- `cargo test --locked --lib` — **389/389**, both new tests green
- The stability vector matches an independently computed SHA-256, confirming output is byte-identical to the previous `{:x}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nQJNW7RKRuRRfzfdvtQYR