### PR TITLE
fix(graph): keep the Windows sign-in dialog in front of the main window

### DIFF
--- a/src-tauri/src/commands/graph_api.rs
+++ b/src-tauri/src/commands/graph_api.rs
@@ -100,16 +100,16 @@ pub async fn graph_request_missing_permissions(
     app: tauri::AppHandle,
     state: tauri::State<'_, GraphAuthState>,
 ) -> CmdResult<GraphPermissionUpgradeResult> {
+    // The guard is held across the await and restores the pin on scope exit,
+    // including the `?` early return below.
     let window = InteractiveAuthWindow::acquire(&app)?;
     let hwnd = window.hwnd();
     let state = state.inner().clone();
-    let result = tauri::async_runtime::spawn_blocking(move || {
+    tauri::async_runtime::spawn_blocking(move || {
         graph_api::request_missing_permissions_on_initialized_worker(&state, hwnd)
     })
     .await
-    .map_err(|error| AppError::Internal(format!("GraphPermissionTaskFailed: {error}")));
-    drop(window);
-    result?
+    .map_err(|error| AppError::Internal(format!("GraphPermissionTaskFailed: {error}")))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/graph_api.rs
+++ b/src-tauri/src/commands/graph_api.rs
@@ -13,25 +13,65 @@ use crate::graph_api::{
 #[cfg(feature = "esp-diagnostics")]
 use cmtraceopen_parser::esp::EspGraphOverlay;
 
-/// Get the HWND of the main Tauri window for WAM dialog parenting.
+/// Owns the main window for the duration of an interactive WAM sign-in.
+///
+/// The account-picker dialog belongs to the Entra broker process. Windows
+/// parents it to the HWND we hand over — which disables our window while it is
+/// up — but cross-process ownership does not make it topmost, and the broker
+/// cannot steal the foreground on its own. Left alone, the dialog is drawn
+/// behind an always-on-top main window that the user then cannot move or
+/// dismiss. So for the length of the call we drop the always-on-top pin, hand
+/// the broker permission to foreground itself, and restore the pin on drop.
 #[cfg(target_os = "windows")]
-fn get_main_hwnd(app: &tauri::AppHandle) -> Result<isize, AppError> {
-    let window = app
-        .get_webview_window("main")
-        .ok_or_else(|| AppError::Internal("No main window found".into()))?;
+struct InteractiveAuthWindow {
+    window: tauri::WebviewWindow,
+    hwnd: isize,
+    restore_always_on_top: bool,
+}
 
-    #[cfg(target_os = "windows")]
-    {
+#[cfg(target_os = "windows")]
+impl InteractiveAuthWindow {
+    fn acquire(app: &tauri::AppHandle) -> Result<Self, AppError> {
+        use windows::Win32::UI::WindowsAndMessaging::{AllowSetForegroundWindow, ASFW_ANY};
+
+        let window = app
+            .get_webview_window("main")
+            .ok_or_else(|| AppError::Internal("No main window found".into()))?;
         let hwnd = window
             .hwnd()
-            .map_err(|e| AppError::Internal(format!("Failed to get HWND: {e}")))?;
-        Ok(hwnd.0 as isize)
+            .map_err(|e| AppError::Internal(format!("Failed to get HWND: {e}")))?
+            .0 as isize;
+
+        let restore_always_on_top = crate::commands::system_preferences::always_on_top_enabled();
+        if restore_always_on_top {
+            let _ = window.set_always_on_top(false);
+            crate::commands::system_preferences::remember_always_on_top(false);
+        }
+
+        // Let the broker process bring its dialog to the foreground; without
+        // this the foreground lock keeps it behind us even unpinned.
+        let _ = unsafe { AllowSetForegroundWindow(ASFW_ANY) };
+        let _ = window.set_focus();
+
+        Ok(Self {
+            window,
+            hwnd,
+            restore_always_on_top,
+        })
     }
 
-    #[cfg(not(target_os = "windows"))]
-    {
-        let _ = window;
-        Ok(0)
+    fn hwnd(&self) -> isize {
+        self.hwnd
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl Drop for InteractiveAuthWindow {
+    fn drop(&mut self) {
+        if self.restore_always_on_top {
+            let _ = self.window.set_always_on_top(true);
+            crate::commands::system_preferences::remember_always_on_top(true);
+        }
     }
 }
 
@@ -41,8 +81,8 @@ pub fn graph_authenticate(
     app: tauri::AppHandle,
     state: tauri::State<'_, GraphAuthState>,
 ) -> CmdResult<GraphAuthStatus> {
-    let hwnd = get_main_hwnd(&app)?;
-    graph_api::authenticate(&state, hwnd)
+    let window = InteractiveAuthWindow::acquire(&app)?;
+    graph_api::authenticate(&state, window.hwnd())
 }
 
 #[tauri::command]
@@ -51,13 +91,16 @@ pub async fn graph_request_missing_permissions(
     app: tauri::AppHandle,
     state: tauri::State<'_, GraphAuthState>,
 ) -> CmdResult<GraphPermissionUpgradeResult> {
-    let hwnd = get_main_hwnd(&app)?;
+    let window = InteractiveAuthWindow::acquire(&app)?;
+    let hwnd = window.hwnd();
     let state = state.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let result = tauri::async_runtime::spawn_blocking(move || {
         graph_api::request_missing_permissions_on_initialized_worker(&state, hwnd)
     })
     .await
-    .map_err(|error| AppError::Internal(format!("GraphPermissionTaskFailed: {error}")))?
+    .map_err(|error| AppError::Internal(format!("GraphPermissionTaskFailed: {error}")));
+    drop(window);
+    result?
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/graph_api.rs
+++ b/src-tauri/src/commands/graph_api.rs
@@ -44,7 +44,14 @@ impl InteractiveAuthWindow {
 
         let restore_always_on_top = crate::commands::system_preferences::always_on_top_enabled();
         if restore_always_on_top {
-            let _ = window.set_always_on_top(false);
+            // Failing to unpin is fatal for this flow: proceeding would raise
+            // the dialog behind a window the user cannot interact with, which
+            // is the very bug this guard exists to prevent.
+            window.set_always_on_top(false).map_err(|error| {
+                AppError::Internal(format!(
+                    "Failed to suspend always-on-top for the sign-in dialog: {error}"
+                ))
+            })?;
             crate::commands::system_preferences::remember_always_on_top(false);
         }
 
@@ -68,8 +75,10 @@ impl InteractiveAuthWindow {
 #[cfg(target_os = "windows")]
 impl Drop for InteractiveAuthWindow {
     fn drop(&mut self) {
-        if self.restore_always_on_top {
-            let _ = self.window.set_always_on_top(true);
+        // Drop cannot report failure, so keep the mirror on whatever the window
+        // ended up in: if re-pinning fails (a closed window, say), the pin is
+        // genuinely off and the mirror must say so.
+        if self.restore_always_on_top && self.window.set_always_on_top(true).is_ok() {
             crate::commands::system_preferences::remember_always_on_top(true);
         }
     }

--- a/src-tauri/src/commands/system_preferences.rs
+++ b/src-tauri/src/commands/system_preferences.rs
@@ -109,9 +109,11 @@ pub fn set_always_on_top<R: tauri::Runtime>(
         window.set_always_on_top(enabled).map_err(|error| {
             crate::error::AppError::Internal(format!("failed to set always-on-top: {error}"))
         })?;
+        // Only mirror state the window actually accepted; a stale mirror would
+        // make the interactive-auth guard drop a pin that is not set, or leave
+        // one set that buries the broker dialog.
+        ALWAYS_ON_TOP.store(enabled, Ordering::Relaxed);
     }
-
-    ALWAYS_ON_TOP.store(enabled, Ordering::Relaxed);
 
     if let Some(menu) = app.menu() {
         if let Some(MenuItemKind::Check(item)) =

--- a/src-tauri/src/commands/system_preferences.rs
+++ b/src-tauri/src/commands/system_preferences.rs
@@ -1,4 +1,25 @@
 use serde::Serialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Mirrors the always-on-top state last applied to the main window. Native
+/// modal dialogs owned by other processes (the Entra WAM broker) are not
+/// promoted to topmost by our window, so an always-on-top main window buries
+/// them; callers that raise such a dialog need to know whether to drop the pin
+/// for the duration.
+static ALWAYS_ON_TOP: AtomicBool = AtomicBool::new(false);
+
+/// Whether the main window is currently pinned always-on-top.
+#[cfg(target_os = "windows")]
+pub fn always_on_top_enabled() -> bool {
+    ALWAYS_ON_TOP.load(Ordering::Relaxed)
+}
+
+/// Record the always-on-top state without going through the command (used when
+/// a native dialog temporarily suspends and then restores the pin).
+#[cfg(target_os = "windows")]
+pub fn remember_always_on_top(enabled: bool) {
+    ALWAYS_ON_TOP.store(enabled, Ordering::Relaxed);
+}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -89,6 +110,8 @@ pub fn set_always_on_top<R: tauri::Runtime>(
             crate::error::AppError::Internal(format!("failed to set always-on-top: {error}"))
         })?;
     }
+
+    ALWAYS_ON_TOP.store(enabled, Ordering::Relaxed);
 
     if let Some(menu) = app.menu() {
         if let Some(MenuItemKind::Check(item)) =

--- a/src-tauri/src/commands/system_preferences.rs
+++ b/src-tauri/src/commands/system_preferences.rs
@@ -10,14 +10,14 @@ static ALWAYS_ON_TOP: AtomicBool = AtomicBool::new(false);
 
 /// Whether the main window is currently pinned always-on-top.
 #[cfg(target_os = "windows")]
-pub fn always_on_top_enabled() -> bool {
+pub(crate) fn always_on_top_enabled() -> bool {
     ALWAYS_ON_TOP.load(Ordering::Relaxed)
 }
 
 /// Record the always-on-top state without going through the command (used when
 /// a native dialog temporarily suspends and then restores the pin).
 #[cfg(target_os = "windows")]
-pub fn remember_always_on_top(enabled: bool) {
+pub(crate) fn remember_always_on_top(enabled: bool) {
     ALWAYS_ON_TOP.store(enabled, Ordering::Relaxed);
 }
 


### PR DESCRIPTION
## Problem

Hitting **Sign in with Windows** raised the Entra broker's account picker *behind* the main window, and the main window locked up — unmovable, with no visible dialog.

## Cause

The picker belongs to the broker process. We parent it to the main HWND, which disables our window for the duration (the "lock up"), but cross-process ownership does not inherit topmost, and the broker cannot take the foreground on its own. With always-on-top pinned, the dialog is drawn behind an unclickable window.

## Fix

New `InteractiveAuthWindow` RAII guard (replaces `get_main_hwnd`), used by both interactive paths — `graph_authenticate` and `graph_request_missing_permissions`. On acquire it:

- drops the always-on-top pin,
- calls `AllowSetForegroundWindow(ASFW_ANY)` so the broker may foreground its dialog,
- focuses the main window,

and restores the pin on drop. `set_always_on_top` was write-only into the window, so the applied state is now also tracked in `system_preferences` for native code to read.

## Verification

- `cargo clippy --all-features --all-targets -- -D warnings` clean
- `cargo test --all-features` green
- `npx tsc --noEmit` clean

Caveat: the new code is `#[cfg(target_os = "windows")]`, so local checks only covered the non-Windows tree. The Windows compile is on CI; the dialog behavior itself needs a manual run on a Windows box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)