### PR TITLE
chore: crates.io metadata for cmtraceopen-parser and cmtrace-open

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Communication is through Tauri's `invoke()` (frontend→backend) and `emit()` (b
 | `parser/` | Log format auto-detection and parsing (CCM, simple, CBS, DISM, Panther, plain text) |
 | `intune/` | IME diagnostics pipeline: event tracking, timeline, download stats, EVTX parsing |
 | `dsregcmd/` | Device registration analysis: output parsing, diagnostic rules, registry hives |
-| `error_db/` | Embedded error code database (120+ Windows/SCCM/Intune codes) |
+| `error_db/` | Embedded error code database (700+ Windows/SCCM/Intune/MSI codes) |
 | `models/` | Shared types: `LogEntry`, `ParseResult`, `FilterCriteria` |
 | `state/` | `AppState` (Mutex-wrapped) — tracks open files, tail sessions |
 | `watcher/` | File watching and real-time tailing via `notify` crate |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ Communication uses Tauri's `invoke()` (frontend to backend) and `emit()` (backen
 | `parser/` | Log format auto-detection and parsing (CCM, simple, CBS, DISM, Panther, plain text) |
 | `intune/` | IME diagnostics pipeline: event tracking, timeline, download stats, EVTX parsing |
 | `dsregcmd/` | Device registration analysis: output parsing, diagnostic rules, registry hives |
-| `error_db/` | Embedded error code database (120+ Windows/SCCM/Intune codes) |
+| `error_db/` | Embedded error code database (700+ Windows/SCCM/Intune/MSI codes) |
 | `models/` | Shared types: `LogEntry`, `ParseResult`, `FilterCriteria` |
 | `state/` | `AppState` (Mutex-wrapped) — tracks open files, tail sessions |
 | `watcher/` | File watching and real-time tailing via `notify` crate |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "cmtraceopen-parser"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Both editions read the same log formats and share the same viewer, so a log you 
 - **Severity color coding** — Errors (red), Warnings (yellow), Info (default)
 - **Find and Filter** — Ctrl+F search with F3 navigation; filter by message, component, thread, or timestamp
 - **Text highlighting** — configurable keyword highlighting
-- **Error code lookup** — 120+ embedded Windows, SCCM, and Intune error codes
+- **Error code lookup** — 700+ embedded Windows, Windows Update, BITS, ConfigMgr, Intune, MSI, and PSADT error codes
 - **Flexible input** — open files, folders, drag and drop, or use built-in source presets
 - **File association** — set as default `.log` file handler on Windows
 

--- a/crates/cmtraceopen-parser/Cargo.toml
+++ b/crates/cmtraceopen-parser/Cargo.toml
@@ -3,8 +3,19 @@ name = "cmtraceopen-parser"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.88"
-description = "Pure-Rust log-format parser, error-code database, and entry models for CMTrace Open. Targets native and wasm32."
+authors = ["Adam Gell"]
+description = "Parse ConfigMgr/SCCM, Intune, CBS, DISM, Panther, MSI, and PSADT logs with format auto-detection, severity classification, and Windows error-code lookup. Pure Rust, no I/O, native + wasm32."
 license = "MIT"
+repository = "https://github.com/adamgell/cmtraceopen"
+homepage = "https://cmtraceopen.com"
+documentation = "https://docs.rs/cmtraceopen-parser"
+readme = "README.md"
+keywords = ["cmtrace", "sccm", "intune", "log-parser", "configmgr"]
+categories = [
+    "parser-implementations",
+    "development-tools::debugging",
+    "os::windows-apis",
+]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/cmtraceopen-parser/Cargo.toml
+++ b/crates/cmtraceopen-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmtraceopen-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Adam Gell"]

--- a/crates/cmtraceopen-parser/README.md
+++ b/crates/cmtraceopen-parser/README.md
@@ -1,0 +1,151 @@
+# cmtraceopen-parser
+
+[![Crates.io](https://img.shields.io/crates/v/cmtraceopen-parser.svg)](https://crates.io/crates/cmtraceopen-parser)
+[![Docs.rs](https://docs.rs/cmtraceopen-parser/badge.svg)](https://docs.rs/cmtraceopen-parser)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/adamgell/cmtraceopen/blob/main/LICENSE)
+
+Pure-Rust parsing for Windows management and deployment logs — ConfigMgr/SCCM, Intune, CBS, DISM, Panther, MSI, PSADT, and more — with format auto-detection, severity classification, and an embedded Windows error-code database.
+
+This is the parsing engine behind [CMTrace Open](https://cmtraceopen.com), extracted as a standalone crate so it can be used without the desktop app.
+
+## Why this crate
+
+If you are writing anything that reads Windows deployment logs — a CI log summarizer, a custom triage tool, a bulk analyzer over collected diagnostics — the tedious part is not reading the file. It is knowing that ConfigMgr wraps entries in `<![LOG[...]LOG]!>`, that older SCCM logs use `$$<` delimiters, that PSADT and MSI logs each timestamp differently, and that a `0x80070005` in the message means "Access is denied."
+
+This crate does that part.
+
+## Design constraints
+
+The crate is deliberately narrow, which is what makes it reusable:
+
+- **No I/O.** Every entry point takes `&str` or `&[u8]`. You decide where bytes come from.
+- **No async runtime**, no `tokio`.
+- **No platform lock-in.** No `windows`/`winreg` crates, no Tauri, no `rayon`. Windows *log formats* are parsed anywhere — you can analyze ConfigMgr logs on Linux or macOS.
+- **Compiles to `wasm32-unknown-unknown`** as well as native targets.
+
+Dependencies are limited to `serde`, `serde_json`, `regex`, `chrono`, `encoding_rs`, `log`, `thiserror`, and `base64`.
+
+## Install
+
+```bash
+cargo add cmtraceopen-parser
+```
+
+## Quick start
+
+Parse a log and let the crate pick the format:
+
+```rust
+use cmtraceopen_parser::parser::parse_content;
+use cmtraceopen_parser::models::log_entry::Severity;
+
+let content = std::fs::read_to_string("CcmExec.log")?;
+let (result, parser) = parse_content(&content, "CcmExec.log", content.len() as u64);
+
+println!("format: {:?}", result.format_detected);
+println!("{} entries across {} lines", result.entries.len(), result.total_lines);
+
+for entry in result.entries.iter().filter(|e| e.severity == Severity::Error) {
+    println!(
+        "[{}] {} — {}",
+        entry.timestamp_display.as_deref().unwrap_or("no timestamp"),
+        entry.component.as_deref().unwrap_or("-"),
+        entry.message
+    );
+}
+```
+
+`parse_content` returns a `ParseResult` (entries, detected format, total lines, parse-error count, byte offset for resuming a tail) plus the `ResolvedParser` that was selected.
+
+### Decoding bytes yourself
+
+Windows logs are frequently not UTF-8. The crate exposes the same encoding fallback the app uses:
+
+```rust
+use cmtraceopen_parser::parser::{decode_bytes, detect_encoding};
+
+let bytes = std::fs::read("dism.log")?;
+let encoding = detect_encoding(&bytes);       // BOM sniffing, UTF-8 → Windows-1252 fallback
+let text = decode_bytes(&bytes, encoding)?;
+```
+
+### Error-code lookup
+
+Over 700 Windows, Windows Update, BITS, ConfigMgr, Intune, Delivery Optimization, MSI, and PSADT codes are embedded — no network calls:
+
+```rust
+use cmtraceopen_parser::error_db::lookup::{detect_error_code_spans, lookup_error_code};
+
+let hit = lookup_error_code("0x80070005");
+assert!(hit.found);
+println!("{} ({}) — {} [{}]", hit.code_hex, hit.code_decimal, hit.description, hit.category);
+
+// Find codes inside a message, with byte offsets for highlighting:
+for span in detect_error_code_spans("Install failed with 0x80070005 after retry") {
+    println!("{:?}", span);
+}
+```
+
+Hex (`0x80070005`), bare hex (`80070005`), unsigned decimal, and signed HRESULT (`-2147024891`) inputs are all accepted.
+
+### Skipping detection
+
+If you already know the format, resolve a parser once and reuse it across chunks:
+
+```rust
+use cmtraceopen_parser::parser::{detect, parse_content_with_selection};
+
+let selection = detect::detect_parser("AppEnforce.log", &first_chunk);
+let chunk = parse_content_with_selection(&next_chunk, "AppEnforce.log", &selection);
+```
+
+## Supported formats
+
+Detection samples the start of the content and selects a parser automatically.
+
+| Format | Typical source |
+|--------|----------------|
+| CCM | ConfigMgr / SCCM client logs (`<![LOG[...]LOG]!>`) |
+| Simple | Older SCCM-style logs (`$$<` delimited) |
+| ReportingEvents | Intune Management Extension `ReportingEvents.log` |
+| CmtLog | CMTrace Open structured capture logs |
+| CBS / DISM / Panther | `CBS.log`, `dism.log`, `setupact.log`, `setuperr.log` |
+| MSI | Windows Installer verbose logs |
+| PSADT (legacy) | PowerShell App Deployment Toolkit |
+| Burn | WiX Burn bootstrapper logs |
+| PatchMyPc detection | PatchMyPC detection-script output |
+| IntuneMacOs | Intune agent logs on macOS |
+| IIS W3C | W3C extended-format web logs |
+| DHCP | Windows DHCP Server logs |
+| DNS debug | Windows DNS Server debug logs |
+| Registry | Exported `.reg` content |
+| SecureBootLog | Secure Boot certificate-rotation logs |
+| Timestamped / Plain | Any log with, or without, a leading timestamp |
+
+The `DnsAudit` parser *kind* exists in the shared models, but DNS audit logs arrive as binary `.evtx`. EVTX decoding is native-only and lives in the CMTrace Open app, not in this crate.
+
+## Beyond the log viewer
+
+The crate also carries the pure-analysis layers the app builds on top of parsing, each usable independently:
+
+| Module | Contents |
+|--------|----------|
+| `parser` | Format detection, per-format parsers, encoding helpers |
+| `models` | `LogEntry`, `ParseResult`, `Severity`, `FilterCriteria`, parser metadata |
+| `error_db` | Embedded error-code database, lookup, in-message span detection |
+| `intune` | IME event extraction and timeline reduction |
+| `esp` | Autopilot Enrollment Status Page evidence normalization, reduction, and redaction |
+| `dsregcmd` | `dsregcmd /status` output parsing and diagnostic rules |
+| `collector` | Diagnostic-collection profile models and environment-variable expansion |
+
+## Versioning
+
+`0.x` — the public API may change in minor releases while it settles. Pin an exact version if you need stability.
+
+## License
+
+MIT. See [LICENSE](https://github.com/adamgell/cmtraceopen/blob/main/LICENSE).
+
+## Disclaimer
+
+CMTrace is a tool developed and distributed by Microsoft Corporation. CMTrace Open and this crate are an independent open-source project, **not** affiliated with, endorsed by, or connected with Microsoft Corporation.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cmtrace-open",
   "version": "1.5.0",
   "private": true,
-  "description": "Open-source CMTrace log viewer with built-in Intune diagnostics",
+  "description": "Free, open-source CMTrace replacement: Windows log viewer with ConfigMgr/SCCM, Intune, and Autopilot ESP diagnostics",
   "scripts": {
     "frontend:dev": "vite",
     "frontend:build": "tsc && vite build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,11 +3,16 @@
 [package]
 name = "cmtrace-open"
 version = "1.5.0"
-description = "Open-source CMTrace log viewer with Intune diagnostics"
+description = "Free, open-source CMTrace replacement: Windows log viewer with ConfigMgr/SCCM, Intune, and Autopilot ESP diagnostics, DSRegCmd triage, and real-time tailing."
 authors = ["Adam Gell"]
 license = "MIT"
 edition = "2021"
 rust-version = "1.88"
+repository = "https://github.com/adamgell/cmtraceopen"
+homepage = "https://cmtraceopen.com"
+readme = "README.md"
+keywords = ["cmtrace", "log-viewer", "sccm", "intune", "tauri"]
+categories = ["gui", "development-tools::debugging", "os::windows-apis"]
 
 [lib]
 name = "app_lib"
@@ -30,7 +35,7 @@ macos-diag = ["dep:plist"]
 secureboot = ["dep:tempfile"]
 
 [dependencies]
-cmtraceopen-parser = { path = "../crates/cmtraceopen-parser" }
+cmtraceopen-parser = { path = "../crates/cmtraceopen-parser", version = "0.1" }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,0 +1,46 @@
+# cmtrace-open
+
+The desktop application crate for [CMTrace Open](https://cmtraceopen.com) — a free, open-source log viewer and Windows troubleshooting tool, built as a modern replacement for Microsoft's CMTrace.exe.
+
+**Most people do not want to build this crate.** CMTrace Open ships as a signed, single-file download for Windows, macOS, and Linux, with no runtime dependencies:
+
+**https://download.cmtraceopen.com**
+
+## What this crate is
+
+This is the Tauri v2 backend for the desktop app: IPC command handlers, file watching and real-time tailing, EVTX and registry readers, platform-gated Windows diagnostics, and the native application menu. It is published so the full source of a signed release is available from crates.io as well as GitHub, and so the workspace resolves for downstream tooling.
+
+It is **not** a general-purpose library. It links Tauri, expects a WebView runtime, and bundles a React frontend that is built separately by Vite — building it from a bare `cargo install` requires the full [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) for your platform plus a built frontend in `../dist`.
+
+## What you probably want instead
+
+If you are writing your own tool and need to parse ConfigMgr/SCCM, Intune, CBS, DISM, MSI, or PSADT logs, use the parsing engine directly — it is a separate, dependency-light crate with no Tauri, no I/O, and no platform lock-in:
+
+```bash
+cargo add cmtraceopen-parser
+```
+
+See [cmtraceopen-parser](https://crates.io/crates/cmtraceopen-parser).
+
+## Building from source
+
+Build the whole app from the repository root, not this crate in isolation:
+
+```bash
+npm ci
+npm run app:build:release
+```
+
+See [CONTRIBUTING.md](https://github.com/adamgell/cmtraceopen/blob/main/CONTRIBUTING.md) for development setup, build commands, and architecture.
+
+## Features
+
+The default `full` feature enables every workspace: Intune diagnostics, Autopilot ESP diagnostics, DSRegCmd, software deployment scanning, Windows Event Log, Sysmon, Secure Boot certificates, macOS diagnostics, and diagnostic collection. Building with `--no-default-features` produces the Lite edition — the core log viewer only.
+
+## License
+
+MIT. See [LICENSE](https://github.com/adamgell/cmtraceopen/blob/main/LICENSE).
+
+## Disclaimer
+
+CMTrace is a tool developed and distributed by Microsoft Corporation. CMTrace Open is an independent open-source project, **not** affiliated with, endorsed by, or connected with Microsoft Corporation.


### PR DESCRIPTION
## Why

`cmtraceopen-parser` 0.1.0 was published to crates.io from a checkout that predated this branch, so it went up with the old description and no `repository`, `homepage`, `keywords`, `categories`, or README. crates.io versions are immutable, so the metadata can only reach the registry via a new version.

This branch supplies that metadata, bumps to 0.1.1, and prepares the app crate so the `cmtrace-open` name can be held by the real crate instead of a placeholder.

## What changed

**`crates/cmtraceopen-parser`**
- Added `repository`, `homepage`, `documentation`, `readme`, `authors`, 5 `keywords`, and 3 `categories`. Expanded the description to name the log formats it parses, since crates.io search indexes that field.
- New crate README: design constraints (no I/O, no async, no platform lock-in, wasm32-capable), quick-start examples for `parse_content`, `detect_encoding`/`decode_bytes`, and `lookup_error_code`, the supported-format table, and the non-parser modules.
- Bumped 0.1.0 to 0.1.1. No code change.

**`src-tauri`**
- Added `repository`, `homepage`, `readme`, 5 `keywords`, 3 `categories`, and a fuller description. Gave the `cmtraceopen-parser` path dependency a `version = "0.1"` requirement, without which the manifest cannot be published at all.
- New `src-tauri/README.md` as the crates.io landing page. It states plainly that this crate is the Tauri app backend rather than a general-purpose library, points users at the signed binary downloads, and redirects library consumers to `cmtraceopen-parser`.

**Docs correction**
- The embedded error database holds 738 entries, not the advertised "120+". Corrected in `README.md`, `CONTRIBUTING.md`, and `CLAUDE.md` to "700+".

## Verification

- `cargo publish --dry-run -p cmtraceopen-parser`: packaged 68 files, 309.5 KiB compressed, builds standalone from its own tarball.
- `cargo test -p cmtraceopen-parser`: 222 passed, 0 failed.
- `cargo check -p cmtrace-open`: passes.
- `cargo package --list -p cmtrace-open`: 194 files including `README.md`, `build.rs`, `tauri.conf.json`, and 17 icons, with nothing from `target/`.
- `npx tsc --noEmit`: clean.

## Not done here

No `cargo publish` has been run from this branch. Publishing is strictly ordered: `cmtraceopen-parser` first, then `cmtrace-open`, because the app crate's version requirement has no registry match until the parser is live. The app crate's verification build has never been exercised, so `cargo publish -p cmtrace-open` may need `--no-verify` if the packaged tarball cannot build without a prebuilt frontend in `../dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)