### PR TITLE
feat(sccm): establish shared diagnostic contract boundary (#318 Phase A)

### DIFF
--- a/crates/cmtraceopen-parser/src/lib.rs
+++ b/crates/cmtraceopen-parser/src/lib.rs
@@ -14,3 +14,4 @@ pub mod esp;
 pub mod intune;
 pub mod models;
 pub mod parser;
+pub mod sccm;

--- a/crates/cmtraceopen-parser/src/sccm/catalog.rs
+++ b/crates/cmtraceopen-parser/src/sccm/catalog.rs
@@ -1,9 +1,10 @@
-use serde::{Deserialize, Serialize};
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
 
-use super::{SccmRole, SccmRotation};
+use super::{SccmRole, SccmRotation, SccmUnknownRotation};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SccmArtifactFamily {
     ClientSetup,
     ClientHealth,
@@ -25,9 +26,72 @@ pub enum SccmArtifactFamily {
     Unknown(String),
 }
 
+impl SccmArtifactFamily {
+    fn serialized_name(&self) -> &str {
+        match self {
+            Self::ClientSetup => "clientSetup",
+            Self::ClientHealth => "clientHealth",
+            Self::ClientIdentity => "clientIdentity",
+            Self::ClientLocation => "clientLocation",
+            Self::ClientPolicy => "clientPolicy",
+            Self::ClientContent => "clientContent",
+            Self::ClientApplication => "clientApplication",
+            Self::ClientUpdates => "clientUpdates",
+            Self::ClientTaskSequence => "clientTaskSequence",
+            Self::SiteComponent => "siteComponent",
+            Self::SiteStatus => "siteStatus",
+            Self::ManagementPoint => "managementPoint",
+            Self::DistributionPoint => "distributionPoint",
+            Self::SoftwareUpdatePoint => "softwareUpdatePoint",
+            Self::Hierarchy => "hierarchy",
+            Self::Provider => "provider",
+            Self::AdminService => "adminService",
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+impl Serialize for SccmArtifactFamily {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.serialized_name())
+    }
+}
+
+impl<'de> Deserialize<'de> for SccmArtifactFamily {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(match String::deserialize(deserializer)? {
+            value if value == "clientSetup" => Self::ClientSetup,
+            value if value == "clientHealth" => Self::ClientHealth,
+            value if value == "clientIdentity" => Self::ClientIdentity,
+            value if value == "clientLocation" => Self::ClientLocation,
+            value if value == "clientPolicy" => Self::ClientPolicy,
+            value if value == "clientContent" => Self::ClientContent,
+            value if value == "clientApplication" => Self::ClientApplication,
+            value if value == "clientUpdates" => Self::ClientUpdates,
+            value if value == "clientTaskSequence" => Self::ClientTaskSequence,
+            value if value == "siteComponent" => Self::SiteComponent,
+            value if value == "siteStatus" => Self::SiteStatus,
+            value if value == "managementPoint" => Self::ManagementPoint,
+            value if value == "distributionPoint" => Self::DistributionPoint,
+            value if value == "softwareUpdatePoint" => Self::SoftwareUpdatePoint,
+            value if value == "hierarchy" => Self::Hierarchy,
+            value if value == "provider" => Self::Provider,
+            value if value == "adminService" => Self::AdminService,
+            value => Self::Unknown(value),
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SccmSourceCatalogEntry {
+    pub basename: String,
     pub logical_name: String,
     pub role: SccmRole,
     pub family: SccmArtifactFamily,
@@ -329,34 +393,72 @@ const SOURCE_CATALOG: &[CatalogSpec] = &[
     CatalogSpec {
         basename: "AdminService",
         logical_name: "adminService",
-        role: SccmRole::Provider,
+        role: SccmRole::AdminService,
         family: SccmArtifactFamily::AdminService,
+    },
+];
+
+struct CatalogRoleAlias {
+    basename: &'static str,
+    role: SccmRole,
+}
+
+const ADDITIONAL_ALLOWED_ROLES: &[CatalogRoleAlias] = &[
+    CatalogRoleAlias {
+        basename: "distmgr",
+        role: SccmRole::DistributionPoint,
+    },
+    CatalogRoleAlias {
+        basename: "PkgXferMgr",
+        role: SccmRole::DistributionPoint,
+    },
+    CatalogRoleAlias {
+        basename: "SMSDPProv",
+        role: SccmRole::SiteServer,
+    },
+    CatalogRoleAlias {
+        basename: "PullDP",
+        role: SccmRole::SiteServer,
+    },
+    CatalogRoleAlias {
+        basename: "WCM",
+        role: SccmRole::WsUs,
+    },
+    CatalogRoleAlias {
+        basename: "WSUSCtrl",
+        role: SccmRole::WsUs,
+    },
+    CatalogRoleAlias {
+        basename: "wsyncmgr",
+        role: SccmRole::WsUs,
+    },
+    CatalogRoleAlias {
+        basename: "SUPSetup",
+        role: SccmRole::WsUs,
     },
 ];
 
 pub fn classify_artifact_name(name: &str, role: SccmRole) -> SccmSourceCatalogEntry {
     let parsed = ParsedArtifactName::from_name(name);
-    let known = if parsed.is_log_name {
-        SOURCE_CATALOG.iter().find(|entry| {
-            entry.basename.eq_ignore_ascii_case(parsed.basename) && entry.role == role
-        })
-    } else {
-        None
-    };
+    let known = SOURCE_CATALOG.iter().find(|entry| {
+        entry.basename.eq_ignore_ascii_case(parsed.basename) && role_is_allowed(entry, &role)
+    });
 
     if let Some(entry) = known {
         return SccmSourceCatalogEntry {
+            basename: format!("{}.log", entry.basename),
             logical_name: entry.logical_name.to_string(),
             role,
             family: entry.family.clone(),
             rotation: parsed.rotation,
             uses_ccm_records: true,
-            supported_for_diagnosis: true,
+            supported_for_diagnosis: parsed.rotation_supported,
         };
     }
 
     let logical_name = lower_camel_identifier(parsed.basename);
     SccmSourceCatalogEntry {
+        basename: format!("{}.log", parsed.basename),
         family: SccmArtifactFamily::Unknown(logical_name.clone()),
         logical_name,
         role,
@@ -366,84 +468,174 @@ pub fn classify_artifact_name(name: &str, role: SccmRole) -> SccmSourceCatalogEn
     }
 }
 
+pub fn declared_source_catalog() -> Vec<SccmSourceCatalogEntry> {
+    let mut declared = Vec::with_capacity(SOURCE_CATALOG.len() + ADDITIONAL_ALLOWED_ROLES.len());
+
+    for entry in SOURCE_CATALOG {
+        declared.push(declared_catalog_entry(entry, entry.role.clone()));
+        for alias in ADDITIONAL_ALLOWED_ROLES
+            .iter()
+            .filter(|alias| alias.basename.eq_ignore_ascii_case(entry.basename))
+        {
+            declared.push(declared_catalog_entry(entry, alias.role.clone()));
+        }
+    }
+
+    declared
+}
+
+fn declared_catalog_entry(entry: &CatalogSpec, role: SccmRole) -> SccmSourceCatalogEntry {
+    SccmSourceCatalogEntry {
+        basename: format!("{}.log", entry.basename),
+        logical_name: entry.logical_name.to_string(),
+        role,
+        family: entry.family.clone(),
+        rotation: SccmRotation::Current,
+        uses_ccm_records: true,
+        supported_for_diagnosis: true,
+    }
+}
+
+fn role_is_allowed(entry: &CatalogSpec, role: &SccmRole) -> bool {
+    entry.role == *role
+        || ADDITIONAL_ALLOWED_ROLES
+            .iter()
+            .any(|alias| alias.basename.eq_ignore_ascii_case(entry.basename) && alias.role == *role)
+}
+
 struct ParsedArtifactName<'a> {
     basename: &'a str,
     rotation: SccmRotation,
-    is_log_name: bool,
+    rotation_supported: bool,
 }
 
 impl<'a> ParsedArtifactName<'a> {
     fn from_name(name: &'a str) -> Self {
         let lowercase = name.to_ascii_lowercase();
 
-        if lowercase.ends_with(".log.lo_") {
+        if lowercase.ends_with(".log") {
             return Self {
-                basename: &name[..name.len() - ".log.lo_".len()],
-                rotation: SccmRotation::LoUnderscore,
-                is_log_name: true,
+                basename: &name[..name.len() - ".log".len()],
+                rotation: SccmRotation::Current,
+                rotation_supported: true,
+            };
+        }
+
+        if let Some(separator) = lowercase.rfind(".log.") {
+            let suffix = &name[separator + ".log.".len()..];
+            let lowercase_suffix = &lowercase[separator + ".log.".len()..];
+            let rotation = if lowercase_suffix == "lo_" {
+                Some(SccmRotation::LoUnderscore)
+            } else if is_canonical_rotation_number(suffix) {
+                suffix.parse::<u32>().ok().map(SccmRotation::Numbered)
+            } else if is_canonical_rotation_timestamp(suffix) {
+                Some(SccmRotation::Timestamped(suffix.to_string()))
+            } else {
+                None
+            };
+
+            if let Some(rotation) = rotation {
+                return Self {
+                    basename: &name[..separator],
+                    rotation,
+                    rotation_supported: true,
+                };
+            }
+
+            return Self {
+                basename: &name[..separator],
+                rotation: unknown_filename_suffix(&name[separator + ".log".len()..]),
+                rotation_supported: false,
             };
         }
 
         if lowercase.ends_with(".lo_") {
             return Self {
                 basename: &name[..name.len() - ".lo_".len()],
-                rotation: SccmRotation::LoUnderscore,
-                is_log_name: true,
+                rotation: unknown_filename_suffix(".lo_"),
+                rotation_supported: false,
             };
         }
 
-        if let Some(separator) = lowercase.rfind(".log.") {
-            let suffix = &lowercase[separator + ".log.".len()..];
-            if !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit()) {
-                if let Ok(number) = suffix.parse::<u32>() {
-                    return Self {
-                        basename: &name[..separator],
-                        rotation: SccmRotation::Numbered(number),
-                        is_log_name: true,
-                    };
-                }
-            }
-        }
-
-        if lowercase.ends_with(".log") {
+        if let Some(separator) = name.rfind('.') {
             return Self {
-                basename: &name[..name.len() - ".log".len()],
-                rotation: SccmRotation::Current,
-                is_log_name: true,
+                basename: &name[..separator],
+                rotation: unknown_filename_suffix(&name[separator..]),
+                rotation_supported: false,
             };
         }
 
         Self {
             basename: name,
-            rotation: SccmRotation::Current,
-            is_log_name: false,
+            rotation: unknown_filename_suffix(""),
+            rotation_supported: false,
         }
     }
 }
 
+fn is_canonical_rotation_number(value: &str) -> bool {
+    value
+        .as_bytes()
+        .first()
+        .is_some_and(|first| first.is_ascii_digit() && *first != b'0')
+        && value.bytes().all(|byte| byte.is_ascii_digit())
+        && value.parse::<u32>().is_ok()
+}
+
+/// Timestamped rotations use exactly `YYYYMMDD-HHMMSS` in the artifact filename.
+fn is_canonical_rotation_timestamp(value: &str) -> bool {
+    value.len() == "YYYYMMDD-HHMMSS".len()
+        && NaiveDateTime::parse_from_str(value, "%Y%m%d-%H%M%S")
+            .is_ok_and(|timestamp| timestamp.format("%Y%m%d-%H%M%S").to_string() == value)
+}
+
+fn unknown_filename_suffix(raw_suffix: &str) -> SccmRotation {
+    SccmRotation::Unknown(SccmUnknownRotation {
+        kind: "filenameSuffix".to_string(),
+        value: Some(Value::String(raw_suffix.to_string())),
+    })
+}
+
 fn lower_camel_identifier(value: &str) -> String {
-    let mut result = String::new();
-    let mut capitalize_next = false;
+    let mut words = value
+        .split(|character: char| !character.is_alphanumeric())
+        .filter(|word| !word.is_empty());
+    let Some(first) = words.next() else {
+        return "unknown".to_string();
+    };
 
-    for character in value.chars() {
-        if !character.is_alphanumeric() {
-            capitalize_next = !result.is_empty();
-            continue;
-        }
-
-        if result.is_empty() {
-            result.extend(character.to_lowercase());
-        } else if capitalize_next {
-            result.extend(character.to_uppercase());
-            capitalize_next = false;
-        } else {
-            result.push(character);
+    let mut result = lower_leading_initialism(first);
+    for word in words {
+        let mut characters = word.chars();
+        if let Some(first) = characters.next() {
+            result.extend(first.to_uppercase());
+            result.extend(characters);
         }
     }
+    result
+}
 
-    if result.is_empty() {
-        "unknown".to_string()
+fn lower_leading_initialism(word: &str) -> String {
+    let characters: Vec<char> = word.chars().collect();
+    let uppercase_run = characters
+        .iter()
+        .take_while(|character| character.is_uppercase())
+        .count();
+    let lowercase_count = if uppercase_run > 1
+        && uppercase_run < characters.len()
+        && characters[uppercase_run].is_lowercase()
+    {
+        uppercase_run - 1
     } else {
-        result
+        uppercase_run
+    };
+
+    let mut result = String::new();
+    for character in &characters[..lowercase_count] {
+        result.extend(character.to_lowercase());
     }
+    for character in &characters[lowercase_count..] {
+        result.push(*character);
+    }
+    result
 }

--- a/crates/cmtraceopen-parser/src/sccm/catalog.rs
+++ b/crates/cmtraceopen-parser/src/sccm/catalog.rs
@@ -1,0 +1,449 @@
+use serde::{Deserialize, Serialize};
+
+use super::{SccmRole, SccmRotation};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmArtifactFamily {
+    ClientSetup,
+    ClientHealth,
+    ClientIdentity,
+    ClientLocation,
+    ClientPolicy,
+    ClientContent,
+    ClientApplication,
+    ClientUpdates,
+    ClientTaskSequence,
+    SiteComponent,
+    SiteStatus,
+    ManagementPoint,
+    DistributionPoint,
+    SoftwareUpdatePoint,
+    Hierarchy,
+    Provider,
+    AdminService,
+    Unknown(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSourceCatalogEntry {
+    pub logical_name: String,
+    pub role: SccmRole,
+    pub family: SccmArtifactFamily,
+    pub rotation: SccmRotation,
+    pub uses_ccm_records: bool,
+    pub supported_for_diagnosis: bool,
+}
+
+struct CatalogSpec {
+    basename: &'static str,
+    logical_name: &'static str,
+    role: SccmRole,
+    family: SccmArtifactFamily,
+}
+
+const SOURCE_CATALOG: &[CatalogSpec] = &[
+    CatalogSpec {
+        basename: "CCMSetup",
+        logical_name: "ccmSetup",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientSetup,
+    },
+    CatalogSpec {
+        basename: "CcmEval",
+        logical_name: "ccmEval",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientHealth,
+    },
+    CatalogSpec {
+        basename: "CcmExec",
+        logical_name: "ccmExec",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientHealth,
+    },
+    CatalogSpec {
+        basename: "CcmRestart",
+        logical_name: "ccmRestart",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientHealth,
+    },
+    CatalogSpec {
+        basename: "ClientIDManagerStartup",
+        logical_name: "clientIdManagerStartup",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientIdentity,
+    },
+    CatalogSpec {
+        basename: "ClientLocation",
+        logical_name: "clientLocation",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientLocation,
+    },
+    CatalogSpec {
+        basename: "LocationServices",
+        logical_name: "locationServices",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientLocation,
+    },
+    CatalogSpec {
+        basename: "CcmMessaging",
+        logical_name: "ccmMessaging",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientLocation,
+    },
+    CatalogSpec {
+        basename: "PolicyAgent",
+        logical_name: "policyAgent",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientPolicy,
+    },
+    CatalogSpec {
+        basename: "PolicyAgentProvider",
+        logical_name: "policyAgentProvider",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientPolicy,
+    },
+    CatalogSpec {
+        basename: "PolicyEvaluator",
+        logical_name: "policyEvaluator",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientPolicy,
+    },
+    CatalogSpec {
+        basename: "Scheduler",
+        logical_name: "scheduler",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientPolicy,
+    },
+    CatalogSpec {
+        basename: "CAS",
+        logical_name: "cas",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientContent,
+    },
+    CatalogSpec {
+        basename: "ContentTransferManager",
+        logical_name: "contentTransferManager",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientContent,
+    },
+    CatalogSpec {
+        basename: "DataTransferService",
+        logical_name: "dataTransferService",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientContent,
+    },
+    CatalogSpec {
+        basename: "AppIntentEval",
+        logical_name: "appIntentEval",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientApplication,
+    },
+    CatalogSpec {
+        basename: "AppDiscovery",
+        logical_name: "appDiscovery",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientApplication,
+    },
+    CatalogSpec {
+        basename: "AppEnforce",
+        logical_name: "appEnforce",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientApplication,
+    },
+    CatalogSpec {
+        basename: "ScanAgent",
+        logical_name: "scanAgent",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientUpdates,
+    },
+    CatalogSpec {
+        basename: "WUAHandler",
+        logical_name: "wuaHandler",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientUpdates,
+    },
+    CatalogSpec {
+        basename: "UpdatesDeployment",
+        logical_name: "updatesDeployment",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientUpdates,
+    },
+    CatalogSpec {
+        basename: "UpdatesHandler",
+        logical_name: "updatesHandler",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientUpdates,
+    },
+    CatalogSpec {
+        basename: "UpdatesStore",
+        logical_name: "updatesStore",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientUpdates,
+    },
+    CatalogSpec {
+        basename: "smsts",
+        logical_name: "smsts",
+        role: SccmRole::Client,
+        family: SccmArtifactFamily::ClientTaskSequence,
+    },
+    CatalogSpec {
+        basename: "sitecomp",
+        logical_name: "sitecomp",
+        role: SccmRole::SiteServer,
+        family: SccmArtifactFamily::SiteComponent,
+    },
+    CatalogSpec {
+        basename: "hman",
+        logical_name: "hman",
+        role: SccmRole::SiteServer,
+        family: SccmArtifactFamily::SiteComponent,
+    },
+    CatalogSpec {
+        basename: "statmgr",
+        logical_name: "statmgr",
+        role: SccmRole::SiteServer,
+        family: SccmArtifactFamily::SiteStatus,
+    },
+    CatalogSpec {
+        basename: "statesys",
+        logical_name: "statesys",
+        role: SccmRole::SiteServer,
+        family: SccmArtifactFamily::SiteStatus,
+    },
+    CatalogSpec {
+        basename: "MP_CliReg",
+        logical_name: "mpCliReg",
+        role: SccmRole::ManagementPoint,
+        family: SccmArtifactFamily::ManagementPoint,
+    },
+    CatalogSpec {
+        basename: "MP_GetAuth",
+        logical_name: "mpGetAuth",
+        role: SccmRole::ManagementPoint,
+        family: SccmArtifactFamily::ManagementPoint,
+    },
+    CatalogSpec {
+        basename: "MP_GetPolicy",
+        logical_name: "mpGetPolicy",
+        role: SccmRole::ManagementPoint,
+        family: SccmArtifactFamily::ManagementPoint,
+    },
+    CatalogSpec {
+        basename: "MP_Location",
+        logical_name: "mpLocation",
+        role: SccmRole::ManagementPoint,
+        family: SccmArtifactFamily::ManagementPoint,
+    },
+    CatalogSpec {
+        basename: "MP_RegistrationManager",
+        logical_name: "mpRegistrationManager",
+        role: SccmRole::ManagementPoint,
+        family: SccmArtifactFamily::ManagementPoint,
+    },
+    CatalogSpec {
+        basename: "mpcontrol",
+        logical_name: "mpcontrol",
+        role: SccmRole::ManagementPoint,
+        family: SccmArtifactFamily::ManagementPoint,
+    },
+    CatalogSpec {
+        basename: "distmgr",
+        logical_name: "distmgr",
+        role: SccmRole::SiteServer,
+        family: SccmArtifactFamily::DistributionPoint,
+    },
+    CatalogSpec {
+        basename: "PkgXferMgr",
+        logical_name: "pkgXferMgr",
+        role: SccmRole::SiteServer,
+        family: SccmArtifactFamily::DistributionPoint,
+    },
+    CatalogSpec {
+        basename: "SMSDPProv",
+        logical_name: "smsDpProv",
+        role: SccmRole::DistributionPoint,
+        family: SccmArtifactFamily::DistributionPoint,
+    },
+    CatalogSpec {
+        basename: "PullDP",
+        logical_name: "pullDp",
+        role: SccmRole::DistributionPoint,
+        family: SccmArtifactFamily::DistributionPoint,
+    },
+    CatalogSpec {
+        basename: "WCM",
+        logical_name: "wcm",
+        role: SccmRole::SoftwareUpdatePoint,
+        family: SccmArtifactFamily::SoftwareUpdatePoint,
+    },
+    CatalogSpec {
+        basename: "WSUSCtrl",
+        logical_name: "wsusCtrl",
+        role: SccmRole::SoftwareUpdatePoint,
+        family: SccmArtifactFamily::SoftwareUpdatePoint,
+    },
+    CatalogSpec {
+        basename: "wsyncmgr",
+        logical_name: "wsyncmgr",
+        role: SccmRole::SoftwareUpdatePoint,
+        family: SccmArtifactFamily::SoftwareUpdatePoint,
+    },
+    CatalogSpec {
+        basename: "SUPSetup",
+        logical_name: "supSetup",
+        role: SccmRole::SoftwareUpdatePoint,
+        family: SccmArtifactFamily::SoftwareUpdatePoint,
+    },
+    CatalogSpec {
+        basename: "replmgr",
+        logical_name: "replmgr",
+        role: SccmRole::SiteServer,
+        family: SccmArtifactFamily::Hierarchy,
+    },
+    CatalogSpec {
+        basename: "rcmctrl",
+        logical_name: "rcmctrl",
+        role: SccmRole::SiteServer,
+        family: SccmArtifactFamily::Hierarchy,
+    },
+    CatalogSpec {
+        basename: "sender",
+        logical_name: "sender",
+        role: SccmRole::SiteServer,
+        family: SccmArtifactFamily::Hierarchy,
+    },
+    CatalogSpec {
+        basename: "despool",
+        logical_name: "despool",
+        role: SccmRole::SiteServer,
+        family: SccmArtifactFamily::Hierarchy,
+    },
+    CatalogSpec {
+        basename: "Smsprov",
+        logical_name: "smsprov",
+        role: SccmRole::Provider,
+        family: SccmArtifactFamily::Provider,
+    },
+    CatalogSpec {
+        basename: "AdminService",
+        logical_name: "adminService",
+        role: SccmRole::Provider,
+        family: SccmArtifactFamily::AdminService,
+    },
+];
+
+pub fn classify_artifact_name(name: &str, role: SccmRole) -> SccmSourceCatalogEntry {
+    let parsed = ParsedArtifactName::from_name(name);
+    let known = if parsed.is_log_name {
+        SOURCE_CATALOG.iter().find(|entry| {
+            entry.basename.eq_ignore_ascii_case(parsed.basename) && entry.role == role
+        })
+    } else {
+        None
+    };
+
+    if let Some(entry) = known {
+        return SccmSourceCatalogEntry {
+            logical_name: entry.logical_name.to_string(),
+            role,
+            family: entry.family.clone(),
+            rotation: parsed.rotation,
+            uses_ccm_records: true,
+            supported_for_diagnosis: true,
+        };
+    }
+
+    let logical_name = lower_camel_identifier(parsed.basename);
+    SccmSourceCatalogEntry {
+        family: SccmArtifactFamily::Unknown(logical_name.clone()),
+        logical_name,
+        role,
+        rotation: parsed.rotation,
+        uses_ccm_records: false,
+        supported_for_diagnosis: false,
+    }
+}
+
+struct ParsedArtifactName<'a> {
+    basename: &'a str,
+    rotation: SccmRotation,
+    is_log_name: bool,
+}
+
+impl<'a> ParsedArtifactName<'a> {
+    fn from_name(name: &'a str) -> Self {
+        let lowercase = name.to_ascii_lowercase();
+
+        if lowercase.ends_with(".log.lo_") {
+            return Self {
+                basename: &name[..name.len() - ".log.lo_".len()],
+                rotation: SccmRotation::LoUnderscore,
+                is_log_name: true,
+            };
+        }
+
+        if lowercase.ends_with(".lo_") {
+            return Self {
+                basename: &name[..name.len() - ".lo_".len()],
+                rotation: SccmRotation::LoUnderscore,
+                is_log_name: true,
+            };
+        }
+
+        if let Some(separator) = lowercase.rfind(".log.") {
+            let suffix = &lowercase[separator + ".log.".len()..];
+            if !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit()) {
+                if let Ok(number) = suffix.parse::<u32>() {
+                    return Self {
+                        basename: &name[..separator],
+                        rotation: SccmRotation::Numbered(number),
+                        is_log_name: true,
+                    };
+                }
+            }
+        }
+
+        if lowercase.ends_with(".log") {
+            return Self {
+                basename: &name[..name.len() - ".log".len()],
+                rotation: SccmRotation::Current,
+                is_log_name: true,
+            };
+        }
+
+        Self {
+            basename: name,
+            rotation: SccmRotation::Current,
+            is_log_name: false,
+        }
+    }
+}
+
+fn lower_camel_identifier(value: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize_next = false;
+
+    for character in value.chars() {
+        if !character.is_alphanumeric() {
+            capitalize_next = !result.is_empty();
+            continue;
+        }
+
+        if result.is_empty() {
+            result.extend(character.to_lowercase());
+        } else if capitalize_next {
+            result.extend(character.to_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(character);
+        }
+    }
+
+    if result.is_empty() {
+        "unknown".to_string()
+    } else {
+        result
+    }
+}

--- a/crates/cmtraceopen-parser/src/sccm/catalog.rs
+++ b/crates/cmtraceopen-parser/src/sccm/catalog.rs
@@ -499,8 +499,8 @@ impl<'a> ParsedArtifactName<'a> {
         if lowercase.ends_with(".lo_") {
             return Self {
                 basename: &name[..name.len() - ".lo_".len()],
-                rotation: unknown_filename_suffix(".lo_"),
-                rotation_supported: false,
+                rotation: SccmRotation::LoUnderscore,
+                rotation_supported: true,
             };
         }
 

--- a/crates/cmtraceopen-parser/src/sccm/catalog.rs
+++ b/crates/cmtraceopen-parser/src/sccm/catalog.rs
@@ -470,10 +470,7 @@ impl<'a> ParsedArtifactName<'a> {
 
         if let Some(separator) = lowercase.rfind(".log.") {
             let suffix = &name[separator + ".log.".len()..];
-            let lowercase_suffix = &lowercase[separator + ".log.".len()..];
-            let rotation = if lowercase_suffix == "lo_" {
-                Some(SccmRotation::LoUnderscore)
-            } else if let Some(number) = parse_canonical_rotation_number(suffix) {
+            let rotation = if let Some(number) = parse_canonical_rotation_number(suffix) {
                 Some(SccmRotation::Numbered(number))
             } else if is_canonical_rotation_timestamp(suffix) {
                 Some(SccmRotation::Timestamped(suffix.to_string()))

--- a/crates/cmtraceopen-parser/src/sccm/catalog.rs
+++ b/crates/cmtraceopen-parser/src/sccm/catalog.rs
@@ -339,7 +339,7 @@ const SOURCE_CATALOG: &[CatalogSpec] = &[
     CatalogSpec {
         basename: "WCM",
         logical_name: "wcm",
-        role: SccmRole::SoftwareUpdatePoint,
+        role: SccmRole::SiteServer,
         family: SccmArtifactFamily::SoftwareUpdatePoint,
     },
     CatalogSpec {
@@ -351,7 +351,7 @@ const SOURCE_CATALOG: &[CatalogSpec] = &[
     CatalogSpec {
         basename: "wsyncmgr",
         logical_name: "wsyncmgr",
-        role: SccmRole::SoftwareUpdatePoint,
+        role: SccmRole::SiteServer,
         family: SccmArtifactFamily::SoftwareUpdatePoint,
     },
     CatalogSpec {
@@ -393,56 +393,16 @@ const SOURCE_CATALOG: &[CatalogSpec] = &[
     CatalogSpec {
         basename: "AdminService",
         logical_name: "adminService",
-        role: SccmRole::AdminService,
+        role: SccmRole::Provider,
         family: SccmArtifactFamily::AdminService,
-    },
-];
-
-struct CatalogRoleAlias {
-    basename: &'static str,
-    role: SccmRole,
-}
-
-const ADDITIONAL_ALLOWED_ROLES: &[CatalogRoleAlias] = &[
-    CatalogRoleAlias {
-        basename: "distmgr",
-        role: SccmRole::DistributionPoint,
-    },
-    CatalogRoleAlias {
-        basename: "PkgXferMgr",
-        role: SccmRole::DistributionPoint,
-    },
-    CatalogRoleAlias {
-        basename: "SMSDPProv",
-        role: SccmRole::SiteServer,
-    },
-    CatalogRoleAlias {
-        basename: "PullDP",
-        role: SccmRole::SiteServer,
-    },
-    CatalogRoleAlias {
-        basename: "WCM",
-        role: SccmRole::WsUs,
-    },
-    CatalogRoleAlias {
-        basename: "WSUSCtrl",
-        role: SccmRole::WsUs,
-    },
-    CatalogRoleAlias {
-        basename: "wsyncmgr",
-        role: SccmRole::WsUs,
-    },
-    CatalogRoleAlias {
-        basename: "SUPSetup",
-        role: SccmRole::WsUs,
     },
 ];
 
 pub fn classify_artifact_name(name: &str, role: SccmRole) -> SccmSourceCatalogEntry {
     let parsed = ParsedArtifactName::from_name(name);
-    let known = SOURCE_CATALOG.iter().find(|entry| {
-        entry.basename.eq_ignore_ascii_case(parsed.basename) && role_is_allowed(entry, &role)
-    });
+    let known = SOURCE_CATALOG
+        .iter()
+        .find(|entry| entry.basename.eq_ignore_ascii_case(parsed.basename) && entry.role == role);
 
     if let Some(entry) = known {
         return SccmSourceCatalogEntry {
@@ -469,16 +429,10 @@ pub fn classify_artifact_name(name: &str, role: SccmRole) -> SccmSourceCatalogEn
 }
 
 pub fn declared_source_catalog() -> Vec<SccmSourceCatalogEntry> {
-    let mut declared = Vec::with_capacity(SOURCE_CATALOG.len() + ADDITIONAL_ALLOWED_ROLES.len());
+    let mut declared = Vec::with_capacity(SOURCE_CATALOG.len());
 
     for entry in SOURCE_CATALOG {
         declared.push(declared_catalog_entry(entry, entry.role.clone()));
-        for alias in ADDITIONAL_ALLOWED_ROLES
-            .iter()
-            .filter(|alias| alias.basename.eq_ignore_ascii_case(entry.basename))
-        {
-            declared.push(declared_catalog_entry(entry, alias.role.clone()));
-        }
     }
 
     declared
@@ -494,13 +448,6 @@ fn declared_catalog_entry(entry: &CatalogSpec, role: SccmRole) -> SccmSourceCata
         uses_ccm_records: true,
         supported_for_diagnosis: true,
     }
-}
-
-fn role_is_allowed(entry: &CatalogSpec, role: &SccmRole) -> bool {
-    entry.role == *role
-        || ADDITIONAL_ALLOWED_ROLES
-            .iter()
-            .any(|alias| alias.basename.eq_ignore_ascii_case(entry.basename) && alias.role == *role)
 }
 
 struct ParsedArtifactName<'a> {

--- a/crates/cmtraceopen-parser/src/sccm/catalog.rs
+++ b/crates/cmtraceopen-parser/src/sccm/catalog.rs
@@ -1,7 +1,7 @@
-use chrono::NaiveDateTime;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
+use super::rotation::{is_canonical_rotation_timestamp, parse_canonical_rotation_number};
 use super::{SccmRole, SccmRotation, SccmUnknownRotation};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -473,8 +473,8 @@ impl<'a> ParsedArtifactName<'a> {
             let lowercase_suffix = &lowercase[separator + ".log.".len()..];
             let rotation = if lowercase_suffix == "lo_" {
                 Some(SccmRotation::LoUnderscore)
-            } else if is_canonical_rotation_number(suffix) {
-                suffix.parse::<u32>().ok().map(SccmRotation::Numbered)
+            } else if let Some(number) = parse_canonical_rotation_number(suffix) {
+                Some(SccmRotation::Numbered(number))
             } else if is_canonical_rotation_timestamp(suffix) {
                 Some(SccmRotation::Timestamped(suffix.to_string()))
             } else {
@@ -518,22 +518,6 @@ impl<'a> ParsedArtifactName<'a> {
             rotation_supported: false,
         }
     }
-}
-
-fn is_canonical_rotation_number(value: &str) -> bool {
-    value
-        .as_bytes()
-        .first()
-        .is_some_and(|first| first.is_ascii_digit() && *first != b'0')
-        && value.bytes().all(|byte| byte.is_ascii_digit())
-        && value.parse::<u32>().is_ok()
-}
-
-/// Timestamped rotations use exactly `YYYYMMDD-HHMMSS` in the artifact filename.
-fn is_canonical_rotation_timestamp(value: &str) -> bool {
-    value.len() == "YYYYMMDD-HHMMSS".len()
-        && NaiveDateTime::parse_from_str(value, "%Y%m%d-%H%M%S")
-            .is_ok_and(|timestamp| timestamp.format("%Y%m%d-%H%M%S").to_string() == value)
 }
 
 fn unknown_filename_suffix(raw_suffix: &str) -> SccmRotation {

--- a/crates/cmtraceopen-parser/src/sccm/mod.rs
+++ b/crates/cmtraceopen-parser/src/sccm/mod.rs
@@ -1,0 +1,3 @@
+pub mod models;
+
+pub use models::*;

--- a/crates/cmtraceopen-parser/src/sccm/mod.rs
+++ b/crates/cmtraceopen-parser/src/sccm/mod.rs
@@ -1,5 +1,6 @@
 pub mod catalog;
 pub mod models;
+mod rotation;
 
 pub use catalog::*;
 pub use models::*;

--- a/crates/cmtraceopen-parser/src/sccm/mod.rs
+++ b/crates/cmtraceopen-parser/src/sccm/mod.rs
@@ -1,3 +1,5 @@
+pub mod catalog;
 pub mod models;
 
+pub use catalog::*;
 pub use models::*;

--- a/crates/cmtraceopen-parser/src/sccm/models.rs
+++ b/crates/cmtraceopen-parser/src/sccm/models.rs
@@ -50,9 +50,13 @@ impl SccmFindingClass {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(tag = "kind", content = "value", rename_all = "camelCase")]
 pub enum SccmRotation {
     Current,
+    LoUnderscore,
+    Numbered(u32),
+    Timestamped(String),
+    Unknown(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/cmtraceopen-parser/src/sccm/models.rs
+++ b/crates/cmtraceopen-parser/src/sccm/models.rs
@@ -1,0 +1,93 @@
+use serde::{Deserialize, Serialize};
+
+pub const SCCM_DIAGNOSTICS_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmCoverageState {
+    Captured,
+    Absent,
+    AccessDenied,
+    Capped,
+    Skipped,
+    Unsupported,
+    ParseFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmRole {
+    Client,
+    SiteServer,
+    ManagementPoint,
+    DistributionPoint,
+    SoftwareUpdatePoint,
+    WsUs,
+    Provider,
+    Unknown(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmFindingClass {
+    Symptom,
+    ConfirmedFailure,
+    BlockedOrDeferred,
+    LikelyContributor,
+    InsufficientEvidence,
+}
+
+impl SccmFindingClass {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Symptom => "symptom",
+            Self::ConfirmedFailure => "confirmedFailure",
+            Self::BlockedOrDeferred => "blockedOrDeferred",
+            Self::LikelyContributor => "likelyContributor",
+            Self::InsufficientEvidence => "insufficientEvidence",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmRotation {
+    Current,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmArtifact {
+    pub artifact_id: String,
+    pub display_name: String,
+    pub original_path: Option<String>,
+    pub host: Option<String>,
+    pub role: SccmRole,
+    pub configmgr_version: Option<String>,
+    pub collected_at_utc: Option<String>,
+    pub rotation: SccmRotation,
+    pub coverage: SccmCoverageState,
+    pub encoding: Option<String>,
+}
+
+impl SccmArtifact {
+    pub fn missing(
+        artifact_id: impl Into<String>,
+        display_name: impl Into<String>,
+        role: SccmRole,
+        coverage: SccmCoverageState,
+    ) -> Self {
+        Self {
+            artifact_id: artifact_id.into(),
+            display_name: display_name.into(),
+            original_path: None,
+            host: None,
+            role,
+            configmgr_version: None,
+            collected_at_utc: None,
+            rotation: SccmRotation::Current,
+            coverage,
+            encoding: None,
+        }
+    }
+}

--- a/crates/cmtraceopen-parser/src/sccm/models.rs
+++ b/crates/cmtraceopen-parser/src/sccm/models.rs
@@ -1,6 +1,8 @@
-use serde::ser::SerializeStruct;
+use serde::ser::{Error as _, SerializeStruct};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
+
+use super::rotation::{is_canonical_rotation_number, is_canonical_rotation_timestamp};
 
 pub const SCCM_DIAGNOSTICS_SCHEMA_VERSION: u32 = 1;
 
@@ -115,6 +117,20 @@ impl Serialize for SccmRotation {
     where
         S: Serializer,
     {
+        match self {
+            Self::Numbered(value) if !is_canonical_rotation_number(*value) => {
+                return Err(S::Error::custom(
+                    "numbered rotation value must be a nonzero u32",
+                ));
+            }
+            Self::Timestamped(value) if !is_canonical_rotation_timestamp(value) => {
+                return Err(S::Error::custom(
+                    "timestamped rotation value must use canonical YYYYMMDD-HHMMSS",
+                ));
+            }
+            _ => {}
+        }
+
         let field_count = match self {
             Self::Current | Self::LoUnderscore => 1,
             Self::Numbered(_) | Self::Timestamped(_) => 2,
@@ -183,6 +199,11 @@ impl<'de> Deserialize<'de> for SccmRotation {
                     .ok_or_else(|| {
                         serde::de::Error::custom("numbered rotation value must be a u32")
                     })?;
+                if !is_canonical_rotation_number(number) {
+                    return Err(serde::de::Error::custom(
+                        "numbered rotation value must be a nonzero u32",
+                    ));
+                }
                 Ok(Self::Numbered(number))
             }
             "timestamped" => {
@@ -191,6 +212,11 @@ impl<'de> Deserialize<'de> for SccmRotation {
                     .ok_or_else(|| {
                         serde::de::Error::custom("timestamped rotation value must be a string")
                     })?;
+                if !is_canonical_rotation_timestamp(&timestamp) {
+                    return Err(serde::de::Error::custom(
+                        "timestamped rotation value must use canonical YYYYMMDD-HHMMSS",
+                    ));
+                }
                 Ok(Self::Timestamped(timestamp))
             }
             _ => Ok(Self::Unknown(SccmUnknownRotation { kind, value })),

--- a/crates/cmtraceopen-parser/src/sccm/models.rs
+++ b/crates/cmtraceopen-parser/src/sccm/models.rs
@@ -1,4 +1,6 @@
-use serde::{Deserialize, Serialize};
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
 
 pub const SCCM_DIAGNOSTICS_SCHEMA_VERSION: u32 = 1;
 
@@ -14,8 +16,7 @@ pub enum SccmCoverageState {
     ParseFailed,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SccmRole {
     Client,
     SiteServer,
@@ -24,7 +25,52 @@ pub enum SccmRole {
     SoftwareUpdatePoint,
     WsUs,
     Provider,
+    AdminService,
     Unknown(String),
+}
+
+impl SccmRole {
+    fn serialized_name(&self) -> &str {
+        match self {
+            Self::Client => "client",
+            Self::SiteServer => "siteServer",
+            Self::ManagementPoint => "managementPoint",
+            Self::DistributionPoint => "distributionPoint",
+            Self::SoftwareUpdatePoint => "softwareUpdatePoint",
+            Self::WsUs => "wsUs",
+            Self::Provider => "provider",
+            Self::AdminService => "adminService",
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+impl Serialize for SccmRole {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.serialized_name())
+    }
+}
+
+impl<'de> Deserialize<'de> for SccmRole {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(match String::deserialize(deserializer)? {
+            value if value == "client" => Self::Client,
+            value if value == "siteServer" => Self::SiteServer,
+            value if value == "managementPoint" => Self::ManagementPoint,
+            value if value == "distributionPoint" => Self::DistributionPoint,
+            value if value == "softwareUpdatePoint" => Self::SoftwareUpdatePoint,
+            value if value == "wsUs" => Self::WsUs,
+            value if value == "provider" => Self::Provider,
+            value if value == "adminService" => Self::AdminService,
+            value => Self::Unknown(value),
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -49,14 +95,119 @@ impl SccmFindingClass {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "kind", content = "value", rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SccmRotation {
     Current,
     LoUnderscore,
     Numbered(u32),
     Timestamped(String),
-    Unknown(String),
+    Unknown(SccmUnknownRotation),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SccmUnknownRotation {
+    pub kind: String,
+    pub value: Option<Value>,
+}
+
+impl Serialize for SccmRotation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let field_count = match self {
+            Self::Current | Self::LoUnderscore => 1,
+            Self::Numbered(_) | Self::Timestamped(_) => 2,
+            Self::Unknown(unknown) => 1 + usize::from(unknown.value.is_some()),
+        };
+        let mut state = serializer.serialize_struct("SccmRotation", field_count)?;
+
+        match self {
+            Self::Current => state.serialize_field("kind", "current")?,
+            Self::LoUnderscore => state.serialize_field("kind", "loUnderscore")?,
+            Self::Numbered(value) => {
+                state.serialize_field("kind", "numbered")?;
+                state.serialize_field("value", value)?;
+            }
+            Self::Timestamped(value) => {
+                state.serialize_field("kind", "timestamped")?;
+                state.serialize_field("value", value)?;
+            }
+            Self::Unknown(unknown) => {
+                state.serialize_field("kind", &unknown.kind)?;
+                if let Some(value) = &unknown.value {
+                    state.serialize_field("value", value)?;
+                }
+            }
+        }
+
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for SccmRotation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let Value::Object(mut fields) = Value::deserialize(deserializer)? else {
+            return Err(serde::de::Error::custom(
+                "SCCM rotation must be a tagged object",
+            ));
+        };
+        let kind = fields
+            .remove("kind")
+            .and_then(|value| value.as_str().map(str::to_owned))
+            .ok_or_else(|| serde::de::Error::custom("SCCM rotation kind must be a string"))?;
+        let value = fields.remove("value");
+
+        if !fields.is_empty() {
+            return Err(serde::de::Error::custom(
+                "SCCM rotation contains unsupported fields",
+            ));
+        }
+
+        match kind.as_str() {
+            "current" => {
+                require_no_rotation_value::<D::Error>(&kind, value)?;
+                Ok(Self::Current)
+            }
+            "loUnderscore" => {
+                require_no_rotation_value::<D::Error>(&kind, value)?;
+                Ok(Self::LoUnderscore)
+            }
+            "numbered" => {
+                let number = value
+                    .and_then(|value| value.as_u64())
+                    .and_then(|value| u32::try_from(value).ok())
+                    .ok_or_else(|| {
+                        serde::de::Error::custom("numbered rotation value must be a u32")
+                    })?;
+                Ok(Self::Numbered(number))
+            }
+            "timestamped" => {
+                let timestamp = value
+                    .and_then(|value| value.as_str().map(str::to_owned))
+                    .ok_or_else(|| {
+                        serde::de::Error::custom("timestamped rotation value must be a string")
+                    })?;
+                Ok(Self::Timestamped(timestamp))
+            }
+            _ => Ok(Self::Unknown(SccmUnknownRotation { kind, value })),
+        }
+    }
+}
+
+fn require_no_rotation_value<E>(kind: &str, value: Option<Value>) -> Result<(), E>
+where
+    E: serde::de::Error,
+{
+    if value.is_some() {
+        return Err(E::custom(format!(
+            "{kind} rotation must not contain a value"
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/cmtraceopen-parser/src/sccm/rotation.rs
+++ b/crates/cmtraceopen-parser/src/sccm/rotation.rs
@@ -1,0 +1,26 @@
+use chrono::{NaiveDateTime, Timelike};
+
+pub(super) fn is_canonical_rotation_number(value: u32) -> bool {
+    value != 0
+}
+
+pub(super) fn parse_canonical_rotation_number(value: &str) -> Option<u32> {
+    let first = value.as_bytes().first()?;
+    if *first == b'0' || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+
+    value
+        .parse::<u32>()
+        .ok()
+        .filter(|value| is_canonical_rotation_number(*value))
+}
+
+/// Timestamped rotations use exactly `YYYYMMDD-HHMMSS`.
+pub(super) fn is_canonical_rotation_timestamp(value: &str) -> bool {
+    value.len() == "YYYYMMDD-HHMMSS".len()
+        && NaiveDateTime::parse_from_str(value, "%Y%m%d-%H%M%S").is_ok_and(|timestamp| {
+            timestamp.nanosecond() < 1_000_000_000
+                && timestamp.format("%Y%m%d-%H%M%S").to_string() == value
+        })
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/spine/artifact-manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/spine/artifact-manifest.json
@@ -1,0 +1,59 @@
+[
+  {
+    "artifactId": "client-policy-agent-current",
+    "displayName": "PolicyAgent.log",
+    "originalPath": "C:\\Windows\\CCM\\Logs\\PolicyAgent.log",
+    "host": "LAB-CLIENT-01",
+    "role": "client",
+    "configmgrVersion": "5.00.9128.1007",
+    "collectedAtUtc": "2026-07-30T15:00:00Z",
+    "rotation": {
+      "kind": "current"
+    },
+    "coverage": "captured",
+    "encoding": "utf-8"
+  },
+  {
+    "artifactId": "client-content-transfer-rotation-2",
+    "displayName": "ContentTransferManager.log.2",
+    "originalPath": "C:\\Windows\\CCM\\Logs\\ContentTransferManager.log.2",
+    "host": "LAB-CLIENT-01",
+    "role": "client",
+    "configmgrVersion": "5.00.9128.1007",
+    "collectedAtUtc": "2026-07-30T15:00:00Z",
+    "rotation": {
+      "kind": "numbered",
+      "value": 2
+    },
+    "coverage": "captured",
+    "encoding": "utf-8"
+  },
+  {
+    "artifactId": "client-app-enforcement",
+    "displayName": "AppEnforce.log",
+    "originalPath": "C:\\Windows\\CCM\\Logs\\AppEnforce.log",
+    "host": "LAB-CLIENT-01",
+    "role": "client",
+    "configmgrVersion": "5.00.9128.1007",
+    "collectedAtUtc": "2026-07-30T15:00:00Z",
+    "rotation": {
+      "kind": "current"
+    },
+    "coverage": "absent",
+    "encoding": null
+  },
+  {
+    "artifactId": "client-config-registry",
+    "displayName": "ClientConfigurationRegistry.json",
+    "originalPath": null,
+    "host": "LAB-CLIENT-01",
+    "role": "client",
+    "configmgrVersion": "5.00.9128.1007",
+    "collectedAtUtc": "2026-07-30T15:00:00Z",
+    "rotation": {
+      "kind": "current"
+    },
+    "coverage": "accessDenied",
+    "encoding": null
+  }
+]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -1,0 +1,19 @@
+use cmtraceopen_parser::sccm::{
+    SccmArtifact, SccmCoverageState, SccmFindingClass, SccmRole, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
+};
+
+#[test]
+fn sccm_contract_is_public_and_versioned() {
+    assert_eq!(SCCM_DIAGNOSTICS_SCHEMA_VERSION, 1);
+    let artifact = SccmArtifact::missing(
+        "client-policy-agent",
+        "PolicyAgent.log",
+        SccmRole::Client,
+        SccmCoverageState::Absent,
+    );
+    assert_eq!(artifact.coverage, SccmCoverageState::Absent);
+    assert_eq!(
+        SccmFindingClass::InsufficientEvidence.as_str(),
+        "insufficientEvidence"
+    );
+}

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -1,8 +1,9 @@
 use cmtraceopen_parser::models::log_entry::ParserKind;
 use cmtraceopen_parser::parser::detect::detect_parser;
 use cmtraceopen_parser::sccm::{
-    classify_artifact_name, SccmArtifact, SccmArtifactFamily, SccmCoverageState, SccmFindingClass,
-    SccmRole, SccmRotation, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
+    classify_artifact_name, declared_source_catalog, SccmArtifact, SccmArtifactFamily,
+    SccmCoverageState, SccmFindingClass, SccmRole, SccmRotation, SccmUnknownRotation,
+    SCCM_DIAGNOSTICS_SCHEMA_VERSION,
 };
 
 #[test]
@@ -19,6 +20,104 @@ fn sccm_contract_is_public_and_versioned() {
         SccmFindingClass::InsufficientEvidence.as_str(),
         "insufficientEvidence"
     );
+}
+
+#[test]
+fn serde_roles_are_string_backed_and_future_tolerant() {
+    assert_eq!(
+        serde_json::to_string(&SccmRole::ManagementPoint).unwrap(),
+        r#""managementPoint""#
+    );
+    assert_eq!(
+        serde_json::to_string(&SccmRole::Unknown("futureEdgeRole".into())).unwrap(),
+        r#""futureEdgeRole""#
+    );
+    assert_eq!(
+        serde_json::from_str::<SccmRole>(r#""futureEdgeRole""#).unwrap(),
+        SccmRole::Unknown("futureEdgeRole".into())
+    );
+
+    let admin_service = serde_json::from_str::<SccmRole>(r#""adminService""#).unwrap();
+    assert_eq!(
+        serde_json::to_string(&admin_service).unwrap(),
+        r#""adminService""#
+    );
+}
+
+#[test]
+fn serde_families_are_string_backed_and_future_tolerant() {
+    assert_eq!(
+        serde_json::to_string(&SccmArtifactFamily::ClientPolicy).unwrap(),
+        r#""clientPolicy""#
+    );
+    assert_eq!(
+        serde_json::to_string(&SccmArtifactFamily::Unknown("futureFamily".into())).unwrap(),
+        r#""futureFamily""#
+    );
+    assert_eq!(
+        serde_json::from_str::<SccmArtifactFamily>(r#""futureFamily""#).unwrap(),
+        SccmArtifactFamily::Unknown("futureFamily".into())
+    );
+}
+
+#[test]
+fn serde_rotations_have_exact_tags_and_preserve_future_values() {
+    let known = [
+        (SccmRotation::Current, r#"{"kind":"current"}"#),
+        (SccmRotation::LoUnderscore, r#"{"kind":"loUnderscore"}"#),
+        (
+            SccmRotation::Numbered(3),
+            r#"{"kind":"numbered","value":3}"#,
+        ),
+        (
+            SccmRotation::Timestamped("20260730-150000".into()),
+            r#"{"kind":"timestamped","value":"20260730-150000"}"#,
+        ),
+    ];
+
+    for (rotation, expected) in known {
+        assert_eq!(serde_json::to_string(&rotation).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_str::<SccmRotation>(expected).unwrap(),
+            rotation
+        );
+    }
+
+    let future = r#"{"kind":"vendorArchive","value":{"lineage":"A7","sequence":4}}"#;
+    let rotation = serde_json::from_str::<SccmRotation>(future).unwrap();
+    let unknown: &SccmUnknownRotation = match &rotation {
+        SccmRotation::Unknown(unknown) => unknown,
+        other => panic!("future rotation did not remain unknown: {other:?}"),
+    };
+    assert_eq!(unknown.kind, "vendorArchive");
+    assert_eq!(
+        unknown.value,
+        Some(serde_json::json!({"lineage": "A7", "sequence": 4}))
+    );
+    assert_eq!(serde_json::to_string(&rotation).unwrap(), future);
+
+    let valueless_future = r#"{"kind":"vendorArchiveWithoutValue"}"#;
+    let rotation = serde_json::from_str::<SccmRotation>(valueless_future).unwrap();
+    assert_eq!(serde_json::to_string(&rotation).unwrap(), valueless_future);
+}
+
+#[test]
+fn serde_known_rotation_tags_reject_malformed_shapes() {
+    for malformed in [
+        r#"{"kind":"current","value":null}"#,
+        r#"{"kind":"loUnderscore","value":"unexpected"}"#,
+        r#"{"kind":"numbered"}"#,
+        r#"{"kind":"numbered","value":-1}"#,
+        r#"{"kind":"numbered","value":4294967296}"#,
+        r#"{"kind":"timestamped"}"#,
+        r#"{"kind":"timestamped","value":3}"#,
+        r#"{"kind":"current","unexpected":true}"#,
+    ] {
+        assert!(
+            serde_json::from_str::<SccmRotation>(malformed).is_err(),
+            "accepted malformed known rotation: {malformed}"
+        );
+    }
 }
 
 #[test]
@@ -47,21 +146,22 @@ fn artifact_round_trip_preserves_capture_and_rotation_provenance() {
 }
 
 #[test]
-fn coverage_states_are_distinct_and_never_deserialize_as_captured() {
-    for state in [
-        SccmCoverageState::Absent,
-        SccmCoverageState::AccessDenied,
-        SccmCoverageState::Capped,
-        SccmCoverageState::Skipped,
-        SccmCoverageState::Unsupported,
-        SccmCoverageState::ParseFailed,
+fn coverage_json_names_are_exact_and_never_collapse_to_captured() {
+    for (state, expected) in [
+        (SccmCoverageState::Captured, r#""captured""#),
+        (SccmCoverageState::Absent, r#""absent""#),
+        (SccmCoverageState::AccessDenied, r#""accessDenied""#),
+        (SccmCoverageState::Capped, r#""capped""#),
+        (SccmCoverageState::Skipped, r#""skipped""#),
+        (SccmCoverageState::Unsupported, r#""unsupported""#),
+        (SccmCoverageState::ParseFailed, r#""parseFailed""#),
     ] {
-        assert_ne!(state, SccmCoverageState::Captured);
-
-        let json = serde_json::to_value(&state).unwrap();
-        let round_trip: SccmCoverageState = serde_json::from_value(json).unwrap();
+        assert_eq!(serde_json::to_string(&state).unwrap(), expected);
+        let round_trip = serde_json::from_str::<SccmCoverageState>(expected).unwrap();
         assert_eq!(round_trip, state);
-        assert_ne!(round_trip, SccmCoverageState::Captured);
+        if expected != r#""captured""# {
+            assert_ne!(round_trip, SccmCoverageState::Captured);
+        }
     }
 }
 
@@ -124,81 +224,668 @@ fn catalog_leaves_unrecognized_sources_explicitly_unknown() {
 }
 
 #[test]
-fn catalog_recognizes_every_declared_initial_source_for_its_role() {
-    let declared = [
-        ("CCMSetup.log", SccmRole::Client),
-        ("CcmEval.log", SccmRole::Client),
-        ("CcmExec.log", SccmRole::Client),
-        ("CcmRestart.log", SccmRole::Client),
-        ("ClientIDManagerStartup.log", SccmRole::Client),
-        ("ClientLocation.log", SccmRole::Client),
-        ("LocationServices.log", SccmRole::Client),
-        ("CcmMessaging.log", SccmRole::Client),
-        ("PolicyAgent.log", SccmRole::Client),
-        ("PolicyAgentProvider.log", SccmRole::Client),
-        ("PolicyEvaluator.log", SccmRole::Client),
-        ("Scheduler.log", SccmRole::Client),
-        ("CAS.log", SccmRole::Client),
-        ("ContentTransferManager.log", SccmRole::Client),
-        ("DataTransferService.log", SccmRole::Client),
-        ("AppIntentEval.log", SccmRole::Client),
-        ("AppDiscovery.log", SccmRole::Client),
-        ("AppEnforce.log", SccmRole::Client),
-        ("ScanAgent.log", SccmRole::Client),
-        ("WUAHandler.log", SccmRole::Client),
-        ("UpdatesDeployment.log", SccmRole::Client),
-        ("UpdatesHandler.log", SccmRole::Client),
-        ("UpdatesStore.log", SccmRole::Client),
-        ("smsts.log", SccmRole::Client),
-        ("sitecomp.log", SccmRole::SiteServer),
-        ("hman.log", SccmRole::SiteServer),
-        ("statmgr.log", SccmRole::SiteServer),
-        ("statesys.log", SccmRole::SiteServer),
-        ("MP_CliReg.log", SccmRole::ManagementPoint),
-        ("MP_GetAuth.log", SccmRole::ManagementPoint),
-        ("MP_GetPolicy.log", SccmRole::ManagementPoint),
-        ("MP_Location.log", SccmRole::ManagementPoint),
-        ("MP_RegistrationManager.log", SccmRole::ManagementPoint),
-        ("mpcontrol.log", SccmRole::ManagementPoint),
-        ("distmgr.log", SccmRole::SiteServer),
-        ("PkgXferMgr.log", SccmRole::SiteServer),
-        ("SMSDPProv.log", SccmRole::DistributionPoint),
-        ("PullDP.log", SccmRole::DistributionPoint),
-        ("WCM.log", SccmRole::SoftwareUpdatePoint),
-        ("WSUSCtrl.log", SccmRole::SoftwareUpdatePoint),
-        ("wsyncmgr.log", SccmRole::SoftwareUpdatePoint),
-        ("SUPSetup.log", SccmRole::SoftwareUpdatePoint),
-        ("replmgr.log", SccmRole::SiteServer),
-        ("rcmctrl.log", SccmRole::SiteServer),
-        ("sender.log", SccmRole::SiteServer),
-        ("despool.log", SccmRole::SiteServer),
-        ("Smsprov.log", SccmRole::Provider),
-        ("AdminService.log", SccmRole::Provider),
-    ];
+fn catalog_exact_declared_tuples_match_the_public_classifier() {
+    let expected = expected_catalog_tuples();
+    let declared = declared_source_catalog();
+    assert_eq!(declared.len(), expected.len());
 
-    for (name, role) in declared {
-        let class = classify_artifact_name(name, role.clone());
-        assert_eq!(class.role, role, "role changed for {name}");
-        assert!(
-            !matches!(class.family, SccmArtifactFamily::Unknown(_)),
-            "{name} was not catalogued"
-        );
-        assert!(class.uses_ccm_records, "{name} lost CCM framing");
-        assert!(class.supported_for_diagnosis, "{name} became unsupported");
+    for (entry, expected) in declared.iter().zip(expected.iter()) {
+        assert_eq!(entry.basename, expected.0);
+        assert_eq!(entry.role, expected.1);
+        assert_eq!(entry.logical_name, expected.2);
+        assert_eq!(entry.family, expected.3);
+        assert_eq!(entry.uses_ccm_records, expected.4);
+        assert_eq!(entry.supported_for_diagnosis, expected.5);
+        assert_eq!(entry.rotation, SccmRotation::Current);
+
+        let classified = classify_artifact_name(expected.0, expected.1.clone());
+        assert_eq!(classified, *entry);
     }
 }
 
 #[test]
-fn catalog_requires_a_declared_role_and_rotation_shape() {
-    let wrong_role = classify_artifact_name("PolicyAgent.log", SccmRole::SiteServer);
-    assert!(matches!(wrong_role.family, SccmArtifactFamily::Unknown(_)));
-    assert!(!wrong_role.supported_for_diagnosis);
+fn catalog_declared_basename_role_tuples_are_unique() {
+    let mut keys = std::collections::BTreeSet::new();
+    for entry in declared_source_catalog() {
+        let role = serde_json::to_string(&entry.role).unwrap();
+        assert!(
+            keys.insert((entry.basename.to_ascii_lowercase(), role)),
+            "duplicate catalog tuple: {} / {:?}",
+            entry.basename,
+            entry.role
+        );
+    }
+}
 
-    let rotated = classify_artifact_name("AppEnforce.lo_", SccmRole::Client);
-    assert_eq!(rotated.family, SccmArtifactFamily::ClientApplication);
-    assert_eq!(rotated.rotation, SccmRotation::LoUnderscore);
+#[test]
+fn catalog_rejects_every_role_not_declared_by_the_exact_table() {
+    let expected = expected_catalog_tuples();
+    let basenames = expected
+        .iter()
+        .map(|entry| entry.0)
+        .collect::<std::collections::BTreeSet<_>>();
 
-    let backup = classify_artifact_name("PolicyAgent.log.backup", SccmRole::Client);
-    assert!(matches!(backup.family, SccmArtifactFamily::Unknown(_)));
-    assert!(!backup.supported_for_diagnosis);
+    for basename in basenames {
+        let allowed_roles = expected
+            .iter()
+            .filter(|entry| entry.0 == basename)
+            .map(|entry| &entry.1)
+            .collect::<Vec<_>>();
+        for role in known_roles() {
+            if allowed_roles.contains(&&role) {
+                continue;
+            }
+
+            let class = classify_artifact_name(basename, role.clone());
+            assert_eq!(class.role, role, "{basename}");
+            assert!(
+                matches!(class.family, SccmArtifactFamily::Unknown(_)),
+                "{basename} accepted undeclared role {:?}",
+                class.role
+            );
+            assert!(!class.supported_for_diagnosis, "{basename}");
+        }
+    }
+}
+
+#[test]
+fn catalog_rotation_grammar_accepts_only_canonical_suffixes() {
+    let canonical = [
+        ("AppEnforce.log", SccmRotation::Current),
+        ("AppEnforce.log.lo_", SccmRotation::LoUnderscore),
+        ("AppEnforce.LOG.LO_", SccmRotation::LoUnderscore),
+        ("AppEnforce.log.3", SccmRotation::Numbered(3)),
+        (
+            "AppEnforce.log.20260730-150000",
+            SccmRotation::Timestamped("20260730-150000".into()),
+        ),
+    ];
+    for (name, expected_rotation) in canonical {
+        let class = classify_artifact_name(name, SccmRole::Client);
+        assert_eq!(
+            class.family,
+            SccmArtifactFamily::ClientApplication,
+            "{name}"
+        );
+        assert_eq!(class.rotation, expected_rotation, "{name}");
+        assert!(class.uses_ccm_records, "{name}");
+        assert!(class.supported_for_diagnosis, "{name}");
+    }
+
+    let rejected = [
+        ("AppEnforce.lo_", ".lo_"),
+        ("AppEnforce.log.0", ".0"),
+        ("AppEnforce.log.03", ".03"),
+        ("AppEnforce.log.backup", ".backup"),
+        ("AppEnforce.log.20261340-996099", ".20261340-996099"),
+    ];
+    for (name, raw_suffix) in rejected {
+        let class = classify_artifact_name(name, SccmRole::Client);
+        assert_eq!(
+            class.family,
+            SccmArtifactFamily::ClientApplication,
+            "{name}"
+        );
+        assert_eq!(class.logical_name, "appEnforce", "{name}");
+        assert_eq!(
+            serde_json::to_value(&class.rotation).unwrap(),
+            serde_json::json!({"kind": "filenameSuffix", "value": raw_suffix}),
+            "{name}"
+        );
+        assert!(class.uses_ccm_records, "{name}");
+        assert!(!class.supported_for_diagnosis, "{name}");
+    }
+}
+
+#[test]
+fn catalog_rotation_grammar_preserves_unknown_suffix_and_initialism() {
+    let class = classify_artifact_name("SMSVendorHook.log.archive", SccmRole::Client);
+    assert_eq!(class.logical_name, "smsVendorHook");
+    assert_eq!(
+        class.family,
+        SccmArtifactFamily::Unknown("smsVendorHook".into())
+    );
+    assert_eq!(
+        serde_json::to_value(&class.rotation).unwrap(),
+        serde_json::json!({"kind": "filenameSuffix", "value": ".archive"})
+    );
+    assert!(!class.uses_ccm_records);
+    assert!(!class.supported_for_diagnosis);
+}
+
+#[test]
+fn catalog_role_matrix_preserves_supplied_dp_and_sup_roles() {
+    let dp_sources = [
+        "distmgr.log",
+        "PkgXferMgr.log",
+        "SMSDPProv.log",
+        "PullDP.log",
+    ];
+    let dp_roles = [SccmRole::SiteServer, SccmRole::DistributionPoint];
+    assert_role_matrix(
+        &dp_sources,
+        &dp_roles,
+        SccmArtifactFamily::DistributionPoint,
+    );
+
+    let sup_sources = ["WCM.log", "WSUSCtrl.log", "wsyncmgr.log", "SUPSetup.log"];
+    let sup_roles = [SccmRole::SoftwareUpdatePoint, SccmRole::WsUs];
+    assert_role_matrix(
+        &sup_sources,
+        &sup_roles,
+        SccmArtifactFamily::SoftwareUpdatePoint,
+    );
+}
+
+#[test]
+fn catalog_role_matrix_keeps_admin_service_distinct_from_provider() {
+    let admin = classify_artifact_name("AdminService.log", SccmRole::AdminService);
+    assert_eq!(admin.role, SccmRole::AdminService);
+    assert_eq!(admin.family, SccmArtifactFamily::AdminService);
+    assert!(admin.supported_for_diagnosis);
+
+    let provider = classify_artifact_name("AdminService.log", SccmRole::Provider);
+    assert_eq!(provider.role, SccmRole::Provider);
+    assert!(matches!(provider.family, SccmArtifactFamily::Unknown(_)));
+    assert!(!provider.supported_for_diagnosis);
+}
+
+fn assert_role_matrix(
+    sources: &[&str],
+    allowed_roles: &[SccmRole],
+    expected_family: SccmArtifactFamily,
+) {
+    for source in sources {
+        for role in &known_roles() {
+            let class = classify_artifact_name(source, role.clone());
+            if allowed_roles.contains(role) {
+                assert_eq!(class.role, *role, "{source}");
+                assert_eq!(class.family, expected_family, "{source} / {role:?}");
+                assert!(class.uses_ccm_records, "{source} / {role:?}");
+                assert!(class.supported_for_diagnosis, "{source} / {role:?}");
+            } else {
+                assert_eq!(class.role, *role, "{source}");
+                assert!(
+                    matches!(class.family, SccmArtifactFamily::Unknown(_)),
+                    "{source} / {role:?}"
+                );
+                assert!(!class.supported_for_diagnosis, "{source} / {role:?}");
+            }
+        }
+    }
+}
+
+fn known_roles() -> [SccmRole; 8] {
+    [
+        SccmRole::Client,
+        SccmRole::SiteServer,
+        SccmRole::ManagementPoint,
+        SccmRole::DistributionPoint,
+        SccmRole::SoftwareUpdatePoint,
+        SccmRole::WsUs,
+        SccmRole::Provider,
+        SccmRole::AdminService,
+    ]
+}
+
+type ExpectedCatalogTuple = (
+    &'static str,
+    SccmRole,
+    &'static str,
+    SccmArtifactFamily,
+    bool,
+    bool,
+);
+
+fn expected_catalog_tuples() -> Vec<ExpectedCatalogTuple> {
+    vec![
+        (
+            "CCMSetup.log",
+            SccmRole::Client,
+            "ccmSetup",
+            SccmArtifactFamily::ClientSetup,
+            true,
+            true,
+        ),
+        (
+            "CcmEval.log",
+            SccmRole::Client,
+            "ccmEval",
+            SccmArtifactFamily::ClientHealth,
+            true,
+            true,
+        ),
+        (
+            "CcmExec.log",
+            SccmRole::Client,
+            "ccmExec",
+            SccmArtifactFamily::ClientHealth,
+            true,
+            true,
+        ),
+        (
+            "CcmRestart.log",
+            SccmRole::Client,
+            "ccmRestart",
+            SccmArtifactFamily::ClientHealth,
+            true,
+            true,
+        ),
+        (
+            "ClientIDManagerStartup.log",
+            SccmRole::Client,
+            "clientIdManagerStartup",
+            SccmArtifactFamily::ClientIdentity,
+            true,
+            true,
+        ),
+        (
+            "ClientLocation.log",
+            SccmRole::Client,
+            "clientLocation",
+            SccmArtifactFamily::ClientLocation,
+            true,
+            true,
+        ),
+        (
+            "LocationServices.log",
+            SccmRole::Client,
+            "locationServices",
+            SccmArtifactFamily::ClientLocation,
+            true,
+            true,
+        ),
+        (
+            "CcmMessaging.log",
+            SccmRole::Client,
+            "ccmMessaging",
+            SccmArtifactFamily::ClientLocation,
+            true,
+            true,
+        ),
+        (
+            "PolicyAgent.log",
+            SccmRole::Client,
+            "policyAgent",
+            SccmArtifactFamily::ClientPolicy,
+            true,
+            true,
+        ),
+        (
+            "PolicyAgentProvider.log",
+            SccmRole::Client,
+            "policyAgentProvider",
+            SccmArtifactFamily::ClientPolicy,
+            true,
+            true,
+        ),
+        (
+            "PolicyEvaluator.log",
+            SccmRole::Client,
+            "policyEvaluator",
+            SccmArtifactFamily::ClientPolicy,
+            true,
+            true,
+        ),
+        (
+            "Scheduler.log",
+            SccmRole::Client,
+            "scheduler",
+            SccmArtifactFamily::ClientPolicy,
+            true,
+            true,
+        ),
+        (
+            "CAS.log",
+            SccmRole::Client,
+            "cas",
+            SccmArtifactFamily::ClientContent,
+            true,
+            true,
+        ),
+        (
+            "ContentTransferManager.log",
+            SccmRole::Client,
+            "contentTransferManager",
+            SccmArtifactFamily::ClientContent,
+            true,
+            true,
+        ),
+        (
+            "DataTransferService.log",
+            SccmRole::Client,
+            "dataTransferService",
+            SccmArtifactFamily::ClientContent,
+            true,
+            true,
+        ),
+        (
+            "AppIntentEval.log",
+            SccmRole::Client,
+            "appIntentEval",
+            SccmArtifactFamily::ClientApplication,
+            true,
+            true,
+        ),
+        (
+            "AppDiscovery.log",
+            SccmRole::Client,
+            "appDiscovery",
+            SccmArtifactFamily::ClientApplication,
+            true,
+            true,
+        ),
+        (
+            "AppEnforce.log",
+            SccmRole::Client,
+            "appEnforce",
+            SccmArtifactFamily::ClientApplication,
+            true,
+            true,
+        ),
+        (
+            "ScanAgent.log",
+            SccmRole::Client,
+            "scanAgent",
+            SccmArtifactFamily::ClientUpdates,
+            true,
+            true,
+        ),
+        (
+            "WUAHandler.log",
+            SccmRole::Client,
+            "wuaHandler",
+            SccmArtifactFamily::ClientUpdates,
+            true,
+            true,
+        ),
+        (
+            "UpdatesDeployment.log",
+            SccmRole::Client,
+            "updatesDeployment",
+            SccmArtifactFamily::ClientUpdates,
+            true,
+            true,
+        ),
+        (
+            "UpdatesHandler.log",
+            SccmRole::Client,
+            "updatesHandler",
+            SccmArtifactFamily::ClientUpdates,
+            true,
+            true,
+        ),
+        (
+            "UpdatesStore.log",
+            SccmRole::Client,
+            "updatesStore",
+            SccmArtifactFamily::ClientUpdates,
+            true,
+            true,
+        ),
+        (
+            "smsts.log",
+            SccmRole::Client,
+            "smsts",
+            SccmArtifactFamily::ClientTaskSequence,
+            true,
+            true,
+        ),
+        (
+            "sitecomp.log",
+            SccmRole::SiteServer,
+            "sitecomp",
+            SccmArtifactFamily::SiteComponent,
+            true,
+            true,
+        ),
+        (
+            "hman.log",
+            SccmRole::SiteServer,
+            "hman",
+            SccmArtifactFamily::SiteComponent,
+            true,
+            true,
+        ),
+        (
+            "statmgr.log",
+            SccmRole::SiteServer,
+            "statmgr",
+            SccmArtifactFamily::SiteStatus,
+            true,
+            true,
+        ),
+        (
+            "statesys.log",
+            SccmRole::SiteServer,
+            "statesys",
+            SccmArtifactFamily::SiteStatus,
+            true,
+            true,
+        ),
+        (
+            "MP_CliReg.log",
+            SccmRole::ManagementPoint,
+            "mpCliReg",
+            SccmArtifactFamily::ManagementPoint,
+            true,
+            true,
+        ),
+        (
+            "MP_GetAuth.log",
+            SccmRole::ManagementPoint,
+            "mpGetAuth",
+            SccmArtifactFamily::ManagementPoint,
+            true,
+            true,
+        ),
+        (
+            "MP_GetPolicy.log",
+            SccmRole::ManagementPoint,
+            "mpGetPolicy",
+            SccmArtifactFamily::ManagementPoint,
+            true,
+            true,
+        ),
+        (
+            "MP_Location.log",
+            SccmRole::ManagementPoint,
+            "mpLocation",
+            SccmArtifactFamily::ManagementPoint,
+            true,
+            true,
+        ),
+        (
+            "MP_RegistrationManager.log",
+            SccmRole::ManagementPoint,
+            "mpRegistrationManager",
+            SccmArtifactFamily::ManagementPoint,
+            true,
+            true,
+        ),
+        (
+            "mpcontrol.log",
+            SccmRole::ManagementPoint,
+            "mpcontrol",
+            SccmArtifactFamily::ManagementPoint,
+            true,
+            true,
+        ),
+        (
+            "distmgr.log",
+            SccmRole::SiteServer,
+            "distmgr",
+            SccmArtifactFamily::DistributionPoint,
+            true,
+            true,
+        ),
+        (
+            "distmgr.log",
+            SccmRole::DistributionPoint,
+            "distmgr",
+            SccmArtifactFamily::DistributionPoint,
+            true,
+            true,
+        ),
+        (
+            "PkgXferMgr.log",
+            SccmRole::SiteServer,
+            "pkgXferMgr",
+            SccmArtifactFamily::DistributionPoint,
+            true,
+            true,
+        ),
+        (
+            "PkgXferMgr.log",
+            SccmRole::DistributionPoint,
+            "pkgXferMgr",
+            SccmArtifactFamily::DistributionPoint,
+            true,
+            true,
+        ),
+        (
+            "SMSDPProv.log",
+            SccmRole::DistributionPoint,
+            "smsDpProv",
+            SccmArtifactFamily::DistributionPoint,
+            true,
+            true,
+        ),
+        (
+            "SMSDPProv.log",
+            SccmRole::SiteServer,
+            "smsDpProv",
+            SccmArtifactFamily::DistributionPoint,
+            true,
+            true,
+        ),
+        (
+            "PullDP.log",
+            SccmRole::DistributionPoint,
+            "pullDp",
+            SccmArtifactFamily::DistributionPoint,
+            true,
+            true,
+        ),
+        (
+            "PullDP.log",
+            SccmRole::SiteServer,
+            "pullDp",
+            SccmArtifactFamily::DistributionPoint,
+            true,
+            true,
+        ),
+        (
+            "WCM.log",
+            SccmRole::SoftwareUpdatePoint,
+            "wcm",
+            SccmArtifactFamily::SoftwareUpdatePoint,
+            true,
+            true,
+        ),
+        (
+            "WCM.log",
+            SccmRole::WsUs,
+            "wcm",
+            SccmArtifactFamily::SoftwareUpdatePoint,
+            true,
+            true,
+        ),
+        (
+            "WSUSCtrl.log",
+            SccmRole::SoftwareUpdatePoint,
+            "wsusCtrl",
+            SccmArtifactFamily::SoftwareUpdatePoint,
+            true,
+            true,
+        ),
+        (
+            "WSUSCtrl.log",
+            SccmRole::WsUs,
+            "wsusCtrl",
+            SccmArtifactFamily::SoftwareUpdatePoint,
+            true,
+            true,
+        ),
+        (
+            "wsyncmgr.log",
+            SccmRole::SoftwareUpdatePoint,
+            "wsyncmgr",
+            SccmArtifactFamily::SoftwareUpdatePoint,
+            true,
+            true,
+        ),
+        (
+            "wsyncmgr.log",
+            SccmRole::WsUs,
+            "wsyncmgr",
+            SccmArtifactFamily::SoftwareUpdatePoint,
+            true,
+            true,
+        ),
+        (
+            "SUPSetup.log",
+            SccmRole::SoftwareUpdatePoint,
+            "supSetup",
+            SccmArtifactFamily::SoftwareUpdatePoint,
+            true,
+            true,
+        ),
+        (
+            "SUPSetup.log",
+            SccmRole::WsUs,
+            "supSetup",
+            SccmArtifactFamily::SoftwareUpdatePoint,
+            true,
+            true,
+        ),
+        (
+            "replmgr.log",
+            SccmRole::SiteServer,
+            "replmgr",
+            SccmArtifactFamily::Hierarchy,
+            true,
+            true,
+        ),
+        (
+            "rcmctrl.log",
+            SccmRole::SiteServer,
+            "rcmctrl",
+            SccmArtifactFamily::Hierarchy,
+            true,
+            true,
+        ),
+        (
+            "sender.log",
+            SccmRole::SiteServer,
+            "sender",
+            SccmArtifactFamily::Hierarchy,
+            true,
+            true,
+        ),
+        (
+            "despool.log",
+            SccmRole::SiteServer,
+            "despool",
+            SccmArtifactFamily::Hierarchy,
+            true,
+            true,
+        ),
+        (
+            "Smsprov.log",
+            SccmRole::Provider,
+            "smsprov",
+            SccmArtifactFamily::Provider,
+            true,
+            true,
+        ),
+        (
+            "AdminService.log",
+            SccmRole::AdminService,
+            "adminService",
+            SccmArtifactFamily::AdminService,
+            true,
+            true,
+        ),
+    ]
 }

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -121,6 +121,59 @@ fn serde_known_rotation_tags_reject_malformed_shapes() {
 }
 
 #[test]
+fn serde_known_rotation_values_reject_noncanonical_values() {
+    for noncanonical in [
+        r#"{"kind":"numbered","value":0}"#,
+        r#"{"kind":"timestamped","value":""}"#,
+        r#"{"kind":"timestamped","value":"20260730-15000"}"#,
+        r#"{"kind":"timestamped","value":"20260730-1500000"}"#,
+        r#"{"kind":"timestamped","value":"2026073A-150000"}"#,
+        r#"{"kind":"timestamped","value":"20260730_150000"}"#,
+        r#"{"kind":"timestamped","value":"20260229-150000"}"#,
+        r#"{"kind":"timestamped","value":"20260730-240000"}"#,
+        r#"{"kind":"timestamped","value":"20260730-156000"}"#,
+        r#"{"kind":"timestamped","value":"20260730-150060"}"#,
+        r#"{"kind":"timestamped","value":"20260730-150000Z"}"#,
+    ] {
+        assert!(
+            serde_json::from_str::<SccmRotation>(noncanonical).is_err(),
+            "accepted noncanonical known rotation: {noncanonical}"
+        );
+    }
+}
+
+#[test]
+fn serde_known_rotation_values_fail_closed_on_serialize() {
+    for rotation in [
+        SccmRotation::Numbered(0),
+        SccmRotation::Timestamped("20260730_150000".into()),
+        SccmRotation::Timestamped("20260229-150000".into()),
+        SccmRotation::Timestamped("20260730-150060".into()),
+    ] {
+        assert!(
+            serde_json::to_string(&rotation).is_err(),
+            "serialized noncanonical known rotation: {rotation:?}"
+        );
+    }
+}
+
+#[test]
+fn serde_canonical_rotation_values_round_trip() {
+    for rotation in [
+        SccmRotation::Numbered(1),
+        SccmRotation::Numbered(u32::MAX),
+        SccmRotation::Timestamped("20240229-000000".into()),
+        SccmRotation::Timestamped("20261231-235959".into()),
+    ] {
+        let json = serde_json::to_string(&rotation).unwrap();
+        assert_eq!(
+            serde_json::from_str::<SccmRotation>(&json).unwrap(),
+            rotation
+        );
+    }
+}
+
+#[test]
 fn artifact_round_trip_preserves_capture_and_rotation_provenance() {
     let artifact = SccmArtifact {
         artifact_id: "client-content-transfer".into(),
@@ -316,7 +369,12 @@ fn catalog_rotation_grammar_accepts_only_canonical_suffixes() {
         ("AppEnforce.lo_", ".lo_"),
         ("AppEnforce.log.0", ".0"),
         ("AppEnforce.log.03", ".03"),
+        ("AppEnforce.log.4294967296", ".4294967296"),
         ("AppEnforce.log.backup", ".backup"),
+        ("AppEnforce.log.20260730_150000", ".20260730_150000"),
+        ("AppEnforce.log.20260229-150000", ".20260229-150000"),
+        ("AppEnforce.log.20260730-240000", ".20260730-240000"),
+        ("AppEnforce.log.20260730-150000Z", ".20260730-150000Z"),
         ("AppEnforce.log.20261340-996099", ".20261340-996099"),
     ];
     for (name, raw_suffix) in rejected {

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -1,5 +1,6 @@
 use cmtraceopen_parser::sccm::{
-    SccmArtifact, SccmCoverageState, SccmFindingClass, SccmRole, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
+    SccmArtifact, SccmCoverageState, SccmFindingClass, SccmRole, SccmRotation,
+    SCCM_DIAGNOSTICS_SCHEMA_VERSION,
 };
 
 #[test]
@@ -16,4 +17,75 @@ fn sccm_contract_is_public_and_versioned() {
         SccmFindingClass::InsufficientEvidence.as_str(),
         "insufficientEvidence"
     );
+}
+
+#[test]
+fn artifact_round_trip_preserves_capture_and_rotation_provenance() {
+    let artifact = SccmArtifact {
+        artifact_id: "client-content-transfer".into(),
+        display_name: "ContentTransferManager.log.2".into(),
+        original_path: Some(r"C:\Windows\CCM\Logs\ContentTransferManager.log.2".into()),
+        host: Some("LAB-CLIENT-01".into()),
+        role: SccmRole::Client,
+        configmgr_version: Some("5.00.9128.1007".into()),
+        collected_at_utc: Some("2026-07-30T15:00:00Z".into()),
+        rotation: SccmRotation::Numbered(2),
+        coverage: SccmCoverageState::Captured,
+        encoding: Some("utf-8".into()),
+    };
+
+    let json = serde_json::to_value(&artifact).unwrap();
+    assert_eq!(json["rotation"]["kind"], "numbered");
+    assert_eq!(json["rotation"]["value"], 2);
+    assert_eq!(json["coverage"], "captured");
+    assert_eq!(
+        serde_json::from_value::<SccmArtifact>(json).unwrap(),
+        artifact
+    );
+}
+
+#[test]
+fn coverage_states_are_distinct_and_never_deserialize_as_captured() {
+    for state in [
+        SccmCoverageState::Absent,
+        SccmCoverageState::AccessDenied,
+        SccmCoverageState::Capped,
+        SccmCoverageState::Skipped,
+        SccmCoverageState::Unsupported,
+        SccmCoverageState::ParseFailed,
+    ] {
+        assert_ne!(state, SccmCoverageState::Captured);
+
+        let json = serde_json::to_value(&state).unwrap();
+        let round_trip: SccmCoverageState = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, state);
+        assert_ne!(round_trip, SccmCoverageState::Captured);
+    }
+}
+
+#[test]
+fn artifact_manifest_fixture_preserves_each_coverage_state() {
+    let artifacts: Vec<SccmArtifact> =
+        serde_json::from_str(include_str!("fixtures/sccm/spine/artifact-manifest.json")).unwrap();
+
+    assert_eq!(artifacts.len(), 4);
+    assert_eq!(artifacts[0].rotation, SccmRotation::Current);
+    assert_eq!(artifacts[1].rotation, SccmRotation::Numbered(2));
+    assert_eq!(
+        artifacts
+            .iter()
+            .map(|artifact| artifact.coverage.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            SccmCoverageState::Captured,
+            SccmCoverageState::Captured,
+            SccmCoverageState::Absent,
+            SccmCoverageState::AccessDenied,
+        ]
+    );
+    assert_eq!(
+        artifacts[0].original_path.as_deref(),
+        Some(r"C:\Windows\CCM\Logs\PolicyAgent.log")
+    );
+    assert_eq!(artifacts[3].encoding, None);
 }

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -354,63 +354,75 @@ fn catalog_rotation_grammar_preserves_unknown_suffix_and_initialism() {
 }
 
 #[test]
-fn catalog_role_matrix_preserves_supplied_dp_and_sup_roles() {
-    let dp_sources = [
-        "distmgr.log",
-        "PkgXferMgr.log",
-        "SMSDPProv.log",
-        "PullDP.log",
+fn catalog_requires_exact_producer_roles_for_server_workflow_sources() {
+    let cases = [
+        (
+            "distmgr.log",
+            SccmRole::SiteServer,
+            SccmArtifactFamily::DistributionPoint,
+        ),
+        (
+            "PkgXferMgr.log",
+            SccmRole::SiteServer,
+            SccmArtifactFamily::DistributionPoint,
+        ),
+        (
+            "SMSDPProv.log",
+            SccmRole::DistributionPoint,
+            SccmArtifactFamily::DistributionPoint,
+        ),
+        (
+            "PullDP.log",
+            SccmRole::DistributionPoint,
+            SccmArtifactFamily::DistributionPoint,
+        ),
+        (
+            "WCM.log",
+            SccmRole::SiteServer,
+            SccmArtifactFamily::SoftwareUpdatePoint,
+        ),
+        (
+            "wsyncmgr.log",
+            SccmRole::SiteServer,
+            SccmArtifactFamily::SoftwareUpdatePoint,
+        ),
+        (
+            "WSUSCtrl.log",
+            SccmRole::SoftwareUpdatePoint,
+            SccmArtifactFamily::SoftwareUpdatePoint,
+        ),
+        (
+            "SUPSetup.log",
+            SccmRole::SoftwareUpdatePoint,
+            SccmArtifactFamily::SoftwareUpdatePoint,
+        ),
+        (
+            "AdminService.log",
+            SccmRole::Provider,
+            SccmArtifactFamily::AdminService,
+        ),
     ];
-    let dp_roles = [SccmRole::SiteServer, SccmRole::DistributionPoint];
-    assert_role_matrix(
-        &dp_sources,
-        &dp_roles,
-        SccmArtifactFamily::DistributionPoint,
-    );
 
-    let sup_sources = ["WCM.log", "WSUSCtrl.log", "wsyncmgr.log", "SUPSetup.log"];
-    let sup_roles = [SccmRole::SoftwareUpdatePoint, SccmRole::WsUs];
-    assert_role_matrix(
-        &sup_sources,
-        &sup_roles,
-        SccmArtifactFamily::SoftwareUpdatePoint,
-    );
-}
+    for (source, producer_role, family) in cases {
+        let class = classify_artifact_name(source, producer_role.clone());
+        assert_eq!(class.role, producer_role, "{source}");
+        assert_eq!(class.family, family, "{source}");
+        assert!(class.uses_ccm_records, "{source}");
+        assert!(class.supported_for_diagnosis, "{source}");
 
-#[test]
-fn catalog_role_matrix_keeps_admin_service_distinct_from_provider() {
-    let admin = classify_artifact_name("AdminService.log", SccmRole::AdminService);
-    assert_eq!(admin.role, SccmRole::AdminService);
-    assert_eq!(admin.family, SccmArtifactFamily::AdminService);
-    assert!(admin.supported_for_diagnosis);
-
-    let provider = classify_artifact_name("AdminService.log", SccmRole::Provider);
-    assert_eq!(provider.role, SccmRole::Provider);
-    assert!(matches!(provider.family, SccmArtifactFamily::Unknown(_)));
-    assert!(!provider.supported_for_diagnosis);
-}
-
-fn assert_role_matrix(
-    sources: &[&str],
-    allowed_roles: &[SccmRole],
-    expected_family: SccmArtifactFamily,
-) {
-    for source in sources {
         for role in &known_roles() {
-            let class = classify_artifact_name(source, role.clone());
-            if allowed_roles.contains(role) {
-                assert_eq!(class.role, *role, "{source}");
-                assert_eq!(class.family, expected_family, "{source} / {role:?}");
-                assert!(class.uses_ccm_records, "{source} / {role:?}");
-                assert!(class.supported_for_diagnosis, "{source} / {role:?}");
-            } else {
-                assert_eq!(class.role, *role, "{source}");
-                assert!(
-                    matches!(class.family, SccmArtifactFamily::Unknown(_)),
-                    "{source} / {role:?}"
-                );
-                assert!(!class.supported_for_diagnosis, "{source} / {role:?}");
+            if *role == producer_role {
+                continue;
             }
+
+            let class = classify_artifact_name(source, role.clone());
+            assert_eq!(class.role, *role, "{source}");
+            assert!(
+                matches!(class.family, SccmArtifactFamily::Unknown(_)),
+                "{source} accepted non-producer role {role:?}"
+            );
+            assert!(!class.uses_ccm_records, "{source} / {role:?}");
+            assert!(!class.supported_for_diagnosis, "{source} / {role:?}");
         }
     }
 }
@@ -720,24 +732,8 @@ fn expected_catalog_tuples() -> Vec<ExpectedCatalogTuple> {
             true,
         ),
         (
-            "distmgr.log",
-            SccmRole::DistributionPoint,
-            "distmgr",
-            SccmArtifactFamily::DistributionPoint,
-            true,
-            true,
-        ),
-        (
             "PkgXferMgr.log",
             SccmRole::SiteServer,
-            "pkgXferMgr",
-            SccmArtifactFamily::DistributionPoint,
-            true,
-            true,
-        ),
-        (
-            "PkgXferMgr.log",
-            SccmRole::DistributionPoint,
             "pkgXferMgr",
             SccmArtifactFamily::DistributionPoint,
             true,
@@ -752,14 +748,6 @@ fn expected_catalog_tuples() -> Vec<ExpectedCatalogTuple> {
             true,
         ),
         (
-            "SMSDPProv.log",
-            SccmRole::SiteServer,
-            "smsDpProv",
-            SccmArtifactFamily::DistributionPoint,
-            true,
-            true,
-        ),
-        (
             "PullDP.log",
             SccmRole::DistributionPoint,
             "pullDp",
@@ -768,24 +756,8 @@ fn expected_catalog_tuples() -> Vec<ExpectedCatalogTuple> {
             true,
         ),
         (
-            "PullDP.log",
+            "WCM.log",
             SccmRole::SiteServer,
-            "pullDp",
-            SccmArtifactFamily::DistributionPoint,
-            true,
-            true,
-        ),
-        (
-            "WCM.log",
-            SccmRole::SoftwareUpdatePoint,
-            "wcm",
-            SccmArtifactFamily::SoftwareUpdatePoint,
-            true,
-            true,
-        ),
-        (
-            "WCM.log",
-            SccmRole::WsUs,
             "wcm",
             SccmArtifactFamily::SoftwareUpdatePoint,
             true,
@@ -800,24 +772,8 @@ fn expected_catalog_tuples() -> Vec<ExpectedCatalogTuple> {
             true,
         ),
         (
-            "WSUSCtrl.log",
-            SccmRole::WsUs,
-            "wsusCtrl",
-            SccmArtifactFamily::SoftwareUpdatePoint,
-            true,
-            true,
-        ),
-        (
             "wsyncmgr.log",
-            SccmRole::SoftwareUpdatePoint,
-            "wsyncmgr",
-            SccmArtifactFamily::SoftwareUpdatePoint,
-            true,
-            true,
-        ),
-        (
-            "wsyncmgr.log",
-            SccmRole::WsUs,
+            SccmRole::SiteServer,
             "wsyncmgr",
             SccmArtifactFamily::SoftwareUpdatePoint,
             true,
@@ -826,14 +782,6 @@ fn expected_catalog_tuples() -> Vec<ExpectedCatalogTuple> {
         (
             "SUPSetup.log",
             SccmRole::SoftwareUpdatePoint,
-            "supSetup",
-            SccmArtifactFamily::SoftwareUpdatePoint,
-            true,
-            true,
-        ),
-        (
-            "SUPSetup.log",
-            SccmRole::WsUs,
             "supSetup",
             SccmArtifactFamily::SoftwareUpdatePoint,
             true,
@@ -881,7 +829,7 @@ fn expected_catalog_tuples() -> Vec<ExpectedCatalogTuple> {
         ),
         (
             "AdminService.log",
-            SccmRole::AdminService,
+            SccmRole::Provider,
             "adminService",
             SccmArtifactFamily::AdminService,
             true,

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -359,8 +359,6 @@ fn catalog_rotation_grammar_accepts_only_canonical_suffixes() {
         ("AppEnforce.log", SccmRotation::Current),
         ("AppEnforce.lo_", SccmRotation::LoUnderscore),
         ("AppEnforce.LO_", SccmRotation::LoUnderscore),
-        ("AppEnforce.log.lo_", SccmRotation::LoUnderscore),
-        ("AppEnforce.LOG.LO_", SccmRotation::LoUnderscore),
         ("AppEnforce.log.3", SccmRotation::Numbered(3)),
         (
             "AppEnforce.log.20260730-150000",
@@ -380,6 +378,8 @@ fn catalog_rotation_grammar_accepts_only_canonical_suffixes() {
     }
 
     let rejected = [
+        ("AppEnforce.log.lo_", ".lo_"),
+        ("AppEnforce.LOG.LO_", ".LO_"),
         ("AppEnforce.log.0", ".0"),
         ("AppEnforce.log.03", ".03"),
         ("AppEnforce.log.4294967296", ".4294967296"),

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -267,6 +267,18 @@ fn catalog_recognizes_rotated_client_log_by_base_name() {
 }
 
 #[test]
+fn catalog_recognizes_standard_lo_rollback_name_by_canonical_log_basename() {
+    let class = classify_artifact_name("CcmExec.lo_", SccmRole::Client);
+
+    assert_eq!(class.basename, "CcmExec.log");
+    assert_eq!(class.logical_name, "ccmExec");
+    assert_eq!(class.family, SccmArtifactFamily::ClientHealth);
+    assert_eq!(class.rotation, SccmRotation::LoUnderscore);
+    assert!(class.uses_ccm_records);
+    assert!(class.supported_for_diagnosis);
+}
+
+#[test]
 fn catalog_leaves_unrecognized_sources_explicitly_unknown() {
     let class = classify_artifact_name("CustomVendorHook.log", SccmRole::Client);
     assert_eq!(
@@ -345,6 +357,8 @@ fn catalog_rejects_every_role_not_declared_by_the_exact_table() {
 fn catalog_rotation_grammar_accepts_only_canonical_suffixes() {
     let canonical = [
         ("AppEnforce.log", SccmRotation::Current),
+        ("AppEnforce.lo_", SccmRotation::LoUnderscore),
+        ("AppEnforce.LO_", SccmRotation::LoUnderscore),
         ("AppEnforce.log.lo_", SccmRotation::LoUnderscore),
         ("AppEnforce.LOG.LO_", SccmRotation::LoUnderscore),
         ("AppEnforce.log.3", SccmRotation::Numbered(3)),
@@ -366,7 +380,6 @@ fn catalog_rotation_grammar_accepts_only_canonical_suffixes() {
     }
 
     let rejected = [
-        ("AppEnforce.lo_", ".lo_"),
         ("AppEnforce.log.0", ".0"),
         ("AppEnforce.log.03", ".03"),
         ("AppEnforce.log.4294967296", ".4294967296"),

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -1,6 +1,8 @@
+use cmtraceopen_parser::models::log_entry::ParserKind;
+use cmtraceopen_parser::parser::detect::detect_parser;
 use cmtraceopen_parser::sccm::{
-    SccmArtifact, SccmCoverageState, SccmFindingClass, SccmRole, SccmRotation,
-    SCCM_DIAGNOSTICS_SCHEMA_VERSION,
+    classify_artifact_name, SccmArtifact, SccmArtifactFamily, SccmCoverageState, SccmFindingClass,
+    SccmRole, SccmRotation, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
 };
 
 #[test]
@@ -88,4 +90,115 @@ fn artifact_manifest_fixture_preserves_each_coverage_state() {
         Some(r"C:\Windows\CCM\Logs\PolicyAgent.log")
     );
     assert_eq!(artifacts[3].encoding, None);
+}
+
+#[test]
+fn catalog_classifies_client_policy_without_changing_ccm_parser_kind() {
+    let class = classify_artifact_name("PolicyAgent.log", SccmRole::Client);
+    assert_eq!(class.family, SccmArtifactFamily::ClientPolicy);
+    assert_eq!(class.logical_name, "policyAgent");
+    assert!(class.uses_ccm_records);
+
+    let ccm = r#"<![LOG[Synthetic policy record]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#;
+    assert_eq!(
+        detect_parser("PolicyAgent.log", ccm).parser,
+        ParserKind::Ccm
+    );
+}
+
+#[test]
+fn catalog_recognizes_rotated_client_log_by_base_name() {
+    let class = classify_artifact_name("AppEnforce.log.3", SccmRole::Client);
+    assert_eq!(class.family, SccmArtifactFamily::ClientApplication);
+    assert_eq!(class.rotation, SccmRotation::Numbered(3));
+}
+
+#[test]
+fn catalog_leaves_unrecognized_sources_explicitly_unknown() {
+    let class = classify_artifact_name("CustomVendorHook.log", SccmRole::Client);
+    assert_eq!(
+        class.family,
+        SccmArtifactFamily::Unknown("customVendorHook".into())
+    );
+    assert!(!class.supported_for_diagnosis);
+}
+
+#[test]
+fn catalog_recognizes_every_declared_initial_source_for_its_role() {
+    let declared = [
+        ("CCMSetup.log", SccmRole::Client),
+        ("CcmEval.log", SccmRole::Client),
+        ("CcmExec.log", SccmRole::Client),
+        ("CcmRestart.log", SccmRole::Client),
+        ("ClientIDManagerStartup.log", SccmRole::Client),
+        ("ClientLocation.log", SccmRole::Client),
+        ("LocationServices.log", SccmRole::Client),
+        ("CcmMessaging.log", SccmRole::Client),
+        ("PolicyAgent.log", SccmRole::Client),
+        ("PolicyAgentProvider.log", SccmRole::Client),
+        ("PolicyEvaluator.log", SccmRole::Client),
+        ("Scheduler.log", SccmRole::Client),
+        ("CAS.log", SccmRole::Client),
+        ("ContentTransferManager.log", SccmRole::Client),
+        ("DataTransferService.log", SccmRole::Client),
+        ("AppIntentEval.log", SccmRole::Client),
+        ("AppDiscovery.log", SccmRole::Client),
+        ("AppEnforce.log", SccmRole::Client),
+        ("ScanAgent.log", SccmRole::Client),
+        ("WUAHandler.log", SccmRole::Client),
+        ("UpdatesDeployment.log", SccmRole::Client),
+        ("UpdatesHandler.log", SccmRole::Client),
+        ("UpdatesStore.log", SccmRole::Client),
+        ("smsts.log", SccmRole::Client),
+        ("sitecomp.log", SccmRole::SiteServer),
+        ("hman.log", SccmRole::SiteServer),
+        ("statmgr.log", SccmRole::SiteServer),
+        ("statesys.log", SccmRole::SiteServer),
+        ("MP_CliReg.log", SccmRole::ManagementPoint),
+        ("MP_GetAuth.log", SccmRole::ManagementPoint),
+        ("MP_GetPolicy.log", SccmRole::ManagementPoint),
+        ("MP_Location.log", SccmRole::ManagementPoint),
+        ("MP_RegistrationManager.log", SccmRole::ManagementPoint),
+        ("mpcontrol.log", SccmRole::ManagementPoint),
+        ("distmgr.log", SccmRole::SiteServer),
+        ("PkgXferMgr.log", SccmRole::SiteServer),
+        ("SMSDPProv.log", SccmRole::DistributionPoint),
+        ("PullDP.log", SccmRole::DistributionPoint),
+        ("WCM.log", SccmRole::SoftwareUpdatePoint),
+        ("WSUSCtrl.log", SccmRole::SoftwareUpdatePoint),
+        ("wsyncmgr.log", SccmRole::SoftwareUpdatePoint),
+        ("SUPSetup.log", SccmRole::SoftwareUpdatePoint),
+        ("replmgr.log", SccmRole::SiteServer),
+        ("rcmctrl.log", SccmRole::SiteServer),
+        ("sender.log", SccmRole::SiteServer),
+        ("despool.log", SccmRole::SiteServer),
+        ("Smsprov.log", SccmRole::Provider),
+        ("AdminService.log", SccmRole::Provider),
+    ];
+
+    for (name, role) in declared {
+        let class = classify_artifact_name(name, role.clone());
+        assert_eq!(class.role, role, "role changed for {name}");
+        assert!(
+            !matches!(class.family, SccmArtifactFamily::Unknown(_)),
+            "{name} was not catalogued"
+        );
+        assert!(class.uses_ccm_records, "{name} lost CCM framing");
+        assert!(class.supported_for_diagnosis, "{name} became unsupported");
+    }
+}
+
+#[test]
+fn catalog_requires_a_declared_role_and_rotation_shape() {
+    let wrong_role = classify_artifact_name("PolicyAgent.log", SccmRole::SiteServer);
+    assert!(matches!(wrong_role.family, SccmArtifactFamily::Unknown(_)));
+    assert!(!wrong_role.supported_for_diagnosis);
+
+    let rotated = classify_artifact_name("AppEnforce.lo_", SccmRole::Client);
+    assert_eq!(rotated.family, SccmArtifactFamily::ClientApplication);
+    assert_eq!(rotated.rotation, SccmRotation::LoUnderscore);
+
+    let backup = classify_artifact_name("PolicyAgent.log.backup", SccmRole::Client);
+    assert!(matches!(backup.family, SccmArtifactFamily::Unknown(_)));
+    assert!(!backup.supported_for_diagnosis);
 }


### PR DESCRIPTION
## Scope

Issue-scoped Phase A of #318 from the SCCM diagnostics execution contract:

- public, versioned SCCM contract boundary in the pure Rust parser crate
- additive artifact, coverage, rotation, role, family, and source-catalog models
- tolerant future-value serialization without changing `LogEntry` or `ParserKind`
- canonical rotation grammar with lossless unsupported provenance
- exact producer-role catalog semantics (`distmgr`/`PkgXferMgr` and `WCM`/`wsyncmgr` remain site-server producers; DP-local/SUP-local sources stay distinct; Admin Service remains a family on the Provider producer)
- synthetic SCCM manifest fixture and exhaustive contract tests

No Windows I/O, Tauri, registry, WMI, network, database, live collection, workflow reducer, or cross-side correlation is added.

## Dependency state

This is the shared API review point. #319 and #335 production intake remain blocked until this Phase A contract is reviewed. Tasks 4–7 of #318 (logical-record evidence, signals, versioned keys, conservative findings) remain follow-up commits on this issue branch after the interface gate.

## Verification

- `cargo test --locked -p cmtraceopen-parser --test sccm_spine_contract` — 17 passed
- `cargo test --locked -p cmtraceopen-parser` — 588 passed in the owner run
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings` — passed
- `cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown` — passed
- `npx tsc --noEmit` — passed
- owned SCCM Rust files are rustfmt-clean
- `git diff --check f2caccf..HEAD` — passed

Repo-wide `cargo fmt --check --all` has unrelated pre-existing ESP/Tauri drift identical to the base commit; this PR does not modify those files.

## Review gates

- independent API review closed the wire-format, unknown-rotation, catalog-test, and string-normalization findings
- producer-role review finding is addressed by commit `e42df2b`
- CodeRabbit CLI review requested; currently rate-limited by the organization seat/cooldown, so it is not counted as a pass
- native Windows acceptance is neither required for this pure contract slice nor claimed

Refs #318
Refs #317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SCCM diagnostics support with structured artifact models, coverage states, roles, findings, and canonical log-rotation metadata.
  * Added catalog-based classification for known SCCM artifacts and rotated filenames, including deterministic handling for unknown sources.
  * Added support for SCCM artifact manifests with host, version, and collection/provenance details.
  * Improved stable JSON serialization of SCCM diagnostic data.
* **Tests**
  * Tightened serialization/deserialization validation for rotation values and expanded the classification test matrix.
  * Added/updated SCCM fixture data and strengthened round-trip and invalid-pattern coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->