### PR TITLE
build(macos): Developer ID signing, notarization env, and entitlements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,11 @@
 # ── macOS code-signing identity (required for signed builds) ──────────────
 # Find your identity with:
 #     security find-identity -v -p codesigning
-# Then paste the full quoted-name string between the quotes below.
-APPLE_SIGNING_IDENTITY="Developer ID Application: YOUR NAME (TEAMID)"
+# Leave this empty until you have a real identity: the build script checks
+# for an empty value and prints exactly how to find yours. A placeholder
+# here would pass that check and fail later inside codesign instead.
+#     APPLE_SIGNING_IDENTITY="Developer ID Application: Jane Doe (ABC1234567)"
+APPLE_SIGNING_IDENTITY=
 
 # ── Notarization: App Store Connect API key (preferred) ───────────────────
 # Generate at https://appstoreconnect.apple.com/access/integrations/api

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# CMTrace Open — local environment template.
+#
+# Copy this file to `.env.local` (gitignored) and fill in real values.
+# `scripts/build-mac-signed.sh` automatically sources `.env.local` from
+# the repo root if it exists, so once filled in you can just run the
+# script with no further setup.
+#
+#     cp .env.example .env.local
+#     $EDITOR .env.local
+#     ./scripts/build-mac-signed.sh
+
+# ── macOS code-signing identity (required for signed builds) ──────────────
+# Find your identity with:
+#     security find-identity -v -p codesigning
+# Then paste the full quoted-name string between the quotes below.
+APPLE_SIGNING_IDENTITY="Developer ID Application: YOUR NAME (TEAMID)"
+
+# ── Notarization: App Store Connect API key (preferred) ───────────────────
+# Generate at https://appstoreconnect.apple.com/access/integrations/api
+# (role: Developer). Download the .p8 once and store it somewhere private.
+# Leave blank to skip notarization (build will sign but not notarize).
+APPLE_API_KEY=
+APPLE_API_ISSUER=
+APPLE_API_KEY_PATH=
+
+# ── Notarization: Apple ID + app-specific password (legacy fallback) ──────
+# Only populate if you're not using the API key above. Generate the password
+# at https://appleid.apple.com/account/manage → "App-Specific Passwords".
+APPLE_ID=
+APPLE_PASSWORD=
+APPLE_TEAM_ID=

--- a/scripts/build-mac-signed.sh
+++ b/scripts/build-mac-signed.sh
@@ -34,10 +34,11 @@
 #   ./scripts/build-mac-signed.sh                # release: signed .app + DMG
 #   ./scripts/build-mac-signed.sh --debug        # debug: signed .app + DMG
 #
-# Note: --no-bundle is intentionally NOT supported. On macOS the signing
-# happens at the .app bundle level (the bundled Mach-O is signed, then the
-# .app envelope is signed). A bare unbundled binary isn't a normal macOS
-# distribution shape, so there's no signed "exe-only" mode.
+# Note: --no-bundle is intentionally NOT supported and is rejected with exit
+# 2 rather than forwarded. On macOS the signing happens at the .app bundle
+# level (the bundled Mach-O is signed, then the .app envelope is signed). A
+# bare unbundled binary isn't a normal macOS distribution shape, so there's
+# no signed "exe-only" mode.
 
 set -euo pipefail
 
@@ -82,6 +83,37 @@ elif [[ -n "${APPLE_ID:-}" && -n "${APPLE_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-}
     NOTARIZE_MODE="apple-id"
 fi
 
+# ── Inspect the forwarded Tauri args ───────────────────────────────────────
+# --no-bundle is rejected rather than forwarded: signing happens at the .app
+# bundle level, so a bundle-less build has nothing to sign and would
+# otherwise exit 0 having produced no distributable artifact.
+# --debug and --target/-t decide where Tauri writes the bundle, which the
+# post-build validation below needs in order to find it.
+BUILD_PROFILE="release"
+BUILD_TARGET=""
+PREV_ARG=""
+for arg in "$@"; do
+    case "${arg}" in
+        --no-bundle)
+            echo "error: --no-bundle is not supported by this signed build flow." >&2
+            echo "       See the note at the top of this script." >&2
+            exit 2
+            ;;
+        --debug)
+            BUILD_PROFILE="debug"
+            ;;
+        --target=*)
+            BUILD_TARGET="${arg#--target=}"
+            ;;
+        *)
+            if [[ "${PREV_ARG}" == "--target" || "${PREV_ARG}" == "-t" ]]; then
+                BUILD_TARGET="${arg}"
+            fi
+            ;;
+    esac
+    PREV_ARG="${arg}"
+done
+
 # ── Build the --config overlay JSON ────────────────────────────────────────
 # Use python rather than ad-hoc string concat so identity values containing
 # parentheses, spaces, or quotes survive the round-trip safely.
@@ -104,12 +136,6 @@ json.dump(overlay, sys.stdout)
 CONFIG_FILE=$(mktemp "${TMPDIR:-/tmp}/cmtrace_tauri_conf_XXXXXX.json")
 printf '%s' "${CONFIG_OVERLAY}" > "${CONFIG_FILE}"
 
-# Determine build profile (release unless --debug is in the forwarded args).
-BUILD_PROFILE="release"
-for arg in "$@"; do
-    [[ "$arg" == "--debug" ]] && BUILD_PROFILE="debug"
-done
-
 # ── Echo plan ──────────────────────────────────────────────────────────────
 echo "──────────────────────────────────────────────────────────────────"
 echo "  CMTrace Open: signed macOS build"
@@ -124,55 +150,89 @@ echo "────────────────────────�
 # environment for notarization. We pass the signing identity via --config
 # so it overrides the on-disk default of "-".
 
-# Capture a reference timestamp immediately before the build so the
-# soft-fail artifact-freshness check can use BSD-compatible `find -newer`.
+# A reference file created immediately before the build. An artifact only
+# counts as this build's output if it is newer than the stamp, so a stale
+# bundle from an earlier run can never stand in for one this build failed to
+# produce. `-newer` is used rather than `-mmin` because BSD find (macOS) has
+# no -mmin. The build log is captured so the soft-fail below can confirm
+# *which* failure it is looking at.
 BUILD_STAMP=$(mktemp "${TMPDIR:-/tmp}/cmtrace_build_stamp_XXXXXX")
-trap 'rm -f "${CONFIG_FILE}" "${BUILD_STAMP}"' EXIT
+BUILD_LOG=$(mktemp "${TMPDIR:-/tmp}/cmtrace_build_log_XXXXXX")
+trap 'rm -f "${CONFIG_FILE}" "${BUILD_STAMP}" "${BUILD_LOG}"' EXIT
 
 set +e
-npx tauri build --config "${CONFIG_FILE}" "$@"
-TAURI_EXIT=$?
+npx tauri build --config "${CONFIG_FILE}" "$@" 2>&1 | tee "${BUILD_LOG}"
+TAURI_EXIT=${PIPESTATUS[0]}
 set -e
 
-# ── Soft-fail handling for the updater signing step ────────────────────────
-# Tauri's bundle pipeline runs an updater-signing step after the DMG is built.
-# It fails with `TAURI_SIGNING_PRIVATE_KEY` errors when that env var isn't
-# set, even though the DMG itself is already signed, notarized, and stapled.
-# We detect that case and downgrade it to a warning: the .app and .dmg are
-# the deliverables this script cares about; updater-bundle signing is only
-# relevant if you're publishing to the auto-update endpoint.
-if [[ $TAURI_EXIT -ne 0 ]]; then
-    # Use -newer (BSD find compatible) against the pre-build stamp to avoid
-    # matching stale artifacts from a previous run.  Honour the correct profile
-    # directory so --debug builds are detected as well as --release.
-    DMG_PATH=$(find "${REPO_ROOT}/src-tauri/target/${BUILD_PROFILE}/bundle/dmg" \
-        -maxdepth 1 -name "*.dmg" -newer "${BUILD_STAMP}" 2>/dev/null | head -1)
-    APP_PATH=$(find "${REPO_ROOT}/src-tauri/target/${BUILD_PROFILE}/bundle/macos" \
-        -maxdepth 1 -name "*.app" -type d -newer "${BUILD_STAMP}" 2>/dev/null | head -1)
+# ── Locate this build's deliverables ───────────────────────────────────────
+if [[ -n "${BUILD_TARGET}" ]]; then
+    BUNDLE_DIR="${REPO_ROOT}/src-tauri/target/${BUILD_TARGET}/${BUILD_PROFILE}/bundle"
+else
+    BUNDLE_DIR="${REPO_ROOT}/src-tauri/target/${BUILD_PROFILE}/bundle"
+fi
 
-    # Validate code-signature (codesign works for signed-but-not-notarized
-    # builds; add stapler check only when notarization was attempted).
-    SIGNING_OK=false
-    if [[ -n "$DMG_PATH" && -n "$APP_PATH" ]] \
-        && codesign --verify --deep --strict "$APP_PATH" >/dev/null 2>&1; then
-        SIGNING_OK=true
-        if [[ "${NOTARIZE_MODE}" != "none" ]]; then
-            xcrun stapler validate "$APP_PATH" >/dev/null 2>&1 || SIGNING_OK=false
-        fi
+APP_PATH=$(find "${BUNDLE_DIR}/macos" -maxdepth 1 -name "*.app" -type d \
+    -newer "${BUILD_STAMP}" 2>/dev/null | head -1)
+DMG_PATH=$(find "${BUNDLE_DIR}/dmg" -maxdepth 1 -name "*.dmg" \
+    -newer "${BUILD_STAMP}" 2>/dev/null | head -1)
+
+# ── Validate the deliverables ──────────────────────────────────────────────
+# This runs on the success path as well, because a zero exit from Tauri is
+# not by itself evidence that a *signed* .app was produced. Shipping an
+# unsigned or unnotarized build to direct download is the failure this
+# guards against. `codesign` alone is the right check when notarization was
+# not attempted, which is the documented signed-but-not-notarized fallback.
+validate_deliverables() {
+    if [[ -z "${APP_PATH}" ]]; then
+        echo "error: no .app newer than the build stamp under ${BUNDLE_DIR}/macos." >&2
+        return 1
+    fi
+    if ! codesign --verify --deep --strict "${APP_PATH}" >/dev/null 2>&1; then
+        echo "error: code signature missing or invalid: ${APP_PATH}" >&2
+        return 1
+    fi
+    if [[ "${NOTARIZE_MODE}" != "none" ]] \
+        && ! xcrun stapler validate "${APP_PATH}" >/dev/null 2>&1; then
+        echo "error: notarization ticket missing or invalid: ${APP_PATH}" >&2
+        return 1
+    fi
+    if [[ -z "${DMG_PATH}" ]]; then
+        echo "warning: no .dmg newer than the build stamp under ${BUNDLE_DIR}/dmg." >&2
+    fi
+    return 0
+}
+
+# ── Soft-fail handling for the updater signing step ────────────────────────
+# With "createUpdaterArtifacts": true, Tauri runs an updater-signing step
+# after the DMG is built. It fails when TAURI_SIGNING_PRIVATE_KEY isn't set,
+# even though the .app and .dmg are already signed (and notarized). ONLY that
+# specific failure is downgraded to a warning, identified by the variable
+# being unset *and* named in the build output. Every other non-zero exit is a
+# real build failure and is propagated unchanged, so an unrelated error can
+# never be reported as a successful build.
+if [[ ${TAURI_EXIT} -ne 0 ]]; then
+    if [[ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]] \
+        || ! grep -qi "TAURI_SIGNING_PRIVATE_KEY" "${BUILD_LOG}"; then
+        echo "error: tauri build failed with exit ${TAURI_EXIT}." >&2
+        exit "${TAURI_EXIT}"
     fi
 
-    if [[ "$SIGNING_OK" == "true" ]]; then
-        cat >&2 <<EOF
-warning: tauri build exited ${TAURI_EXIT}, but the signed .app and .dmg are
-         present and the signature is valid. The exit code is from the
-         updater-bundle signing step (TAURI_SIGNING_PRIVATE_KEY).
+    validate_deliverables || exit "${TAURI_EXIT}"
+
+    cat >&2 <<EOF
+warning: tauri build exited ${TAURI_EXIT}, but the signed .app is present and
+         its signature is valid. The exit code is from the updater-bundle
+         signing step (TAURI_SIGNING_PRIVATE_KEY is not set).
          Treating as success.
 EOF
-        echo
-        echo "Built artifacts:"
-        echo "  ${APP_PATH}"
-        echo "  ${DMG_PATH}"
-        exit 0
-    fi
-    exit $TAURI_EXIT
+else
+    validate_deliverables || exit 1
+fi
+
+echo
+echo "Built artifacts:"
+echo "  ${APP_PATH}"
+if [[ -n "${DMG_PATH}" ]]; then
+    echo "  ${DMG_PATH}"
 fi

--- a/scripts/build-mac-signed.sh
+++ b/scripts/build-mac-signed.sh
@@ -115,20 +115,14 @@ for arg in "$@"; do
 done
 
 # ── Build the --config overlay JSON ────────────────────────────────────────
-# Use python rather than ad-hoc string concat so identity values containing
-# parentheses, spaces, or quotes survive the round-trip safely.
+# Built with node rather than ad-hoc string concat so identity values
+# containing parentheses, spaces, or quotes survive the round-trip safely.
+# node is used in preference to python3 because this script already requires
+# it for `npx tauri`, so the overlay adds no new runtime dependency.
 CONFIG_OVERLAY=$(
-    python3 -c '
-import json, os, sys
-overlay = {
-    "bundle": {
-        "macOS": {
-            "signingIdentity": os.environ["APPLE_SIGNING_IDENTITY"]
-        }
-    }
-}
-json.dump(overlay, sys.stdout)
-'
+    node -e 'process.stdout.write(JSON.stringify({
+        bundle: { macOS: { signingIdentity: process.env.APPLE_SIGNING_IDENTITY } }
+    }))'
 )
 
 # ── Write config overlay to a temp file ────────────────────────────────────

--- a/scripts/build-mac-signed.sh
+++ b/scripts/build-mac-signed.sh
@@ -99,6 +99,17 @@ json.dump(overlay, sys.stdout)
 '
 )
 
+# ── Write config overlay to a temp file ────────────────────────────────────
+# `tauri build --config` expects a file path, not an inline JSON string.
+CONFIG_FILE=$(mktemp "${TMPDIR:-/tmp}/cmtrace_tauri_conf_XXXXXX.json")
+printf '%s' "${CONFIG_OVERLAY}" > "${CONFIG_FILE}"
+
+# Determine build profile (release unless --debug is in the forwarded args).
+BUILD_PROFILE="release"
+for arg in "$@"; do
+    [[ "$arg" == "--debug" ]] && BUILD_PROFILE="debug"
+done
+
 # ── Echo plan ──────────────────────────────────────────────────────────────
 echo "──────────────────────────────────────────────────────────────────"
 echo "  CMTrace Open: signed macOS build"
@@ -112,8 +123,14 @@ echo "────────────────────────�
 # Tauri reads APPLE_API_KEY*, APPLE_ID/PASSWORD/TEAM_ID directly from the
 # environment for notarization. We pass the signing identity via --config
 # so it overrides the on-disk default of "-".
+
+# Capture a reference timestamp immediately before the build so the
+# soft-fail artifact-freshness check can use BSD-compatible `find -newer`.
+BUILD_STAMP=$(mktemp "${TMPDIR:-/tmp}/cmtrace_build_stamp_XXXXXX")
+trap 'rm -f "${CONFIG_FILE}" "${BUILD_STAMP}"' EXIT
+
 set +e
-npx tauri build --config "${CONFIG_OVERLAY}" "$@"
+npx tauri build --config "${CONFIG_FILE}" "$@"
 TAURI_EXIT=$?
 set -e
 
@@ -125,17 +142,30 @@ set -e
 # the deliverables this script cares about; updater-bundle signing is only
 # relevant if you're publishing to the auto-update endpoint.
 if [[ $TAURI_EXIT -ne 0 ]]; then
-    DMG_PATH=$(find "${REPO_ROOT}/src-tauri/target/release/bundle/dmg" \
-        -maxdepth 1 -name "*.dmg" -mmin -10 2>/dev/null | head -1)
-    APP_PATH=$(find "${REPO_ROOT}/src-tauri/target/release/bundle/macos" \
-        -maxdepth 1 -name "*.app" -type d -mmin -10 2>/dev/null | head -1)
+    # Use -newer (BSD find compatible) against the pre-build stamp to avoid
+    # matching stale artifacts from a previous run.  Honour the correct profile
+    # directory so --debug builds are detected as well as --release.
+    DMG_PATH=$(find "${REPO_ROOT}/src-tauri/target/${BUILD_PROFILE}/bundle/dmg" \
+        -maxdepth 1 -name "*.dmg" -newer "${BUILD_STAMP}" 2>/dev/null | head -1)
+    APP_PATH=$(find "${REPO_ROOT}/src-tauri/target/${BUILD_PROFILE}/bundle/macos" \
+        -maxdepth 1 -name "*.app" -type d -newer "${BUILD_STAMP}" 2>/dev/null | head -1)
 
+    # Validate code-signature (codesign works for signed-but-not-notarized
+    # builds; add stapler check only when notarization was attempted).
+    SIGNING_OK=false
     if [[ -n "$DMG_PATH" && -n "$APP_PATH" ]] \
-        && xcrun stapler validate "$APP_PATH" >/dev/null 2>&1; then
+        && codesign --verify --deep --strict "$APP_PATH" >/dev/null 2>&1; then
+        SIGNING_OK=true
+        if [[ "${NOTARIZE_MODE}" != "none" ]]; then
+            xcrun stapler validate "$APP_PATH" >/dev/null 2>&1 || SIGNING_OK=false
+        fi
+    fi
+
+    if [[ "$SIGNING_OK" == "true" ]]; then
         cat >&2 <<EOF
 warning: tauri build exited ${TAURI_EXIT}, but the signed .app and .dmg are
-         present and the notarization ticket validated. The exit code is
-         from the updater-bundle signing step (TAURI_SIGNING_PRIVATE_KEY).
+         present and the signature is valid. The exit code is from the
+         updater-bundle signing step (TAURI_SIGNING_PRIVATE_KEY).
          Treating as success.
 EOF
         echo

--- a/scripts/build-mac-signed.sh
+++ b/scripts/build-mac-signed.sh
@@ -46,6 +46,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${REPO_ROOT}"
 
+# ── Auto-load .env.local if present ────────────────────────────────────────
+# Convention: developers copy .env.example → .env.local (gitignored) and
+# fill in their signing/notarization credentials there. We source it before
+# validating env vars below so they take effect for this build.
+if [[ -f "${REPO_ROOT}/.env.local" ]]; then
+    # shellcheck disable=SC1091
+    set -a; source "${REPO_ROOT}/.env.local"; set +a
+    echo "info: loaded credentials from ${REPO_ROOT}/.env.local"
+fi
+
 # ── Validate signing identity ──────────────────────────────────────────────
 if [[ -z "${APPLE_SIGNING_IDENTITY:-}" ]]; then
     cat >&2 <<'EOF'

--- a/scripts/build-mac-signed.sh
+++ b/scripts/build-mac-signed.sh
@@ -31,9 +31,13 @@
 # build time without touching the file on disk.
 #
 # Usage:
-#   ./scripts/build-mac-signed.sh                # release build
-#   ./scripts/build-mac-signed.sh --debug        # debug build
-#   ./scripts/build-mac-signed.sh --no-bundle    # exe only, skip DMG
+#   ./scripts/build-mac-signed.sh                # release: signed .app + DMG
+#   ./scripts/build-mac-signed.sh --debug        # debug: signed .app + DMG
+#
+# Note: --no-bundle is intentionally NOT supported. On macOS the signing
+# happens at the .app bundle level (the bundled Mach-O is signed, then the
+# .app envelope is signed). A bare unbundled binary isn't a normal macOS
+# distribution shape, so there's no signed "exe-only" mode.
 
 set -euo pipefail
 

--- a/scripts/build-mac-signed.sh
+++ b/scripts/build-mac-signed.sh
@@ -112,4 +112,37 @@ echo "────────────────────────�
 # Tauri reads APPLE_API_KEY*, APPLE_ID/PASSWORD/TEAM_ID directly from the
 # environment for notarization. We pass the signing identity via --config
 # so it overrides the on-disk default of "-".
-exec npx tauri build --config "${CONFIG_OVERLAY}" "$@"
+set +e
+npx tauri build --config "${CONFIG_OVERLAY}" "$@"
+TAURI_EXIT=$?
+set -e
+
+# ── Soft-fail handling for the updater signing step ────────────────────────
+# Tauri's bundle pipeline runs an updater-signing step after the DMG is built.
+# It fails with `TAURI_SIGNING_PRIVATE_KEY` errors when that env var isn't
+# set, even though the DMG itself is already signed, notarized, and stapled.
+# We detect that case and downgrade it to a warning: the .app and .dmg are
+# the deliverables this script cares about; updater-bundle signing is only
+# relevant if you're publishing to the auto-update endpoint.
+if [[ $TAURI_EXIT -ne 0 ]]; then
+    DMG_PATH=$(find "${REPO_ROOT}/src-tauri/target/release/bundle/dmg" \
+        -maxdepth 1 -name "*.dmg" -mmin -10 2>/dev/null | head -1)
+    APP_PATH=$(find "${REPO_ROOT}/src-tauri/target/release/bundle/macos" \
+        -maxdepth 1 -name "*.app" -type d -mmin -10 2>/dev/null | head -1)
+
+    if [[ -n "$DMG_PATH" && -n "$APP_PATH" ]] \
+        && xcrun stapler validate "$APP_PATH" >/dev/null 2>&1; then
+        cat >&2 <<EOF
+warning: tauri build exited ${TAURI_EXIT}, but the signed .app and .dmg are
+         present and the notarization ticket validated. The exit code is
+         from the updater-bundle signing step (TAURI_SIGNING_PRIVATE_KEY).
+         Treating as success.
+EOF
+        echo
+        echo "Built artifacts:"
+        echo "  ${APP_PATH}"
+        echo "  ${DMG_PATH}"
+        exit 0
+    fi
+    exit $TAURI_EXIT
+fi

--- a/scripts/build-mac-signed.sh
+++ b/scripts/build-mac-signed.sh
@@ -88,9 +88,11 @@ fi
 # bundle level, so a bundle-less build has nothing to sign and would
 # otherwise exit 0 having produced no distributable artifact.
 # --debug and --target/-t decide where Tauri writes the bundle, which the
-# post-build validation below needs in order to find it.
+# post-build validation below needs in order to find it. --bundles/-b decides
+# whether a DMG is among the expected deliverables.
 BUILD_PROFILE="release"
 BUILD_TARGET=""
+BUILD_BUNDLES=""
 PREV_ARG=""
 for arg in "$@"; do
     case "${arg}" in
@@ -105,14 +107,29 @@ for arg in "$@"; do
         --target=*)
             BUILD_TARGET="${arg#--target=}"
             ;;
+        --bundles=*)
+            BUILD_BUNDLES="${arg#--bundles=}"
+            ;;
         *)
             if [[ "${PREV_ARG}" == "--target" || "${PREV_ARG}" == "-t" ]]; then
                 BUILD_TARGET="${arg}"
+            elif [[ "${PREV_ARG}" == "--bundles" || "${PREV_ARG}" == "-b" ]]; then
+                BUILD_BUNDLES="${arg}"
             fi
             ;;
     esac
     PREV_ARG="${arg}"
 done
+
+# A DMG is expected unless the caller restricted --bundles to a list without
+# one. Tauri accepts the list space- or comma-separated.
+DMG_EXPECTED="true"
+if [[ -n "${BUILD_BUNDLES}" ]]; then
+    case ",${BUILD_BUNDLES//[[:space:]]/,}," in
+        *,dmg,*) DMG_EXPECTED="true" ;;
+        *) DMG_EXPECTED="false" ;;
+    esac
+fi
 
 # ── Build the --config overlay JSON ────────────────────────────────────────
 # Built with node rather than ad-hoc string concat so identity values
@@ -127,7 +144,12 @@ CONFIG_OVERLAY=$(
 
 # ── Write config overlay to a temp file ────────────────────────────────────
 # `tauri build --config` expects a file path, not an inline JSON string.
-CONFIG_FILE=$(mktemp "${TMPDIR:-/tmp}/cmtrace_tauri_conf_XXXXXX.json")
+# BSD mktemp only substitutes a *trailing* run of Xs, so a template ending in
+# `.json` was left completely literal: every run produced the same predictable
+# path instead of a unique one. A private temp directory keeps the .json
+# extension while actually being unique.
+CONFIG_DIR=$(mktemp -d "${TMPDIR:-/tmp}/cmtrace_tauri_conf_XXXXXX")
+CONFIG_FILE="${CONFIG_DIR}/config.json"
 printf '%s' "${CONFIG_OVERLAY}" > "${CONFIG_FILE}"
 
 # ── Echo plan ──────────────────────────────────────────────────────────────
@@ -152,7 +174,7 @@ echo "────────────────────────�
 # *which* failure it is looking at.
 BUILD_STAMP=$(mktemp "${TMPDIR:-/tmp}/cmtrace_build_stamp_XXXXXX")
 BUILD_LOG=$(mktemp "${TMPDIR:-/tmp}/cmtrace_build_log_XXXXXX")
-trap 'rm -f "${CONFIG_FILE}" "${BUILD_STAMP}" "${BUILD_LOG}"' EXIT
+trap 'rm -rf "${CONFIG_DIR}"; rm -f "${BUILD_STAMP}" "${BUILD_LOG}"' EXIT
 
 set +e
 npx tauri build --config "${CONFIG_FILE}" "$@" 2>&1 | tee "${BUILD_LOG}"
@@ -175,24 +197,43 @@ DMG_PATH=$(find "${BUNDLE_DIR}/dmg" -maxdepth 1 -name "*.dmg" \
 # This runs on the success path as well, because a zero exit from Tauri is
 # not by itself evidence that a *signed* .app was produced. Shipping an
 # unsigned or unnotarized build to direct download is the failure this
-# guards against. `codesign` alone is the right check when notarization was
-# not attempted, which is the documented signed-but-not-notarized fallback.
+# guards against.
+#
+# The DMG is checked as strictly as the .app, because it is the artifact
+# users actually download. Tauri's own DMG bundler signs it and staples the
+# notarization ticket to it (`codesign -s "${SIGNATURE}" "${DMG_DIR}/${DMG_NAME}"`
+# and `xcrun stapler staple "${DMG_DIR}/${DMG_NAME}"` in its bundle_dmg.sh),
+# so a DMG that fails these checks means that step did not happen.
+#
+# `stapler` is conditional on NOTARIZE_MODE because the documented
+# signed-but-not-notarized fallback has no ticket to validate.
+validate_one() {
+    local kind="$1" path="$2"
+    if ! codesign --verify --deep --strict "${path}" >/dev/null 2>&1; then
+        echo "error: ${kind} code signature missing or invalid: ${path}" >&2
+        return 1
+    fi
+    if [[ "${NOTARIZE_MODE}" != "none" ]] \
+        && ! xcrun stapler validate "${path}" >/dev/null 2>&1; then
+        echo "error: ${kind} notarization ticket missing or invalid: ${path}" >&2
+        return 1
+    fi
+    return 0
+}
+
 validate_deliverables() {
     if [[ -z "${APP_PATH}" ]]; then
         echo "error: no .app newer than the build stamp under ${BUNDLE_DIR}/macos." >&2
         return 1
     fi
-    if ! codesign --verify --deep --strict "${APP_PATH}" >/dev/null 2>&1; then
-        echo "error: code signature missing or invalid: ${APP_PATH}" >&2
-        return 1
-    fi
-    if [[ "${NOTARIZE_MODE}" != "none" ]] \
-        && ! xcrun stapler validate "${APP_PATH}" >/dev/null 2>&1; then
-        echo "error: notarization ticket missing or invalid: ${APP_PATH}" >&2
-        return 1
-    fi
-    if [[ -z "${DMG_PATH}" ]]; then
-        echo "warning: no .dmg newer than the build stamp under ${BUNDLE_DIR}/dmg." >&2
+    validate_one ".app" "${APP_PATH}" || return 1
+
+    if [[ "${DMG_EXPECTED}" == "true" ]]; then
+        if [[ -z "${DMG_PATH}" ]]; then
+            echo "error: no .dmg newer than the build stamp under ${BUNDLE_DIR}/dmg." >&2
+            return 1
+        fi
+        validate_one ".dmg" "${DMG_PATH}" || return 1
     fi
     return 0
 }
@@ -215,9 +256,9 @@ if [[ ${TAURI_EXIT} -ne 0 ]]; then
     validate_deliverables || exit "${TAURI_EXIT}"
 
     cat >&2 <<EOF
-warning: tauri build exited ${TAURI_EXIT}, but the signed .app is present and
-         its signature is valid. The exit code is from the updater-bundle
-         signing step (TAURI_SIGNING_PRIVATE_KEY is not set).
+warning: tauri build exited ${TAURI_EXIT}, but the expected deliverables are
+         present and their signatures validate. The exit code is from the
+         updater-bundle signing step (TAURI_SIGNING_PRIVATE_KEY is not set).
          Treating as success.
 EOF
 else

--- a/scripts/build-mac-signed.sh
+++ b/scripts/build-mac-signed.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Build CMTrace Open for macOS with Developer ID signing (and optional notarization).
+#
+# All credentials come from environment variables — nothing is hardcoded so the
+# script is safe to commit and contributors can configure their own identity.
+#
+# Required:
+#   APPLE_SIGNING_IDENTITY    Full identity string from `security find-identity
+#                             -v -p codesigning`, e.g.
+#                             "Developer ID Application: Jane Doe (ABC1234567)"
+#
+# Optional (for notarization):
+#   APPLE_API_KEY             App Store Connect API key ID
+#   APPLE_API_ISSUER          App Store Connect API issuer UUID
+#   APPLE_API_KEY_PATH        Path to the .p8 private key file
+#
+#   --- OR (legacy, less preferred) ---
+#   APPLE_ID                  Apple ID email
+#   APPLE_PASSWORD            App-specific password
+#   APPLE_TEAM_ID             10-character team ID
+#
+# Notarization is automatic if the credentials are present; otherwise the
+# script signs but skips notarization. A Developer ID-signed but unnotarized
+# build will Gatekeeper-warn on first launch (right-click → Open accepts it).
+#
+# Why this script overrides via --config rather than the env var directly:
+# tauri.conf.json keeps "signingIdentity": "-" as the default so contributors
+# without an Apple Developer cert can still produce ad-hoc-signed builds. The
+# JSON value takes precedence over APPLE_SIGNING_IDENTITY when both are set,
+# so this script forwards a `--config` overlay that swaps the identity at
+# build time without touching the file on disk.
+#
+# Usage:
+#   ./scripts/build-mac-signed.sh                # release build
+#   ./scripts/build-mac-signed.sh --debug        # debug build
+#   ./scripts/build-mac-signed.sh --no-bundle    # exe only, skip DMG
+
+set -euo pipefail
+
+# ── Resolve repo root from script location ─────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# ── Validate signing identity ──────────────────────────────────────────────
+if [[ -z "${APPLE_SIGNING_IDENTITY:-}" ]]; then
+    cat >&2 <<'EOF'
+error: APPLE_SIGNING_IDENTITY is not set.
+
+Pick an identity from your keychain:
+    security find-identity -v -p codesigning
+
+Then export it:
+    export APPLE_SIGNING_IDENTITY="Developer ID Application: Jane Doe (ABC1234567)"
+
+For unsigned ad-hoc builds (which is what contributors without a cert get
+by default), use `npm run app:build:release` instead — it reads the
+"signingIdentity": "-" entry in tauri.conf.json.
+EOF
+    exit 1
+fi
+
+# ── Detect notarization mode ───────────────────────────────────────────────
+NOTARIZE_MODE="none"
+if [[ -n "${APPLE_API_KEY:-}" && -n "${APPLE_API_ISSUER:-}" && -n "${APPLE_API_KEY_PATH:-}" ]]; then
+    NOTARIZE_MODE="api-key"
+elif [[ -n "${APPLE_ID:-}" && -n "${APPLE_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-}" ]]; then
+    NOTARIZE_MODE="apple-id"
+fi
+
+# ── Build the --config overlay JSON ────────────────────────────────────────
+# Use python rather than ad-hoc string concat so identity values containing
+# parentheses, spaces, or quotes survive the round-trip safely.
+CONFIG_OVERLAY=$(
+    python3 -c '
+import json, os, sys
+overlay = {
+    "bundle": {
+        "macOS": {
+            "signingIdentity": os.environ["APPLE_SIGNING_IDENTITY"]
+        }
+    }
+}
+json.dump(overlay, sys.stdout)
+'
+)
+
+# ── Echo plan ──────────────────────────────────────────────────────────────
+echo "──────────────────────────────────────────────────────────────────"
+echo "  CMTrace Open: signed macOS build"
+echo "──────────────────────────────────────────────────────────────────"
+echo "  Identity:     ${APPLE_SIGNING_IDENTITY}"
+echo "  Notarize:     ${NOTARIZE_MODE}"
+echo "  Tauri args:   $*"
+echo "──────────────────────────────────────────────────────────────────"
+
+# ── Run Tauri build ────────────────────────────────────────────────────────
+# Tauri reads APPLE_API_KEY*, APPLE_ID/PASSWORD/TEAM_ID directly from the
+# environment for notarization. We pass the signing identity via --config
+# so it overrides the on-disk default of "-".
+exec npx tauri build --config "${CONFIG_OVERLAY}" "$@"

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -14,9 +14,10 @@
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
 
-    <!-- The app reads user-selected log files; do not sandbox arbitrary file access. -->
-    <key>com.apple.security.app-sandbox</key>
-    <false/>
+    <!-- Deliberately NOT sandboxed: the app reads user-selected log files from
+         arbitrary paths. Entitlements are expressed by presence, so the
+         sandbox is disabled by omitting com.apple.security.app-sandbox
+         entirely rather than by setting it to false. -->
 
     <!-- Allow outbound network for the auto-updater and JAMF JSS connectivity probes. -->
     <key>com.apple.security.network.client</key>

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required for Tauri's WebKit/JavaScriptCore JIT under hardened runtime. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+
+    <!-- Tauri injects bytes into the WebView; needed for hardened runtime. -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+
+    <!-- Some Tauri plugins (notify, watcher) load dylibs at runtime. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+
+    <!-- The app reads user-selected log files; do not sandbox arbitrary file access. -->
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+
+    <!-- Allow outbound network for the auto-updater and JAMF JSS connectivity probes. -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -80,7 +80,8 @@
     },
     "macOS": {
       "minimumSystemVersion": "10.15",
-      "signingIdentity": "-"
+      "signingIdentity": "-",
+      "entitlements": "entitlements.plist"
     },
     "linux": {
       "deb": {


### PR DESCRIPTION
Split out of #315 — these 4 commits were sitting in the JAMF workspace branch but have nothing to do with JAMF, and they touch no files that branch touches. Extracted onto current `main` so they can land on their own instead of waiting on a 47-file workspace review.

Related: #314

## What this adds

- **`scripts/build-mac-signed.sh`** — a signed/notarized macOS build script
- **`src-tauri/entitlements.plist`** plus `"entitlements": "entitlements.plist"` under `bundle.macOS` in `tauri.conf.json` (a 2-line config change; `signingIdentity` is untouched)
- **`.env.example`** — a template documenting `APPLE_SIGNING_IDENTITY`, the App Store Connect API key trio, and the legacy Apple-ID fallback. The script auto-sources `.env.local` from the repo root, so filling in the copy is the whole setup.
- **Updater-key handling** — a missing updater key is now a warning rather than a hard failure, so a signed build is possible without one
- **Docs fix** — clarifies that `--no-bundle` is unsupported for this flow

## Secrets handling

`.env.example` contains placeholders only — no real identities, keys, or passwords. `.env.local` is already covered by `.gitignore:39` (verified with `git check-ignore`), so a filled-in copy cannot be committed by accident. Notarization is skipped rather than failed when the credentials are blank.

## Verification

- `cargo check` — clean; confirms Tauri still parses the modified `tauri.conf.json`
- `tauri.conf.json` — valid JSON, version reads 1.5.0
- `src-tauri/entitlements.plist` — `plutil -lint` OK
- `scripts/build-mac-signed.sh` — `bash -n` parses
- All 4 commits cherry-picked onto current `main` with **no conflicts**

## Not verified

A real signed-and-notarized build has not been produced from this branch — that needs Developer ID credentials I don't have. The config is validated as parseable and the script as syntactically sound, but the signing path itself is unexercised. Worth one `./scripts/build-mac-signed.sh` run with your credentials before relying on it for a release.

Note that the repo already signs macOS releases through CI (`codesign.yml`), so this is a **local** signed-build path rather than a change to release automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS workflow for creating signed application packages with optional notarization.
  * Added configuration guidance for Apple signing identities and notarization credentials.
  * Added macOS entitlements supporting required runtime capabilities and network access.

* **Bug Fixes**
  * Improved build handling so valid signed application artifacts can still be produced when optional updater signing fails.
  * Added validation for application signatures, fresh build artifacts, and notarization stapling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->