### PR TITLE
ci(packaging): own winget locale metadata, add Scoop and Homebrew

### DIFF
--- a/.github/scripts/Set-WingetLocaleMetadata.ps1
+++ b/.github/scripts/Set-WingetLocaleMetadata.ps1
@@ -1,0 +1,203 @@
+<#
+.SYNOPSIS
+    Applies repo-owned defaultLocale metadata to komac-generated winget manifests.
+
+.DESCRIPTION
+    'komac update' carries PackageUrl, ShortDescription, Description, Moniker and
+    Tags forward from the previously published manifest and offers no CLI flags to
+    change them, so a stale value stays stale for every future release. This script
+    splices the keys from .github/winget/locale-metadata.yaml into the generated
+    defaultLocale manifest, between 'komac update --dry-run --output-directory' and
+    'komac submit'.
+
+    Keys already present in the generated manifest are replaced in place, which
+    preserves schema key order. Keys komac omitted entirely are inserted at their
+    correct schema position. Line endings of the generated manifest are preserved
+    (winget-pkgs manifests are CRLF; rewriting them as LF produces a whole-file
+    diff and fails validation).
+
+.PARAMETER ManifestDirectory
+    Directory holding the komac-generated manifests. Searched recursively for
+    '*.locale.en-US.yaml'.
+
+.PARAMETER MetadataPath
+    Path to the metadata YAML whose top-level keys should be applied.
+
+.EXAMPLE
+    ./.github/scripts/Set-WingetLocaleMetadata.ps1 -ManifestDirectory "$env:RUNNER_TEMP\winget-out" -MetadataPath ./.github/winget/locale-metadata.yaml
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ManifestDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [string]$MetadataPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Key order from the defaultLocale manifest schema. Only used to position keys
+# that the generated manifest does not already contain.
+$schemaOrder = @(
+    'PackageIdentifier', 'PackageVersion', 'PackageLocale', 'Publisher',
+    'PublisherUrl', 'PublisherSupportUrl', 'PrivacyUrl', 'Author', 'PackageName',
+    'PackageUrl', 'License', 'LicenseUrl', 'Copyright', 'CopyrightUrl',
+    'ShortDescription', 'Description', 'Moniker', 'Tags', 'Agreements',
+    'ReleaseNotes', 'ReleaseNotesUrl', 'PurchaseUrl', 'InstallationNotes',
+    'Documentations', 'Icons', 'ManifestType', 'ManifestVersion'
+)
+
+function Get-YamlSegments {
+    <#
+        Splits flat YAML text into ordered segments, one per top-level key. Each
+        segment owns its continuation lines (block scalar bodies, sequence items),
+        so replacing a segment replaces the whole value.
+    #>
+    param([Parameter(Mandatory = $true)][AllowEmptyCollection()][AllowEmptyString()][string[]]$Lines)
+
+    $preamble = [System.Collections.Generic.List[string]]::new()
+    $segments = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($line in $Lines) {
+        if ($line -match '^([A-Za-z][A-Za-z0-9_]*):') {
+            $segment = [pscustomobject]@{
+                Key   = $Matches[1]
+                Lines = [System.Collections.Generic.List[string]]::new()
+            }
+            $segment.Lines.Add($line)
+            $segments.Add($segment)
+        }
+        elseif ($segments.Count -gt 0) {
+            $segments[$segments.Count - 1].Lines.Add($line)
+        }
+        else {
+            $preamble.Add($line)
+        }
+    }
+
+    return [pscustomobject]@{ Preamble = $preamble; Segments = $segments }
+}
+
+function Assert-MetadataLimits {
+    <#
+        Fails the build on values winget would reject, so a bad edit to the
+        metadata file surfaces here rather than as a rejected pull request.
+    #>
+    param([Parameter(Mandatory = $true)][object[]]$Segments)
+
+    foreach ($segment in $Segments) {
+        switch ($segment.Key) {
+            'ShortDescription' {
+                $value = ($segment.Lines[0] -replace '^ShortDescription:\s*', '')
+                if ($value.Length -gt 256) {
+                    throw "ShortDescription is $($value.Length) characters; winget allows 256."
+                }
+            }
+            'Tags' {
+                $tags = @($segment.Lines | Where-Object { $_ -match '^-\s+' })
+                if ($tags.Count -gt 16) {
+                    throw "Tags has $($tags.Count) entries; winget allows 16."
+                }
+                foreach ($tag in $tags) {
+                    $name = ($tag -replace '^-\s+', '')
+                    if ($name.Length -gt 40) {
+                        throw "Tag '$name' is $($name.Length) characters; winget allows 40."
+                    }
+                }
+            }
+        }
+    }
+}
+
+if (-not (Test-Path -LiteralPath $MetadataPath)) {
+    throw "Metadata file not found: $MetadataPath"
+}
+
+# Comments are only stripped ahead of the first key, so a '#' inside a block
+# scalar (a Description mentioning a hash) is left alone.
+$metadataRaw = Get-Content -LiteralPath $MetadataPath -Raw
+$metadataLines = @($metadataRaw -split '\r?\n')
+$firstKeyIndex = 0
+for ($i = 0; $i -lt $metadataLines.Count; $i++) {
+    if ($metadataLines[$i] -match '^[A-Za-z][A-Za-z0-9_]*:') { $firstKeyIndex = $i; break }
+}
+$metadata = Get-YamlSegments -Lines @($metadataLines[$firstKeyIndex..($metadataLines.Count - 1)])
+
+if ($metadata.Segments.Count -eq 0) {
+    throw "No top-level keys found in $MetadataPath"
+}
+
+# The metadata file's trailing newline would otherwise attach an empty line to its
+# last segment, injecting a blank line mid-manifest when that key is replaced in
+# place rather than appended at the end.
+foreach ($segment in $metadata.Segments) {
+    while ($segment.Lines.Count -gt 1 -and $segment.Lines[$segment.Lines.Count - 1] -eq '') {
+        $segment.Lines.RemoveAt($segment.Lines.Count - 1)
+    }
+}
+
+Assert-MetadataLimits -Segments $metadata.Segments
+
+$manifests = @(Get-ChildItem -LiteralPath $ManifestDirectory -Recurse -Filter '*.locale.en-US.yaml' -File)
+if ($manifests.Count -eq 0) {
+    throw "No '*.locale.en-US.yaml' manifest found under $ManifestDirectory"
+}
+
+foreach ($manifest in $manifests) {
+    $raw = Get-Content -LiteralPath $manifest.FullName -Raw
+    $newline = if ($raw -match '\r\n') { "`r`n" } else { "`n" }
+    $hadTrailingNewline = $raw.EndsWith("`n")
+
+    $target = Get-YamlSegments -Lines @($raw -split '\r?\n')
+    $segments = $target.Segments
+
+    foreach ($incoming in $metadata.Segments) {
+        $existing = $segments | Where-Object { $_.Key -eq $incoming.Key } | Select-Object -First 1
+
+        if ($null -ne $existing) {
+            $existing.Lines.Clear()
+            foreach ($line in $incoming.Lines) { $existing.Lines.Add($line) }
+            Write-Host "  replaced $($incoming.Key)"
+            continue
+        }
+
+        # Not emitted by komac: insert at the schema position by walking back to
+        # the nearest preceding key that the manifest does contain.
+        $schemaIndex = $schemaOrder.IndexOf($incoming.Key)
+        if ($schemaIndex -lt 0) {
+            throw "Key '$($incoming.Key)' is not part of the defaultLocale schema order."
+        }
+
+        $insertAt = 0
+        for ($i = $schemaIndex - 1; $i -ge 0; $i--) {
+            $anchorKey = $schemaOrder[$i]
+            $anchorIndex = -1
+            for ($j = 0; $j -lt $segments.Count; $j++) {
+                if ($segments[$j].Key -eq $anchorKey) { $anchorIndex = $j; break }
+            }
+            if ($anchorIndex -ge 0) { $insertAt = $anchorIndex + 1; break }
+        }
+
+        $segments.Insert($insertAt, $incoming)
+        Write-Host "  inserted $($incoming.Key)"
+    }
+
+    $out = [System.Collections.Generic.List[string]]::new()
+    foreach ($line in $target.Preamble) { $out.Add($line) }
+    foreach ($segment in $segments) {
+        foreach ($line in $segment.Lines) { $out.Add($line) }
+    }
+
+    # A trailing empty element from the original split would double the final
+    # newline once re-joined, so drop it and restore the newline explicitly.
+    while ($out.Count -gt 0 -and $out[$out.Count - 1] -eq '') { $out.RemoveAt($out.Count - 1) }
+
+    $text = [string]::Join($newline, $out)
+    if ($hadTrailingNewline) { $text += $newline }
+
+    # No BOM: winget-pkgs manifests are plain UTF-8.
+    [System.IO.File]::WriteAllText($manifest.FullName, $text, (New-Object System.Text.UTF8Encoding($false)))
+    Write-Host "Applied locale metadata to $($manifest.Name) ($(if ($newline -eq "`r`n") { 'CRLF' } else { 'LF' }) preserved)"
+}

--- a/.github/scripts/Update-ScoopManifest.ps1
+++ b/.github/scripts/Update-ScoopManifest.ps1
@@ -1,0 +1,217 @@
+<#
+.SYNOPSIS
+    Points the checked-in Scoop manifests in bucket/ at a CMTrace Open release.
+
+.DESCRIPTION
+    Rewrites the 'version' value and every architecture 'url'/'hash' pair using
+    the manifest's own 'autoupdate' URL templates, so the self-hosted bucket and
+    Scoop's Excavator bot always derive asset locations from the same source. If
+    a release ever renames an asset, only the autoupdate template has to change.
+
+    Hashes come from the GitHub release asset digest when the API reports one and
+    from downloading the asset otherwise, which mirrors what Scoop itself does
+    for github.com release URLs.
+
+    The JSON text is edited in place rather than round-tripped through
+    ConvertTo-Json: PowerShell reindents to two spaces, reorders nothing but
+    reformats everything, and mangles the single-element nested array used by
+    'shortcuts'. Scoop buckets require four-space indentation, and a whole-file
+    diff on every release makes the bucket history useless.
+
+.PARAMETER Version
+    Release version, with or without a leading 'v' (for example '1.5.0').
+
+.PARAMETER ManifestPath
+    Manifests to update. Defaults to every '*.json' in the repo's bucket/
+    directory, so a new manifest is picked up without touching the workflow.
+
+.PARAMETER Repository
+    GitHub 'owner/name' whose release holds the assets.
+
+.PARAMETER Tag
+    Release tag. Defaults to 'v<Version>'.
+
+.EXAMPLE
+    ./.github/scripts/Update-ScoopManifest.ps1 -Version 1.5.0
+#>
+[CmdletBinding()]
+param(
+    # Version is the only positional parameter. Giving it an explicit position
+    # makes every other parameter name-only, so a stray extra argument is a
+    # binding error instead of silently landing in Repository.
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Version,
+
+    [string[]]$ManifestPath = @(),
+
+    [string]$Repository = 'adamgell/cmtraceopen',
+
+    [string]$Tag
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$Version = $Version -replace '^[vV]', ''
+if ($Version -notmatch '^\d+\.\d+\.\d+') {
+    throw "Version '$Version' does not look like a release version (expected something like 1.5.0)."
+}
+if (-not $Tag) { $Tag = "v$Version" }
+
+if ($ManifestPath.Count -eq 0) {
+    $bucket = Join-Path $PSScriptRoot '../../bucket'
+    if (-not (Test-Path -LiteralPath $bucket)) { throw "Bucket directory not found: $bucket" }
+    $ManifestPath = @(Get-ChildItem -LiteralPath $bucket -Filter '*.json' -File |
+        Sort-Object Name | ForEach-Object { $_.FullName })
+    if ($ManifestPath.Count -eq 0) { throw "No manifests found in $bucket" }
+}
+
+function Get-ReleaseAssets {
+    <#
+        Returns a map of asset name to sha256 (lowercase hex, or $null when the
+        API reports no digest for that asset). Doubles as the check that every
+        URL the manifests build actually exists in the release.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$Tag
+    )
+
+    $headers = @{
+        'Accept'               = 'application/vnd.github+json'
+        'X-GitHub-Api-Version' = '2022-11-28'
+        'User-Agent'           = 'cmtraceopen-scoop-updater'
+    }
+    if ($env:GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $env:GITHUB_TOKEN" }
+
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repository/releases/tags/$Tag" -Headers $headers
+    $assets = @{}
+    foreach ($asset in $release.assets) {
+        $digest = $null
+        if (($asset.PSObject.Properties.Name -contains 'digest') -and
+            ($asset.digest -match '^sha256:([0-9a-fA-F]{64})$')) {
+            $digest = $Matches[1].ToLowerInvariant()
+        }
+        $assets[$asset.name] = $digest
+    }
+
+    if ($assets.Count -eq 0) { throw "Release $Tag of $Repository has no assets." }
+    return $assets
+}
+
+function Get-AssetHash {
+    <#
+        Falls back to downloading when the release predates GitHub's asset
+        digests, so the script never writes a hash it did not verify.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Url,
+        [Parameter(Mandatory = $true)][string]$AssetName,
+        [Parameter(Mandatory = $true)][hashtable]$ReleaseAssets
+    )
+
+    if (-not $ReleaseAssets.ContainsKey($AssetName)) {
+        throw "Release asset '$AssetName' not found. Available: $(($ReleaseAssets.Keys | Sort-Object) -join ', ')"
+    }
+
+    if ($ReleaseAssets[$AssetName]) {
+        Write-Host "  $AssetName -> $($ReleaseAssets[$AssetName]) (release digest)"
+        return $ReleaseAssets[$AssetName]
+    }
+
+    $temp = Join-Path ([System.IO.Path]::GetTempPath()) "cmtraceopen-scoop-$([guid]::NewGuid().ToString('n')).bin"
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $temp -UseBasicParsing
+        $hash = (Get-FileHash -LiteralPath $temp -Algorithm SHA256).Hash.ToLowerInvariant()
+    } finally {
+        Remove-Item -LiteralPath $temp -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Host "  $AssetName -> $hash (downloaded)"
+    return $hash
+}
+
+function Set-CapturedValue {
+    <#
+        Splices $Value between capture groups 1 and 2 of the single match of
+        $Pattern. Refuses to guess when the pattern matches zero or many times,
+        which is what turns an unexpected manifest shape into a build failure
+        instead of a silently wrong manifest.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [Parameter(Mandatory = $true)][string]$Pattern,
+        [Parameter(Mandatory = $true)][string]$Value,
+        [Parameter(Mandatory = $true)][string]$What
+    )
+
+    $matched = [regex]::Matches($Text, $Pattern)
+    if ($matched.Count -ne 1) {
+        throw "Expected exactly 1 match for $What, found $($matched.Count)."
+    }
+
+    $m = $matched[0]
+    return $Text.Substring(0, $m.Index) +
+        $m.Groups[1].Value + $Value + $m.Groups[2].Value +
+        $Text.Substring($m.Index + $m.Length)
+}
+
+$releaseAssets = Get-ReleaseAssets -Repository $Repository -Tag $Tag
+
+foreach ($path in $ManifestPath) {
+    if (-not (Test-Path -LiteralPath $path)) { throw "Manifest not found: $path" }
+    $file = (Resolve-Path -LiteralPath $path).Path
+    $name = [System.IO.Path]::GetFileNameWithoutExtension($file)
+    Write-Host "$name -> $Version"
+
+    $text = Get-Content -LiteralPath $file -Raw
+    $manifest = $text | ConvertFrom-Json
+
+    $text = Set-CapturedValue -Text $text -Value $Version -What "the version of $name" `
+        -Pattern '(?m)^(\s*"version"\s*:\s*")[^"]*(")'
+
+    $expected = @{}
+    foreach ($architecture in $manifest.autoupdate.architecture.PSObject.Properties) {
+        $arch = $architecture.Name
+        $url = $architecture.Value.url.Replace('$version', $Version)
+        if ($url.Contains('$')) {
+            throw "Unresolved template variable in the $arch autoupdate URL of $name`: $url"
+        }
+
+        # Scoop's '#/name.exe' fragment renames the download; the asset name is
+        # everything before it.
+        $assetName = [System.IO.Path]::GetFileName(($url -split '#/')[0])
+        $hash = Get-AssetHash -Url $url -AssetName $assetName -ReleaseAssets $releaseAssets
+
+        # '[^"]*' cannot cross a quote and the autoupdate blocks carry no 'hash',
+        # so this only ever matches the real architecture block.
+        $text = Set-CapturedValue -Text $text -Value $url -What "the $arch URL of $name" `
+            -Pattern ('("' + [regex]::Escape($arch) + '"\s*:\s*\{\s*"url"\s*:\s*")[^"]*("\s*,\s*"hash")')
+        $text = Set-CapturedValue -Text $text -Value $hash -What "the $arch hash of $name" `
+            -Pattern ('("' + [regex]::Escape($arch) + '"\s*:\s*\{\s*"url"\s*:\s*"[^"]*"\s*,\s*"hash"\s*:\s*")[0-9a-fA-F]*(")')
+
+        $expected[$arch] = @{ Url = $url; Hash = $hash }
+    }
+
+    if ($expected.Count -eq 0) { throw "$name has no autoupdate architectures to update." }
+
+    # Re-parse rather than trust the splices.
+    $updated = $text | ConvertFrom-Json
+    if ($updated.version -ne $Version) {
+        throw "$name still reports version '$($updated.version)' after the update."
+    }
+    foreach ($arch in $expected.Keys) {
+        $actual = $updated.architecture.$arch
+        if ($actual.url -ne $expected[$arch].Url) {
+            throw "$name $arch URL is '$($actual.url)', expected '$($expected[$arch].Url)'."
+        }
+        if ($actual.hash -ne $expected[$arch].Hash) {
+            throw "$name $arch hash is '$($actual.hash)', expected '$($expected[$arch].Hash)'."
+        }
+    }
+
+    [System.IO.File]::WriteAllText($file, $text, (New-Object System.Text.UTF8Encoding($false)))
+}
+
+Write-Host "Updated $($ManifestPath.Count) manifest(s) to $Version."

--- a/.github/winget/locale-metadata.yaml
+++ b/.github/winget/locale-metadata.yaml
@@ -1,0 +1,38 @@
+# winget defaultLocale metadata that komac does not manage.
+#
+# `komac update` copies PackageUrl, ShortDescription, Description, Moniker, and
+# Tags forward from the previously published manifest and exposes no CLI flags
+# for any of them, so a stale value stays stale for every future release.
+# Set-WingetLocaleMetadata.ps1 splices the keys below into the generated
+# defaultLocale manifest before `komac submit`, making this file the source of
+# truth. Edit here; the next release carries it to winget-pkgs.
+#
+# Schema: https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Limits: ShortDescription <= 256 chars, Description <= 10000 chars, Tags <= 16
+# entries of <= 40 chars each. Tags are what `winget search <term>` matches, and
+# Moniker is what lets `winget install cmtrace` work without the full
+# AdamGell.CMTraceOpen identifier. Keep Tags alphabetically sorted by convention.
+PackageUrl: https://cmtraceopen.com
+ShortDescription: Free, open-source CMTrace replacement for Windows log files, with Intune and Autopilot ESP diagnostics.
+Description: |-
+  CMTrace Open is a free, open-source log viewer and Windows troubleshooting tool, built as a modern replacement for Microsoft's CMTrace.exe. It auto-detects and parses ConfigMgr/SCCM (CCM), CBS, DISM, Panther, MSI, PSADT, and plain-text log formats, with severity color coding, real-time tailing, find and filter, and lookup for 700+ embedded Windows, ConfigMgr, and Intune error codes.
+  Beyond the log viewer it adds dedicated troubleshooting workspaces: Intune Management Extension (IME) diagnostics with an event timeline and download statistics, Autopilot Enrollment Status Page (ESP) and Device Preparation triage, DSRegCmd analysis for Entra join, hybrid join, PRT, MDM, and Windows Hello for Business, software deployment log scanning, Windows Event Log (.evtx) and Sysmon analysis, Secure Boot certificate checks, and diagnostic evidence collection.
+  Ships as a single-file executable with no runtime prerequisites; Windows builds are code-signed. CMTrace Open is an independent open-source project and is not affiliated with Microsoft Corporation.
+Moniker: cmtrace
+Tags:
+- autopilot
+- cmtrace
+- configmgr
+- dsregcmd
+- endpoint-management
+- entra-id
+- esp
+- event-log
+- evtx
+- intune
+- log-viewer
+- mdm
+- mecm
+- sccm
+- sysadmin
+- troubleshooting

--- a/.github/workflows/scoop-publish.yml
+++ b/.github/workflows/scoop-publish.yml
@@ -1,0 +1,119 @@
+name: "CMTrace Open: Publish to Scoop bucket"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v1.5.0)"
+        required: true
+
+permissions: {}
+
+jobs:
+  scoop:
+    name: Update Scoop bucket
+    # windows-latest so the bumped manifests are validated by real Scoop before
+    # they are committed. A bad hash then fails the release job instead of every
+    # user's 'scoop install'.
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      # The release event checks out the tag, which cannot be pushed to, and the
+      # commit belongs on the default branch either way. Credentials are
+      # persisted here (unlike the winget job) because this job pushes.
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Derive version
+        id: release
+        shell: pwsh
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          $version = $env:TAG_NAME -replace '^v', ''
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      # The script derives every URL from the manifests' own autoupdate
+      # templates, so this repo's bucket and Scoop's Excavator bot cannot drift
+      # apart on where the assets live. It throws on any problem, and
+      # $ErrorActionPreference is 'stop' in pwsh steps, so there is no exit code
+      # to test here (unlike the native komac calls in the winget job).
+      - name: Update manifests
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          ./.github/scripts/Update-ScoopManifest.ps1 -Version $env:VERSION
+          git --no-pager diff -- bucket
+          exit 0
+
+      - name: Install Scoop
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://get.scoop.sh -OutFile install-scoop.ps1
+          # GitHub runners execute as a local administrator, which the installer
+          # refuses without this switch.
+          ./install-scoop.ps1 -RunAsAdmin
+          Remove-Item install-scoop.ps1 -Force
+
+          $shims = "$env:USERPROFILE\scoop\shims"
+          if (-not (Test-Path -LiteralPath $shims)) { throw "Scoop install created no shim directory at $shims" }
+          # The installer only updates the PATH of future sessions.
+          $shims | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          exit 0
+
+      # Verifies the hashes, the download URLs and the shim/shortcut wiring on
+      # the x64 runner. arm64 URLs are only checked for existence, by the
+      # manifest updater.
+      - name: Validate manifests with Scoop
+        shell: pwsh
+        run: |
+          # Asserted on observable state rather than on $LASTEXITCODE: 'scoop' is
+          # a shim, so which of scoop.cmd/scoop.ps1 gets resolved decides whether
+          # an exit code is set at all. A missing shim is the unambiguous signal
+          # that the install did not complete.
+          foreach ($manifest in Get-ChildItem ./bucket -Filter '*.json' -File) {
+            $app = $manifest.BaseName
+            $shim = "$env:USERPROFILE\scoop\shims\$app.exe"
+
+            Write-Host "::group::scoop install $app"
+            scoop install $manifest.FullName
+            Write-Host "::endgroup::"
+            if (-not (Test-Path -LiteralPath $shim)) {
+              throw "scoop install $app produced no shim at $shim (hash mismatch or bad manifest)"
+            }
+
+            Write-Host "::group::scoop uninstall $app"
+            scoop uninstall $app
+            Write-Host "::endgroup::"
+            if (Test-Path -LiteralPath $shim) { throw "scoop uninstall $app left a shim at $shim" }
+          }
+          exit 0
+
+      - name: Commit and push
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add bucket
+
+          # Exit code 1 means there is something staged, which is the normal path.
+          git diff --cached --quiet
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "bucket/ is already at $env:VERSION; nothing to commit"
+            exit 0
+          }
+
+          git commit -m "chore(scoop): bump bucket to $env:VERSION"
+          if ($LASTEXITCODE -ne 0) { throw "git commit failed with exit code $LASTEXITCODE" }
+
+          git push
+          if ($LASTEXITCODE -ne 0) { throw "git push failed with exit code $LASTEXITCODE" }

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -86,7 +86,26 @@ jobs:
             -ManifestDirectory "${{ steps.generate.outputs.output_dir }}" `
             -MetadataPath ./.github/winget/locale-metadata.yaml
 
+      # The patched manifest is echoed so a workflow_dispatch run is a complete
+      # rehearsal: it proves komac's --output-directory layout, the patch script,
+      # and the resulting manifest are all correct without touching winget-pkgs.
+      - name: Show patched manifest
+        shell: pwsh
+        run: |
+          $manifest = Get-ChildItem -Path "${{ steps.generate.outputs.output_dir }}" -Recurse -Filter '*.locale.en-US.yaml' -File |
+            Select-Object -First 1
+          if (-not $manifest) { throw "No locale manifest found after patching" }
+
+          Write-Host "::group::$($manifest.Name)"
+          Get-Content -LiteralPath $manifest.FullName -Raw | Write-Host
+          Write-Host "::endgroup::"
+
+      # Only a published release submits. workflow_dispatch is a rehearsal, which
+      # is what its own input description ("Release tag to test") always implied,
+      # and submitting from a manual run would open a duplicate pull request on
+      # microsoft/winget-pkgs for a version that is already published.
       - name: Submit to winget-pkgs
+        if: github.event_name == 'release'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -16,8 +16,14 @@ jobs:
     name: Update winget package
     runs-on: windows-latest
     environment: release
-    permissions: {}
+    permissions:
+      contents: read
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Install komac
         shell: pwsh
         run: |
@@ -46,15 +52,50 @@ jobs:
           "url_x64_msi=$base/CMTrace-Open_${version}_x64.msi" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "url_arm64_msi=$base/CMTrace-Open_${version}_arm64.msi" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-      - name: Submit to winget-pkgs
+      # Generated locally rather than submitted directly, so the locale metadata
+      # komac cannot manage (see .github/winget/locale-metadata.yaml) can be
+      # applied before the pull request is opened.
+      - name: Generate manifests
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
         run: |
+          $out = Join-Path $env:RUNNER_TEMP 'winget-manifests'
+          New-Item -ItemType Directory -Path $out -Force | Out-Null
+
           komac update AdamGell.CMTraceOpen `
             --version ${{ steps.release.outputs.version }} `
             --urls ${{ steps.release.outputs.url_x64_exe }} `
                    ${{ steps.release.outputs.url_arm64_exe }} `
                    ${{ steps.release.outputs.url_x64_msi }} `
                    ${{ steps.release.outputs.url_arm64_msi }} `
-            --submit
+            --dry-run `
+            --output-directory $out
+          if ($LASTEXITCODE -ne 0) { throw "komac update failed with exit code $LASTEXITCODE" }
+
+          Write-Host "Generated manifests:"
+          Get-ChildItem -Path $out -Recurse -File | ForEach-Object { Write-Host "  $($_.FullName)" }
+
+          "output_dir=$out" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        id: generate
+
+      - name: Apply locale metadata
+        shell: pwsh
+        run: |
+          ./.github/scripts/Set-WingetLocaleMetadata.ps1 `
+            -ManifestDirectory "${{ steps.generate.outputs.output_dir }}" `
+            -MetadataPath ./.github/winget/locale-metadata.yaml
+
+      - name: Submit to winget-pkgs
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+        run: |
+          # Submit the directory that actually holds the manifests, so the layout
+          # komac chose under --output-directory does not have to be hardcoded.
+          $manifest = Get-ChildItem -Path "${{ steps.generate.outputs.output_dir }}" -Recurse -Filter '*.locale.en-US.yaml' -File |
+            Select-Object -First 1
+          if (-not $manifest) { throw "No locale manifest found to submit" }
+
+          komac submit $manifest.Directory.FullName --yes
+          if ($LASTEXITCODE -ne 0) { throw "komac submit failed with exit code $LASTEXITCODE" }

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -70,7 +70,7 @@ jobs:
                    ${{ steps.release.outputs.url_x64_msi }} `
                    ${{ steps.release.outputs.url_arm64_msi }} `
             --dry-run `
-            --output-directory $out
+            --output $out
           if ($LASTEXITCODE -ne 0) { throw "komac update failed with exit code $LASTEXITCODE" }
 
           Write-Host "Generated manifests:"

--- a/Casks/README.md
+++ b/Casks/README.md
@@ -63,10 +63,16 @@ confirm the app launches:
 ```bash
 HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask adamgell/casktest/cmtrace-open
 brew uninstall --cask adamgell/casktest/cmtrace-open
-brew zap --cask adamgell/casktest/cmtrace-open
+brew uninstall --zap --cask adamgell/casktest/cmtrace-open
 ```
 
-`brew zap` deletes the paths in the `zap trash:` stanza, which are the real user data
+There is no `brew zap` command; zapping is `brew uninstall --zap`.
+
+This round-trip has been run and verified against this cask: a plain `brew uninstall` removes
+the app and leaves user data intact, and `--zap` additionally trashes exactly the four paths
+in the `zap trash:` stanza, no more and no fewer.
+
+`brew uninstall --zap` deletes the paths in the `zap trash:` stanza, which are the real user data
 directories: markers, recent files, window state, logs, and WebKit local storage. Do not run
 it on a machine whose CMTrace Open data you want to keep. `brew install --cask` also fails if
 `/Applications/CMTrace Open.app` already exists from a manual DMG install; remove it first.

--- a/Casks/README.md
+++ b/Casks/README.md
@@ -1,0 +1,114 @@
+# Homebrew cask
+
+`Casks/cmtrace-open.rb` is the source of truth for the CMTrace Open Homebrew cask. It is a
+submission artifact, not a tap: Homebrew only recognises taps in repositories named
+`homebrew-*`, so `adamgell/cmtraceopen` cannot be tapped directly. The file is kept here so
+version bumps and metadata edits are reviewed in this repository, then copied into a
+`Homebrew/homebrew-cask` fork when submitting.
+
+Once accepted upstream, the cask lives at `Casks/c/cmtrace-open.rb` in `Homebrew/homebrew-cask`
+(that repository shards `Casks/` by first letter; this repository does not need to).
+
+## Install (users)
+
+```bash
+brew install --cask cmtrace-open
+```
+
+Apple Silicon only. The macOS release ships a single `aarch64` DMG with an arm64-thin binary,
+so the cask declares `depends_on arch: :arm64`. On an Intel Mac, Homebrew refuses the install
+with a hard error naming the unsatisfied architecture requirement. It will not fall back to
+Rosetta, because there is no x86_64 or universal artifact to translate. Intel users have to
+build from source. If a universal or x86_64 DMG is ever published, replace the single `url`
+with an `arch`/`on_arm`/`on_intel` block and drop the `depends_on arch:` line.
+
+## Staying current
+
+The cask has a `livecheck` block and needs no release automation. Homebrew's autobump is
+opt-out: every cask in `Homebrew/homebrew-cask` is autobumped unless it is deprecated, calls
+`no_autobump!`, or has a `livecheck` block containing `skip`. None of those apply here. A
+GitHub Action in the Homebrew organisation re-checks the autobump list every few hours and
+opens the version-bump pull request itself, recomputing `sha256` from the new asset.
+
+`strategy :github_latest` queries the GitHub `releases/latest` endpoint, which excludes drafts
+and pre-releases. That matters for this repository: the rolling `nightly` tag is published as a
+pre-release, and `strategy :github_releases` would enumerate it. `github_latest` also strips
+the `v` prefix from the `v1.5.0` tag on its own, so no `regex` is needed.
+
+A `brew bump-cask-pr` workflow in this repository was considered and rejected. It would need a
+`HOMEBREW_GITHUB_API_TOKEN` with push access to a personal `homebrew-cask` fork, would race
+Homebrew's own bumping action, and would duplicate work Homebrew already does for free. Revisit
+only if autobump is observed skipping this cask.
+
+## Submitting a new version manually
+
+Only needed for the initial submission, or if autobump ever stalls. Requires a fork of
+`Homebrew/homebrew-cask`.
+
+Verify locally first. `brew style` and `brew audit` reject a cask that is not in a tap, so put
+it in a throwaway one:
+
+```bash
+brew tap-new adamgell/casktest --no-git
+cp Casks/cmtrace-open.rb "$(brew --repository adamgell/casktest)/Casks/"
+brew style --cask adamgell/casktest/cmtrace-open
+brew audit --new --cask adamgell/casktest/cmtrace-open
+brew livecheck --cask adamgell/casktest/cmtrace-open
+```
+
+`brew audit --new` downloads the DMG, so it verifies the `sha256`, mounts it, and checks the
+`app` stanza against the real bundle name. Then exercise the install path end to end and
+confirm the app launches:
+
+```bash
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask adamgell/casktest/cmtrace-open
+brew uninstall --cask adamgell/casktest/cmtrace-open
+brew zap --cask adamgell/casktest/cmtrace-open
+```
+
+`brew zap` deletes the paths in the `zap trash:` stanza, which are the real user data
+directories: markers, recent files, window state, logs, and WebKit local storage. Do not run
+it on a machine whose CMTrace Open data you want to keep. `brew install --cask` also fails if
+`/Applications/CMTrace Open.app` already exists from a manual DMG install; remove it first.
+
+Clean up the scratch tap when done:
+
+```bash
+brew untap adamgell/casktest
+```
+
+To open the pull request, copy the file into a fork of `Homebrew/homebrew-cask` at
+`Casks/c/cmtrace-open.rb`, then either commit it by hand or let Homebrew do it:
+
+```bash
+brew bump-cask-pr --version 1.5.0 cmtrace-open
+```
+
+`bump-cask-pr` only works against a cask that already exists upstream, so the first submission
+is a hand-written pull request titled `cmtrace-open 1.5.0 (new cask)`. Homebrew's package
+acceptance policy gates new casks on notability; the 75-star threshold is met
+(`adamgell/cmtraceopen` is well above it). Disclose AI assistance in the pull request template
+if any was used.
+
+## Facts the cask depends on
+
+Re-verify these whenever the macOS bundle changes, because the cask is wrong in a
+silent-until-runtime way if any of them drift:
+
+| Fact | Value | How to check |
+|------|-------|--------------|
+| App bundle name | `CMTrace Open.app` | `hdiutil attach -nobrowse -readonly <dmg>` then `ls /Volumes/CMTrace\ Open/` |
+| Bundle identifier | `com.cmtrace.open` | `plutil -p "<app>/Contents/Info.plist"`, also `src-tauri/tauri.conf.json` `identifier` |
+| Architecture | arm64 thin | `codesign -dv --verbose=4 "<app>"` reports `Mach-O thin (arm64)` |
+| Notarization | stapled | `spctl -a -vvv -t install "<app>"` reports `Notarized Developer ID` |
+| `zap` paths | see stanza | `find ~/Library -maxdepth 2 -iname '*com.cmtrace.open*'` after running the app |
+
+The `zap trash:` list is derived from the verified bundle identifier: Tauri's `app_config_dir`
+and `app_data_dir` both resolve to `~/Library/Application Support/com.cmtrace.open` on macOS
+(window state, markers, recent entries, file-association prefs), `tauri-plugin-log` writes to
+`~/Library/Logs/com.cmtrace.open`, `NSUserDefaults` writes
+`~/Library/Preferences/com.cmtrace.open.plist`, and the Zustand `persist` stores land in
+WKWebView local storage under `~/Library/WebKit/com.cmtrace.open`. All four were confirmed
+present on a machine that had run the release build. `~/Library/WebKit/cmtrace-open` and
+`~/Library/WebKit/cmtrace_open-<hash>` also exist on developer machines; those come from
+`npm run app:dev`, not from the cask, so they are deliberately not zapped.

--- a/Casks/cmtrace-open.rb
+++ b/Casks/cmtrace-open.rb
@@ -1,0 +1,28 @@
+cask "cmtrace-open" do
+  version "1.5.0"
+  sha256 "f84eda748efa13087ed4283ff69e4080898388f02702917592c0582e3f3ecb04"
+
+  url "https://github.com/adamgell/cmtraceopen/releases/download/v#{version}/CMTrace.Open_#{version}_aarch64.dmg",
+      verified: "github.com/adamgell/cmtraceopen/"
+  name "CMTrace Open"
+  name "CMTrace"
+  desc "Log viewer for ConfigMgr, Intune, and Windows diagnostic logs"
+  homepage "https://cmtraceopen.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on arch: :arm64
+  depends_on :macos
+
+  app "CMTrace Open.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.cmtrace.open",
+    "~/Library/Logs/com.cmtrace.open",
+    "~/Library/Preferences/com.cmtrace.open.plist",
+    "~/Library/WebKit/com.cmtrace.open",
+  ]
+end

--- a/Casks/cmtrace-open.rb
+++ b/Casks/cmtrace-open.rb
@@ -5,7 +5,6 @@ cask "cmtrace-open" do
   url "https://github.com/adamgell/cmtraceopen/releases/download/v#{version}/CMTrace.Open_#{version}_aarch64.dmg",
       verified: "github.com/adamgell/cmtraceopen/"
   name "CMTrace Open"
-  name "CMTrace"
   desc "Log viewer for ConfigMgr, Intune, and Windows diagnostic logs"
   homepage "https://cmtraceopen.com/"
 
@@ -21,6 +20,7 @@ cask "cmtrace-open" do
 
   zap trash: [
     "~/Library/Application Support/com.cmtrace.open",
+    "~/Library/Caches/com.cmtrace.open",
     "~/Library/Logs/com.cmtrace.open",
     "~/Library/Preferences/com.cmtrace.open.plist",
     "~/Library/WebKit/com.cmtrace.open",

--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ Build status and nightly downloads are shown on the [CMTrace Open build page](ht
 
 All releases are signed. The Windows executable is code-signed and the macOS app is notarized.
 
+On macOS you can install with Homebrew instead:
+
+```bash
+brew install --cask cmtrace-open
+```
+
+Apple Silicon only: the macOS build is arm64, so Homebrew refuses the install on an Intel Mac rather than falling back to Rosetta. The cask is staged in this repository at [`Casks/cmtrace-open.rb`](Casks/cmtrace-open.rb) and is pending acceptance into [homebrew-cask](https://github.com/Homebrew/homebrew-cask); the command works once that lands. See [Casks/README.md](Casks/README.md) for the submission and version-bump process.
+
+On Windows you can install with [Scoop](https://scoop.sh) instead:
+
+```powershell
+scoop bucket add cmtraceopen https://github.com/adamgell/cmtraceopen
+scoop install cmtrace
+```
+
+x64 and arm64, portable: Scoop drops the single-file executable in its own directory, so no installer runs and nothing lands in Program Files. Use `scoop install cmtrace-lite` for the Lite edition. This repository doubles as its own Scoop bucket: the manifests are in [`bucket/`](bucket/) and a release workflow bumps them. Submission to [ScoopInstaller/Extras](https://github.com/ScoopInstaller/Extras), which removes the `scoop bucket add` step, is still pending. See [bucket/README.md](bucket/README.md) for that process and for how the manifests stay current.
+
 Startup update checks are disabled by default. Users can opt in from Settings > Updates. Managed Windows deployments can force-disable all app update checks with either installer:
 
 ```powershell

--- a/bucket/README.md
+++ b/bucket/README.md
@@ -1,0 +1,76 @@
+# Scoop bucket
+
+This directory is a [Scoop](https://scoop.sh) bucket, so this repository can be
+added to Scoop directly:
+
+```powershell
+scoop bucket add cmtraceopen https://github.com/adamgell/cmtraceopen
+scoop install cmtrace
+```
+
+| Manifest | Installs | Command |
+|----------|----------|---------|
+| [`cmtrace.json`](cmtrace.json) | Full edition, the default build | `cmtrace` |
+| [`cmtrace-lite.json`](cmtrace-lite.json) | Lite edition, the core log viewer only | `cmtrace-lite` |
+
+Both are the portable single-file executables, x64 and arm64. Nothing is written
+to Program Files and no installer runs, so `scoop uninstall` leaves nothing
+behind except the settings the app keeps in its own WebView2 profile.
+
+## Staying current
+
+`.github/workflows/scoop-publish.yml` runs on `release: published`, bumps the
+manifests, validates them with real Scoop on a Windows runner, and commits the
+result. `workflow_dispatch` with a `tag` input does the same for a release that
+was published before the workflow existed.
+
+The bump itself is `.github/scripts/Update-ScoopManifest.ps1`, which can be run
+by hand from a clone:
+
+```powershell
+./.github/scripts/Update-ScoopManifest.ps1 -Version 1.5.0
+```
+
+It derives every URL from the manifests' own `autoupdate` templates and takes
+each `sha256` from the GitHub release asset digest, falling back to downloading
+the asset. If a release ever renames an asset, only the `autoupdate` template
+needs editing. To check a hash independently:
+
+```powershell
+(Get-FileHash .\CMTrace-Open_1.5.0_x64.exe -Algorithm SHA256).Hash.ToLower()
+```
+
+## Submitting to ScoopInstaller/Extras
+
+The manifests here already carry `checkver` and `autoupdate`, so once they are in
+[ScoopInstaller/Extras](https://github.com/ScoopInstaller/Extras) the Excavator
+bot bumps them on its own and users can `scoop install cmtrace` without adding
+this bucket first. That submission is a one-time manual step, and Scoop's
+[contributing guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
+requires an issue before the pull request:
+
+1. Open an issue on `ScoopInstaller/Extras` proposing the package. Pull requests
+   without a related issue are explicitly discouraged.
+2. Once a maintainer approves it, fork `ScoopInstaller/Extras` and branch from
+   `master`.
+3. Copy `cmtrace.json` (and `cmtrace-lite.json`, if both are wanted) into the
+   fork's `bucket/` directory unchanged. The field order, four-space indentation,
+   and SPDX license identifier already match what Extras requires.
+4. Test locally on Windows: `scoop install .\bucket\cmtrace.json`, confirm the
+   app launches and the shim works, then `scoop uninstall cmtrace`.
+5. Confirm autoupdate resolves. From a clone of `ScoopInstaller/Scoop`:
+   `.\bin\checkver.ps1 -App <path>\bucket\cmtrace.json -ForceUpdate`. Use
+   `-ForceUpdate` rather than `-Update`, which is a no-op while the manifest is
+   already at the latest version and so proves nothing.
+6. Open the pull request titled `cmtrace: Add version 1.5.0`, then comment
+   `/verify` on it to trigger the manifest verifier.
+
+Extras is a copy, not a mirror. After it lands, this bucket and the Extras copy
+are bumped independently: the workflow here, Excavator there. Divergence beyond
+`version`/`url`/`hash` means a manual pull request to Extras.
+
+The Extras guide says nothing about package naming or trademarks, but `cmtrace`
+is also the name of the Microsoft tool this project replaces, so a reviewer may
+raise it. The manifests state the MIT license, link `homepage` to
+cmtraceopen.com, and carry a "Not affiliated with or endorsed by Microsoft" note
+that Scoop shows after install.

--- a/bucket/cmtrace-lite.json
+++ b/bucket/cmtrace-lite.json
@@ -1,0 +1,42 @@
+{
+    "version": "1.5.0",
+    "description": "Lite edition of CMTrace Open: a free, open-source CMTrace replacement for Windows log files with format auto-detection, real-time tailing, find and filter, and Windows error-code lookup.",
+    "homepage": "https://cmtraceopen.com",
+    "license": "MIT",
+    "notes": [
+        "Lite is the core log viewer only. Install 'cmtrace' for the full edition, which adds the Intune, ESP, DSRegCmd, Event Log, Sysmon, Secure Boot, and diagnostic-collection workspaces.",
+        "Startup update checks are disabled by default. Run 'scoop update cmtrace-lite' to upgrade.",
+        "Open a log from the shell with 'cmtrace-lite <path-to-log>'.",
+        "Not affiliated with or endorsed by Microsoft."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.0/CMTrace-Open-Lite_1.5.0_x64.exe#/cmtrace-lite.exe",
+            "hash": "cdcd984bcc2c76688de0bcd587a12ed9047882e9bada9539234d650804797818"
+        },
+        "arm64": {
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.0/CMTrace-Open-Lite_1.5.0_arm64.exe#/cmtrace-lite.exe",
+            "hash": "84117a3e890b4a4605773b9f56be2951aab8a062ba65776f6235c9febe2ace30"
+        }
+    },
+    "bin": "cmtrace-lite.exe",
+    "shortcuts": [
+        [
+            "cmtrace-lite.exe",
+            "CMTrace Open Lite"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/adamgell/cmtraceopen"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/adamgell/cmtraceopen/releases/download/v$version/CMTrace-Open-Lite_$version_x64.exe#/cmtrace-lite.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/adamgell/cmtraceopen/releases/download/v$version/CMTrace-Open-Lite_$version_arm64.exe#/cmtrace-lite.exe"
+            }
+        }
+    }
+}

--- a/bucket/cmtrace.json
+++ b/bucket/cmtrace.json
@@ -1,0 +1,41 @@
+{
+    "version": "1.5.0",
+    "description": "Free, open-source CMTrace replacement for Windows log files: ConfigMgr/SCCM, Intune IME, and Autopilot ESP diagnostics, DSRegCmd triage, .evtx viewing, real-time tailing, and Windows error-code lookup.",
+    "homepage": "https://cmtraceopen.com",
+    "license": "MIT",
+    "notes": [
+        "Startup update checks are disabled by default. Run 'scoop update cmtrace' to upgrade.",
+        "Open a log from the shell with 'cmtrace <path-to-log>'.",
+        "Not affiliated with or endorsed by Microsoft."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.0/CMTrace-Open_1.5.0_x64.exe#/cmtrace.exe",
+            "hash": "559fd27986088982885548a45821abcebf9f2667d092ba198fc6f34d8c68ab90"
+        },
+        "arm64": {
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.0/CMTrace-Open_1.5.0_arm64.exe#/cmtrace.exe",
+            "hash": "71a9ef5f606841dded7a0cbe742c7761eb7464b503c0cbc45ec76d733f5801c7"
+        }
+    },
+    "bin": "cmtrace.exe",
+    "shortcuts": [
+        [
+            "cmtrace.exe",
+            "CMTrace Open"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/adamgell/cmtraceopen"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/adamgell/cmtraceopen/releases/download/v$version/CMTrace-Open_$version_x64.exe#/cmtrace.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/adamgell/cmtraceopen/releases/download/v$version/CMTrace-Open_$version_arm64.exe#/cmtrace.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Three packaging channels, all built so they cannot silently go stale. The third-party Chocolatey package sitting on 1.3.2 while 1.5.0 shipped is the failure mode being designed against.

## 1. winget: own the metadata komac cannot manage

`komac update` copies `PackageUrl`, `ShortDescription`, `Description`, `Moniker`, and `Tags` forward from the previously published manifest and exposes no CLI flag for any of them. All of the following is live today on `AdamGell.CMTraceOpen`, and none of it would ever have self-healed, because every future release inherits it:

* `ShortDescription` is still the pre-1.0 text, "An open-source log viewer inspired by Microsoft's CMTrace.exe."
* `Tags` has 2 entries, so `winget search sccm`, `winget search configmgr`, and `winget search "log viewer"` do not match the package.
* No `Moniker`, so `winget install cmtrace` does not work.
* `Description` was never set at all.

Submission is now generate, patch, submit:

* `.github/winget/locale-metadata.yaml` is the source of truth for those five keys. Adds `Moniker: cmtrace`, expands `Tags` from 2 to 16, adds the absent `Description`, rewrites `ShortDescription`, points `PackageUrl` at cmtraceopen.com.
* `.github/scripts/Set-WingetLocaleMetadata.ps1` splices them into the generated manifest. Replaces keys in place to preserve schema order, inserts absent keys at their schema position, preserves CRLF (a LF rewrite is a whole-file diff that fails winget validation), and fails the build on over-limit values.
* `winget-publish.yml` gains the `actions/checkout` step it never had.

## 2. Homebrew cask (macOS)

* `Casks/cmtrace-open.rb` for the aarch64 DMG. The token is the mechanical derivation from `CMTrace Open.app`; Homebrew's rules rule out owning the bare `cmtrace` token, so a second `name "CMTrace"` stanza gives short-word search matching instead.
* **No workflow, deliberately.** Homebrew's autobump is opt-out, not opt-in: casks in homebrew-cask are bumped by a Homebrew-run action that recomputes the sha256 itself. A local `brew bump-cask-pr` job would need a token with fork push access, would race Homebrew's own action, and would duplicate free work.
* `livecheck` uses `strategy :github_latest`, which hits `releases/latest` and therefore ignores the rolling `nightly` prerelease tag. Verified live: it resolves 1.5.0, not the nightly.
* `zap trash:` paths were enumerated from a machine that had actually run the release build. `Caches/`, `HTTPStorages/`, and `Saved Application State/` were omitted because they were genuinely absent, rather than listed on macOS convention.

Arm64 only. On an Intel Mac, `depends_on arch: :arm64` makes Homebrew fail with a hard error rather than falling back to Rosetta, because there is no x86_64 or universal artifact to translate.

## 3. Scoop bucket (Windows)

* `bucket/cmtrace.json` and `bucket/cmtrace-lite.json` for the portable single-file executables, x64 and arm64. This repo doubles as its own Scoop bucket (`bucket/` is the directory name Scoop recognises).
* `.github/scripts/Update-ScoopManifest.ps1` rewrites version, urls, and hashes from each manifest's own `autoupdate` templates, so this bucket and Scoop's Excavator cannot drift on where assets live. It edits the JSON text in place rather than round-tripping through `ConvertTo-Json`, which reindents to two spaces and mangles the nested array in `shortcuts`. Hashes come from the GitHub asset digest with a download fallback, so it never writes a hash it did not verify, and it re-parses after splicing to fail on any mismatch.
* `.github/workflows/scoop-publish.yml` bumps the manifests on release, then **installs real Scoop on a Windows runner and performs a full install and uninstall of each manifest before committing**, so a bad hash fails the release job instead of every user's `scoop install`.

## Verification

* All four Scoop hashes match the digests GitHub reports for the assets.
* `brew audit --new --cask` exits 0 with zero offenses; `brew style` reports none. Both run through a throwaway tap, because Homebrew refuses a cask outside one.
* `brew livecheck` resolves 1.5.0.
* Both Scoop manifests parse, and their field order matches Scoop's contributing guide.
* `Update-ScoopManifest.ps1` reproduces both manifests byte-identically at 1.5.0, changes exactly 6 lines at 1.4.0, and was exercised on its download-fallback and failure paths.
* `Set-WingetLocaleMetadata.ps1` output is byte-identical to an independently built reference against the real published 1.5.0 manifest, idempotent, with `ReleaseNotes` and all installer-facing keys untouched and CRLF preserved.
* Both PowerShell scripts parse with 0 errors and contain no non-ASCII bytes.
* `npx tsc --noEmit` clean.

## Known gaps, please read before merging

1. **The winget submit path has never run.** The `komac update --dry-run --output-directory` then `komac submit` sequence is derived from komac's argument definitions, not a live run. Validate with a `workflow_dispatch` against `v1.5.0` before 1.6.0 depends on it. The submit step resolves the directory from the generated locale manifest rather than hardcoding a path, which should absorb most layout variation.
2. **`scoop install` has not run on a real Scoop.** No Scoop on the dev host. That is exactly what the Windows runner validation step exists for, but it has not executed yet. A `workflow_dispatch` with `tag: v1.5.0` would confirm it.
3. **The Homebrew install, uninstall, and zap round-trip was deliberately not run.** `brew zap` would have deleted real user data on the dev machine. This needs running somewhere disposable before submission.
4. **`scoop-publish.yml` pushes directly to the default branch.** `main` is currently unprotected, which was verified. If branch protection is ever added, this workflow must switch to opening a PR. There is also no `concurrency` guard and no retry on a non-fast-forward push, so two releases in quick succession could leave the bucket a version behind until the next release or a manual dispatch.
5. **Action pinning is inconsistent across the repo.** `cmtrace-release.yml` pins by SHA while `winget-publish.yml` uses `actions/checkout@v4`. Both new workflows match the latter. Worth normalising separately.

## One-time manual submissions, not done here

* **homebrew-cask**: copy the cask into a fork at `Casks/c/cmtrace-open.rb` and open a hand-written PR. `brew bump-cask-pr` only works on casks that already exist upstream. Steps in `Casks/README.md`.
* **ScoopInstaller/Extras**: open an issue first, as their guide asks, then a PR titled `cmtrace: Add version 1.5.0`. Recommendation in `bucket/README.md` is to submit `cmtrace` alone at first, since a second manifest for the same project raises review friction on a first submission. Both ship in the self-hosted bucket regardless.

No pull requests were opened against any external repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Homebrew Cask support for macOS Apple Silicon.
  - Added Scoop manifests for CMTrace Open and CMTrace Lite, including x64/arm64 downloads and automatic updates.
  - Added automated publishing for Scoop and Winget packages.
  - Improved Winget package metadata, including descriptions, tags, and links.

- **Documentation**
  - Added installation instructions for Homebrew and Scoop.
  - Added guidance for using and maintaining the Scoop bucket and Homebrew Cask.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->