### PR TITLE
Harden all supported log parsers and add format contracts

### DIFF
--- a/crates/cmtraceopen-parser/src/parser/plain.rs
+++ b/crates/cmtraceopen-parser/src/parser/plain.rs
@@ -9,6 +9,7 @@ use crate::models::log_entry::{LogEntry, LogFormat};
 /// Parse all lines as plain text.
 pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
     let mut entries = Vec::with_capacity(lines.len());
+    let mut next_id = 0u64;
 
     for (i, line) in lines.iter().enumerate() {
         if line.trim().is_empty() {
@@ -18,7 +19,7 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
         let severity = detect_severity_from_text(line);
 
         entries.push(LogEntry {
-            id: i as u64,
+            id: next_id,
             line_number: (i + 1) as u32,
             message: line.to_string(),
             component: None,
@@ -67,6 +68,7 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
             iteration: None,
             tags: None,
         });
+        next_id += 1;
     }
 
     // Plain text never has parse errors (every line is valid)

--- a/crates/cmtraceopen-parser/src/parser/psadt.rs
+++ b/crates/cmtraceopen-parser/src/parser/psadt.rs
@@ -53,7 +53,8 @@ fn map_severity(token: &str) -> Severity {
     match token {
         "Error" => Severity::Error,
         "Warning" | "Warn" => Severity::Warning,
-        // "Info", "Information", "Success", or anything else → Info
+        "Success" => Severity::Success,
+        // "Info", "Information", or anything else → Info
         _ => Severity::Info,
     }
 }
@@ -311,10 +312,10 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_success_maps_to_info() {
+    fn test_parse_success_maps_to_success() {
         let line = "[2024-12-24 14:44:14.000] [Post-Install] [Test-Function] [Success] :: All good";
         let parsed = parse_line(line).expect("should parse");
-        assert_eq!(parsed.severity, Severity::Info);
+        assert_eq!(parsed.severity, Severity::Success);
     }
 
     #[test]

--- a/crates/cmtraceopen-parser/src/parser/registry.rs
+++ b/crates/cmtraceopen-parser/src/parser/registry.rs
@@ -112,12 +112,18 @@ pub fn parse_registry_content(
 
         // Value line — only valid inside a key
         if let Some(ref mut key) = current_key {
-            if let Some(value) = parse_value_line(trimmed, (i + 1) as u32, &lines, &mut i) {
-                total_values += 1;
-                key.values.push(value);
-            } else {
-                parse_errors += 1;
-                i += 1;
+            let start_index = i;
+            match parse_value_line(trimmed, (i + 1) as u32, &lines, &mut i) {
+                Ok(value) => {
+                    total_values += 1;
+                    key.values.push(value);
+                }
+                Err(_) => {
+                    parse_errors += 1;
+                    if i <= start_index {
+                        i = start_index + 1;
+                    }
+                }
             }
         } else {
             parse_errors += 1;
@@ -142,6 +148,9 @@ pub fn parse_registry_content(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RegistryValueParseError;
+
 /// Parse a value line, consuming continuation lines for hex data.
 /// Advances `line_idx` past any consumed continuation lines.
 fn parse_value_line(
@@ -149,22 +158,22 @@ fn parse_value_line(
     line_number: u32,
     all_lines: &[&str],
     line_idx: &mut usize,
-) -> Option<RegistryValue> {
+) -> Result<RegistryValue, RegistryValueParseError> {
     // Default value: @=<data>
     let (name, data_str) = if let Some(stripped) = first_line.strip_prefix("@=") {
         ("(Default)".to_string(), stripped)
     } else if first_line.starts_with('"') {
         // "name"=<data> or "name"=-
-        let closing_quote = find_closing_quote(first_line, 1)?;
+        let closing_quote = find_closing_quote(first_line, 1).ok_or(RegistryValueParseError)?;
         let name = unescape_reg_string(&first_line[1..closing_quote]);
         let after = first_line[closing_quote + 1..].trim_start();
         if !after.starts_with('=') {
-            return None;
+            return Err(RegistryValueParseError);
         }
         let data_str = after[1..].trim_start();
         (name, data_str)
     } else {
-        return None;
+        return Err(RegistryValueParseError);
     };
 
     // Collect full data string, joining continuation lines
@@ -179,7 +188,7 @@ fn parse_value_line(
             full_data.push_str(cont);
             *line_idx += 1;
         } else {
-            break;
+            return Err(RegistryValueParseError);
         }
     }
 
@@ -187,7 +196,7 @@ fn parse_value_line(
 
     // Delete marker
     if full_data == "-" {
-        return Some(RegistryValue {
+        return Ok(RegistryValue {
             name,
             kind: RegistryValueKind::DeleteMarker,
             data: "(value deleted)".to_string(),
@@ -197,12 +206,12 @@ fn parse_value_line(
 
     // String value: "..."
     if full_data.starts_with('"') && full_data.len() >= 2 {
-        let inner = if let Some(close) = find_closing_quote(full_data, 1) {
-            unescape_reg_string(&full_data[1..close])
-        } else {
-            full_data[1..].to_string()
-        };
-        return Some(RegistryValue {
+        let close = find_closing_quote(full_data, 1).ok_or(RegistryValueParseError)?;
+        if !full_data[close + 1..].trim().is_empty() {
+            return Err(RegistryValueParseError);
+        }
+        let inner = unescape_reg_string(&full_data[1..close]);
+        return Ok(RegistryValue {
             name,
             kind: RegistryValueKind::String,
             data: inner,
@@ -212,8 +221,15 @@ fn parse_value_line(
 
     // DWORD: dword:XXXXXXXX
     if let Some(hex_str) = full_data.strip_prefix("dword:") {
-        let value = u32::from_str_radix(hex_str.trim(), 16).unwrap_or(0);
-        return Some(RegistryValue {
+        let hex_str = hex_str.trim();
+        if hex_str.is_empty()
+            || hex_str.len() > 8
+            || !hex_str.bytes().all(|byte| byte.is_ascii_hexdigit())
+        {
+            return Err(RegistryValueParseError);
+        }
+        let value = u32::from_str_radix(hex_str, 16).map_err(|_| RegistryValueParseError)?;
+        return Ok(RegistryValue {
             name,
             kind: RegistryValueKind::Dword,
             data: format!("0x{:08x} ({})", value, value),
@@ -223,9 +239,12 @@ fn parse_value_line(
 
     // hex(b): QWORD
     if let Some(hex_bytes_str) = full_data.strip_prefix("hex(b):") {
-        let bytes = parse_hex_bytes(hex_bytes_str);
+        let bytes = parse_hex_bytes(hex_bytes_str)?;
+        if bytes.len() != 8 {
+            return Err(RegistryValueParseError);
+        }
         let value = bytes_to_qword(&bytes);
-        return Some(RegistryValue {
+        return Ok(RegistryValue {
             name,
             kind: RegistryValueKind::Qword,
             data: format!("0x{:016x} ({})", value, value),
@@ -235,9 +254,9 @@ fn parse_value_line(
 
     // hex(2): REG_EXPAND_SZ (UTF-16LE encoded)
     if let Some(hex_bytes_str) = full_data.strip_prefix("hex(2):") {
-        let bytes = parse_hex_bytes(hex_bytes_str);
+        let bytes = parse_hex_bytes(hex_bytes_str)?;
         let decoded = decode_utf16le_bytes(&bytes);
-        return Some(RegistryValue {
+        return Ok(RegistryValue {
             name,
             kind: RegistryValueKind::ExpandString,
             data: decoded,
@@ -247,9 +266,9 @@ fn parse_value_line(
 
     // hex(7): REG_MULTI_SZ (UTF-16LE encoded, null-separated)
     if let Some(hex_bytes_str) = full_data.strip_prefix("hex(7):") {
-        let bytes = parse_hex_bytes(hex_bytes_str);
+        let bytes = parse_hex_bytes(hex_bytes_str)?;
         let decoded = decode_utf16le_multi_string(&bytes);
-        return Some(RegistryValue {
+        return Ok(RegistryValue {
             name,
             kind: RegistryValueKind::MultiString,
             data: decoded,
@@ -259,8 +278,8 @@ fn parse_value_line(
 
     // hex(0): REG_NONE
     if let Some(hex_bytes_str) = full_data.strip_prefix("hex(0):") {
-        let bytes = parse_hex_bytes(hex_bytes_str);
-        return Some(RegistryValue {
+        let bytes = parse_hex_bytes(hex_bytes_str)?;
+        return Ok(RegistryValue {
             name,
             kind: RegistryValueKind::None,
             data: format_hex_display(&bytes),
@@ -270,8 +289,8 @@ fn parse_value_line(
 
     // hex: REG_BINARY
     if let Some(hex_bytes_str) = full_data.strip_prefix("hex:") {
-        let bytes = parse_hex_bytes(hex_bytes_str);
-        return Some(RegistryValue {
+        let bytes = parse_hex_bytes(hex_bytes_str)?;
+        return Ok(RegistryValue {
             name,
             kind: RegistryValueKind::Binary,
             data: format_hex_display(&bytes),
@@ -283,8 +302,8 @@ fn parse_value_line(
     if full_data.starts_with("hex(") {
         if let Some(colon_pos) = full_data.find("):") {
             let hex_bytes_str = &full_data[colon_pos + 2..];
-            let bytes = parse_hex_bytes(hex_bytes_str);
-            return Some(RegistryValue {
+            let bytes = parse_hex_bytes(hex_bytes_str)?;
+            return Ok(RegistryValue {
                 name,
                 kind: RegistryValueKind::Binary,
                 data: format_hex_display(&bytes),
@@ -294,7 +313,7 @@ fn parse_value_line(
     }
 
     // Unrecognized format
-    Some(RegistryValue {
+    Ok(RegistryValue {
         name,
         kind: RegistryValueKind::String,
         data: full_data.to_string(),
@@ -343,15 +362,18 @@ fn unescape_reg_string(s: &str) -> String {
 }
 
 /// Parse comma-separated hex bytes like "01,00,04,80".
-fn parse_hex_bytes(s: &str) -> Vec<u8> {
+fn parse_hex_bytes(s: &str) -> Result<Vec<u8>, RegistryValueParseError> {
+    if s.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
     s.split(',')
-        .filter_map(|b| {
-            let trimmed = b.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                u8::from_str_radix(trimmed, 16).ok()
+        .map(|token| {
+            let token = token.trim();
+            if token.len() != 2 || !token.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                return Err(RegistryValueParseError);
             }
+            u8::from_str_radix(token, 16).map_err(|_| RegistryValueParseError)
         })
         .collect()
 }
@@ -568,5 +590,52 @@ mod tests {
         assert_eq!(result.total_keys, 0);
         assert_eq!(result.total_values, 0);
         assert_eq!(result.parse_errors, 0);
+    }
+
+    #[test]
+    fn malformed_values_increment_errors_without_fabricating_zeroes() {
+        let content = concat!(
+            "Windows Registry Editor Version 5.00\n\n",
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\CMTraceOpenTest]\n",
+            "\"BadDword\"=dword:nothex\n",
+            "\"BadBinary\"=hex:01,GG,03\n",
+            "\"BadString\"=\"unterminated\n",
+            "\"BadContinuation\"=hex:01,02,\\\n",
+        );
+        let result = parse_registry_content(content, "bad.reg", content.len() as u64);
+        assert_eq!(result.total_keys, 1);
+        assert_eq!(result.total_values, 0);
+        assert_eq!(result.parse_errors, 4);
+    }
+
+    #[test]
+    fn valid_zero_and_empty_values_remain_valid() {
+        let content = concat!(
+            "Windows Registry Editor Version 5.00\n\n",
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\CMTraceOpenTest]\n",
+            "\"ZeroDword\"=dword:00000000\n",
+            "\"ZeroQword\"=hex(b):00,00,00,00,00,00,00,00\n",
+            "\"EmptyBinary\"=hex:\n",
+            "\"EmptyString\"=\"\"\n",
+        );
+        let result = parse_registry_content(content, "zero.reg", content.len() as u64);
+        assert_eq!(result.total_values, 4);
+        assert_eq!(result.parse_errors, 0);
+        assert_eq!(result.keys[0].values[0].data, "0x00000000 (0)");
+        assert_eq!(result.keys[0].values[1].data, "0x0000000000000000 (0)");
+        assert_eq!(result.keys[0].values[2].data, "(zero-length binary value)");
+        assert_eq!(result.keys[0].values[3].data, "");
+    }
+
+    #[test]
+    fn qword_requires_exactly_eight_bytes() {
+        let content = concat!(
+            "Windows Registry Editor Version 5.00\n\n",
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\CMTraceOpenTest]\n",
+            "\"ShortQword\"=hex(b):01,02,03,04\n",
+        );
+        let result = parse_registry_content(content, "short-qword.reg", content.len() as u64);
+        assert_eq!(result.total_values, 0);
+        assert_eq!(result.parse_errors, 1);
     }
 }

--- a/crates/cmtraceopen-parser/src/parser/registry.rs
+++ b/crates/cmtraceopen-parser/src/parser/registry.rs
@@ -298,18 +298,20 @@ fn parse_value_line(
         });
     }
 
-    // Other hex(N): types — treat as binary
-    if full_data.starts_with("hex(") {
-        if let Some(colon_pos) = full_data.find("):") {
-            let hex_bytes_str = &full_data[colon_pos + 2..];
-            let bytes = parse_hex_bytes(hex_bytes_str)?;
-            return Ok(RegistryValue {
-                name,
-                kind: RegistryValueKind::Binary,
-                data: format_hex_display(&bytes),
-                line_number,
-            });
+    // Other syntactically valid hex(N) types retain their bytes as REG_NONE.
+    if let Some(typed_hex) = full_data.strip_prefix("hex(") {
+        let (type_tag, hex_bytes_str) =
+            typed_hex.split_once("):").ok_or(RegistryValueParseError)?;
+        if type_tag.is_empty() || !type_tag.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(RegistryValueParseError);
         }
+        let bytes = parse_hex_bytes(hex_bytes_str)?;
+        return Ok(RegistryValue {
+            name,
+            kind: RegistryValueKind::None,
+            data: format_hex_display(&bytes),
+            line_number,
+        });
     }
 
     // Unrecognized format
@@ -637,5 +639,32 @@ mod tests {
         let result = parse_registry_content(content, "short-qword.reg", content.len() as u64);
         assert_eq!(result.total_values, 0);
         assert_eq!(result.parse_errors, 1);
+    }
+
+    #[test]
+    fn unsupported_typed_hex_is_preserved_as_none_when_valid() {
+        let content = concat!(
+            "Windows Registry Editor Version 5.00\n\n",
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\CMTraceOpenTest]\n",
+            "\"ResourceList\"=hex(8):01,02,03,04\n",
+        );
+        let result = parse_registry_content(content, "typed-hex.reg", content.len() as u64);
+        assert_eq!(result.total_values, 1);
+        assert_eq!(result.parse_errors, 0);
+        assert_eq!(result.keys[0].values[0].kind, RegistryValueKind::None);
+        assert_eq!(result.keys[0].values[0].data, "01 02 03 04");
+    }
+
+    #[test]
+    fn unsupported_typed_hex_requires_a_valid_type_tag() {
+        let content = concat!(
+            "Windows Registry Editor Version 5.00\n\n",
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\CMTraceOpenTest]\n",
+            "\"BadTag\"=hex(foo):01,02\n",
+            "\"MissingDelimiter\"=hex(8)01,02\n",
+        );
+        let result = parse_registry_content(content, "bad-tag.reg", content.len() as u64);
+        assert_eq!(result.total_values, 0);
+        assert_eq!(result.parse_errors, 2);
     }
 }

--- a/crates/cmtraceopen-parser/src/parser/secureboot_log.rs
+++ b/crates/cmtraceopen-parser/src/parser/secureboot_log.rs
@@ -32,13 +32,19 @@ fn secureboot_log_re() -> &'static Regex {
 
 /// Check if a line matches the SecureBoot certificate update log format.
 pub fn matches_secureboot_log_record(line: &str) -> bool {
-    secureboot_log_re().is_match(line)
+    secureboot_log_re()
+        .captures(line)
+        .and_then(|caps| {
+            chrono::NaiveDateTime::parse_from_str(caps.get(1)?.as_str(), "%Y-%m-%d %H:%M:%S").ok()
+        })
+        .is_some()
 }
 
 fn severity_from_level(level: &str) -> Severity {
     match level {
         "ERROR" => Severity::Error,
         "WARNING" => Severity::Warning,
+        "SUCCESS" => Severity::Success,
         _ => Severity::Info,
     }
 }
@@ -55,7 +61,14 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
             continue;
         }
 
-        if let Some(caps) = secureboot_log_re().captures(trimmed) {
+        let parsed = secureboot_log_re().captures(trimmed).and_then(|caps| {
+            let ts_str = caps.get(1)?.as_str();
+            let timestamp =
+                chrono::NaiveDateTime::parse_from_str(ts_str, "%Y-%m-%d %H:%M:%S").ok()?;
+            Some((caps, timestamp))
+        });
+
+        if let Some((caps, parsed_timestamp)) = parsed {
             let ts_str = caps.get(1).unwrap().as_str();
             let script_name = caps.get(2).unwrap().as_str();
             let level = caps.get(3).unwrap().as_str();
@@ -66,9 +79,7 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
 
             let severity = severity_from_level(level);
 
-            let timestamp = chrono::NaiveDateTime::parse_from_str(ts_str, "%Y-%m-%d %H:%M:%S")
-                .ok()
-                .map(|dt| dt.and_utc().timestamp_millis());
+            let timestamp = Some(parsed_timestamp.and_utc().timestamp_millis());
 
             let timestamp_display = Some(format!("{}.000", ts_str));
 
@@ -218,7 +229,7 @@ mod tests {
         let lines = vec!["2026-04-07 11:25:48 [DETECT] [SUCCESS] Secure Boot is ENABLED"];
         let (entries, errors) = parse_lines(&lines, "SecureBootCertificateUpdate.log");
         assert_eq!(errors, 0);
-        assert_eq!(entries[0].severity, Severity::Info);
+        assert_eq!(entries[0].severity, Severity::Success);
         assert_eq!(entries[0].component.as_deref(), Some("DETECT"));
     }
 
@@ -246,6 +257,13 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_timestamp_does_not_match_secureboot_record() {
+        assert!(!matches_secureboot_log_record(
+            "2026-13-40 25:61:61 [DETECT] [INFO] impossible timestamp"
+        ));
+    }
+
+    #[test]
     fn test_parse_multiple_lines() {
         let lines = vec![
             "2026-04-07 11:25:47 [DETECT] [INFO] Script Version: 4.0",
@@ -257,7 +275,7 @@ mod tests {
         assert_eq!(errors, 0);
         assert_eq!(entries.len(), 4);
         assert_eq!(entries[0].severity, Severity::Info);
-        assert_eq!(entries[1].severity, Severity::Info);
+        assert_eq!(entries[1].severity, Severity::Success);
         assert_eq!(entries[2].severity, Severity::Warning);
         assert_eq!(entries[3].severity, Severity::Info);
     }

--- a/docs/superpowers/plans/2026-07-29-log-parser-hardening.md
+++ b/docs/superpowers/plans/2026-07-29-log-parser-hardening.md
@@ -1,0 +1,650 @@
+# Log Parser Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add deterministic contracts for every supported log parser and harden the concrete malformed-input and severity defects exposed by the parser audit.
+
+**Architecture:** A new integration contract suite will exercise parser detection, selection metadata, file decoding, and representative structured output for all 20 `ParserKind` values plus IME specialization. Native Registry and DNS Audit formats retain their dedicated paths: Registry gets a real `.reg` file-boundary test, while DNS Audit gains a pure serialized-record adapter used by both the EVTX reader and deterministic synthetic unit tests.
+
+**Tech Stack:** Rust 1.88, Cargo workspace, `cmtraceopen-parser`, Tauri backend crate `cmtrace-open`, `chrono`, `encoding_rs`, `evtx`, standard Rust test framework.
+
+## Global Constraints
+
+- Cover all 20 `ParserKind` variants and the IME specialization.
+- Preserve input rather than silently dropping malformed records.
+- Increment `parse_errors` for recoverable malformed structured input.
+- Keep logical-record line numbers tied to the first source line.
+- Do not add parser-framework or fixture-generation dependencies.
+- Preserve serialized field names and frontend compatibility.
+- Do not commit customer, tenant, device, user, or private-domain data in fixtures.
+- Make every production change through a demonstrated red-green test cycle.
+- Keep the existing unrelated changes in `src-tauri/src/commands/graph_api.rs` and `src-tauri/src/commands/system_preferences.rs` unstaged and untouched.
+
+---
+
+## File Structure
+
+- Create `src-tauri/tests/parser_supported_formats.rs`: exhaustive support inventory, clean-format contracts, IME contract, and file-decoding contracts.
+- Create clean fixtures under `src-tauri/tests/corpus/{timestamped,iis_w3c,psadt,intune_macos,dhcp,burn,patchmypc_detection,registry,secureboot,cmtlog}/clean/`.
+- Reuse existing fixtures for CCM, Simple, Plain, Panther, CBS, DISM, ReportingEvents, MSI, DNS Debug, and IME.
+- Modify `crates/cmtraceopen-parser/src/parser/plain.rs`: contiguous entry IDs across blank physical lines.
+- Modify `crates/cmtraceopen-parser/src/parser/psadt.rs`: map the explicit `Success` level to `Severity::Success`.
+- Modify `crates/cmtraceopen-parser/src/parser/secureboot_log.rs`: map `SUCCESS` correctly and reject impossible structured timestamps.
+- Modify `crates/cmtraceopen-parser/src/parser/registry.rs`: reject malformed values and incomplete continuations instead of converting them to valid-looking values.
+- Modify `src-tauri/src/parser/dns_audit.rs`: separate serialized-record conversion from EVTX iteration for deterministic tests.
+- Modify `src-tauri/tests/dns_audit_real.rs`: keep the optional real-EVTX smoke test and make its skip status explicit.
+
+---
+
+### Task 1: Add the Exhaustive Supported-Format Contract
+
+**Files:**
+- Create: `src-tauri/tests/parser_supported_formats.rs`
+- Create: `src-tauri/tests/corpus/timestamped/clean/mixed.log`
+- Create: `src-tauri/tests/corpus/iis_w3c/clean/u_ex260329.log`
+- Create: `src-tauri/tests/corpus/psadt/clean/Deploy-Application.log`
+- Create: `src-tauri/tests/corpus/intune_macos/clean/IntuneMDMDaemon.log`
+- Create: `src-tauri/tests/corpus/dhcp/clean/DhcpSrvLog-Mon.log`
+- Create: `src-tauri/tests/corpus/burn/clean/bundle.log`
+- Create: `src-tauri/tests/corpus/patchmypc_detection/clean/detection.log`
+- Create: `src-tauri/tests/corpus/registry/clean/basic.reg`
+- Create: `src-tauri/tests/corpus/secureboot/clean/SecureBootCertificateUpdate.log`
+- Create: `src-tauri/tests/corpus/cmtlog/clean/basic.cmtlog`
+- Reuse: `src-tauri/tests/common/mod.rs`
+- Reuse: existing corpus paths named in the design spec
+
+**Interfaces:**
+- Consumes: `app_lib::parser::detect::detect_parser(path, content)`, `app_lib::parser::parse_file(path)`, `ParserKind`, `ParserImplementation`, `ParserSpecialization`, `LogFormat`.
+- Produces: `const DECLARED_PARSER_KINDS: [ParserKind; 20]`, exhaustive `contract_name(ParserKind) -> &'static str`, and one field-level contract test per text format.
+
+- [ ] **Step 1: Add the inventory test before adding new fixtures**
+
+Create the test module with an exhaustive match and a unique 20-kind inventory:
+
+```rust
+use app_lib::models::log_entry::ParserKind;
+use std::collections::BTreeSet;
+
+const DECLARED_PARSER_KINDS: [ParserKind; 20] = [
+    ParserKind::Ccm,
+    ParserKind::Simple,
+    ParserKind::Timestamped,
+    ParserKind::Plain,
+    ParserKind::IisW3c,
+    ParserKind::Panther,
+    ParserKind::Cbs,
+    ParserKind::Dism,
+    ParserKind::ReportingEvents,
+    ParserKind::Msi,
+    ParserKind::PsadtLegacy,
+    ParserKind::IntuneMacOs,
+    ParserKind::Dhcp,
+    ParserKind::Burn,
+    ParserKind::PatchMyPcDetection,
+    ParserKind::Registry,
+    ParserKind::SecureBootLog,
+    ParserKind::DnsDebug,
+    ParserKind::DnsAudit,
+    ParserKind::CmtLog,
+];
+
+fn contract_name(kind: ParserKind) -> &'static str {
+    match kind {
+        ParserKind::Ccm => "ccm",
+        ParserKind::Simple => "simple",
+        ParserKind::Timestamped => "timestamped",
+        ParserKind::Plain => "plain",
+        ParserKind::IisW3c => "iis_w3c",
+        ParserKind::Panther => "panther",
+        ParserKind::Cbs => "cbs",
+        ParserKind::Dism => "dism",
+        ParserKind::ReportingEvents => "reporting_events",
+        ParserKind::Msi => "msi",
+        ParserKind::PsadtLegacy => "psadt",
+        ParserKind::IntuneMacOs => "intune_macos",
+        ParserKind::Dhcp => "dhcp",
+        ParserKind::Burn => "burn",
+        ParserKind::PatchMyPcDetection => "patchmypc_detection",
+        ParserKind::Registry => "registry",
+        ParserKind::SecureBootLog => "secureboot",
+        ParserKind::DnsDebug => "dns_debug",
+        ParserKind::DnsAudit => "dns_audit",
+        ParserKind::CmtLog => "cmtlog",
+    }
+}
+
+#[test]
+fn support_inventory_names_every_parser_kind_once() {
+    let names = DECLARED_PARSER_KINDS
+        .into_iter()
+        .map(contract_name)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(names.len(), DECLARED_PARSER_KINDS.len());
+}
+```
+
+- [ ] **Step 2: Run the compile-exhaustiveness inventory test**
+
+Run:
+
+```bash
+cargo test -p cmtrace-open --test parser_supported_formats support_inventory_names_every_parser_kind_once -- --exact
+```
+
+Expected: PASS. This is a characterization/coverage guard and requires no production change; adding a future `ParserKind` will make the exhaustive `contract_name` match fail to compile until the contract is named.
+
+- [ ] **Step 3: Add the clean fixtures**
+
+Use these sanitized representative records:
+
+```text
+# timestamped/clean/mixed.log
+2026-07-29T09:15:30.125Z service started
+07/29/2026 09:15:31 warning: retry scheduled
+Jul 29 09:15:32 host daemon: request complete
+09:15:33.250 final message
+```
+
+```text
+# iis_w3c/clean/u_ex260329.log
+#Software: Microsoft Internet Information Services 10.0
+#Version: 1.0
+#Fields: date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) sc-status sc-substatus sc-win32-status time-taken
+2026-03-29 18:48:23 10.0.0.5 GET /default.htm - 443 - 203.0.113.10 Agent/1.0 200 0 0 12
+2026-03-29 18:48:24 10.0.0.5 POST /api/devices id=42 443 EXAMPLE\\operator 203.0.113.11 Agent/1.1 404 7 2 35
+```
+
+```text
+# psadt/clean/Deploy-Application.log
+[2026-07-29 09:00:00.100] [Initialization] [Open-ADTSession] [Info] :: Session opened
+[2026-07-29 09:00:01.200] [Install] [Start-ADTMsiProcess] [Success] :: Installation complete
+```
+
+```text
+# intune_macos/clean/IntuneMDMDaemon.log
+2026-07-29 09:10:11:888 | IntuneMDM-Daemon | I | 100 | SyncActivityTracer | Reporting results
+2026-07-29 09:10:12:999 | IntuneMDM-Daemon | E | 101 | AppInstaller | Installation failed
+```
+
+```text
+# dhcp/clean/DhcpSrvLog-Mon.log
+Microsoft DHCP Service Activity Log
+11,07/29/26,09:20:00,Renew,192.0.2.10,device.example.test,001122334455,,1,0,,,,0x00,client,,,,0
+31,07/29/26,09:20:01,DNS Update Failed,2001:db8::10,device-v6.example.test,001122334466,,2,0,6,,,,,,,,,9560
+```
+
+```text
+# burn/clean/bundle.log
+[07A4:0CBC][2026-07-29T09:30:00]i001: Burn bundle started
+[07A4:0CBC][2026-07-29T09:30:01]e000: Error 0x80070005: Access denied
+```
+
+```text
+# patchmypc_detection/clean/detection.log
+07/29/2026 09:40:00~[Example App 1.0]~[Found:False]~[Purpose:Detection]~[Context:TESTDEVICE$)]~[Hive:HKLM:\software\example]
+07/29/2026 09:40:01~[Example App 1.0]~[Found:True]~[Purpose:Requirement]~[Context:TESTDEVICE$)]~[Hive:HKLM:\software\example]
+```
+
+```text
+# registry/clean/basic.reg
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\CMTraceOpenTest]
+@="Default"
+"Enabled"=dword:00000001
+"Names"=hex(7):4f,00,6e,00,65,00,00,00,54,00,77,00,6f,00,00,00,00,00
+```
+
+```text
+# secureboot/clean/SecureBootCertificateUpdate.log
+2026-07-29 09:50:00 [DETECT] [INFO] Detection started
+2026-07-29 09:50:01 [DETECT] [SUCCESS] Secure Boot is enabled
+```
+
+```text
+# cmtlog/clean/basic.cmtlog
+<![LOG[Parser contract]LOG]!><time="10:00:00.000+000" date="07-29-2026" component="__HEADER__" context="" type="1" thread="0" file="" script="ParserContract.ps1" version="1.0.0" runid="test-run" mode="Normal" ps_version="7.4.0">
+<![LOG[Detection]LOG]!><time="10:00:01.000+000" date="07-29-2026" component="__SECTION__" context="" type="1" thread="0" file="" color="#5b9aff">
+<![LOG[Iteration 1]LOG]!><time="10:00:02.000+000" date="07-29-2026" component="__ITERATION__" context="" type="1" thread="0" file="" iteration="1/1" color="#a78bfa">
+<![LOG[Policy present]LOG]!><time="10:00:03.000+000" date="07-29-2026" component="ParserContract" context="" type="0" thread="42" file="" section="detection" iteration="1/1" tag="contract:clean" whatif="1">
+```
+
+- [ ] **Step 4: Add field-level contract tests**
+
+Add a `parse_fixture` helper that uses `CARGO_MANIFEST_DIR/tests/corpus`, then write tests named:
+
+```rust
+text_contract_ccm
+text_contract_simple
+text_contract_timestamped
+text_contract_plain
+text_contract_iis_w3c
+text_contract_panther
+text_contract_cbs
+text_contract_dism
+text_contract_reporting_events
+text_contract_msi
+text_contract_psadt_legacy
+text_contract_intune_macos
+text_contract_dhcp
+text_contract_burn
+text_contract_patchmypc_detection
+selection_contract_registry
+text_contract_secureboot
+text_contract_dns_debug
+selection_contract_dns_audit
+text_contract_cmtlog
+specialization_contract_ime
+```
+
+For every text contract, assert `selection.parser`, `selection.implementation`, `selection.provenance`, `selection.record_framing`, `result.format_detected`, `parse_errors`, and at least two format-specific fields from the design table. For Registry, assert detection returns `Registry` and defer structured values to Task 4. For DNS Audit, assert `ResolvedParser::dns_audit().to_info()` metadata and defer record conversion to Task 5. For IME, assert `ParserKind::Ccm`, `ParserImplementation::Ccm`, and `specialization == Some(ParserSpecialization::Ime)`.
+
+- [ ] **Step 5: Run the supported-format contract**
+
+Run:
+
+```bash
+cargo test -p cmtrace-open --test parser_supported_formats
+```
+
+Expected: PASS for all characterization and inventory contracts. Explicit `Success` severity behavior is introduced test-first in Task 3.
+
+- [ ] **Step 6: Commit the characterization contracts**
+
+```bash
+git add src-tauri/tests/parser_supported_formats.rs src-tauri/tests/corpus
+git commit -m "test(parser): cover every supported log format"
+```
+
+---
+
+### Task 2: Harden Shared File Decoding and Plain Entry Identity
+
+**Files:**
+- Modify: `src-tauri/tests/parser_supported_formats.rs`
+- Modify: `crates/cmtraceopen-parser/src/parser/plain.rs`
+
+**Interfaces:**
+- Consumes: `detect_encoding`, `decode_bytes`, `parse_file`, and plain `LogEntry.id`.
+- Produces: portable encoding tests and contiguous IDs for emitted plain entries.
+
+- [ ] **Step 1: Add failing decoding and ID tests**
+
+```rust
+#[test]
+fn plain_ids_are_contiguous_across_blank_lines() {
+    let lines = ["first", "", "third"];
+    let (entries, errors) =
+        app_lib::parser::plain::parse_lines(&lines, "plain.log");
+    assert_eq!(errors, 0);
+    assert_eq!(entries.iter().map(|entry| entry.id).collect::<Vec<_>>(), vec![0, 1]);
+    assert_eq!(entries.iter().map(|entry| entry.line_number).collect::<Vec<_>>(), vec![1, 3]);
+}
+```
+
+Add file-boundary tests that create temporary byte fixtures for UTF-8 BOM, UTF-16LE BOM, UTF-16BE BOM, and the Windows-1252 bytes for `caf\xe9`. Assert decoded messages, `file_size`, and `byte_offset`. Add a UTF-16LE Registry fixture assertion that verifies `Enabled` is parsed as DWORD `1`.
+
+- [ ] **Step 2: Verify the contiguous-ID regression fails**
+
+Run:
+
+```bash
+cargo test -p cmtrace-open --test parser_supported_formats plain_ids_are_contiguous_across_blank_lines -- --exact
+```
+
+Expected: FAIL with actual IDs `[0, 2]`.
+
+- [ ] **Step 3: Use an emitted-entry counter in the plain parser**
+
+Replace `id: i as u64` with a `next_id` initialized before the loop and incremented only after an entry is pushed. Keep `line_number: (i + 1) as u32` unchanged.
+
+- [ ] **Step 4: Verify decoding and identity contracts**
+
+Run:
+
+```bash
+cargo test -p cmtrace-open --test parser_supported_formats encoding_
+cargo test -p cmtrace-open --test parser_supported_formats plain_ids_are_contiguous_across_blank_lines -- --exact
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cmtraceopen-parser/src/parser/plain.rs src-tauri/tests/parser_supported_formats.rs
+git commit -m "fix(parser): stabilize plain entries across encodings"
+```
+
+---
+
+### Task 3: Correct Explicit Success Severity and Secure Boot Timestamp Recovery
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/src/parser/psadt.rs`
+- Modify: `crates/cmtraceopen-parser/src/parser/secureboot_log.rs`
+- Modify: `src-tauri/tests/parser_supported_formats.rs`
+
+**Interfaces:**
+- Consumes: `Severity::Success`.
+- Produces: explicit success labels serialize as `Success`; impossible Secure Boot dates become preserved plain fallback entries and increment `parse_errors`.
+
+- [ ] **Step 1: Add failing severity and timestamp tests**
+
+```rust
+#[test]
+fn psadt_success_is_success_severity() {
+    let lines = [
+        "[2026-07-29 09:00:01.200] [Install] [Start-ADTMsiProcess] [Success] :: Installation complete",
+    ];
+    let (entries, errors) = app_lib::parser::psadt::parse_lines(&lines, "Deploy-Application.log");
+    assert_eq!(errors, 0);
+    assert_eq!(entries[0].severity, app_lib::models::log_entry::Severity::Success);
+}
+
+#[test]
+fn secureboot_success_is_success_severity() {
+    let lines = ["2026-07-29 09:50:01 [DETECT] [SUCCESS] Secure Boot is enabled"];
+    let (entries, errors) =
+        app_lib::parser::secureboot_log::parse_lines(&lines, "SecureBootCertificateUpdate.log");
+    assert_eq!(errors, 0);
+    assert_eq!(entries[0].severity, app_lib::models::log_entry::Severity::Success);
+}
+
+#[test]
+fn secureboot_invalid_timestamp_is_preserved_as_parse_error() {
+    let invalid = "2026-13-40 25:61:61 [DETECT] [INFO] impossible timestamp";
+    let (entries, errors) =
+        app_lib::parser::secureboot_log::parse_lines(&[invalid], "SecureBootCertificateUpdate.log");
+    assert_eq!(errors, 1);
+    assert_eq!(entries[0].message, invalid);
+    assert_eq!(entries[0].format, app_lib::models::log_entry::LogFormat::Plain);
+    assert!(entries[0].timestamp.is_none());
+    assert!(entries[0].timestamp_display.is_none());
+}
+```
+
+- [ ] **Step 2: Verify all three tests fail for the intended values**
+
+Run each exact test separately:
+
+```bash
+cargo test -p cmtrace-open --test parser_supported_formats psadt_success_is_success_severity -- --exact
+cargo test -p cmtrace-open --test parser_supported_formats secureboot_success_is_success_severity -- --exact
+cargo test -p cmtrace-open --test parser_supported_formats secureboot_invalid_timestamp_is_preserved_as_parse_error -- --exact
+```
+
+Expected: the first two report `Info` instead of `Success`; the third reports zero errors and a structured `Timestamped` entry.
+
+- [ ] **Step 3: Implement the minimal mappings and validated timestamp branch**
+
+In `psadt::map_severity`, map case-insensitive `success` to `Severity::Success`.
+
+In `secureboot_log::severity_from_level`, map `SUCCESS` to `Severity::Success`.
+
+In `secureboot_log::parse_lines`, parse the captured timestamp before constructing a structured entry. Construct the structured entry only when `NaiveDateTime::parse_from_str` succeeds; otherwise route the untouched line through the existing plain fallback branch and increment `parse_errors`. Set `timestamp_display` only from the validated timestamp.
+
+- [ ] **Step 4: Update obsolete focused expectations**
+
+Change the existing PSADT and Secure Boot unit tests that explicitly expect `Info` for success labels to expect `Severity::Success`. No other severity mapping changes.
+
+- [ ] **Step 5: Verify focused and module tests**
+
+```bash
+cargo test -p cmtraceopen-parser parser::psadt
+cargo test -p cmtraceopen-parser parser::secureboot_log
+cargo test -p cmtrace-open --test parser_supported_formats
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cmtraceopen-parser/src/parser/psadt.rs crates/cmtraceopen-parser/src/parser/secureboot_log.rs src-tauri/tests/parser_supported_formats.rs
+git commit -m "fix(parser): preserve explicit success and invalid timestamps"
+```
+
+---
+
+### Task 4: Make Registry Malformation Observable
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/src/parser/registry.rs`
+- Modify: `src-tauri/tests/parser_supported_formats.rs`
+
+**Interfaces:**
+- Consumes: `.reg` value syntax and `RegistryParseResult.parse_errors`.
+- Produces: `parse_value_line(...) -> Result<RegistryValue, RegistryValueParseError>` and `parse_hex_bytes(...) -> Result<Vec<u8>, RegistryValueParseError>`.
+
+- [ ] **Step 1: Add failing registry tests**
+
+Add unit tests for invalid numeric values, invalid hex tokens, unclosed strings, and incomplete continuation:
+
+```rust
+#[test]
+fn malformed_values_increment_errors_without_fabricating_zeroes() {
+    let content = concat!(
+        "Windows Registry Editor Version 5.00\n\n",
+        "[HKEY_LOCAL_MACHINE\\SOFTWARE\\CMTraceOpenTest]\n",
+        "\"BadDword\"=dword:nothex\n",
+        "\"BadBinary\"=hex:01,GG,03\n",
+        "\"BadString\"=\"unterminated\n",
+        "\"BadContinuation\"=hex:01,02,\\\n",
+    );
+    let result = parse_registry_content(content, "bad.reg", content.len() as u64);
+    assert_eq!(result.total_keys, 1);
+    assert_eq!(result.total_values, 0);
+    assert_eq!(result.parse_errors, 4);
+}
+```
+
+Keep a clean test that proves valid zero DWORD, zero QWORD, empty binary, and quoted empty string remain valid values.
+
+- [ ] **Step 2: Verify the malformed registry test fails**
+
+```bash
+cargo test -p cmtraceopen-parser parser::registry::tests::malformed_values_increment_errors_without_fabricating_zeroes -- --exact
+```
+
+Expected: FAIL because malformed numeric and hex data currently become valid-looking zero/partial values.
+
+- [ ] **Step 3: Return explicit parse errors**
+
+Add a private zero-sized `RegistryValueParseError` and change `parse_value_line` and `parse_hex_bytes` to return `Result`.
+
+Validation rules:
+
+- a quoted string must have a closing unescaped quote;
+- DWORD requires 1-8 ASCII hex digits;
+- QWORD requires exactly eight decoded bytes;
+- binary/typed hex tokens must be two ASCII hex digits each;
+- a trailing continuation backslash at EOF is an error;
+- unsupported typed hex remains `RegistryValueKind::None` only when its bytes are syntactically valid.
+
+In the outer loop, preserve forward progress:
+
+```rust
+let start_index = i;
+match parse_value_line(trimmed, (i + 1) as u32, &lines, &mut i) {
+    Ok(value) => {
+        total_values += 1;
+        key.values.push(value);
+    }
+    Err(_) => {
+        parse_errors += 1;
+        if i <= start_index {
+            i = start_index + 1;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Verify Registry unit and file-boundary tests**
+
+```bash
+cargo test -p cmtraceopen-parser parser::registry
+cargo test -p cmtrace-open --test parser_supported_formats registry
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cmtraceopen-parser/src/parser/registry.rs src-tauri/tests/parser_supported_formats.rs
+git commit -m "fix(parser): reject malformed registry values"
+```
+
+---
+
+### Task 5: Make DNS Audit Parsing Deterministic in CI
+
+**Files:**
+- Modify: `src-tauri/src/parser/dns_audit.rs`
+- Modify: `src-tauri/tests/dns_audit_real.rs`
+
+**Interfaces:**
+- Consumes: serialized JSON from `evtx::EvtxParser::records_json()`.
+- Produces: private `parse_serialized_record(serialized: &str, file_path: &str, id: u64) -> Result<Option<LogEntry>, ()>` shared by production EVTX iteration and unit tests.
+
+- [ ] **Step 1: Add failing synthetic record tests**
+
+Inside `dns_audit.rs`, add tests with sanitized JSON:
+
+```rust
+const DNS_CREATE_RECORD: &str = r#"{
+  "Event": {
+    "System": {
+      "Provider": {"#attributes": {"Name": "Microsoft-Windows-DNSServer"}},
+      "EventID": 515,
+      "TimeCreated": {"#attributes": {"SystemTime": "2026-07-29T14:00:00.000Z"}}
+    },
+    "EventData": {
+      "NAME": "host.example.test",
+      "Type": "1",
+      "Zone": "example.test",
+      "TTL": "3600"
+    }
+  }
+}"#;
+
+#[test]
+fn serialized_dns_record_maps_provider_event_and_fields() {
+    let entry = parse_serialized_record(DNS_CREATE_RECORD, "dns-audit.evtx", 7)
+        .expect("valid JSON")
+        .expect("DNS record");
+    assert_eq!(entry.id, 7);
+    assert_eq!(entry.dns_event_id, Some(515));
+    assert_eq!(entry.query_name.as_deref(), Some("host.example.test"));
+    assert_eq!(entry.query_type.as_deref(), Some("A"));
+    assert_eq!(entry.zone_name.as_deref(), Some("example.test"));
+    assert!(entry.timestamp.is_some());
+}
+```
+
+Add one non-DNS provider test expecting `Ok(None)` and one malformed JSON test expecting `Err(())`.
+
+- [ ] **Step 2: Verify the adapter test fails to compile**
+
+```bash
+cargo test -p cmtrace-open --features event-log parser::dns_audit::tests::serialized_dns_record_maps_provider_event_and_fields -- --exact
+```
+
+Expected: FAIL because `parse_serialized_record` does not exist.
+
+- [ ] **Step 3: Extract the record adapter**
+
+Move JSON decoding, provider filtering, EventID extraction, timestamp parsing, field extraction, and `LogEntry` construction from `parse_evtx` into the private adapter. Keep error-code annotation at the final result level.
+
+Update `parse_evtx` so:
+
+- EVTX reader errors increment `parse_errors`;
+- adapter `Err(())` increments `parse_errors`;
+- `Ok(None)` skips non-DNS records without error;
+- IDs increment only when a DNS entry is emitted.
+
+Update `is_dns_evtx` to reuse a small `serialized_record_is_dns_provider(&str) -> bool` helper rather than duplicating the JSON path.
+
+- [ ] **Step 4: Clarify the optional real-file smoke test**
+
+Rename the test to `real_dns_audit_evtx_smoke_when_local_fixture_exists` and keep the early return. The deterministic serialized-record tests are the CI contract; the smoke test verifies the `evtx` crate boundary only when the ignored local fixture is present.
+
+- [ ] **Step 5: Verify DNS Audit paths**
+
+```bash
+cargo test -p cmtrace-open --features event-log parser::dns_audit
+cargo test -p cmtrace-open --features event-log --test dns_audit_real
+```
+
+Expected: synthetic tests PASS on every machine; the real fixture test either PASSes or prints its explicit skip.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/parser/dns_audit.rs src-tauri/tests/dns_audit_real.rs
+git commit -m "test(parser): make DNS audit records deterministic"
+```
+
+---
+
+### Task 6: Run the Complete Parser Verification
+
+**Files:**
+- No planned file changes; this task is verification-only.
+
+**Interfaces:**
+- Consumes: all parser contracts and existing suites.
+- Produces: fresh verification evidence with platform limitations stated exactly.
+
+- [ ] **Step 1: Run parser-crate tests**
+
+```bash
+cargo test -p cmtraceopen-parser
+```
+
+Expected: PASS with zero failures.
+
+- [ ] **Step 2: Run the supported-format and existing corpus suites**
+
+```bash
+cargo test -p cmtrace-open --test parser_supported_formats
+cargo test -p cmtrace-open --test parser_expanded_corpus
+cargo test -p cmtrace-open --test parser_regression_corpus
+cargo test -p cmtrace-open --test cmtlog_parser
+cargo test -p cmtrace-open --features event-log --test dns_audit_real
+```
+
+Expected: PASS; `dns_audit_real` may explicitly skip only when its ignored local fixture is absent.
+
+- [ ] **Step 3: Run the full backend suite**
+
+```bash
+cargo test -p cmtrace-open
+```
+
+Expected: PASS with zero failures.
+
+- [ ] **Step 4: Run formatting and lint checks**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy -p cmtraceopen-parser -p cmtrace-open --all-targets --all-features -- -D warnings
+git diff --check
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 5: Inspect final scope**
+
+```bash
+git status --short
+git diff --stat HEAD~5..HEAD
+git log --oneline -6
+```
+
+Confirm parser commits contain only the planned parser, fixture, and test files. Confirm the pre-existing edits in `src-tauri/src/commands/graph_api.rs` and `src-tauri/src/commands/system_preferences.rs` were neither staged nor changed by this work.
+
+- [ ] **Step 6: Request final code review**
+
+Use `superpowers:requesting-code-review` against the complete parser diff, apply only verified actionable findings, and rerun the affected verification commands before reporting completion.

--- a/docs/superpowers/specs/2026-07-29-log-parser-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-29-log-parser-hardening-design.md
@@ -1,0 +1,175 @@
+# Log Parser Hardening Design
+
+**Date:** 2026-07-29
+**Status:** Approved design; awaiting written-spec review
+**Scope:** Every declared log parser kind, the IME specialization, file decoding, parser selection, structured extraction, and malformed-input recovery
+
+## Goal
+
+Make parser support explicit and regression-proof. Every supported log format must have a deterministic automated contract that proves the correct parser is selected and representative records are parsed into the expected `LogEntry` or dedicated structured result.
+
+The work must harden defects exposed by those contracts without broad parser rewrites or unrelated behavior changes.
+
+## Supported Parser Inventory
+
+The authoritative inventory is the `ParserKind` enum in `crates/cmtraceopen-parser/src/models/log_entry.rs`. It currently contains 20 parser kinds:
+
+1. CCM
+2. Simple
+3. Generic timestamped
+4. Plain text
+5. IIS W3C
+6. Panther
+7. CBS
+8. DISM
+9. ReportingEvents
+10. MSI
+11. PSADT Legacy
+12. Intune macOS
+13. DHCP
+14. Burn
+15. Patch My PC detection
+16. Registry export
+17. Secure Boot update log
+18. DNS debug
+19. DNS Audit EVTX
+20. CmtLog
+
+IME is a `ParserSpecialization` layered on the CCM implementation. It is part of the support contract and requires its own fixture even though it is not a separate `ParserKind`.
+
+## Architecture
+
+### Contract matrix
+
+Add a single integration-level parser contract matrix as the visible inventory of supported formats. Each contract identifies:
+
+- parser kind and implementation;
+- representative fixture or in-memory native record;
+- expected provenance, parse quality, record framing, date order, and specialization;
+- expected compatibility `LogFormat`;
+- format-specific output assertions;
+- expected parse-error behavior.
+
+The matrix will use an exhaustive match over `ParserKind` and assert unique coverage for every declared kind. This gives future parser additions a clear compiler/test failure until a contract is added. IME coverage is asserted separately because it is a specialization.
+
+### Existing focused tests
+
+Existing parser unit tests remain the place for detailed grammar cases. Existing regression and expanded-corpus tests remain valid. The new matrix does not duplicate every assertion; it proves the end-to-end contract from detection or native routing through structured output.
+
+### Native-only formats
+
+Registry and DNS Audit do not use the line-based dispatch in `parse_lines_with_selection`:
+
+- Registry contracts call the dedicated registry parser and file command boundary using `.reg` content.
+- DNS Audit contracts exercise provider recognition and event conversion with deterministic, synthetic serialized-event data. The existing local real-EVTX test remains an optional smoke test, but CI correctness must not depend on the ignored `Logs/` directory.
+
+If the EVTX reader cannot be exercised deterministically without committing a large or sensitive binary, extract a small internal adapter that accepts serialized EVTX event JSON. Test the adapter and DNS provider routing with synthetic records, while retaining the real-file smoke test for the `evtx` crate boundary.
+
+No customer, tenant, device, user, or private-domain data may be added to fixtures.
+
+## Fixture Strategy
+
+Text fixtures live under `src-tauri/tests/corpus/<format>/<case>/` and are intentionally small. Each clean fixture contains enough records to satisfy production detection thresholds without relying on a misleading filename unless path-based detection is itself part of the format contract.
+
+Each format receives:
+
+- one clean fixture proving detection and representative field extraction;
+- one focused malformed or boundary fixture when the parser has logical-record framing, continuation syntax, quoting/escaping, or multi-line data;
+- exact assertions on meaningful fields rather than only entry counts.
+
+Existing fixtures are reused where they already express the contract. New fixtures are required for missing kinds rather than generating test data at runtime, except for synthetic DNS Audit serialized events.
+
+## Required Assertions by Format
+
+| Format | Required proof |
+|---|---|
+| CCM | Logical-record recovery, multiline message preservation, severity types 0-3, component, thread, source file, timezone |
+| IME specialization | IME filename/content selects CCM plus `Ime`; representative IME record fields remain intact |
+| Simple | Component, timestamp, thread, severity, malformed suffix fallback |
+| Generic timestamped | ISO, slash-date, syslog, and time-only recognition; month/day order; continuation handling |
+| Plain | Every non-empty line is preserved with stable line numbers and no invented timestamp |
+| IIS W3C | `#Fields` mapping, URI/query, status/substatus, Win32 status, timing, and missing-column behavior |
+| Panther | Logical records, continuation lines, component/severity, result and GLE codes, setup phase and operation |
+| CBS | Logical records, continuation lines, component, severity, and mixed fallback segments |
+| DISM | Logical records, DISM and CBS-style components, continuation lines, and mixed fallback segments |
+| ReportingEvents | Record framing, event metadata/message, timestamp, and malformed record preservation |
+| MSI | Header/action records, timestamp, component/severity, and unstructured continuation text |
+| PSADT Legacy | Legacy delimiter parsing, severity mapping, component, and plain fallback |
+| Intune macOS | Timestamp, process/component, severity, message, and plain fallback |
+| DHCP | IPv4 and IPv6 server records, event ID, IP, host, MAC, and invalid record handling |
+| Burn | Timestamp, engine/component, severity, message, and continuation/fallback behavior |
+| Patch My PC detection | Detection signature, timestamp, severity, message, and false-positive boundary |
+| Registry | Version 5 and REGEDIT4 headers; default/named values; string, DWORD, QWORD, binary, expand, multi-string, delete markers, continuation lines, UTF-16LE file decoding, malformed value count |
+| Secure Boot update | Path/content detection, timestamp, level/severity, event fields, and plain fallback |
+| DNS debug | Month-first/day-first/ISO dates, query name/type, RCODE severity, protocol/direction, IPv4/IPv6, and logical details |
+| DNS Audit EVTX | DNS provider recognition, event ID dispatch, timestamp, DNS fields, severity, non-DNS filtering, malformed serialized record counting |
+| CmtLog | Header/section/iteration/log kinds, inherited section color, tags, WhatIf, severity, and heuristic `.log` detection |
+
+## Encoding and File-Boundary Coverage
+
+The shared file reader must be covered independently from grammar tests:
+
+- UTF-8 with and without BOM;
+- UTF-16LE with BOM;
+- UTF-16BE with BOM;
+- Windows-1252 fallback;
+- CRLF normalization where applicable;
+- byte offset and file size consistency.
+
+At least CCM and Registry must pass through the file boundary using their common Windows encodings. Encoding tests assert decoded content and parsed values so a decoder regression cannot pass by only producing valid Unicode.
+
+## Hardening Rules
+
+Parser changes follow test-driven development:
+
+1. Add one focused contract or regression assertion.
+2. Run it and confirm it fails for the intended behavioral reason.
+3. Make the smallest parser change that satisfies the contract.
+4. Re-run the focused test and relevant parser suite.
+5. Refactor only after green.
+
+Hardening priorities are:
+
+- preserve input rather than silently drop malformed records;
+- increment `parse_errors` for recoverable malformed structured input;
+- prevent one format's heuristic from stealing another format's records;
+- keep line numbers tied to source lines or logical-record starts;
+- avoid panics on truncated input, invalid dates, invalid numerics, and incomplete continuations;
+- preserve current public serialization names and frontend compatibility.
+
+The work will not add a parser plugin architecture, replace regex-based parsers wholesale, or redesign the log viewer.
+
+## Verification
+
+Focused verification:
+
+```bash
+cargo test -p cmtraceopen-parser parser
+cargo test -p cmtrace-open --test parser_supported_formats
+cargo test -p cmtrace-open --test parser_expanded_corpus
+cargo test -p cmtrace-open --test parser_regression_corpus
+cargo test -p cmtrace-open --features event-log --test dns_audit_real
+```
+
+The DNS Audit real-file test may report a deliberate skip when the ignored local fixture is unavailable; synthetic DNS Audit contract tests must still execute and pass in CI.
+
+Final verification:
+
+```bash
+cargo test -p cmtraceopen-parser
+cargo test -p cmtrace-open
+cargo fmt --all -- --check
+cargo clippy -p cmtraceopen-parser -p cmtrace-open --all-targets --all-features -- -D warnings
+```
+
+Any platform-specific test that cannot execute on macOS must have a portable pure-parser contract and be called out explicitly rather than reported as locally verified.
+
+## Success Criteria
+
+- All 20 `ParserKind` variants have a deterministic contract.
+- IME specialization has a deterministic contract.
+- Each contract asserts parser selection and meaningful parsed fields.
+- Registry and DNS Audit are tested through their dedicated architecture.
+- File encodings and byte accounting are covered.
+- Every hardening change has a demonstrated red-green regression test.
+- Parser suites, formatting, and linting pass, with platform-specific limits reported precisely.

--- a/src-tauri/src/parser/dns_audit.rs
+++ b/src-tauri/src/parser/dns_audit.rs
@@ -34,13 +34,8 @@ pub fn is_dns_evtx(path: &Path) -> bool {
     };
 
     for record in parser.records_json().take(5).flatten() {
-        if let Ok(json) = serde_json::from_str::<Value>(&record.data) {
-            let provider = json["Event"]["System"]["Provider"]["#attributes"]["Name"]
-                .as_str()
-                .unwrap_or("");
-            if provider == DNS_PROVIDER {
-                return true;
-            }
+        if serialized_record_is_dns_provider(&record.data) {
+            return true;
         }
     }
     false
@@ -76,88 +71,16 @@ pub fn parse_evtx(path: &str) -> Result<ParseResult, String> {
             }
         };
 
-        let json: Value = match serde_json::from_str(&record.data) {
-            Ok(v) => v,
-            Err(_) => {
-                parse_errors += 1;
-                continue;
+        match parse_serialized_record(&record.data, path, id) {
+            Ok(Some(entry)) => {
+                entries.push(entry);
+                id += 1;
             }
-        };
-
-        let system = &json["Event"]["System"];
-
-        // Only process DNS Server events
-        let provider = system["Provider"]["#attributes"]["Name"]
-            .as_str()
-            .unwrap_or("");
-        if provider != DNS_PROVIDER {
-            continue;
+            Ok(None) => {}
+            Err(()) => {
+                parse_errors += 1;
+            }
         }
-
-        let event_id = extract_event_id(system);
-        let event_data = &json["Event"]["EventData"];
-
-        let (timestamp_ms, timestamp_display) = parse_evtx_timestamp(
-            system["TimeCreated"]["#attributes"]["SystemTime"]
-                .as_str()
-                .unwrap_or(""),
-        );
-
-        let (message, query_name, query_type, response_code, zone_name, source_ip, severity) =
-            extract_event_fields(event_id, event_data);
-
-        entries.push(LogEntry {
-            id,
-            line_number: id as u32 + 1,
-            message,
-            component: Some("DNSServer".to_string()),
-            timestamp: timestamp_ms,
-            timestamp_display,
-            severity,
-            thread: None,
-            thread_display: None,
-            source_file: None,
-            format: LogFormat::DnsAudit,
-            file_path: path.to_string(),
-            timezone_offset: None,
-            error_code_spans: Vec::new(),
-            ip_address: None,
-            host_name: None,
-            mac_address: None,
-            result_code: None,
-            gle_code: None,
-            setup_phase: None,
-            operation_name: None,
-            http_method: None,
-            uri_stem: None,
-            uri_query: None,
-            status_code: None,
-            sub_status: None,
-            time_taken_ms: None,
-            client_ip: None,
-            server_ip: None,
-            user_agent: None,
-            server_port: None,
-            username: None,
-            win32_status: None,
-            query_name,
-            query_type,
-            response_code,
-            dns_direction: None,
-            dns_protocol: None,
-            source_ip,
-            dns_flags: None,
-            dns_event_id: Some(event_id),
-            zone_name,
-            entry_kind: None,
-            whatif: None,
-            section_name: None,
-            section_color: None,
-            iteration: None,
-            tags: None,
-        });
-
-        id += 1;
     }
 
     super::annotate_error_code_spans(&mut entries);
@@ -188,6 +111,93 @@ pub fn parse_evtx(path: &str) -> Result<ParseResult, String> {
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+fn serialized_record_is_dns_provider(serialized: &str) -> bool {
+    serde_json::from_str::<Value>(serialized)
+        .ok()
+        .and_then(|json| {
+            json["Event"]["System"]["Provider"]["#attributes"]["Name"]
+                .as_str()
+                .map(|provider| provider == DNS_PROVIDER)
+        })
+        .unwrap_or(false)
+}
+
+fn parse_serialized_record(
+    serialized: &str,
+    file_path: &str,
+    id: u64,
+) -> Result<Option<LogEntry>, ()> {
+    let json: Value = serde_json::from_str(serialized).map_err(|_| ())?;
+    let system = &json["Event"]["System"];
+    let provider = system["Provider"]["#attributes"]["Name"]
+        .as_str()
+        .unwrap_or("");
+    if provider != DNS_PROVIDER {
+        return Ok(None);
+    }
+
+    let event_id = extract_event_id(system);
+    let event_data = &json["Event"]["EventData"];
+    let (timestamp_ms, timestamp_display) = parse_evtx_timestamp(
+        system["TimeCreated"]["#attributes"]["SystemTime"]
+            .as_str()
+            .unwrap_or(""),
+    );
+    let (message, query_name, query_type, response_code, zone_name, source_ip, severity) =
+        extract_event_fields(event_id, event_data);
+
+    Ok(Some(LogEntry {
+        id,
+        line_number: id as u32 + 1,
+        message,
+        component: Some("DNSServer".to_string()),
+        timestamp: timestamp_ms,
+        timestamp_display,
+        severity,
+        thread: None,
+        thread_display: None,
+        source_file: None,
+        format: LogFormat::DnsAudit,
+        file_path: file_path.to_string(),
+        timezone_offset: None,
+        error_code_spans: Vec::new(),
+        ip_address: None,
+        host_name: None,
+        mac_address: None,
+        result_code: None,
+        gle_code: None,
+        setup_phase: None,
+        operation_name: None,
+        http_method: None,
+        uri_stem: None,
+        uri_query: None,
+        status_code: None,
+        sub_status: None,
+        time_taken_ms: None,
+        client_ip: None,
+        server_ip: None,
+        user_agent: None,
+        server_port: None,
+        username: None,
+        win32_status: None,
+        query_name,
+        query_type,
+        response_code,
+        dns_direction: None,
+        dns_protocol: None,
+        source_ip,
+        dns_flags: None,
+        dns_event_id: Some(event_id),
+        zone_name,
+        entry_kind: None,
+        whatif: None,
+        section_name: None,
+        section_color: None,
+        iteration: None,
+        tags: None,
+    }))
+}
 
 /// Extract the EventID from the EVTX System block.
 ///
@@ -475,6 +485,22 @@ fn extract_generic(event_id: u32, data: &Value) -> EventFields {
 mod tests {
     use super::*;
 
+    const DNS_CREATE_RECORD: &str = r##"{
+      "Event": {
+        "System": {
+          "Provider": {"#attributes": {"Name": "Microsoft-Windows-DNSServer"}},
+          "EventID": 515,
+          "TimeCreated": {"#attributes": {"SystemTime": "2026-07-29T14:00:00.000Z"}}
+        },
+        "EventData": {
+          "NAME": "host.example.test",
+          "Type": "1",
+          "Zone": "example.test",
+          "TTL": "3600"
+        }
+      }
+    }"##;
+
     fn make_event_data(fields: &[(&str, &str)]) -> Value {
         let mut map = serde_json::Map::new();
         for (k, v) in fields {
@@ -578,5 +604,35 @@ mod tests {
 
         assert_eq!(millis, None);
         assert_eq!(display, None);
+    }
+
+    #[test]
+    fn serialized_dns_record_maps_provider_event_and_fields() {
+        let entry = parse_serialized_record(DNS_CREATE_RECORD, "dns-audit.evtx", 7)
+            .expect("valid JSON")
+            .expect("DNS record");
+        assert_eq!(entry.id, 7);
+        assert_eq!(entry.line_number, 8);
+        assert_eq!(entry.dns_event_id, Some(515));
+        assert_eq!(entry.query_name.as_deref(), Some("host.example.test"));
+        assert_eq!(entry.query_type.as_deref(), Some("A"));
+        assert_eq!(entry.zone_name.as_deref(), Some("example.test"));
+        assert!(entry.timestamp.is_some());
+    }
+
+    #[test]
+    fn serialized_non_dns_record_is_filtered_without_error() {
+        let record = DNS_CREATE_RECORD.replace(
+            "Microsoft-Windows-DNSServer",
+            "Microsoft-Windows-OtherProvider",
+        );
+        assert!(parse_serialized_record(&record, "other.evtx", 0)
+            .expect("valid JSON")
+            .is_none());
+    }
+
+    #[test]
+    fn malformed_serialized_record_is_a_parse_error() {
+        assert!(parse_serialized_record("{not-json", "dns-audit.evtx", 0).is_err());
     }
 }

--- a/src-tauri/tests/corpus/burn/clean/bundle.log
+++ b/src-tauri/tests/corpus/burn/clean/bundle.log
@@ -1,0 +1,2 @@
+[07A4:0CBC][2026-07-29T09:30:00]i001: Burn bundle started
+[07A4:0CBC][2026-07-29T09:30:01]e000: Error 0x80070005: Access denied

--- a/src-tauri/tests/corpus/cmtlog/clean/basic.cmtlog
+++ b/src-tauri/tests/corpus/cmtlog/clean/basic.cmtlog
@@ -1,0 +1,4 @@
+<![LOG[Parser contract]LOG]!><time="10:00:00.000+000" date="07-29-2026" component="__HEADER__" context="" type="1" thread="0" file="" script="ParserContract.ps1" version="1.0.0" runid="test-run" mode="Normal" ps_version="7.4.0">
+<![LOG[Detection]LOG]!><time="10:00:01.000+000" date="07-29-2026" component="__SECTION__" context="" type="1" thread="0" file="" color="#5b9aff">
+<![LOG[Iteration 1]LOG]!><time="10:00:02.000+000" date="07-29-2026" component="__ITERATION__" context="" type="1" thread="0" file="" iteration="1/1" color="#a78bfa">
+<![LOG[Policy present]LOG]!><time="10:00:03.000+000" date="07-29-2026" component="ParserContract" context="" type="0" thread="42" file="" section="detection" iteration="1/1" tag="contract:clean" whatif="1">

--- a/src-tauri/tests/corpus/dhcp/clean/DhcpSrvLog-Mon.log
+++ b/src-tauri/tests/corpus/dhcp/clean/DhcpSrvLog-Mon.log
@@ -1,0 +1,3 @@
+Microsoft DHCP Service Activity Log
+11,07/29/26,09:20:00,Renew,192.0.2.10,device.example.test,001122334455,,1,0,,,,0x00,client,,,,0
+31,07/29/26,09:20:01,DNS Update Failed,2001:db8::10,device-v6.example.test,001122334466,,2,0,6,,,,,,,,,9560

--- a/src-tauri/tests/corpus/iis_w3c/clean/u_ex260329.log
+++ b/src-tauri/tests/corpus/iis_w3c/clean/u_ex260329.log
@@ -1,0 +1,5 @@
+#Software: Microsoft Internet Information Services 10.0
+#Version: 1.0
+#Fields: date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) sc-status sc-substatus sc-win32-status time-taken
+2026-03-29 18:48:23 10.0.0.5 GET /default.htm - 443 - 203.0.113.10 Agent/1.0 200 0 0 12
+2026-03-29 18:48:24 10.0.0.5 POST /api/devices id=42 443 EXAMPLE\operator 203.0.113.11 Agent/1.1 404 7 2 35

--- a/src-tauri/tests/corpus/intune_macos/clean/IntuneMDMDaemon.log
+++ b/src-tauri/tests/corpus/intune_macos/clean/IntuneMDMDaemon.log
@@ -1,0 +1,2 @@
+2026-07-29 09:10:11:888 | IntuneMDM-Daemon | I | 100 | SyncActivityTracer | Reporting results
+2026-07-29 09:10:12:999 | IntuneMDM-Daemon | E | 101 | AppInstaller | Installation failed

--- a/src-tauri/tests/corpus/patchmypc_detection/clean/detection.log
+++ b/src-tauri/tests/corpus/patchmypc_detection/clean/detection.log
@@ -1,0 +1,2 @@
+07/29/2026 09:40:00~[Example App 1.0]~[Found:False]~[Purpose:Detection]~[Context:TESTDEVICE$)]~[Hive:HKLM:\software\example]
+07/29/2026 09:40:01~[Example App 1.0]~[Found:True]~[Purpose:Requirement]~[Context:TESTDEVICE$)]~[Hive:HKLM:\software\example]

--- a/src-tauri/tests/corpus/psadt/clean/Deploy-Application.log
+++ b/src-tauri/tests/corpus/psadt/clean/Deploy-Application.log
@@ -1,0 +1,2 @@
+[2026-07-29 09:00:00.100] [Initialization] [Open-ADTSession] [Info] :: Session opened
+[2026-07-29 09:00:01.200] [Install] [Start-ADTMsiProcess] [Success] :: Installation complete

--- a/src-tauri/tests/corpus/registry/clean/basic.reg
+++ b/src-tauri/tests/corpus/registry/clean/basic.reg
@@ -1,0 +1,6 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\CMTraceOpenTest]
+@="Default"
+"Enabled"=dword:00000001
+"Names"=hex(7):4f,00,6e,00,65,00,00,00,54,00,77,00,6f,00,00,00,00,00

--- a/src-tauri/tests/corpus/secureboot/clean/SecureBootCertificateUpdate.log
+++ b/src-tauri/tests/corpus/secureboot/clean/SecureBootCertificateUpdate.log
@@ -1,0 +1,2 @@
+2026-07-29 09:50:00 [DETECT] [INFO] Detection started
+2026-07-29 09:50:01 [DETECT] [SUCCESS] Secure Boot is enabled

--- a/src-tauri/tests/corpus/simple/clean/basic.log
+++ b/src-tauri/tests/corpus/simple/clean/basic.log
@@ -1,3 +1,3 @@
-$$<CcmExec><03-15-2026 08:00:00.000+000><thread=100 (0x64)>Starting CcmExec service
-$$<PolicyAgent><03-15-2026 08:00:01.000+000><thread=101 (0x65)>Processing policy update
-$$<CcmExec><03-15-2026 08:00:02.000+000><thread=100 (0x64)>Error: connection failed
+Starting CcmExec service$$<CcmExec><03-15-2026 08:00:00.000+000><thread=100 (0x64)>
+Processing policy update$$<PolicyAgent><03-15-2026 08:00:01.000+000><thread=101 (0x65)>
+Error: connection failed$$<CcmExec><03-15-2026 08:00:02.000+000><thread=100 (0x64)>

--- a/src-tauri/tests/corpus/timestamped/clean/mixed.log
+++ b/src-tauri/tests/corpus/timestamped/clean/mixed.log
@@ -1,0 +1,4 @@
+2026-07-29T09:15:30.125Z service started
+07/29/2026 09:15:31 warning: retry scheduled
+Jul 29 09:15:32 host daemon: request complete
+09:15:33.250 final message

--- a/src-tauri/tests/dns_audit_real.rs
+++ b/src-tauri/tests/dns_audit_real.rs
@@ -11,7 +11,7 @@ const FIXTURE_PATH: &str = concat!(
 );
 
 #[test]
-fn test_real_dns_audit_evtx() {
+fn real_dns_audit_evtx_smoke_when_local_fixture_exists() {
     if !Path::new(FIXTURE_PATH).exists() {
         eprintln!(
             "Skipping: real DNS audit EVTX fixture not found at {}",

--- a/src-tauri/tests/parser_supported_formats.rs
+++ b/src-tauri/tests/parser_supported_formats.rs
@@ -564,3 +564,34 @@ fn encoding_utf16le_registry_reaches_dedicated_parser_without_data_loss() {
     assert_eq!(result.keys[0].values[0].name, "Enabled");
     assert_eq!(result.keys[0].values[0].data, "0x00000001 (1)");
 }
+
+#[test]
+fn psadt_success_is_success_severity() {
+    let lines = [
+        "[2026-07-29 09:00:01.200] [Install] [Start-ADTMsiProcess] [Success] :: Installation complete",
+    ];
+    let (entries, errors) = app_lib::parser::psadt::parse_lines(&lines, "Deploy-Application.log");
+    assert_eq!(errors, 0);
+    assert_eq!(entries[0].severity, Severity::Success);
+}
+
+#[test]
+fn secureboot_success_is_success_severity() {
+    let lines = ["2026-07-29 09:50:01 [DETECT] [SUCCESS] Secure Boot is enabled"];
+    let (entries, errors) =
+        app_lib::parser::secureboot_log::parse_lines(&lines, "SecureBootCertificateUpdate.log");
+    assert_eq!(errors, 0);
+    assert_eq!(entries[0].severity, Severity::Success);
+}
+
+#[test]
+fn secureboot_invalid_timestamp_is_preserved_as_parse_error() {
+    let invalid = "2026-13-40 25:61:61 [DETECT] [INFO] impossible timestamp";
+    let (entries, errors) =
+        app_lib::parser::secureboot_log::parse_lines(&[invalid], "SecureBootCertificateUpdate.log");
+    assert_eq!(errors, 1);
+    assert_eq!(entries[0].message, invalid);
+    assert_eq!(entries[0].format, LogFormat::Plain);
+    assert!(entries[0].timestamp.is_none());
+    assert!(entries[0].timestamp_display.is_none());
+}

--- a/src-tauri/tests/parser_supported_formats.rs
+++ b/src-tauri/tests/parser_supported_formats.rs
@@ -1,0 +1,465 @@
+use app_lib::models::log_entry::{
+    DateFieldOrder, EntryKind, LogFormat, ParseResult, ParserImplementation, ParserKind,
+    ParserSpecialization, RecordFraming, Severity,
+};
+use app_lib::parser::ResolvedParser;
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+const DECLARED_PARSER_KINDS: [ParserKind; 20] = [
+    ParserKind::Ccm,
+    ParserKind::Simple,
+    ParserKind::Timestamped,
+    ParserKind::Plain,
+    ParserKind::IisW3c,
+    ParserKind::Panther,
+    ParserKind::Cbs,
+    ParserKind::Dism,
+    ParserKind::ReportingEvents,
+    ParserKind::Msi,
+    ParserKind::PsadtLegacy,
+    ParserKind::IntuneMacOs,
+    ParserKind::Dhcp,
+    ParserKind::Burn,
+    ParserKind::PatchMyPcDetection,
+    ParserKind::Registry,
+    ParserKind::SecureBootLog,
+    ParserKind::DnsDebug,
+    ParserKind::DnsAudit,
+    ParserKind::CmtLog,
+];
+
+fn contract_name(kind: ParserKind) -> &'static str {
+    match kind {
+        ParserKind::Ccm => "ccm",
+        ParserKind::Simple => "simple",
+        ParserKind::Timestamped => "timestamped",
+        ParserKind::Plain => "plain",
+        ParserKind::IisW3c => "iis_w3c",
+        ParserKind::Panther => "panther",
+        ParserKind::Cbs => "cbs",
+        ParserKind::Dism => "dism",
+        ParserKind::ReportingEvents => "reporting_events",
+        ParserKind::Msi => "msi",
+        ParserKind::PsadtLegacy => "psadt",
+        ParserKind::IntuneMacOs => "intune_macos",
+        ParserKind::Dhcp => "dhcp",
+        ParserKind::Burn => "burn",
+        ParserKind::PatchMyPcDetection => "patchmypc_detection",
+        ParserKind::Registry => "registry",
+        ParserKind::SecureBootLog => "secureboot",
+        ParserKind::DnsDebug => "dns_debug",
+        ParserKind::DnsAudit => "dns_audit",
+        ParserKind::CmtLog => "cmtlog",
+    }
+}
+
+#[test]
+fn support_inventory_names_every_parser_kind_once() {
+    let names = DECLARED_PARSER_KINDS
+        .into_iter()
+        .map(contract_name)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(names.len(), DECLARED_PARSER_KINDS.len());
+}
+
+fn fixture_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("corpus")
+        .join(relative)
+}
+
+fn parse_fixture(relative: &str) -> (ParseResult, ResolvedParser) {
+    let path = fixture_path(relative);
+    app_lib::parser::parse_file(&path.to_string_lossy()).expect("fixture should parse")
+}
+
+fn detect_fixture(relative: &str) -> ResolvedParser {
+    let path = fixture_path(relative);
+    let content = std::fs::read_to_string(&path).expect("fixture should be UTF-8");
+    app_lib::parser::detect::detect_parser(&path.to_string_lossy(), &content)
+}
+
+fn assert_selection(
+    selection: &ResolvedParser,
+    parser: ParserKind,
+    implementation: ParserImplementation,
+    framing: RecordFraming,
+) {
+    assert_eq!(selection.parser, parser);
+    assert_eq!(selection.implementation, implementation);
+    assert_eq!(selection.record_framing, framing);
+}
+
+#[test]
+fn text_contract_ccm() {
+    let (result, selection) = parse_fixture("ccm/clean/basic.log");
+    assert_selection(
+        &selection,
+        ParserKind::Ccm,
+        ParserImplementation::Ccm,
+        RecordFraming::LogicalRecord,
+    );
+    assert_eq!(result.format_detected, LogFormat::Ccm);
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries[0].component.as_deref(), Some("CcmExec"));
+    assert_eq!(result.entries[0].thread, Some(100));
+    assert_eq!(result.entries[2].severity, Severity::Error);
+}
+
+#[test]
+fn text_contract_simple() {
+    let (result, selection) = parse_fixture("simple/clean/basic.log");
+    assert_selection(
+        &selection,
+        ParserKind::Simple,
+        ParserImplementation::Simple,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.format_detected, LogFormat::Simple);
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries[0].component.as_deref(), Some("CcmExec"));
+    assert_eq!(result.entries[0].thread, Some(100));
+    assert_eq!(result.entries[2].severity, Severity::Error);
+}
+
+#[test]
+fn text_contract_timestamped() {
+    let (result, selection) = parse_fixture("timestamped/clean/mixed.log");
+    assert_selection(
+        &selection,
+        ParserKind::Timestamped,
+        ParserImplementation::GenericTimestamped,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(
+        selection.to_info().date_order,
+        Some(DateFieldOrder::MonthFirst)
+    );
+    assert_eq!(result.format_detected, LogFormat::Timestamped);
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries.len(), 4);
+    assert!(result.entries[..3]
+        .iter()
+        .all(|entry| entry.timestamp.is_some()));
+    assert!(result.entries[3].timestamp.is_none());
+    assert_eq!(
+        result.entries[3].timestamp_display.as_deref(),
+        Some("09:15:33.250")
+    );
+    assert_eq!(result.entries[1].severity, Severity::Warning);
+}
+
+#[test]
+fn text_contract_plain() {
+    let (result, selection) = parse_fixture("plain/unstructured.txt");
+    assert_selection(
+        &selection,
+        ParserKind::Plain,
+        ParserImplementation::PlainText,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.format_detected, LogFormat::Plain);
+    assert_eq!(result.parse_errors, 0);
+    assert!(result
+        .entries
+        .iter()
+        .all(|entry| entry.timestamp.is_none() && entry.component.is_none()));
+}
+
+#[test]
+fn text_contract_iis_w3c() {
+    let (result, selection) = parse_fixture("iis_w3c/clean/u_ex260329.log");
+    assert_selection(
+        &selection,
+        ParserKind::IisW3c,
+        ParserImplementation::IisW3c,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.format_detected, LogFormat::Timestamped);
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries[0].http_method.as_deref(), Some("GET"));
+    assert_eq!(result.entries[0].status_code, Some(200));
+    assert_eq!(result.entries[1].uri_query.as_deref(), Some("id=42"));
+    assert_eq!(result.entries[1].sub_status, Some(7));
+}
+
+#[test]
+fn text_contract_panther() {
+    let (result, selection) = parse_fixture("panther/clean/setupact.log");
+    assert_selection(
+        &selection,
+        ParserKind::Panther,
+        ParserImplementation::GenericTimestamped,
+        RecordFraming::LogicalRecord,
+    );
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries[0].component.as_deref(), Some("MIG"));
+    assert!(result.entries[0]
+        .message
+        .contains("Additional migration detail"));
+    assert_eq!(result.entries[1].severity, Severity::Warning);
+}
+
+#[test]
+fn text_contract_cbs() {
+    let (result, selection) = parse_fixture("cbs/clean/CBS.log");
+    assert_selection(
+        &selection,
+        ParserKind::Cbs,
+        ParserImplementation::GenericTimestamped,
+        RecordFraming::LogicalRecord,
+    );
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries[0].component.as_deref(), Some("CBS"));
+    assert!(result.entries[0].message.contains("Continuation detail"));
+    assert_eq!(result.entries[1].severity, Severity::Error);
+}
+
+#[test]
+fn text_contract_dism() {
+    let (result, selection) = parse_fixture("dism/clean/dism.log");
+    assert_selection(
+        &selection,
+        ParserKind::Dism,
+        ParserImplementation::GenericTimestamped,
+        RecordFraming::LogicalRecord,
+    );
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries[0].component.as_deref(), Some("DISM"));
+    assert!(result.entries[0].message.contains("Continuation detail"));
+    assert_eq!(result.entries[1].severity, Severity::Warning);
+}
+
+#[test]
+fn text_contract_reporting_events() {
+    let (result, selection) = parse_fixture("reporting_events/clean/ReportingEvents.log");
+    assert_selection(
+        &selection,
+        ParserKind::ReportingEvents,
+        ParserImplementation::ReportingEvents,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(
+        result.entries[0].component.as_deref(),
+        Some("Windows Update Agent")
+    );
+    assert!(result.entries[0]
+        .message
+        .contains("Installation Successful"));
+    assert_eq!(result.entries[1].severity, Severity::Error);
+}
+
+#[test]
+fn text_contract_msi() {
+    let (result, selection) = parse_fixture("msi/clean/basic.log");
+    assert_selection(
+        &selection,
+        ParserKind::Msi,
+        ParserImplementation::Msi,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.parse_errors, 0);
+    assert!(result.entries.len() >= 6);
+    assert!(result.entries.iter().any(|entry| entry
+        .component
+        .as_deref()
+        .is_some_and(|component| component.starts_with("MSI-"))));
+    assert!(result
+        .entries
+        .iter()
+        .any(|entry| entry.message.contains("InstallInitialize")));
+}
+
+#[test]
+fn text_contract_psadt_legacy() {
+    let (result, selection) = parse_fixture("psadt/clean/Deploy-Application.log");
+    assert_selection(
+        &selection,
+        ParserKind::PsadtLegacy,
+        ParserImplementation::PsadtLegacy,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(
+        result.entries[0].component.as_deref(),
+        Some("Initialization")
+    );
+    assert_eq!(
+        result.entries[1].source_file.as_deref(),
+        Some("Start-ADTMsiProcess")
+    );
+}
+
+#[test]
+fn text_contract_intune_macos() {
+    let (result, selection) = parse_fixture("intune_macos/clean/IntuneMDMDaemon.log");
+    assert_selection(
+        &selection,
+        ParserKind::IntuneMacOs,
+        ParserImplementation::IntuneMacOs,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(
+        result.entries[0].component.as_deref(),
+        Some("IntuneMDM-Daemon")
+    );
+    assert_eq!(
+        result.entries[0].source_file.as_deref(),
+        Some("SyncActivityTracer")
+    );
+    assert_eq!(result.entries[1].severity, Severity::Error);
+}
+
+#[test]
+fn text_contract_dhcp() {
+    let (result, selection) = parse_fixture("dhcp/clean/DhcpSrvLog-Mon.log");
+    assert_selection(
+        &selection,
+        ParserKind::Dhcp,
+        ParserImplementation::Dhcp,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries[0].ip_address.as_deref(), Some("192.0.2.10"));
+    assert_eq!(
+        result.entries[0].mac_address.as_deref(),
+        Some("00:11:22:33:44:55")
+    );
+    assert_eq!(
+        result.entries[1].ip_address.as_deref(),
+        Some("2001:db8::10")
+    );
+    assert_eq!(result.entries[1].severity, Severity::Error);
+}
+
+#[test]
+fn text_contract_burn() {
+    let (result, selection) = parse_fixture("burn/clean/bundle.log");
+    assert_selection(
+        &selection,
+        ParserKind::Burn,
+        ParserImplementation::Burn,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries[0].component.as_deref(), Some("i001"));
+    assert_eq!(result.entries[0].thread, Some(0x07A4));
+    assert_eq!(result.entries[1].severity, Severity::Error);
+}
+
+#[test]
+fn text_contract_patchmypc_detection() {
+    let (result, selection) = parse_fixture("patchmypc_detection/clean/detection.log");
+    assert_selection(
+        &selection,
+        ParserKind::PatchMyPcDetection,
+        ParserImplementation::PatchMyPcDetection,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries[0].component.as_deref(), Some("PatchMyPC"));
+    assert_eq!(result.entries[0].host_name.as_deref(), Some("TESTDEVICE"));
+    assert_eq!(
+        result.entries[1].operation_name.as_deref(),
+        Some("Requirement")
+    );
+}
+
+#[test]
+fn selection_contract_registry() {
+    let selection = detect_fixture("registry/clean/basic.reg");
+    assert_selection(
+        &selection,
+        ParserKind::Registry,
+        ParserImplementation::Registry,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(selection.compatibility_format(), LogFormat::Plain);
+}
+
+#[test]
+fn text_contract_secureboot() {
+    let (result, selection) = parse_fixture("secureboot/clean/SecureBootCertificateUpdate.log");
+    assert_selection(
+        &selection,
+        ParserKind::SecureBootLog,
+        ParserImplementation::SecureBootLog,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries[0].component.as_deref(), Some("DETECT"));
+    assert!(result.entries[0].timestamp.is_some());
+    assert_eq!(result.entries[1].message, "Secure Boot is enabled");
+}
+
+#[test]
+fn text_contract_dns_debug() {
+    let (result, selection) = parse_fixture("dns_debug/clean/basic.log");
+    assert_selection(
+        &selection,
+        ParserKind::DnsDebug,
+        ParserImplementation::DnsDebug,
+        RecordFraming::LogicalRecord,
+    );
+    assert_eq!(result.format_detected, LogFormat::DnsDebug);
+    assert_eq!(result.parse_errors, 0);
+    assert!(result
+        .entries
+        .iter()
+        .any(|entry| entry.query_name.as_deref() == Some("home.gell.one")));
+    assert!(result
+        .entries
+        .iter()
+        .any(|entry| entry.dns_protocol.as_deref() == Some("UDP")));
+}
+
+#[test]
+fn selection_contract_dns_audit() {
+    let selection = ResolvedParser::dns_audit();
+    assert_selection(
+        &selection,
+        ParserKind::DnsAudit,
+        ParserImplementation::DnsAudit,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(selection.compatibility_format(), LogFormat::DnsAudit);
+}
+
+#[test]
+fn text_contract_cmtlog() {
+    let (result, selection) = parse_fixture("cmtlog/clean/basic.cmtlog");
+    assert_selection(
+        &selection,
+        ParserKind::CmtLog,
+        ParserImplementation::CmtLog,
+        RecordFraming::PhysicalLine,
+    );
+    assert_eq!(result.format_detected, LogFormat::CmtLog);
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.entries[0].entry_kind, Some(EntryKind::Header));
+    assert_eq!(result.entries[1].entry_kind, Some(EntryKind::Section));
+    assert_eq!(result.entries[2].entry_kind, Some(EntryKind::Iteration));
+    assert_eq!(result.entries[3].severity, Severity::Success);
+    assert_eq!(result.entries[3].whatif, Some(true));
+}
+
+#[test]
+fn specialization_contract_ime() {
+    let (result, selection) = parse_fixture("ime/multiline/HealthScripts.log");
+    assert_selection(
+        &selection,
+        ParserKind::Ccm,
+        ParserImplementation::Ccm,
+        RecordFraming::LogicalRecord,
+    );
+    assert_eq!(selection.specialization, Some(ParserSpecialization::Ime));
+    assert_eq!(result.parse_errors, 0);
+    assert!(result.entries[1]
+        .message
+        .contains("Invoke-RestMethod -Method Post"));
+    assert_eq!(result.entries[1].line_number, 2);
+}

--- a/src-tauri/tests/parser_supported_formats.rs
+++ b/src-tauri/tests/parser_supported_formats.rs
@@ -463,3 +463,104 @@ fn specialization_contract_ime() {
         .contains("Invoke-RestMethod -Method Post"));
     assert_eq!(result.entries[1].line_number, 2);
 }
+
+#[test]
+fn plain_ids_are_contiguous_across_blank_lines() {
+    let lines = ["first", "", "third"];
+    let (entries, errors) = app_lib::parser::plain::parse_lines(&lines, "plain.log");
+    assert_eq!(errors, 0);
+    assert_eq!(
+        entries.iter().map(|entry| entry.id).collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+    assert_eq!(
+        entries
+            .iter()
+            .map(|entry| entry.line_number)
+            .collect::<Vec<_>>(),
+        vec![1, 3]
+    );
+}
+
+fn utf16_bytes(content: &str, little_endian: bool) -> Vec<u8> {
+    let mut bytes = if little_endian {
+        vec![0xFF, 0xFE]
+    } else {
+        vec![0xFE, 0xFF]
+    };
+    for unit in content.encode_utf16() {
+        let encoded = if little_endian {
+            unit.to_le_bytes()
+        } else {
+            unit.to_be_bytes()
+        };
+        bytes.extend_from_slice(&encoded);
+    }
+    bytes
+}
+
+#[test]
+fn encoding_boms_and_windows_1252_decode_at_file_boundary() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let cases = [
+        (
+            "utf8.log",
+            b"\xEF\xBB\xBFutf8 message".to_vec(),
+            "utf8 message",
+        ),
+        (
+            "utf16le.log",
+            utf16_bytes("little endian", true),
+            "little endian",
+        ),
+        (
+            "utf16be.log",
+            utf16_bytes("big endian", false),
+            "big endian",
+        ),
+        (
+            "windows1252.log",
+            b"caf\xE9 message".to_vec(),
+            "caf\u{e9} message",
+        ),
+    ];
+
+    for (name, bytes, expected_message) in cases {
+        let path = temp.path().join(name);
+        std::fs::write(&path, &bytes).expect("write encoded fixture");
+        let (result, selection) =
+            app_lib::parser::parse_file(&path.to_string_lossy()).expect("parse encoded fixture");
+        assert_eq!(selection.parser, ParserKind::Plain, "{name}");
+        assert_eq!(result.entries[0].message, expected_message, "{name}");
+        assert_eq!(result.file_size, bytes.len() as u64, "{name}");
+        assert_eq!(result.byte_offset, bytes.len() as u64, "{name}");
+    }
+}
+
+#[test]
+fn encoding_utf16le_registry_reaches_dedicated_parser_without_data_loss() {
+    let content = concat!(
+        "Windows Registry Editor Version 5.00\r\n\r\n",
+        "[HKEY_LOCAL_MACHINE\\SOFTWARE\\CMTraceOpenTest]\r\n",
+        "\"Enabled\"=dword:00000001\r\n",
+    );
+    let bytes = utf16_bytes(content, true);
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join("contract.reg");
+    std::fs::write(&path, &bytes).expect("write UTF-16LE Registry fixture");
+
+    let decoded =
+        app_lib::parser::read_file_content(&path.to_string_lossy()).expect("decode Registry file");
+    let result = app_lib::parser::registry::parse_registry_content(
+        &decoded,
+        &path.to_string_lossy(),
+        bytes.len() as u64,
+    );
+
+    assert_eq!(result.file_size, bytes.len() as u64);
+    assert_eq!(result.total_keys, 1);
+    assert_eq!(result.total_values, 1);
+    assert_eq!(result.parse_errors, 0);
+    assert_eq!(result.keys[0].values[0].name, "Enabled");
+    assert_eq!(result.keys[0].values[0].data, "0x00000001 (1)");
+}


### PR DESCRIPTION
## Summary

- add exhaustive parser contracts and sanitized fixtures for all 20 supported `ParserKind` values plus IME specialization
- verify parser selection, framing, structured fields, encoding boundaries, and malformed-input recovery
- harden Plain, PSADT, Secure Boot, Registry, and DNS Audit parsing
- preserve explicit success severities, invalid timestamps, contiguous IDs, and unsupported Registry value types
- make DNS Audit record conversion deterministic without requiring a local EVTX fixture in CI

## Why

Several supported formats lacked end-to-end contract coverage, allowing malformed records, encoding boundaries, severity mappings, and parser-selection regressions to go unnoticed. Registry parsing also converted some malformed or unsupported values into misleading valid-looking data.

## Impact

Each supported format now has a deterministic parsing contract. Recoverable malformed structured input is observable through `parse_errors`, valid edge cases remain accepted, and DNS Audit behavior is covered using synthetic serialized records. The existing Simple fixture was corrected to the actual supported field order.

## Validation

- `cargo test -p cmtraceopen-parser` — passed (355 unit tests and 222 integration tests)
- `cargo test -p cmtrace-open` — passed
- `cargo clippy -p cmtraceopen-parser -p cmtrace-open --all-targets --all-features -- -D warnings` — passed
- task-local `rustfmt --check` for every changed Rust file — passed
- `git diff --check a1bc8fe1..HEAD` — passed

Repository-wide `cargo fmt --all -- --check` continues to report pre-existing formatting drift in unrelated ESP/Graph files; no unrelated formatting was changed here.

The optional real DNS Audit EVTX smoke test skips when its ignored local fixture is absent; deterministic DNS provider, event dispatch, field extraction, filtering, and malformed-record tests run in CI.