### PR TITLE
fix(log-view): size the message column to the window on open

### DIFF
--- a/e2e/log-view-fit.spec.ts
+++ b/e2e/log-view-fit.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Layout regression guard for #254 — "Log view opens with a horizontal scrollbar".
+ *
+ * These assertions cannot live in vitest: jsdom performs no layout, so
+ * scrollWidth/clientWidth are always 0 there and a unit test can only check the
+ * width arithmetic (see src/lib/column-config.test.ts). Real layout is the only
+ * way to prove the acceptance criterion, so it is asserted in a real browser.
+ *
+ * Entries are injected straight into the live Vite store singletons — the same
+ * technique the screenshot harness uses, where `await import("/src/...")`
+ * resolves to the module instances the running app already holds.
+ */
+import { test, expect } from "./fixtures";
+
+/** Comfortably wider than MAX_AUTOFIT_WIDTH (1200px) once rendered. */
+const VERY_WIDE_MESSAGE =
+  "Failed to install application: " +
+  "C:\\Windows\\CCM\\Logs\\AppEnforce.log ".repeat(40) +
+  "exit code 0x80070005";
+
+async function seedWideLog(page: import("@playwright/test").Page, rows = 200) {
+  await page.evaluate(
+    async ({ message, count }) => {
+      const { useLogStore } = await import("/src/stores/log-store.ts");
+      const entries = Array.from({ length: count }, (_, index) => ({
+        id: index + 1,
+        lineNumber: index + 1,
+        message: `${message} #${index}`,
+        component: "AppEnforce",
+        timestamp: 1_700_000_000_000 + index * 1000,
+        timestampDisplay: "2026-07-26 12:00:00.000",
+        severity: index % 7 === 0 ? "Error" : "Info",
+        thread: "1234",
+        threadDisplay: "1234",
+        sourceFile: null,
+        format: "Timestamped",
+        filePath: "C:/Windows/CCM/Logs/AppEnforce.log",
+        timezoneOffset: null,
+      }));
+      useLogStore.getState().setActiveColumns([
+        "severity",
+        "dateTime",
+        "message",
+        "component",
+        "thread",
+      ]);
+      useLogStore.getState().setEntries(entries as never);
+    },
+    { message: VERY_WIDE_MESSAGE, count: rows },
+  );
+
+  // The auto-expand effect is debounced by 100ms and then writes a width.
+  await page.waitForTimeout(400);
+}
+
+/** The virtualized log list container is the element that would scroll. */
+const LIST = '[data-log-list="true"]';
+
+async function overflow(page: import("@playwright/test").Page) {
+  return page.evaluate((selector) => {
+    const element = document.querySelector<HTMLElement>(selector);
+    if (!element) return null;
+    return {
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+    };
+  }, LIST);
+}
+
+test.describe("log view fit-to-window (#254)", () => {
+  test("opening a log with very wide lines does not overflow horizontally", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForSelector("#splash", { state: "detached", timeout: 10_000 });
+    await seedWideLog(page);
+
+    await expect(page.locator(`${LIST} .log-row`).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const metrics = await overflow(page);
+    expect(metrics).not.toBeNull();
+    // Allow a 1px rounding tolerance from fractional device pixels.
+    expect(
+      metrics!.scrollWidth,
+      `log list overflows: scrollWidth=${metrics!.scrollWidth} clientWidth=${metrics!.clientWidth}`,
+    ).toBeLessThanOrEqual(metrics!.clientWidth + 1);
+  });
+
+  test("a narrow window still opens without a horizontal scrollbar", async ({
+    page,
+  }) => {
+    // Narrower than the 1200px auto-fit cap, which is the case that used to
+    // guarantee an overflow.
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.goto("/");
+    await page.waitForSelector("#splash", { state: "detached", timeout: 10_000 });
+    await seedWideLog(page);
+
+    await expect(page.locator(`${LIST} .log-row`).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const metrics = await overflow(page);
+    expect(metrics).not.toBeNull();
+    expect(
+      metrics!.scrollWidth,
+      `log list overflows at 1024px: scrollWidth=${metrics!.scrollWidth} clientWidth=${metrics!.clientWidth}`,
+    ).toBeLessThanOrEqual(metrics!.clientWidth + 1);
+  });
+
+  test("double-click Fit can still widen a column past the viewport", async ({
+    page,
+  }) => {
+    // The clamp must not remove the deliberate, user-initiated fit action:
+    // acceptance criterion 3 keeps that working for people who want it.
+    await page.goto("/");
+    await page.waitForSelector("#splash", { state: "detached", timeout: 10_000 });
+    await seedWideLog(page);
+
+    await expect(page.locator(`${LIST} .log-row`).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const before = await page.evaluate(async () => {
+      const { useUiStore } = await import("/src/stores/ui-store.ts");
+      return useUiStore.getState().columnWidths.message ?? null;
+    });
+
+    // Double-clicking anywhere on the header triggers Fit for that column.
+    const header = page
+      .getByTitle("Double-click to auto-fit this column")
+      .filter({ hasText: "Log Text" })
+      .first();
+    await expect(header).toBeVisible({ timeout: 10_000 });
+    await header.dblclick();
+    await page.waitForTimeout(200);
+
+    const after = await page.evaluate(async () => {
+      const { useUiStore } = await import("/src/stores/ui-store.ts");
+      return useUiStore.getState().columnWidths.message ?? null;
+    });
+
+    expect(after).not.toBeNull();
+    expect(after).not.toBe(before);
+  });
+});

--- a/src/components/log-view/LogListView.tsx
+++ b/src/components/log-view/LogListView.tsx
@@ -33,6 +33,8 @@ import {
   getColumnDef,
   calcAutoFitWidth,
   getAutoExpandedColumnWidth,
+  getAvailableColumnWidth,
+  ROW_MARKER_WIDTH,
   type ColumnId,
   type ColumnDefinition,
 } from "../../lib/column-config";
@@ -639,11 +641,28 @@ export function LogListView({ dataSource }: { dataSource?: LogListDataSource } =
         contentFont,
         headerFont
       );
+      // Clamp to what is left after the other visible columns, so opening a log
+      // never introduces a horizontal scrollbar on its own (#254). When the
+      // container is unmeasured this is null and the width stays unclamped.
+      // Widths are read fresh rather than from the effect closure so a resize
+      // of another column between open and this timer is accounted for without
+      // adding the whole map to the dependency array (which would re-run the
+      // effect on every width write it performs).
+      const availableWidth = getAvailableColumnWidth(
+        visibleColumns,
+        "message",
+        parentRef.current?.clientWidth ?? 0,
+        useUiStore.getState().columnWidths,
+        ROW_MARKER_WIDTH
+      );
       const nextWidth = getAutoExpandedColumnWidth(
         columnWidths.message,
         autoFitWidth,
         messageCol.defaultWidth,
-        autoSizedMessageWidthRef.current
+        autoSizedMessageWidthRef.current,
+        availableWidth === null
+          ? null
+          : { available: availableWidth, minWidth: messageCol.minWidth }
       );
 
       if (nextWidth === null) return;
@@ -661,6 +680,7 @@ export function LogListView({ dataSource }: { dataSource?: LogListDataSource } =
     autoSizeSourcePath,
     setColumnWidth,
     sourceOpenMode,
+    visibleColumns,
   ]);
 
   const visibleErrorCount = useMemo(() => {
@@ -768,7 +788,7 @@ export function LogListView({ dataSource }: { dataSource?: LogListDataSource } =
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: `20px ${gridTemplateColumns}`,
+          gridTemplateColumns: `${ROW_MARKER_WIDTH}px ${gridTemplateColumns}`,
           backgroundColor: tokens.colorNeutralBackground4,
           borderBottom: `2px solid ${tokens.colorNeutralStroke2}`,
           fontSize: `${listMetrics.headerFontSize}px`,

--- a/src/components/log-view/LogRow.tsx
+++ b/src/components/log-view/LogRow.tsx
@@ -2,7 +2,7 @@ import { tokens } from "@fluentui/react-components";
 import type { LogEntry, ErrorCodeSpan, Severity } from "../../types/log";
 import type { Marker, MarkerCategory } from "../../types/markers";
 import type { LogSeverityPalette } from "../../lib/constants";
-import type { ColumnDefinition } from "../../lib/column-config";
+import { ROW_MARKER_WIDTH, type ColumnDefinition } from "../../lib/column-config";
 import { formatLogEntryTimestamp } from "../../lib/date-time-format";
 import { LOG_UI_FONT_FAMILY } from "../../lib/log-accessibility";
 
@@ -314,7 +314,7 @@ export const LogRow = memo(function LogRow({
       style={{
         ...style,
         display: "grid",
-        gridTemplateColumns: `20px ${gridTemplateColumns}`,
+        gridTemplateColumns: `${ROW_MARKER_WIDTH}px ${gridTemplateColumns}`,
         cursor: "pointer",
         borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
         fontSize: `${listFontSize}px`,

--- a/src/lib/column-config.test.ts
+++ b/src/lib/column-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   getAutoExpandedColumnWidth,
+  getAvailableColumnWidth,
   getColumnDef,
   getColumnsForParser,
 } from "./column-config";
@@ -78,5 +79,107 @@ describe("column-config", () => {
     expect(getAutoExpandedColumnWidth(920, 880, 600, 920)).toBeNull();
     // Existing persisted/manual widths are treated as user-owned from the start.
     expect(getAutoExpandedColumnWidth(920, 1080, 600, null)).toBeNull();
+  });
+});
+
+describe("fit-to-window clamping (#254)", () => {
+  const columns = getColumnsForParser("simple").map((id) => getColumnDef(id)!);
+
+  it("reports the width left for message after the other columns", () => {
+    const total = columns
+      .filter((col) => col.id !== "message")
+      .reduce((sum, col) => sum + col.defaultWidth, 0);
+
+    expect(getAvailableColumnWidth(columns, "message", total + 500)).toBe(500);
+  });
+
+  it("subtracts overridden widths rather than defaults", () => {
+    const messageDef = getColumnDef("message")!;
+    const other = columns.find((col) => col.id !== "message")!;
+    const baseline = getAvailableColumnWidth(columns, "message", 2000)!;
+    const widened = getAvailableColumnWidth(columns, "message", 2000, {
+      [other.id]: other.defaultWidth + 100,
+    })!;
+
+    expect(widened).toBe(baseline - 100);
+    expect(messageDef.id).toBe("message");
+  });
+
+  it("returns null when the container is unmeasured or the column is absent", () => {
+    // 0 during first paint and in jsdom, which has no layout.
+    expect(getAvailableColumnWidth(columns, "message", 0)).toBeNull();
+    expect(getAvailableColumnWidth(columns, "message", Number.NaN)).toBeNull();
+    expect(getAvailableColumnWidth(columns, "lineNumber", 2000)).toBeNull();
+  });
+
+  it("caps auto-expansion at the available width instead of the content width", () => {
+    // Content wants 1100px but only 800px remains: take 800, not 1100.
+    expect(
+      getAutoExpandedColumnWidth(undefined, 1100, 600, null, {
+        available: 800,
+        minWidth: 100,
+      })
+    ).toBe(800);
+  });
+
+  it("shrinks below the default when the row would otherwise overflow", () => {
+    // The real case from #254: 528px of fixed columns plus a 600px message
+    // column needs 1128px, but the list is ~1000px wide. Capping growth alone
+    // leaves the overflow, so the column must give up width too.
+    expect(
+      getAutoExpandedColumnWidth(undefined, 1100, 600, null, {
+        available: 472,
+        minWidth: 100,
+      })
+    ).toBe(472);
+  });
+
+  it("never shrinks past the column minimum", () => {
+    // Below the floor a scrollbar is unavoidable; legibility wins.
+    expect(
+      getAutoExpandedColumnWidth(undefined, 1100, 600, null, {
+        available: 40,
+        minWidth: 100,
+      })
+    ).toBe(100);
+    expect(
+      getAutoExpandedColumnWidth(undefined, 1100, 600, null, {
+        available: -50,
+        minWidth: 100,
+      })
+    ).toBe(100);
+  });
+
+  it("still uses the content width when it is narrower than the space available", () => {
+    expect(
+      getAutoExpandedColumnWidth(undefined, 900, 600, null, {
+        available: 1500,
+        minWidth: 100,
+      })
+    ).toBe(900);
+  });
+
+  it("reports no change when the clamped target already matches", () => {
+    expect(
+      getAutoExpandedColumnWidth(600, 1100, 600, 600, {
+        available: 600,
+        minWidth: 100,
+      })
+    ).toBeNull();
+  });
+
+  it("keeps the unclamped grow-only behaviour when no bounds are supplied", () => {
+    expect(getAutoExpandedColumnWidth(undefined, 1100, 600, null)).toBe(1100);
+    expect(getAutoExpandedColumnWidth(undefined, 1100, 600, null, null)).toBe(1100);
+    expect(getAutoExpandedColumnWidth(undefined, 520, 600, null, null)).toBeNull();
+  });
+
+  it("does not override a user-owned width even when space is available", () => {
+    expect(
+      getAutoExpandedColumnWidth(920, 1080, 600, null, {
+        available: 2000,
+        minWidth: 100,
+      })
+    ).toBeNull();
   });
 });

--- a/src/lib/column-config.ts
+++ b/src/lib/column-config.ts
@@ -492,11 +492,53 @@ export function calcAutoFitWidth(
   );
 }
 
+/**
+ * Width `columnId` may occupy if the row is to fit `containerWidth` without
+ * overflowing horizontally: the container minus every other visible column's
+ * effective width (override, else default) — mirroring how
+ * `buildGridTemplateColumns` sizes the grid.
+ *
+ * Returns null when the container has not been measured yet (0 during the first
+ * paint, or in jsdom), so callers can fall back to unclamped behaviour rather
+ * than collapsing the column to nothing.
+ */
+export function getAvailableColumnWidth(
+  columns: ColumnDefinition[],
+  columnId: ColumnId,
+  containerWidth: number,
+  widthOverrides?: Record<string, number>,
+  reservedWidth = 0
+): number | null {
+  if (!Number.isFinite(containerWidth) || containerWidth <= 0) return null;
+  let othersWidth = 0;
+  let found = false;
+  for (const col of columns) {
+    if (col.id === columnId) {
+      found = true;
+      continue;
+    }
+    othersWidth += widthOverrides?.[col.id] ?? col.defaultWidth;
+  }
+  if (!found) return null;
+  return containerWidth - othersWidth - reservedWidth;
+}
+
+/**
+ * @param fit Fit-to-window bounds (#254). When supplied, the column is sized to
+ *   the space actually available rather than to its content, which means it may
+ *   also *shrink* below `defaultWidth` — necessary because the default widths
+ *   alone already overflow a typical container (e.g. 528px of fixed columns plus
+ *   a 600px message column needs 1128px, but the list is ~1000px at a 1440px
+ *   window). `minWidth` floors the result so the column stays legible; if the
+ *   available space is below that floor a scrollbar is unavoidable and the
+ *   floor wins. Omit to keep the historical grow-only behaviour.
+ */
 export function getAutoExpandedColumnWidth(
   currentWidth: number | undefined,
   autoFitWidth: number,
   defaultWidth: number,
-  lastAutoWidth: number | null
+  lastAutoWidth: number | null,
+  fit: { available: number; minWidth: number } | null = null
 ): number | null {
   // When a width already exists before this session auto-sizes the column,
   // treat it as a user-owned override (persisted manual resize or fit action).
@@ -513,7 +555,18 @@ export function getAutoExpandedColumnWidth(
   }
 
   const baselineWidth = currentWidth ?? defaultWidth;
-  return autoFitWidth > baselineWidth ? autoFitWidth : null;
+
+  if (fit === null) {
+    return autoFitWidth > baselineWidth ? autoFitWidth : null;
+  }
+
+  // Never wider than the content needs, never wider than the space left, never
+  // narrower than the column's own minimum.
+  const targetWidth = Math.max(
+    fit.minWidth,
+    Math.min(autoFitWidth, fit.available)
+  );
+  return targetWidth === baselineWidth ? null : targetWidth;
 }
 
 export function applyColumnOrder(
@@ -553,6 +606,14 @@ export function getVisibleColumns(
  * Build a CSS grid-template-columns string from visible column definitions.
  * Uses width overrides from user preferences when available, otherwise defaults.
  */
+/**
+ * Leading grid track reserved for the row marker gutter. The log row and the
+ * header both prepend it to `buildGridTemplateColumns`, so any calculation of
+ * "how wide is a row" must include it — see getAvailableColumnWidth's
+ * `reservedWidth`.
+ */
+export const ROW_MARKER_WIDTH = 20;
+
 export function buildGridTemplateColumns(
   columns: ColumnDefinition[],
   widthOverrides?: Record<string, number>


### PR DESCRIPTION
Closes #254.

Opening a log almost always produced a horizontal scrollbar. The message column auto-expanded to fit the widest line in the file, capped only by `MAX_AUTOFIT_WIDTH` (1200px) — a bound unrelated to how much room the window actually had.

`calcAutoFitWidth` still measures content, but the result is now clamped to the space genuinely left over: container width, minus the other visible columns, minus the row marker gutter, floored at the column's own `minWidth`.

## The browser disproved my first attempt — twice

I wrote the Playwright assertion first and it failed, which changed the design.

**1. Capping growth is not enough — the clamp must be bidirectional.** The defaults already do not fit. The seeded CCM column set is `28 + 200 + 180 + 120 = 528px` of fixed columns plus a **600px** message column = **1128px**, while the list is only ~**1000px** wide inside a 1440px window. Declining to grow past the viewport left the overflow untouched; the message column has to *give up* width too.

**2. A `20px` gutter nobody had named.** After making it bidirectional the test *still* failed, by exactly 20px — `scrollWidth 1020` vs `clientWidth 1000`. A bare `20px` literal is prepended to the grid template in **two** files (`LogRow.tsx` and the header in `LogListView.tsx`) and is not part of `visibleColumns`, so every width calculation was silently short. It is now `ROW_MARKER_WIDTH`, exported from `column-config` and passed as `getAvailableColumnWidth`'s `reservedWidth`.

Neither would have been caught by unit tests.

## Deliberately unchanged

Double-click **"Fit this column"** and drag-resize still widen past the viewport. Those are explicit user actions, and once a width is user-owned the auto-sizer leaves it alone — acceptance criterion 3. There is an e2e guard for it.

## Verification

jsdom performs no layout, so `scrollWidth`/`clientWidth` are always 0 there and **no vitest test can prove the acceptance criterion**. So it is split:

- **Width arithmetic** — 13 unit cases in `column-config.test.ts` covering shrink, grow, the `minWidth` floor, unmeasured containers, and the unclamped legacy path
- **The criterion itself** — `e2e/log-view-fit.spec.ts` asserts `scrollWidth <= clientWidth` in a real browser at **1440px** and **1024px**, plus the Fit guard. All three fail against the pre-fix code.

Full suites: `tsc --noEmit` clean, **vitest 513/513**.

> The 3 failing `esp-diagnostics.spec.ts` e2e cases are **pre-existing** — I verified they fail identically on a pristine `origin/main` worktree. `test:e2e` is not among the required CI checks (CI runs `npm run test`, i.e. vitest).

## Scope note

The issue also suggested a persisted preference. That is not included: `resetColumnWidths()` fires on every open path (`log-source.ts` 182/354/669/830), so column widths do not currently survive a file open or tab switch at all — a persisted "keep my widths" setting would not work without fixing that first. This PR makes the default behaviour correct for everyone instead, which is what the reported complaint was about. Happy to follow up with the preference if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nQJNW7RKRuRRfzfdvtQYR