### PR TITLE
fix(metrics): exclude draft releases and enforce collector output outside the repository

### DIFF
--- a/.github/workflows/download-metrics.yml
+++ b/.github/workflows/download-metrics.yml
@@ -39,13 +39,19 @@ jobs:
       - name: Open dedicated metrics worktree
         shell: bash
         run: |
+          # Kept OUTSIDE the repository: the collector owns its output directory
+          # and replaces reports/ within it, so it rejects any path at or below
+          # the repository root (see safeOutputDirectory in src/collect.ts).
+          worktree="${RUNNER_TEMP}/metrics-worktree"
+          git worktree prune
+          rm -rf "${worktree}"
           if git ls-remote --exit-code --heads origin refs/heads/download-metrics >/dev/null 2>&1; then
             git fetch origin refs/heads/download-metrics:refs/remotes/origin/download-metrics
-            git worktree add --detach metrics-worktree origin/download-metrics
+            git worktree add --detach "${worktree}" origin/download-metrics
           else
-            git worktree add --detach metrics-worktree HEAD
-            git -C metrics-worktree switch --orphan download-metrics
-            git -C metrics-worktree rm -rf --ignore-unmatch .
+            git worktree add --detach "${worktree}" HEAD
+            git -C "${worktree}" switch --orphan download-metrics
+            git -C "${worktree}" rm -rf --ignore-unmatch .
           fi
 
       - name: Collect cumulative asset counters
@@ -54,7 +60,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          metrics_root="${GITHUB_WORKSPACE}/metrics-worktree"
+          metrics_root="${RUNNER_TEMP}/metrics-worktree"
           args=(--output "${metrics_root}")
           if [[ -f "${metrics_root}/reports/latest-assets.json" ]]; then
             args+=(--previous "${metrics_root}/reports/latest-assets.json")
@@ -64,11 +70,12 @@ jobs:
       - name: Commit and update only download-metrics
         shell: bash
         run: |
-          git -C metrics-worktree config user.name "github-actions[bot]"
-          git -C metrics-worktree config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git -C metrics-worktree add -- snapshots reports
-          if git -C metrics-worktree diff --cached --quiet; then
+          worktree="${RUNNER_TEMP}/metrics-worktree"
+          git -C "${worktree}" config user.name "github-actions[bot]"
+          git -C "${worktree}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "${worktree}" add -- snapshots reports
+          if git -C "${worktree}" diff --cached --quiet; then
             exit 0
           fi
-          git -C metrics-worktree commit -m "chore: snapshot release download metrics"
-          git -C metrics-worktree push origin HEAD:download-metrics
+          git -C "${worktree}" commit -m "chore: snapshot release download metrics"
+          git -C "${worktree}" push origin HEAD:download-metrics

--- a/tools/download-metrics/README.md
+++ b/tools/download-metrics/README.md
@@ -8,7 +8,14 @@ conversion measurements.
 ## Local use
 
 Use Node.js 22 or newer, install the locked dependencies, and choose a dedicated
-output directory outside this repository root and its `.git` directory:
+output directory that is fully outside this repository. The collector owns that
+directory — it replaces `reports/` inside it and removes its own staging and
+backup paths — so it rejects any path at or below the repository root (not just
+the root itself), any path inside `.git`, and any path that *contains* the
+repository, such as `..` or your home directory. Symlinks are resolved before
+the check, so a link pointing back into the repository is rejected too. Draft
+releases are excluded from every snapshot; prereleases (the nightly channel) are
+included.
 
 ```bash
 npm ci

--- a/tools/download-metrics/src/collect.ts
+++ b/tools/download-metrics/src/collect.ts
@@ -100,11 +100,37 @@ async function safeOutputDirectory(
   const output = await canonicalPath(outputDirectory);
   const root = await canonicalPath(repositoryRoot);
   const gitDirectory = await canonicalPath(join(repositoryRoot, ".git"));
-  if (output === root || isAtOrBelow(output, gitDirectory)) {
+
+  // Checked before the repository-root rule so a .git that lives outside the
+  // working tree (symlinked, or a linked worktree's gitdir) still reports the
+  // reason that actually applies.
+  if (isAtOrBelow(output, gitDirectory)) {
     throw new Error(
-      "Unsafe output directory: repository root and .git paths are not allowed",
+      `Unsafe output directory: ${output} is inside the repository's .git directory`,
     );
   }
+
+  // publishAtomically replaces <output>/reports and removes its own staging and
+  // backup paths under <output>, so the collector must own that directory
+  // outright. Anything at or below the repository root is off limits, not just
+  // the root itself.
+  if (isAtOrBelow(output, root)) {
+    throw new Error(
+      `Unsafe output directory: ${output} is at or below the repository root ${root}; ` +
+        "use a dedicated directory outside the repository",
+    );
+  }
+
+  // The mirror case, which is the more destructive one: an ancestor of the
+  // repository (--output .., ~, or /) would put the collector's rm -rf of
+  // reports/ beside unrelated files.
+  if (isAtOrBelow(root, output)) {
+    throw new Error(
+      `Unsafe output directory: ${output} contains the repository root ${root}; ` +
+        "use a dedicated directory that does not enclose the repository",
+    );
+  }
+
   return output;
 }
 

--- a/tools/download-metrics/src/github.ts
+++ b/tools/download-metrics/src/github.ts
@@ -36,7 +36,14 @@ export async function listReleases(
     const pageReleases = (await response.json()) as GitHubRelease[];
     releases.push(...pageReleases);
     if (pageReleases.length < PER_PAGE) {
-      return releases;
+      // Drafts are excluded here, at the single exit, rather than before the
+      // short-page check above. That check is the loop's ONLY termination
+      // signal, and it is a statement about the server's page size -- filtering
+      // first would silently repurpose it as "fewer than PER_PAGE survived my
+      // filter", so one draft on a full page would end pagination early and
+      // drop every later release. Prereleases are kept: they are the published
+      // nightly channel (see SnapshotAsset.prerelease and the CSV column).
+      return releases.filter((release) => !release.draft);
     }
   }
 }

--- a/tools/download-metrics/tests/collect.test.ts
+++ b/tools/download-metrics/tests/collect.test.ts
@@ -140,6 +140,52 @@ describe("deterministic download collection", () => {
     await expectMissing(join(root, "reports"));
   });
 
+  it("never records assets from a draft release", async () => {
+    // cmtrace-release.yml sets releaseDraft: true, so a stable release exists
+    // as a draft with its assets already uploaded until someone publishes it.
+    // The workflow's GITHUB_TOKEN makes those drafts visible to the API, so an
+    // unfiltered run attributes real download counts to an unpublished release.
+    const root = await temporaryRoot();
+    const output = join(root, "output");
+    const draftRelease: GitHubRelease = {
+      id: 16,
+      tag_name: "v1.5.0",
+      name: "CMTrace Open 1.5.0",
+      published_at: "2026-07-14T00:00:00Z",
+      prerelease: false,
+      draft: true,
+      assets: [asset(104, "CMTrace-Open_1.5.0_x64-setup.exe", 999)],
+    };
+
+    const result = await collectDownloads({
+      outputDirectory: output,
+      fetcher: fetcherFor([
+        ...releases({ portable: 12, setup: 8, manifest: 30 }),
+        draftRelease,
+      ]),
+      clock,
+      repositoryRoot: join(root, "source-repository"),
+    });
+
+    const snapshot = JSON.parse(
+      await readFile(result.paths.snapshot, "utf8"),
+    ) as Snapshot;
+    expect(snapshot.assets).toHaveLength(3);
+    expect(snapshot.assets.some((entry) => entry.releaseTag === "v1.5.0")).toBe(
+      false,
+    );
+    expect(snapshot.assets.some((entry) => entry.assetId === 104)).toBe(false);
+
+    const csv = await readFile(join(output, "reports/latest-assets.csv"), "utf8");
+    expect(csv).not.toContain("v1.5.0");
+
+    // The draft's 999 downloads must not inflate any delivery role.
+    const summary = JSON.parse(
+      await readFile(join(output, "reports/summary.json"), "utf8"),
+    );
+    expect(summary["mixed-manual-update"]).toEqual({ cumulative: 8, delta: 0 });
+  });
+
   it("uses the prior latest report by default and emits real deltas", async () => {
     const root = await temporaryRoot();
     const output = join(root, "output");

--- a/tools/download-metrics/tests/collect.test.ts
+++ b/tools/download-metrics/tests/collect.test.ts
@@ -214,17 +214,27 @@ describe("deterministic download collection", () => {
 });
 
 describe("collector safety and failure behavior", () => {
-  it.each(["repository root", ".git", ".git descendant"])(
+  it.each<[string, (repositoryRoot: string) => string]>([
+    ["repository root", (repositoryRoot) => repositoryRoot],
+    [".git", (repositoryRoot) => join(repositoryRoot, ".git")],
+    [".git descendant", (repositoryRoot) => join(repositoryRoot, ".git", "objects")],
+    // The reported case in #264: a plain repository descendant was accepted.
+    ["repository descendant", (repositoryRoot) => join(repositoryRoot, "reports")],
+    [
+      "nested repository descendant",
+      (repositoryRoot) => join(repositoryRoot, "tools", "download-metrics", "out"),
+    ],
+    // publishAtomically would rm -rf <output>/reports beside the repository.
+    ["repository parent", (repositoryRoot) => dirname(repositoryRoot)],
+  ])(
     "rejects the %s as an output directory without writing",
-    async (kind) => {
+    async (_kind, toOutput) => {
       const root = await temporaryRoot();
       const repositoryRoot = join(root, "repository");
-      const output =
-        kind === "repository root"
-          ? repositoryRoot
-          : kind === ".git"
-            ? join(repositoryRoot, ".git")
-            : join(repositoryRoot, ".git", "objects");
+      // Created so the expectMissing assertions below are meaningful rather
+      // than passing vacuously against a directory that never existed.
+      await mkdir(repositoryRoot, { recursive: true });
+      const output = toOutput(repositoryRoot);
 
       await expect(
         collectDownloads({
@@ -234,9 +244,48 @@ describe("collector safety and failure behavior", () => {
           repositoryRoot,
         }),
       ).rejects.toThrow("Unsafe output directory");
-      await expectMissing(output);
+      await expectMissing(join(output, "reports"));
+      await expectMissing(join(repositoryRoot, "snapshots"));
     },
   );
+
+  it("rejects an output symlink that resolves to a repository descendant", async () => {
+    const root = await temporaryRoot();
+    const repositoryRoot = join(root, "repository");
+    const insideRepo = join(repositoryRoot, "metrics");
+    const outputLink = join(root, "descendant-link");
+    await mkdir(insideRepo, { recursive: true });
+    await symlink(insideRepo, outputLink);
+
+    await expect(
+      collectDownloads({
+        outputDirectory: outputLink,
+        fetcher: fetcherFor([]),
+        clock,
+        repositoryRoot,
+      }),
+    ).rejects.toThrow("is at or below the repository root");
+    await expectMissing(join(insideRepo, "reports"));
+  });
+
+  it("accepts a sibling directory whose name merely prefixes the repository", async () => {
+    // Guards the containment test against a startsWith-style regression:
+    // "<root>/repository-metrics" is not inside "<root>/repository".
+    const root = await temporaryRoot();
+    const repositoryRoot = join(root, "repository");
+    const output = join(root, "repository-metrics");
+    await mkdir(repositoryRoot, { recursive: true });
+
+    const result = await collectDownloads({
+      outputDirectory: output,
+      fetcher: fetcherFor(releases({ portable: 12, setup: 8, manifest: 30 })),
+      clock,
+      repositoryRoot,
+    });
+
+    expect(result.paths.snapshot.startsWith(output)).toBe(true);
+    await expectMissing(join(repositoryRoot, "reports"));
+  });
 
   it("rejects an output symlink that resolves inside .git", async () => {
     const root = await temporaryRoot();
@@ -394,14 +443,23 @@ describe("dedicated download-metrics workflow", () => {
     expect(workflow).toContain("npm run check");
     expect(workflow).toContain("metrics-worktree");
     expect(workflow).toContain(
-      "git -C metrics-worktree rm -rf --ignore-unmatch .",
+      'git -C "${worktree}" rm -rf --ignore-unmatch .',
     );
-    expect(workflow).toContain("git -C metrics-worktree add -- snapshots reports");
+    expect(workflow).toContain('git -C "${worktree}" add -- snapshots reports');
     expect(workflow).toContain(
-      "git -C metrics-worktree push origin HEAD:download-metrics",
+      'git -C "${worktree}" push origin HEAD:download-metrics',
     );
     expect(workflow).not.toMatch(/git push[^\n]*\bmain\b/);
     expect(workflow.match(/push origin/g)).toHaveLength(1);
+
+    // The worktree must stay outside the repository: safeOutputDirectory now
+    // rejects any output at or below the repository root, so siting it under
+    // the workspace would fail the nightly run. Matching the variable rather
+    // than a literal path catches ${GITHUB_WORKSPACE}, $GITHUB_WORKSPACE and
+    // ${{ github.workspace }} alike.
+    expect(workflow).toContain('worktree="${RUNNER_TEMP}/metrics-worktree"');
+    expect(workflow).toContain('metrics_root="${RUNNER_TEMP}/metrics-worktree"');
+    expect(workflow).not.toMatch(/GITHUB_WORKSPACE|github\.workspace/);
   });
 
   it("documents local use, baseline semantics, direct traffic, and inactive status", async () => {

--- a/tools/download-metrics/tests/github.test.ts
+++ b/tools/download-metrics/tests/github.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import { listReleases } from "../src/github";
 import type { GitHubRelease } from "../src/types";
 
-const release = (id: number): GitHubRelease => ({
+const release = (
+  id: number,
+  overrides: Partial<GitHubRelease> = {},
+): GitHubRelease => ({
   id,
   tag_name: `v${id}`,
   name: `Release ${id}`,
@@ -22,7 +25,17 @@ const release = (id: number): GitHubRelease => ({
       browser_download_url: `https://github.com/adamgell/cmtraceopen/releases/download/v${id}/asset-${id}.exe`,
     },
   ],
+  ...overrides,
 });
+
+const jsonPages = (pages: GitHubRelease[][]) =>
+  vi.fn(
+    async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      new Response(JSON.stringify(pages.shift()), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  );
 
 describe("GitHub release pagination", () => {
   it("requests full pages until GitHub returns an empty page", async () => {
@@ -91,5 +104,59 @@ describe("GitHub release pagination", () => {
     await expect(listReleases(fetcher)).rejects.toThrow(
       "GitHub releases request failed on page 1: 403 Forbidden",
     );
+  });
+});
+
+describe("draft release exclusion", () => {
+  it("omits draft releases while keeping published ones", async () => {
+    // cmtrace-release.yml sets releaseDraft: true, so every stable release
+    // exists as a draft with its assets already uploaded until a human
+    // publishes it. An authenticated token sees those drafts.
+    const published = release(1);
+    const draft = release(2, { draft: true });
+
+    const result = await listReleases(jsonPages([[published, draft]]));
+
+    expect(result).toEqual([published]);
+  });
+
+  it("keeps prereleases, which are the published nightly channel", async () => {
+    const stable = release(1);
+    const nightly = release(2, { prerelease: true });
+
+    const result = await listReleases(jsonPages([[stable, nightly]]));
+
+    expect(result).toEqual([stable, nightly]);
+  });
+
+  it("does not let a draft on a full page terminate pagination early", async () => {
+    // Regression guard for the tempting one-line fix. Filtering before the
+    // short-page check makes this first page look like 99 < PER_PAGE, so the
+    // loop would return after one request and silently drop page two.
+    const first = Array.from({ length: 100 }, (_, index) =>
+      index === 50 ? release(index + 1, { draft: true }) : release(index + 1),
+    );
+    const second = [release(101)];
+    const fetcher = jsonPages([first, second]);
+
+    const result = await listReleases(fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(100);
+    expect(result.some((entry) => entry.draft)).toBe(false);
+    expect(result.at(-1)?.id).toBe(101);
+  });
+
+  it("keeps paginating when an entire full page is drafts", async () => {
+    const first = Array.from({ length: 100 }, (_, index) =>
+      release(index + 1, { draft: true }),
+    );
+    const second = [release(101)];
+    const fetcher = jsonPages([first, second]);
+
+    const result = await listReleases(fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([release(101)]);
   });
 });


### PR DESCRIPTION
Closes #263. Closes #264.

Both bugs are in `tools/download-metrics`, the isolated collector project. Verified with its **own pinned toolchain** (TypeScript 6.0.3 — not the repo root's 7.0.2, which is what an unscoped `npx tsc` would pick up): `npm run check` clean, **127/127** tests pass (117 before).

---

## #263 — draft releases polluted snapshots

`listReleases` appended every release the API returned without checking `draft`, so draft assets flowed through reconcile into snapshot rows, `latest-assets.{json,csv}` and `summary.json`.

**This is not theoretical.** `cmtrace-release.yml:128` sets `releaseDraft: true`, so *every* stable release exists as a draft with its assets already uploaded until a human publishes it — and `download-metrics.yml` passes `GITHUB_TOKEN`, exactly the credential that makes the API return drafts. The 00:17 UTC cron can land inside that window on any release day.

### The subtle part

The filter goes at the function's **single `return`**, not where the page is read. That check — `pageReleases.length < PER_PAGE` — is the loop's only termination signal, and it is a statement about *the server's page size*. The tempting one-liner (filter the page as it arrives) silently repurposes it as "fewer than PER_PAGE survived my filter", so **one draft on a full page ends pagination after one request and drops every later release**. Downstream that is worse than the original bug: reconcile turns vanished releases into `deleted` tombstones, so a truncated read would mass-tombstone live assets.

Prereleases are deliberately **kept** — they are the published nightly channel, carried by `SnapshotAsset.prerelease` and the CSV `prerelease` column.

### Tests, verified load-bearing

Reverting the fix fails **3**; implementing the naive filter-before-the-check variant fails exactly the **2 pagination guards**. Coverage spans the unit boundary (draft omitted, prerelease retained, draft on a full page, a whole page of drafts) and the contract layer — a new `collect.test.ts` case asserting a draft never reaches `snapshot.assets`, the CSV, or the summary totals.

---

## #264 — collector output was allowed inside the repository

`safeOutputDirectory` rejected only the repository root itself and paths under `.git`, so `<repo>/reports` was accepted. That matters because `publishAtomically` **owns** the output directory — it replaces `<output>/reports` and removes its own staging and backup paths there.

Now rejects, with a distinct message per reason:

1. anything inside `.git` (checked first, so a `.git` outside the working tree still reports the reason that actually applies)
2. anything **at or below** the repository root — the reported bug
3. anything that **contains** the repository root

> **Case 3 was not in the issue and is the more destructive direction.** `--output ..`, `--output ~` and `--output /` were all accepted, each putting an `rm -rf` of `reports/` beside unrelated files. Fixing only the reported direction would have left it — and the new error text would have steered users straight into it.

Containment uses the existing `isAtOrBelow` helper, which is `relative`-based rather than `startsWith`, so a sibling like `<root>/repository-metrics` is **not** treated as inside `<root>/repository`. A test pins that so the predicate cannot regress to prefix matching. Paths are canonicalised first, so symlinked descendants are caught too.

### Required companion change — this would otherwise break the nightly job

`download-metrics.yml` created its worktree as `metrics-worktree` relative to the workspace and passed `--output "${GITHUB_WORKSPACE}/metrics-worktree"` — **a repository descendant**. Landing the guard alone would have failed the next scheduled run.

The worktree now lives at `${RUNNER_TEMP}/metrics-worktree`, with `git worktree prune` and an `rm -rf` first so a stale path on a persistent runner cannot fail `worktree add`. The workflow contract test asserts the new location and that no `GITHUB_WORKSPACE`/`github.workspace` reference returns.

### Test structure

The 3-case `it.each` became a `[label, path-builder]` tuple table rather than growing into a 5-way nested ternary, and now covers repository descendant, nested descendant, repository parent, symlink-resolved descendant, and the accepted prefix-sharing sibling. Fixtures now create `repositoryRoot` so the `expectMissing` assertions are meaningful instead of passing vacuously. Restoring the old guard fails exactly the 4 new rejection cases.

---

## Known, deliberately out of scope

- `--previous` is still unvalidated. It is read-only, so not a safety gap — flagged so reviewers don't assume #264 closed it.
- `GitHubRelease.published_at` is typed `string` but GitHub returns `null` for drafts. Drafts are now filtered at the boundary so no null reaches a snapshot; narrowing the type properly would cascade into `flattenCurrent`, `reconcileSnapshots` and their fixtures.
- The collector has **no CI job** — `tsconfig.json`/`vitest.config.ts` at the repo root scope to `src/`, and the only thing running it is `download-metrics.yml`'s own `Verify isolated collector` step, which is schedule-only. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nQJNW7RKRuRRfzfdvtQYR