### PR TITLE
test(e2e): disambiguate ESP app-name locators

### DIFF
--- a/e2e/esp-diagnostics.spec.ts
+++ b/e2e/esp-diagnostics.spec.ts
@@ -202,7 +202,12 @@ test.describe("ESP Diagnostics workspace", () => {
     await expect(
       page.getByText("Required security application is blocking ESP"),
     ).toBeVisible();
-    await expect(page.getByText("Contoso Endpoint Security")).toBeVisible();
+    // Scoped to the evidence heading's title attribute: the app name also
+    // appears in the "Force ESP past a failed app" control and in a
+    // "Graph · <name>" attribution line, so a bare getByText is ambiguous.
+    await expect(
+      page.getByTitle("Contoso Endpoint Security", { exact: true }),
+    ).toBeVisible();
     await expect(
       page.getByRole("region", { name: "Live activity" }),
     ).toContainText("VPN installer started");
@@ -509,7 +514,9 @@ test.describe("ESP Diagnostics workspace", () => {
       .getByRole("button", { name: "Import captured evidence" })
       .click();
     await expect(page.getByText("ESP only")).toBeVisible();
-    await expect(page.getByText("Contoso Endpoint Security")).toBeVisible();
+    await expect(
+      page.getByTitle("Contoso Endpoint Security", { exact: true }),
+    ).toBeVisible();
     await expect(
       page.getByRole("region", {
         name: "Administrator coverage recommendation",
@@ -647,8 +654,13 @@ test.describe("ESP Diagnostics workspace", () => {
     await openEspWorkspace(page);
     await analyzeWithConnectedGraph(page, cloneSnapshot());
 
+    // The Graph record itself, not the evidence heading or the live-task line
+    // that also echo the friendly name -- this test is specifically about Graph
+    // supplying it alongside the raw local id asserted below.
     await expect(
-      page.getByText("Contoso VPN Client from Graph", { exact: true }),
+      page
+        .getByTestId("graph-record-66666666-6666-4666-8666-666666666666")
+        .getByText("Contoso VPN Client from Graph", { exact: true }),
     ).toBeVisible();
     await expect(
       page


### PR DESCRIPTION
Fixes the three ESP Diagnostics e2e tests that fail on `main` today. I hit these while verifying #292 and confirmed they were pre-existing by reproducing them on a pristine `origin/main` worktree.

## What was wrong

Playwright **strict-mode violations** — `getByText` resolving to 3 elements instead of 1:

| Test | Text |
|---|---|
| `:168`, `:492` | `Contoso Endpoint Security` |
| `:641` | `Contoso VPN Client from Graph` |

**This is test brittleness, not an app defect.** The workspace legitimately renders an application name on several surfaces, and the assertions predate some of them:

- *Contoso Endpoint Security* → the **"Force ESP past a failed app"** control, the evidence heading's `<strong title=…>`, and a **"Graph · \<name\>"** attribution line
- *Contoso VPN Client from Graph* → the **"Current task: INSTALLING."** line, the evidence heading, and the **Graph record**

## The fix

Each assertion now targets the surface it is actually about:

- **`:168`, `:492`** → `getByTitle(name, { exact: true })`, the evidence heading — which is what "the blocking app is shown" and "the imported bundle rendered" actually mean.
- **`:641`** → the `graph-record-<appId>` test id from `GraphEnrichmentPanel`. This test is specifically about Graph supplying a friendly name *next to* the raw local id it asserts immediately afterwards, so the Graph record is the precise target.

**Deliberately not `.first()`.** With three candidates that would keep passing even if the intended surface disappeared — which is how these assertions lost their meaning in the first place. Comments record why the locators are narrow so they don't get loosened again.

## Verification

- `esp-diagnostics.spec.ts` — **13/13**
- Full e2e suite — **18/18**

Both against the same `origin/main` commit where the three previously failed.

> Note: `test:e2e` is not among the required CI checks (CI runs `npm run test`, i.e. vitest), so these failures were not gating anything — but they made the suite useless as a signal locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nQJNW7RKRuRRfzfdvtQYR