### PR TITLE
ci: run the Playwright e2e suite on every PR

### DIFF
--- a/.github/workflows/cmtrace-ci.yml
+++ b/.github/workflows/cmtrace-ci.yml
@@ -153,6 +153,60 @@ jobs:
         run: npm audit --audit-level=high
         continue-on-error: true
 
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Keyed on the resolved @playwright/test version so a bump busts the cache
+      # rather than running against browsers built for a different client.
+      - name: Resolve Playwright version
+        id: playwright
+        run: |
+          version="$(node -p "require('@playwright/test/package.json').version")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      # A cache hit restores the browser binaries but not the apt packages they
+      # link against, so the system dependencies are always ensured.
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      # playwright.config.ts starts the Vite dev server itself and the Tauri IPC
+      # shim mocks the backend, so no Rust build is needed here.
+      - name: Run end-to-end tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   windows-esp:
     name: ESP Diagnostics (Windows)
     runs-on: windows-latest


### PR DESCRIPTION
The e2e suite was **not wired into CI at all** — `npm run test:e2e` only ever ran locally, on demand. That is exactly how three `esp-diagnostics` specs (fixed in #293) were able to sit broken on `main`: nothing was watching them, so the suite quietly stopped being a signal.

## The job

Adds `E2E (Playwright)` to `cmtrace-ci.yml`. It needs **no Rust build** — the Tauri IPC shim mocks the backend and `playwright.config.ts` starts the Vite dev server itself, so this is a Node-only ubuntu job that runs in parallel with the existing ones.

No config change was needed: `playwright.config.ts` is already CI-aware (`forbidOnly`, 2 retries, single worker under `process.env.CI`).

## Two details worth calling out

**Cache key is the resolved Playwright version, not the lockfile hash.** A Playwright bump then busts the cache, instead of running a new client against browsers built for a different version.

**A cache hit still needs `install-deps`.** The cache restores the browser *binaries* but not the apt packages they link against, so the system dependencies are ensured on the hit path; on a miss, `install --with-deps` covers both. Getting this wrong produces a job that passes for weeks and then fails mysteriously on a runner image update.

The HTML report uploads as an artifact on failure — a red e2e job is close to undebuggable without it.

The screenshot harness stays out: it has its own opt-in config and writes committed PNGs, and `playwright.config.ts` already excludes it via `testIgnore`.

## Making it *required* is a second step

The branch ruleset can only require a status check context once it exists on `main`, so I'll add `E2E (Playwright)` to the `Protect` ruleset's required checks **after** this merges. Doing it in the other order would block every open PR on a context that never reports.

## Verification

- `npm run test:e2e` — **18/18** locally
- Workflow parses; job list is `check, msrv, frontend, e2e, windows-esp, build`
- CI bundle output contract tests still **22/22** (they assert on this very file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nQJNW7RKRuRRfzfdvtQYR