### PR TITLE
feat(sccm): add logical CCM evidence framing

### DIFF
--- a/crates/cmtraceopen-parser/src/parser/ccm.rs
+++ b/crates/cmtraceopen-parser/src/parser/ccm.rs
@@ -24,7 +24,7 @@ fn ccm_re() -> &'static Regex {
     CELL.get_or_init(|| {
         Regex::new(concat!(
             r#"<!\[LOG\[(?P<msg>[\s\S]*?)\]LOG\]!>"#,
-            r#"<time="(?P<h>\d{1,2}):(?P<m>\d{1,2}):(?P<s>\d{1,2})\.(?P<ms>\d+)(?P<tz>[+-]*\d+)""#,
+            r#"<time="(?P<h>\d{1,2}):(?P<m>\d{1,2}):(?P<s>\d{1,2})\.(?P<time_tail>\d+(?:[+-]\d+)?)""#,
             r#"\s+date="(?P<mon>\d{1,2})-(?P<day>\d{1,2})-(?P<yr>\d{4})""#,
             r#"\s+component="(?P<comp>[^"]*)""#,
             r#"\s+context="(?P<context>[^"]*)""#,
@@ -168,6 +168,28 @@ pub(crate) fn truncate_subsecond_to_millis(value: &str) -> Option<u32> {
     } else {
         value.parse().ok()
     }
+}
+
+/// Split CCM's fractional-second field from its optional timezone offset.
+///
+/// A signed offset is self-delimiting. The documented legacy `%03u%d`
+/// grammar also permits a signless three-digit offset after exactly three
+/// millisecond digits. Other digit-only tails are fractional seconds with no
+/// source offset, including the seven-digit precision emitted by IME logs.
+fn split_ccm_time_tail(value: &str) -> (&str, Option<&str>) {
+    if let Some(index) = value
+        .as_bytes()
+        .iter()
+        .position(|byte| matches!(byte, b'+' | b'-'))
+    {
+        return (&value[..index], Some(&value[index..]));
+    }
+
+    if value.len() == 6 {
+        return (&value[..3], Some(&value[3..]));
+    }
+
+    (value, None)
 }
 
 /// Convert a naive local datetime + optional timezone offset (in minutes) to UTC epoch millis.
@@ -384,17 +406,23 @@ fn scan_ccm_content(content: &str, file_path: &str, mode: CcmScanMode) -> CcmSca
 /// Parse named captures from a CCM regex match into a CcmParsed struct.
 fn parse_captures(caps: &regex::Captures<'_>) -> Option<CcmParsed> {
     let msg = caps.name("msg").map(|m| m.as_str().to_string())?;
-    let h: u32 = caps.name("h")?.as_str().parse().ok()?;
-    let m: u32 = caps.name("m")?.as_str().parse().ok()?;
-    let s: u32 = caps.name("s")?.as_str().parse().ok()?;
-    let ms_str = caps.name("ms")?.as_str();
+    let h_text = caps.name("h")?.as_str();
+    let m_text = caps.name("m")?.as_str();
+    let s_text = caps.name("s")?.as_str();
+    let h: u32 = h_text.parse().ok()?;
+    let m: u32 = m_text.parse().ok()?;
+    let s: u32 = s_text.parse().ok()?;
+    let time_tail = caps.name("time_tail")?.as_str();
+    let (ms_str, timezone_text) = split_ccm_time_tail(time_tail);
     let ms = truncate_subsecond_to_millis(ms_str)?;
-    let timezone_text = caps.name("tz")?.as_str();
-    let parsed_timezone = timezone_text.parse::<i32>().ok();
-    let timezone_is_explicit = timezone_text.starts_with('+') || timezone_text.starts_with('-');
-    let mon: u32 = caps.name("mon")?.as_str().parse().ok()?;
-    let day: u32 = caps.name("day")?.as_str().parse().ok()?;
-    let yr: i32 = caps.name("yr")?.as_str().parse().ok()?;
+    let parsed_timezone = timezone_text.and_then(|value| value.parse::<i32>().ok());
+    let timezone_is_explicit = timezone_text.is_some();
+    let mon_text = caps.name("mon")?.as_str();
+    let day_text = caps.name("day")?.as_str();
+    let yr_text = caps.name("yr")?.as_str();
+    let mon: u32 = mon_text.parse().ok()?;
+    let day: u32 = day_text.parse().ok()?;
+    let yr: i32 = yr_text.parse().ok()?;
     let comp = caps.name("comp").map(|m| m.as_str().to_string());
     let context = caps.name("context").map(|m| m.as_str().to_string());
     // Preserve absent/empty/unparseable type as `None` so it falls back to
@@ -429,7 +457,9 @@ fn parse_captures(caps: &regex::Captures<'_>) -> Option<CcmParsed> {
         CcmTimestampParseState::OffsetInvalid
     };
     let timestamp_parse = CcmTimestampParse {
-        original_display: timestamp_display.clone(),
+        original_display: Some(format!(
+            "{mon_text}-{day_text}-{yr_text} {h_text}:{m_text}:{s_text}.{ms_str}"
+        )),
         offset_minutes: timezone_is_explicit.then_some(parsed_timezone).flatten(),
         utc_millis: normalized_timestamp,
         ordering_state,
@@ -448,7 +478,7 @@ fn parse_captures(caps: &regex::Captures<'_>) -> Option<CcmParsed> {
         timezone_offset: parsed_timezone.unwrap_or_default(),
         context,
         timestamp_parse,
-        public_compatible: parsed_timezone.is_some(),
+        public_compatible: timezone_text.is_none() || parsed_timezone.is_some(),
     })
 }
 

--- a/crates/cmtraceopen-parser/src/parser/ccm.rs
+++ b/crates/cmtraceopen-parser/src/parser/ccm.rs
@@ -192,6 +192,25 @@ fn split_ccm_time_tail(value: &str) -> (&str, Option<&str>) {
     (value, None)
 }
 
+/// Reproduce the pre-SCCM-spine public regex projection.
+///
+/// The legacy `(?P<ms>\d+)(?P<tz>[+-]*\d+)` captures greedily assigned the
+/// final digit of an unsigned tail to `timezoneOffset`. Public `LogEntry`
+/// callers retain that observable behavior; the SCCM envelope uses
+/// `split_ccm_time_tail` above for corrected provenance.
+fn split_legacy_public_time_tail(value: &str) -> Option<(&str, &str)> {
+    if let Some(index) = value
+        .as_bytes()
+        .iter()
+        .position(|byte| matches!(byte, b'+' | b'-'))
+    {
+        return (index > 0).then_some((&value[..index], &value[index..]));
+    }
+
+    let split_at = value.len().checked_sub(1)?;
+    (split_at > 0).then_some((&value[..split_at], &value[split_at..]))
+}
+
 /// Convert a naive local datetime + optional timezone offset (in minutes) to UTC epoch millis.
 /// Falls back to treating naive as UTC if the offset is invalid or overflows.
 pub(crate) fn naive_to_utc_millis(
@@ -436,8 +455,25 @@ fn parse_captures(caps: &regex::Captures<'_>) -> Option<CcmParsed> {
     let file = caps.name("file").map(|m| m.as_str().to_string());
 
     let severity = severity_from_type_field(typ, &msg);
-    let (timestamp, timestamp_display) =
-        build_timestamp(mon, day, yr, h, m, s, ms, parsed_timezone);
+    let public_timestamp = split_legacy_public_time_tail(time_tail).and_then(
+        |(public_ms_text, public_timezone_text)| {
+            let public_ms = truncate_subsecond_to_millis(public_ms_text)?;
+            let public_timezone = public_timezone_text.parse::<i32>().ok()?;
+            let (timestamp, timestamp_display) =
+                build_timestamp(mon, day, yr, h, m, s, public_ms, Some(public_timezone));
+            Some((timestamp, timestamp_display, public_timezone))
+        },
+    );
+    let public_compatible = public_timestamp.is_some();
+    let (timestamp, timestamp_display, timezone_offset) = public_timestamp.unwrap_or_else(|| {
+        let (timestamp, timestamp_display) =
+            build_timestamp(mon, day, yr, h, m, s, ms, parsed_timezone);
+        (
+            timestamp,
+            timestamp_display,
+            parsed_timezone.unwrap_or_default(),
+        )
+    });
     let naive = chrono::NaiveDate::from_ymd_opt(yr, mon, day)
         .and_then(|date| date.and_hms_milli_opt(h, m, s, ms));
     let normalized_timestamp = if timezone_is_explicit {
@@ -475,10 +511,10 @@ fn parse_captures(caps: &regex::Captures<'_>) -> Option<CcmParsed> {
         thread: thr,
         thread_display,
         source_file: file,
-        timezone_offset: parsed_timezone.unwrap_or_default(),
+        timezone_offset,
         context,
         timestamp_parse,
-        public_compatible: timezone_text.is_none() || parsed_timezone.is_some(),
+        public_compatible,
     })
 }
 

--- a/crates/cmtraceopen-parser/src/parser/ccm.rs
+++ b/crates/cmtraceopen-parser/src/parser/ccm.rs
@@ -27,7 +27,7 @@ fn ccm_re() -> &'static Regex {
             r#"<time="(?P<h>\d{1,2}):(?P<m>\d{1,2}):(?P<s>\d{1,2})\.(?P<ms>\d+)(?P<tz>[+-]*\d+)""#,
             r#"\s+date="(?P<mon>\d{1,2})-(?P<day>\d{1,2})-(?P<yr>\d{4})""#,
             r#"\s+component="(?P<comp>[^"]*)""#,
-            r#"\s+context="[^"]*""#,
+            r#"\s+context="(?P<context>[^"]*)""#,
             r#"\s+type="(?P<typ>\d)?""#,
             r#"\s+thread="(?P<thr>\d+)?""#,
             r#"(?:\s+file="(?P<file>[^"]*)")?>"#,
@@ -40,7 +40,8 @@ fn ccm_re() -> &'static Regex {
 /// Returns None if the line doesn't match the CCM format.
 fn parse_line(line: &str) -> Option<CcmParsed> {
     let caps = ccm_re().captures(line)?;
-    parse_captures(&caps)
+    let parsed = parse_captures(&caps)?;
+    parsed.public_compatible.then_some(parsed)
 }
 
 struct CcmParsed {
@@ -53,6 +54,112 @@ struct CcmParsed {
     thread_display: Option<String>,
     source_file: Option<String>,
     timezone_offset: i32,
+    context: Option<String>,
+    timestamp_parse: CcmTimestampParse,
+    public_compatible: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CcmTimestampParseState {
+    NormalizedUtc,
+    OffsetMissing,
+    OffsetInvalid,
+    TimestampMissing,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CcmTimestampParse {
+    pub original_display: Option<String>,
+    pub offset_minutes: Option<i32>,
+    pub utc_millis: Option<i64>,
+    pub ordering_state: CcmTimestampParseState,
+}
+
+impl CcmTimestampParse {
+    fn missing() -> Self {
+        Self {
+            original_display: None,
+            offset_minutes: None,
+            utc_millis: None,
+            ordering_state: CcmTimestampParseState::TimestampMissing,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CcmLogicalRecord {
+    pub entry: LogEntry,
+    pub context: Option<String>,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub timestamp: CcmTimestampParse,
+}
+
+impl CcmParsed {
+    fn into_logical_record(
+        self,
+        id: u64,
+        line_start: u32,
+        line_end: u32,
+        file_path: &str,
+    ) -> CcmLogicalRecord {
+        CcmLogicalRecord {
+            entry: LogEntry {
+                id,
+                line_number: line_start,
+                message: self.message,
+                component: self.component,
+                timestamp: self.timestamp,
+                timestamp_display: self.timestamp_display,
+                severity: self.severity,
+                thread: Some(self.thread),
+                thread_display: self.thread_display,
+                source_file: self.source_file,
+                format: LogFormat::Ccm,
+                file_path: file_path.to_string(),
+                timezone_offset: Some(self.timezone_offset),
+                error_code_spans: Vec::new(),
+                ip_address: None,
+                host_name: None,
+                mac_address: None,
+                result_code: None,
+                gle_code: None,
+                setup_phase: None,
+                operation_name: None,
+                http_method: None,
+                uri_stem: None,
+                uri_query: None,
+                status_code: None,
+                sub_status: None,
+                time_taken_ms: None,
+                client_ip: None,
+                server_ip: None,
+                user_agent: None,
+                server_port: None,
+                username: None,
+                win32_status: None,
+                query_name: None,
+                query_type: None,
+                response_code: None,
+                dns_direction: None,
+                dns_protocol: None,
+                source_ip: None,
+                dns_flags: None,
+                dns_event_id: None,
+                zone_name: None,
+                entry_kind: None,
+                whatif: None,
+                section_name: None,
+                section_color: None,
+                iteration: None,
+                tags: None,
+            },
+            context: self.context,
+            line_start,
+            line_end,
+            timestamp: self.timestamp_parse,
+        }
+    }
 }
 
 pub(crate) fn truncate_subsecond_to_millis(value: &str) -> Option<u32> {
@@ -69,16 +176,17 @@ pub(crate) fn naive_to_utc_millis(
     naive: chrono::NaiveDateTime,
     offset_minutes: Option<i32>,
 ) -> i64 {
-    if let Some(offset_minutes) = offset_minutes {
-        offset_minutes
-            .checked_mul(60)
-            .and_then(FixedOffset::east_opt)
-            .and_then(|offset| offset.from_local_datetime(&naive).single())
-            .map(|dt| dt.timestamp_millis())
-            .unwrap_or_else(|| naive.and_utc().timestamp_millis())
-    } else {
-        naive.and_utc().timestamp_millis()
-    }
+    offset_minutes
+        .and_then(|offset| normalized_utc_millis(naive, offset))
+        .unwrap_or_else(|| naive.and_utc().timestamp_millis())
+}
+
+fn normalized_utc_millis(naive: chrono::NaiveDateTime, offset_minutes: i32) -> Option<i64> {
+    offset_minutes
+        .checked_mul(60)
+        .and_then(FixedOffset::east_opt)
+        .and_then(|offset| offset.from_local_datetime(&naive).single())
+        .map(|datetime| datetime.timestamp_millis())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -153,8 +261,38 @@ pub fn parse_content(
 /// matched as a single logical record.  Text between matched records is
 /// emitted as individual plain-text entries, preserving line numbers.
 fn parse_content_multiline(content: &str, file_path: &str) -> (Vec<LogEntry>, u32) {
+    let scan = scan_ccm_content(content, file_path, CcmScanMode::PublicProjection);
+    (
+        scan.records
+            .into_iter()
+            .map(|record| record.entry)
+            .collect(),
+        scan.errors,
+    )
+}
+
+pub(crate) fn scan_logical_records(content: &str, file_path: &str) -> Vec<CcmLogicalRecord> {
+    scan_ccm_content(content, file_path, CcmScanMode::SccmEvidence)
+        .records
+        .into_iter()
+        .filter(|record| record.entry.format == LogFormat::Ccm)
+        .collect()
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CcmScanMode {
+    PublicProjection,
+    SccmEvidence,
+}
+
+struct CcmScan {
+    records: Vec<CcmLogicalRecord>,
+    errors: u32,
+}
+
+fn scan_ccm_content(content: &str, file_path: &str, mode: CcmScanMode) -> CcmScan {
     let line_starts = build_line_starts(content);
-    let mut entries: Vec<LogEntry> = Vec::new();
+    let mut records = Vec::new();
     let mut errors = 0u32;
     let mut id_counter = 0u64;
     let mut cursor = 0usize;
@@ -171,72 +309,36 @@ fn parse_content_multiline(content: &str, file_path: &str) -> (Vec<LogEntry>, u3
             cursor,
             &line_starts,
             file_path,
-            &mut entries,
+            &mut records,
             &mut id_counter,
             &mut errors,
         );
 
-        // Parse the matched CCM record
-        let line_number = line_number_for_offset(&line_starts, full_match.start());
+        let line_start = line_number_for_offset(&line_starts, full_match.start());
+        let line_end = line_number_for_offset(&line_starts, full_match.end().saturating_sub(1));
         if let Some(parsed) = parse_captures(&caps) {
-            entries.push(LogEntry {
-                id: id_counter,
-                line_number,
-                message: parsed.message,
-                component: parsed.component,
-                timestamp: parsed.timestamp,
-                timestamp_display: parsed.timestamp_display,
-                severity: parsed.severity,
-                thread: Some(parsed.thread),
-                thread_display: parsed.thread_display,
-                source_file: parsed.source_file,
-                format: LogFormat::Ccm,
-                file_path: file_path.to_string(),
-                timezone_offset: Some(parsed.timezone_offset),
-                error_code_spans: Vec::new(),
-                ip_address: None,
-                host_name: None,
-                mac_address: None,
-                result_code: None,
-                gle_code: None,
-                setup_phase: None,
-                operation_name: None,
-                http_method: None,
-                uri_stem: None,
-                uri_query: None,
-                status_code: None,
-                sub_status: None,
-                time_taken_ms: None,
-                client_ip: None,
-                server_ip: None,
-                user_agent: None,
-                server_port: None,
-                username: None,
-                win32_status: None,
-                query_name: None,
-                query_type: None,
-                response_code: None,
-                dns_direction: None,
-                dns_protocol: None,
-                source_ip: None,
-                dns_flags: None,
-                dns_event_id: None,
-                zone_name: None,
-                entry_kind: None,
-                whatif: None,
-                section_name: None,
-                section_color: None,
-                iteration: None,
-                tags: None,
-            });
-            id_counter += 1;
+            if parsed.public_compatible || mode == CcmScanMode::SccmEvidence {
+                records
+                    .push(parsed.into_logical_record(id_counter, line_start, line_end, file_path));
+                id_counter += 1;
+            } else {
+                push_unmatched_plain(
+                    full_match.as_str(),
+                    full_match.start(),
+                    &line_starts,
+                    file_path,
+                    &mut records,
+                    &mut id_counter,
+                    &mut errors,
+                );
+            }
         } else {
             push_unmatched_plain(
                 full_match.as_str(),
                 full_match.start(),
                 &line_starts,
                 file_path,
-                &mut entries,
+                &mut records,
                 &mut id_counter,
                 &mut errors,
             );
@@ -252,18 +354,31 @@ fn parse_content_multiline(content: &str, file_path: &str) -> (Vec<LogEntry>, u3
         cursor,
         &line_starts,
         file_path,
-        &mut entries,
+        &mut records,
         &mut id_counter,
         &mut errors,
     );
 
     if !matched_any {
-        // No CCM records found at all — fall back to line-by-line
         let lines: Vec<&str> = content.lines().collect();
-        return parse_lines(&lines, file_path);
+        let (entries, errors) = parse_lines(&lines, file_path);
+        let records = entries
+            .into_iter()
+            .map(|entry| {
+                let line = entry.line_number;
+                CcmLogicalRecord {
+                    entry,
+                    context: None,
+                    line_start: line,
+                    line_end: line,
+                    timestamp: CcmTimestampParse::missing(),
+                }
+            })
+            .collect();
+        return CcmScan { records, errors };
     }
 
-    (entries, errors)
+    CcmScan { records, errors }
 }
 
 /// Parse named captures from a CCM regex match into a CcmParsed struct.
@@ -274,11 +389,14 @@ fn parse_captures(caps: &regex::Captures<'_>) -> Option<CcmParsed> {
     let s: u32 = caps.name("s")?.as_str().parse().ok()?;
     let ms_str = caps.name("ms")?.as_str();
     let ms = truncate_subsecond_to_millis(ms_str)?;
-    let tz: i32 = caps.name("tz")?.as_str().parse().ok()?;
+    let timezone_text = caps.name("tz")?.as_str();
+    let parsed_timezone = timezone_text.parse::<i32>().ok();
+    let timezone_is_explicit = timezone_text.starts_with('+') || timezone_text.starts_with('-');
     let mon: u32 = caps.name("mon")?.as_str().parse().ok()?;
     let day: u32 = caps.name("day")?.as_str().parse().ok()?;
     let yr: i32 = caps.name("yr")?.as_str().parse().ok()?;
     let comp = caps.name("comp").map(|m| m.as_str().to_string());
+    let context = caps.name("context").map(|m| m.as_str().to_string());
     // Preserve absent/empty/unparseable type as `None` so it falls back to
     // text-based detection. Coercing to `Some(0)` would misclassify neutral
     // lines as Success now that type="0" maps to Severity::Success.
@@ -290,7 +408,32 @@ fn parse_captures(caps: &regex::Captures<'_>) -> Option<CcmParsed> {
     let file = caps.name("file").map(|m| m.as_str().to_string());
 
     let severity = severity_from_type_field(typ, &msg);
-    let (timestamp, timestamp_display) = build_timestamp(mon, day, yr, h, m, s, ms, Some(tz));
+    let (timestamp, timestamp_display) =
+        build_timestamp(mon, day, yr, h, m, s, ms, parsed_timezone);
+    let naive = chrono::NaiveDate::from_ymd_opt(yr, mon, day)
+        .and_then(|date| date.and_hms_milli_opt(h, m, s, ms));
+    let normalized_timestamp = if timezone_is_explicit {
+        naive.and_then(|value| {
+            parsed_timezone.and_then(|offset| normalized_utc_millis(value, offset))
+        })
+    } else {
+        None
+    };
+    let ordering_state = if naive.is_none() {
+        CcmTimestampParseState::TimestampMissing
+    } else if !timezone_is_explicit {
+        CcmTimestampParseState::OffsetMissing
+    } else if normalized_timestamp.is_some() {
+        CcmTimestampParseState::NormalizedUtc
+    } else {
+        CcmTimestampParseState::OffsetInvalid
+    };
+    let timestamp_parse = CcmTimestampParse {
+        original_display: timestamp_display.clone(),
+        offset_minutes: timezone_is_explicit.then_some(parsed_timezone).flatten(),
+        utc_millis: normalized_timestamp,
+        ordering_state,
+    };
     let thread_display = Some(format_thread_display(thr));
 
     Some(CcmParsed {
@@ -302,7 +445,10 @@ fn parse_captures(caps: &regex::Captures<'_>) -> Option<CcmParsed> {
         thread: thr,
         thread_display,
         source_file: file,
-        timezone_offset: tz,
+        timezone_offset: parsed_timezone.unwrap_or_default(),
+        context,
+        timestamp_parse,
+        public_compatible: parsed_timezone.is_some(),
     })
 }
 
@@ -323,13 +469,13 @@ fn line_number_for_offset(line_starts: &[usize], offset: usize) -> u32 {
     }
 }
 
-/// Emit each non-empty physical line in `segment` as a plain-text LogEntry.
+/// Emit each non-empty physical line in `segment` as a plain-text envelope.
 fn push_unmatched_plain(
     segment: &str,
     base_offset: usize,
     line_starts: &[usize],
     file_path: &str,
-    entries: &mut Vec<LogEntry>,
+    records: &mut Vec<CcmLogicalRecord>,
     id_counter: &mut u64,
     errors: &mut u32,
 ) {
@@ -338,9 +484,10 @@ fn push_unmatched_plain(
         let line = piece.trim_end_matches(['\r', '\n']);
         let trimmed = line.trim();
         if !trimmed.is_empty() {
-            entries.push(LogEntry {
+            let line_number = line_number_for_offset(line_starts, base_offset + local_offset);
+            let entry = LogEntry {
                 id: *id_counter,
-                line_number: line_number_for_offset(line_starts, base_offset + local_offset),
+                line_number,
                 message: trimmed.to_string(),
                 component: None,
                 timestamp: None,
@@ -387,6 +534,13 @@ fn push_unmatched_plain(
                 section_color: None,
                 iteration: None,
                 tags: None,
+            };
+            records.push(CcmLogicalRecord {
+                entry,
+                context: None,
+                line_start: line_number,
+                line_end: line_number,
+                timestamp: CcmTimestampParse::missing(),
             });
             *id_counter += 1;
             *errors += 1;
@@ -418,56 +572,12 @@ pub fn parse_lines(lines: &[&str], file_path: &str) -> (Vec<LogEntry>, u32) {
 
         match parse_line(line) {
             Some(parsed) => {
-                entries.push(LogEntry {
-                    id: id_counter,
-                    line_number: (i + 1) as u32,
-                    message: parsed.message,
-                    component: parsed.component,
-                    timestamp: parsed.timestamp,
-                    timestamp_display: parsed.timestamp_display,
-                    severity: parsed.severity,
-                    thread: Some(parsed.thread),
-                    thread_display: parsed.thread_display,
-                    source_file: parsed.source_file,
-                    format: LogFormat::Ccm,
-                    file_path: file_path.to_string(),
-                    timezone_offset: Some(parsed.timezone_offset),
-                    error_code_spans: Vec::new(),
-                    ip_address: None,
-                    host_name: None,
-                    mac_address: None,
-                    result_code: None,
-                    gle_code: None,
-                    setup_phase: None,
-                    operation_name: None,
-                    http_method: None,
-                    uri_stem: None,
-                    uri_query: None,
-                    status_code: None,
-                    sub_status: None,
-                    time_taken_ms: None,
-                    client_ip: None,
-                    server_ip: None,
-                    user_agent: None,
-                    server_port: None,
-                    username: None,
-                    win32_status: None,
-                    query_name: None,
-                    query_type: None,
-                    response_code: None,
-                    dns_direction: None,
-                    dns_protocol: None,
-                    source_ip: None,
-                    dns_flags: None,
-                    dns_event_id: None,
-                    zone_name: None,
-                    entry_kind: None,
-                    whatif: None,
-                    section_name: None,
-                    section_color: None,
-                    iteration: None,
-                    tags: None,
-                });
+                let line_number = (i + 1) as u32;
+                entries.push(
+                    parsed
+                        .into_logical_record(id_counter, line_number, line_number, file_path)
+                        .entry,
+                );
                 id_counter += 1;
             }
             None => {
@@ -765,5 +875,33 @@ mod tests {
             "extreme offset should fall back to UTC"
         );
         assert!(display.is_some(), "display should always be present");
+    }
+
+    #[test]
+    fn logical_scanner_retains_multiline_metadata() {
+        let text = concat!(
+            "<![LOG[Policy request completed for assignment\n",
+            "{11111111-1111-1111-1111-111111111111}]LOG]!>",
+            "<time=\"10:00:00.000-240\" date=\"07-30-2026\" ",
+            "component=\"PolicyAgent\" context=\"NT AUTHORITY\\SYSTEM\" ",
+            "type=\"1\" thread=\"42\" file=\"policyagent.cpp\">"
+        );
+
+        let records = scan_logical_records(text, "PolicyAgent.log");
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].line_start, 1);
+        assert_eq!(records[0].line_end, 2);
+        assert_eq!(records[0].context.as_deref(), Some(r"NT AUTHORITY\SYSTEM"));
+        assert_eq!(
+            records[0].timestamp.original_display.as_deref(),
+            Some("07-30-2026 10:00:00.000")
+        );
+        assert_eq!(records[0].timestamp.offset_minutes, Some(-240));
+        assert_eq!(
+            records[0].timestamp.ordering_state,
+            CcmTimestampParseState::NormalizedUtc
+        );
+        assert!(records[0].timestamp.utc_millis.is_some());
     }
 }

--- a/crates/cmtraceopen-parser/src/sccm/evidence.rs
+++ b/crates/cmtraceopen-parser/src/sccm/evidence.rs
@@ -1,13 +1,8 @@
 use crate::parser::ccm::{CcmLogicalRecord, CcmTimestampParse, CcmTimestampParseState};
 
 use super::models::{
-    SccmArtifact, SccmEvidence, SccmEvidenceRef, SccmRole, SccmSensitiveHandle,
-    SccmTimeOrderingState, SccmTimestamp,
+    SccmArtifact, SccmEvidence, SccmEvidenceRef, SccmRole, SccmTimeOrderingState, SccmTimestamp,
 };
-
-const CONTEXT_HANDLE_SCHEME: &str = "sccm-context-fnv1a64-v1";
-const FNV1A64_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
-const FNV1A64_PRIME: u64 = 0x00000100000001b3;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct SccmRawEvidenceSnapshot {
@@ -58,11 +53,10 @@ impl SccmRawEvidenceSnapshot {
             ccm_source_file: self.ccm_source_file.clone(),
             message: self.message.clone(),
             timestamp: self.timestamp.clone(),
-            execution_context: self
-                .raw_execution_context
-                .as_deref()
-                .filter(|context| !context.trim().is_empty())
-                .map(sensitive_context_handle),
+            // Raw execution context remains available only to this
+            // crate-private snapshot. A public handle requires a separately
+            // reviewed keyed scheme and explicit caller-provided key.
+            execution_context: None,
         }
     }
 }
@@ -86,23 +80,6 @@ impl From<CcmTimestampParseState> for SccmTimeOrderingState {
             CcmTimestampParseState::OffsetInvalid => Self::OffsetInvalid,
             CcmTimestampParseState::TimestampMissing => Self::TimestampMissing,
         }
-    }
-}
-
-fn sensitive_context_handle(context: &str) -> SccmSensitiveHandle {
-    let mut hash = FNV1A64_OFFSET_BASIS;
-    for byte in b"sccm-context-v1\0"
-        .iter()
-        .copied()
-        .chain(context.as_bytes().iter().copied())
-    {
-        hash ^= u64::from(byte);
-        hash = hash.wrapping_mul(FNV1A64_PRIME);
-    }
-
-    SccmSensitiveHandle {
-        scheme: CONTEXT_HANDLE_SCHEME.to_string(),
-        value: format!("{hash:016x}"),
     }
 }
 
@@ -145,6 +122,6 @@ mod tests {
         assert!(!serde_json::to_string(&exported)
             .unwrap()
             .contains(r"NT AUTHORITY\\SYSTEM"));
-        assert!(exported.execution_context.is_some());
+        assert_eq!(exported.execution_context, None);
     }
 }

--- a/crates/cmtraceopen-parser/src/sccm/evidence.rs
+++ b/crates/cmtraceopen-parser/src/sccm/evidence.rs
@@ -1,8 +1,112 @@
 use crate::parser::ccm::{CcmLogicalRecord, CcmTimestampParse, CcmTimestampParseState};
+use regex::Regex;
+use std::sync::OnceLock;
 
 use super::models::{
     SccmArtifact, SccmEvidence, SccmEvidenceRef, SccmRole, SccmTimeOrderingState, SccmTimestamp,
 };
+
+const PUBLIC_MESSAGE_PROFILE: &str = "sccm-public-message-v1";
+const PUBLIC_MESSAGE_REDACTION: &str = "[redacted:sccm-public-message-v1]";
+
+fn sensitive_message_label_re() -> &'static Regex {
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    CELL.get_or_init(|| {
+        Regex::new(
+            r"(?i)\b(?:authorization|shared[_-]?access[_-]?signature|client[_-]?secret|(?:client|access|refresh|id|device|session)[_-]?token|api[_-]?key|account[_-]?key|credential|password|passwd|secret|token|username|user|sig)\b\s*(?::|=)\s*",
+        )
+        .expect("SCCM sensitive message label regex must compile")
+    })
+}
+
+fn windows_identity_re() -> &'static Regex {
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    CELL.get_or_init(|| {
+        Regex::new(r"(?i)\b(?:NT AUTHORITY|[A-Z0-9][A-Z0-9._-]*)\\[A-Z0-9][A-Z0-9._$-]*\b")
+            .expect("SCCM Windows identity regex must compile")
+    })
+}
+
+/// Profile v1 is a deterministic, parser-only public projection. It removes
+/// recognized identity and secret-bearing values while leaving diagnostic
+/// codes and approved structured keys outside those values unchanged. It does
+/// not imply native collector validation.
+fn project_public_message_v1(raw: &str) -> String {
+    let redacted = redact_sensitive_segments(raw);
+    let projected = redact_windows_identities(&redacted);
+
+    format!("[{PUBLIC_MESSAGE_PROFILE}] {projected}")
+}
+
+fn redact_sensitive_segments(value: &str) -> String {
+    let mut projected = String::with_capacity(value.len());
+    let mut copied_through = 0;
+    let mut search_from = 0;
+
+    while let Some(label) = sensitive_message_label_re().find_at(value, search_from) {
+        projected.push_str(&value[copied_through..label.start()]);
+        projected.push_str(PUBLIC_MESSAGE_REDACTION);
+
+        let value_end = sensitive_value_end(value, label.end());
+        copied_through = value_end;
+        search_from = value_end;
+    }
+
+    projected.push_str(&value[copied_through..]);
+    projected
+}
+
+fn sensitive_value_end(value: &str, value_start: usize) -> usize {
+    let remaining = &value[value_start..];
+    let Some(first) = remaining.chars().next() else {
+        return value.len();
+    };
+
+    if matches!(first, '"' | '\'') {
+        let quote_width = first.len_utf8();
+        let mut escaped = false;
+        for (offset, character) in remaining[quote_width..].char_indices() {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == first {
+                return value_start + quote_width + offset + character.len_utf8();
+            }
+        }
+
+        return value.len();
+    }
+
+    remaining
+        .char_indices()
+        .find_map(|(offset, character)| {
+            matches!(character, ',' | ';' | '\r' | '\n').then_some(value_start + offset)
+        })
+        .unwrap_or(value.len())
+}
+
+fn redact_windows_identities(value: &str) -> String {
+    let mut projected = String::with_capacity(value.len());
+    let mut copied_through = 0;
+
+    for matched in windows_identity_re().find_iter(value) {
+        let preceding = value[..matched.start()].chars().next_back();
+        let following = value[matched.end()..].chars().next();
+        let path_adjacent =
+            matches!(preceding, Some('\\' | '/' | ':')) || matches!(following, Some('\\' | '/'));
+        if path_adjacent {
+            continue;
+        }
+
+        projected.push_str(&value[copied_through..matched.start()]);
+        projected.push_str(PUBLIC_MESSAGE_REDACTION);
+        copied_through = matched.end();
+    }
+
+    projected.push_str(&value[copied_through..]);
+    projected
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct SccmRawEvidenceSnapshot {
@@ -51,7 +155,7 @@ impl SccmRawEvidenceSnapshot {
             role: self.role.clone(),
             component: self.component.clone(),
             ccm_source_file: self.ccm_source_file.clone(),
-            message: self.message.clone(),
+            message: project_public_message_v1(&self.message),
             timestamp: self.timestamp.clone(),
             // Raw execution context remains available only to this
             // crate-private snapshot. A public handle requires a separately
@@ -91,8 +195,11 @@ mod tests {
     use crate::sccm::models::{SccmCoverageState, SccmRole, SccmRotation};
 
     #[test]
-    fn export_redaction_does_not_mutate_raw_context_snapshot() {
-        let text = include_str!("../../tests/fixtures/sccm/spine/multiline-policy.log");
+    fn export_redaction_does_not_mutate_raw_snapshot() {
+        let raw_message = r#"Policy id={ABCDEFAB-0000-0000-0000-000000000001} failed hr=0x80070005 user=LAB\SyntheticUser token=synthetic-secret"#;
+        let text = format!(
+            r#"<![LOG[{raw_message}]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="NT AUTHORITY\SYSTEM" type="1" thread="42" file="policyagent.cpp">"#
+        );
         let artifact = SccmArtifact {
             artifact_id: "client-policy-agent".into(),
             display_name: "PolicyAgent.log".into(),
@@ -105,7 +212,7 @@ mod tests {
             coverage: SccmCoverageState::Captured,
             encoding: Some("utf-8".into()),
         };
-        let record = scan_logical_records(text, &artifact.display_name)
+        let record = scan_logical_records(&text, &artifact.display_name)
             .into_iter()
             .next()
             .expect("fixture contains one CCM record");
@@ -119,9 +226,16 @@ mod tests {
             snapshot.raw_execution_context.as_deref(),
             Some(r"NT AUTHORITY\SYSTEM")
         );
-        assert!(!serde_json::to_string(&exported)
-            .unwrap()
-            .contains(r"NT AUTHORITY\\SYSTEM"));
+        assert_eq!(snapshot.message, raw_message);
+        let exported_json = serde_json::to_string(&exported).unwrap();
+        assert!(!exported_json.contains(r"NT AUTHORITY\\SYSTEM"));
+        assert!(!exported_json.contains(r"LAB\\SyntheticUser"));
+        assert!(!exported_json.contains("synthetic-secret"));
+        assert!(exported.message.starts_with("[sccm-public-message-v1] "));
+        assert!(exported.message.contains("hr=0x80070005"));
+        assert!(exported
+            .message
+            .contains("{ABCDEFAB-0000-0000-0000-000000000001}"));
         assert_eq!(exported.execution_context, None);
     }
 }

--- a/crates/cmtraceopen-parser/src/sccm/evidence.rs
+++ b/crates/cmtraceopen-parser/src/sccm/evidence.rs
@@ -13,7 +13,32 @@ fn sensitive_message_label_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
         Regex::new(
-            r"(?i)\b(?:authorization|shared[_-]?access[_-]?signature|client[_-]?secret|(?:client|access|refresh|id|device|session)[_-]?token|api[_-]?key|account[_-]?key|credential|password|passwd|secret|token|username|user|sig)\b\s*(?::|=)\s*",
+            r"(?ix)
+            \b(?:
+                authorization\b
+                    (?:[\x20\t]*[:=][\x20\t]*|[\x20\t]+)
+                    (?:[a-z][a-z0-9._-]*[\x20\t]+)?
+                |
+                bearer\b(?:[\x20\t]*[:=][\x20\t]*|[\x20\t]+)
+                |
+                (?:
+                    shared[\x20_-]?access[\x20_-]?signature
+                    | client[\x20_-]?secret
+                    | (?:client|access|refresh|id|device|session)[\x20_-]?token
+                    | api[\x20_-]?key
+                    | account[\x20_-]?key
+                    | user[\x20_-]?principal[\x20_-]?name
+                    | credential
+                    | password
+                    | passwd
+                    | secret
+                    | token
+                    | username
+                    | user
+                    | upn
+                    | sig
+                )\b(?:[\x20\t]*[:=][\x20\t]*|[\x20\t]+)
+            )",
         )
         .expect("SCCM sensitive message label regex must compile")
     })
@@ -22,8 +47,16 @@ fn sensitive_message_label_re() -> &'static Regex {
 fn windows_identity_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
-        Regex::new(r"(?i)\b(?:NT AUTHORITY|[A-Z0-9][A-Z0-9._-]*)\\[A-Z0-9][A-Z0-9._$-]*\b")
+        Regex::new(r"(?i)(?:\b(?:NT AUTHORITY|[A-Z0-9][A-Z0-9._-]*)|\.)\\[A-Z0-9][A-Z0-9._$-]*\b")
             .expect("SCCM Windows identity regex must compile")
+    })
+}
+
+fn email_identity_re() -> &'static Regex {
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    CELL.get_or_init(|| {
+        Regex::new(r"(?i)\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b")
+            .expect("SCCM email identity regex must compile")
     })
 }
 
@@ -33,7 +66,8 @@ fn windows_identity_re() -> &'static Regex {
 /// not imply native collector validation.
 fn project_public_message_v1(raw: &str) -> String {
     let redacted = redact_sensitive_segments(raw);
-    let projected = redact_windows_identities(&redacted);
+    let identities_redacted = redact_windows_identities(&redacted);
+    let projected = redact_email_identities(&identities_redacted);
 
     format!("[{PUBLIC_MESSAGE_PROFILE}] {projected}")
 }
@@ -81,7 +115,8 @@ fn sensitive_value_end(value: &str, value_start: usize) -> usize {
     remaining
         .char_indices()
         .find_map(|(offset, character)| {
-            matches!(character, ',' | ';' | '\r' | '\n').then_some(value_start + offset)
+            (character.is_whitespace() || matches!(character, ',' | ';'))
+                .then_some(value_start + offset)
         })
         .unwrap_or(value.len())
 }
@@ -106,6 +141,12 @@ fn redact_windows_identities(value: &str) -> String {
 
     projected.push_str(&value[copied_through..]);
     projected
+}
+
+fn redact_email_identities(value: &str) -> String {
+    email_identity_re()
+        .replace_all(value, PUBLIC_MESSAGE_REDACTION)
+        .into_owned()
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/cmtraceopen-parser/src/sccm/evidence.rs
+++ b/crates/cmtraceopen-parser/src/sccm/evidence.rs
@@ -130,7 +130,7 @@ fn redact_windows_identities(value: &str) -> String {
         let preceding = value[..matched.start()].chars().next_back();
         let following = value[matched.end()..].chars().next();
         let path_adjacent =
-            matches!(preceding, Some('\\' | '/' | ':')) || matches!(following, Some('\\' | '/'));
+            matches!(preceding, Some('\\' | '/')) || matches!(following, Some('\\' | '/'));
         if path_adjacent {
             continue;
         }

--- a/crates/cmtraceopen-parser/src/sccm/evidence.rs
+++ b/crates/cmtraceopen-parser/src/sccm/evidence.rs
@@ -1,0 +1,150 @@
+use crate::parser::ccm::{CcmLogicalRecord, CcmTimestampParse, CcmTimestampParseState};
+
+use super::models::{
+    SccmArtifact, SccmEvidence, SccmEvidenceRef, SccmRole, SccmSensitiveHandle,
+    SccmTimeOrderingState, SccmTimestamp,
+};
+
+const CONTEXT_HANDLE_SCHEME: &str = "sccm-context-fnv1a64-v1";
+const FNV1A64_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+const FNV1A64_PRIME: u64 = 0x00000100000001b3;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SccmRawEvidenceSnapshot {
+    evidence_id: String,
+    reference: SccmEvidenceRef,
+    role: SccmRole,
+    component: Option<String>,
+    ccm_source_file: Option<String>,
+    message: String,
+    timestamp: SccmTimestamp,
+    raw_execution_context: Option<String>,
+}
+
+impl SccmRawEvidenceSnapshot {
+    pub(crate) fn from_record(artifact: &SccmArtifact, record: CcmLogicalRecord) -> Self {
+        let CcmLogicalRecord {
+            entry,
+            context,
+            line_start,
+            line_end,
+            timestamp,
+        } = record;
+        let entry_id = format!("{}:{line_start}-{line_end}", artifact.artifact_id);
+
+        Self {
+            evidence_id: entry_id.clone(),
+            reference: SccmEvidenceRef {
+                artifact_id: artifact.artifact_id.clone(),
+                entry_id,
+                line_start: Some(line_start),
+                line_end: Some(line_end),
+            },
+            role: artifact.role.clone(),
+            component: entry.component,
+            ccm_source_file: entry.source_file,
+            message: entry.message,
+            timestamp: timestamp.into(),
+            raw_execution_context: context,
+        }
+    }
+
+    pub(crate) fn export(&self) -> SccmEvidence {
+        SccmEvidence {
+            evidence_id: self.evidence_id.clone(),
+            reference: self.reference.clone(),
+            role: self.role.clone(),
+            component: self.component.clone(),
+            ccm_source_file: self.ccm_source_file.clone(),
+            message: self.message.clone(),
+            timestamp: self.timestamp.clone(),
+            execution_context: self
+                .raw_execution_context
+                .as_deref()
+                .filter(|context| !context.trim().is_empty())
+                .map(sensitive_context_handle),
+        }
+    }
+}
+
+impl From<CcmTimestampParse> for SccmTimestamp {
+    fn from(timestamp: CcmTimestampParse) -> Self {
+        Self {
+            original_display: timestamp.original_display,
+            offset_minutes: timestamp.offset_minutes,
+            utc_millis: timestamp.utc_millis,
+            ordering_state: timestamp.ordering_state.into(),
+        }
+    }
+}
+
+impl From<CcmTimestampParseState> for SccmTimeOrderingState {
+    fn from(state: CcmTimestampParseState) -> Self {
+        match state {
+            CcmTimestampParseState::NormalizedUtc => Self::NormalizedUtc,
+            CcmTimestampParseState::OffsetMissing => Self::OffsetMissing,
+            CcmTimestampParseState::OffsetInvalid => Self::OffsetInvalid,
+            CcmTimestampParseState::TimestampMissing => Self::TimestampMissing,
+        }
+    }
+}
+
+fn sensitive_context_handle(context: &str) -> SccmSensitiveHandle {
+    let mut hash = FNV1A64_OFFSET_BASIS;
+    for byte in b"sccm-context-v1\0"
+        .iter()
+        .copied()
+        .chain(context.as_bytes().iter().copied())
+    {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV1A64_PRIME);
+    }
+
+    SccmSensitiveHandle {
+        scheme: CONTEXT_HANDLE_SCHEME.to_string(),
+        value: format!("{hash:016x}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::ccm::scan_logical_records;
+
+    use super::*;
+    use crate::sccm::models::{SccmCoverageState, SccmRole, SccmRotation};
+
+    #[test]
+    fn export_redaction_does_not_mutate_raw_context_snapshot() {
+        let text = include_str!("../../tests/fixtures/sccm/spine/multiline-policy.log");
+        let artifact = SccmArtifact {
+            artifact_id: "client-policy-agent".into(),
+            display_name: "PolicyAgent.log".into(),
+            original_path: None,
+            host: None,
+            role: SccmRole::Client,
+            configmgr_version: None,
+            collected_at_utc: None,
+            rotation: SccmRotation::Current,
+            coverage: SccmCoverageState::Captured,
+            encoding: Some("utf-8".into()),
+        };
+        let record = scan_logical_records(text, &artifact.display_name)
+            .into_iter()
+            .next()
+            .expect("fixture contains one CCM record");
+        let snapshot = SccmRawEvidenceSnapshot::from_record(&artifact, record);
+        let before = snapshot.clone();
+
+        let exported = snapshot.export();
+
+        assert_eq!(snapshot, before);
+        assert_eq!(
+            snapshot.raw_execution_context.as_deref(),
+            Some(r"NT AUTHORITY\SYSTEM")
+        );
+        assert!(!serde_json::to_string(&exported)
+            .unwrap()
+            .contains(r"NT AUTHORITY\\SYSTEM"));
+        assert!(exported.execution_context.is_some());
+    }
+}

--- a/crates/cmtraceopen-parser/src/sccm/evidence.rs
+++ b/crates/cmtraceopen-parser/src/sccm/evidence.rs
@@ -13,15 +13,16 @@ fn sensitive_message_label_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
         Regex::new(
-            r"(?ix)
-            \b(?:
-                authorization\b
+            r#"(?ix)
+            (?:
+                ["']?\b authorization\b ["']?
                     (?:[\x20\t]*[:=][\x20\t]*|[\x20\t]+)
                     (?:[a-z][a-z0-9._-]*[\x20\t]+)?
                 |
-                bearer\b(?:[\x20\t]*[:=][\x20\t]*|[\x20\t]+)
+                ["']?\b bearer\b ["']?
+                    (?:[\x20\t]*[:=][\x20\t]*|[\x20\t]+)
                 |
-                (?:
+                ["']?\b(?:
                     shared[\x20_-]?access[\x20_-]?signature
                     | client[\x20_-]?secret
                     | (?:client|access|refresh|id|device|session)[\x20_-]?token
@@ -37,8 +38,8 @@ fn sensitive_message_label_re() -> &'static Regex {
                     | user
                     | upn
                     | sig
-                )\b(?:[\x20\t]*[:=][\x20\t]*|[\x20\t]+)
-            )",
+                )\b["']?(?:[\x20\t]*[:=][\x20\t]*|[\x20\t]+)
+            )"#,
         )
         .expect("SCCM sensitive message label regex must compile")
     })
@@ -115,7 +116,7 @@ fn sensitive_value_end(value: &str, value_start: usize) -> usize {
     remaining
         .char_indices()
         .find_map(|(offset, character)| {
-            (character.is_whitespace() || matches!(character, ',' | ';'))
+            (character.is_whitespace() || matches!(character, ',' | ';' | '&'))
                 .then_some(value_start + offset)
         })
         .unwrap_or(value.len())
@@ -237,7 +238,7 @@ mod tests {
 
     #[test]
     fn export_redaction_does_not_mutate_raw_snapshot() {
-        let raw_message = r#"Policy id={ABCDEFAB-0000-0000-0000-000000000001} failed hr=0x80070005 user=LAB\SyntheticUser token=synthetic-secret"#;
+        let raw_message = r#"Policy id={ABCDEFAB-0000-0000-0000-000000000001} failed hr=0x80070005 user=LAB\SyntheticUser token=synthetic-secret payload={"token":"synthetic-json-secret","user":"SyntheticJsonUser"} url=https://example.invalid/?token=synthetic-query-secret&status=71"#;
         let text = format!(
             r#"<![LOG[{raw_message}]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="NT AUTHORITY\SYSTEM" type="1" thread="42" file="policyagent.cpp">"#
         );
@@ -272,8 +273,12 @@ mod tests {
         assert!(!exported_json.contains(r"NT AUTHORITY\\SYSTEM"));
         assert!(!exported_json.contains(r"LAB\\SyntheticUser"));
         assert!(!exported_json.contains("synthetic-secret"));
+        assert!(!exported_json.contains("synthetic-json-secret"));
+        assert!(!exported_json.contains("SyntheticJsonUser"));
+        assert!(!exported_json.contains("synthetic-query-secret"));
         assert!(exported.message.starts_with("[sccm-public-message-v1] "));
         assert!(exported.message.contains("hr=0x80070005"));
+        assert!(exported.message.contains("&status=71"));
         assert!(exported
             .message
             .contains("{ABCDEFAB-0000-0000-0000-000000000001}"));

--- a/crates/cmtraceopen-parser/src/sccm/ingest.rs
+++ b/crates/cmtraceopen-parser/src/sccm/ingest.rs
@@ -1,0 +1,11 @@
+use crate::parser::ccm::scan_logical_records;
+
+use super::evidence::SccmRawEvidenceSnapshot;
+use super::models::{SccmArtifact, SccmEvidence};
+
+pub fn normalize_ccm_artifact(artifact: SccmArtifact, content: &str) -> Vec<SccmEvidence> {
+    scan_logical_records(content, &artifact.display_name)
+        .into_iter()
+        .map(|record| SccmRawEvidenceSnapshot::from_record(&artifact, record).export())
+        .collect()
+}

--- a/crates/cmtraceopen-parser/src/sccm/mod.rs
+++ b/crates/cmtraceopen-parser/src/sccm/mod.rs
@@ -1,6 +1,9 @@
 pub mod catalog;
+mod evidence;
+mod ingest;
 pub mod models;
 mod rotation;
 
 pub use catalog::*;
+pub use ingest::*;
 pub use models::*;

--- a/crates/cmtraceopen-parser/src/sccm/models.rs
+++ b/crates/cmtraceopen-parser/src/sccm/models.rs
@@ -97,6 +97,53 @@ impl SccmFindingClass {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmTimeOrderingState {
+    NormalizedUtc,
+    OffsetMissing,
+    OffsetInvalid,
+    TimestampMissing,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmTimestamp {
+    pub original_display: Option<String>,
+    pub offset_minutes: Option<i32>,
+    pub utc_millis: Option<i64>,
+    pub ordering_state: SccmTimeOrderingState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmEvidenceRef {
+    pub artifact_id: String,
+    pub entry_id: String,
+    pub line_start: Option<u32>,
+    pub line_end: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSensitiveHandle {
+    pub scheme: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmEvidence {
+    pub evidence_id: String,
+    pub reference: SccmEvidenceRef,
+    pub role: SccmRole,
+    pub component: Option<String>,
+    pub ccm_source_file: Option<String>,
+    pub message: String,
+    pub timestamp: SccmTimestamp,
+    pub execution_context: Option<SccmSensitiveHandle>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum SccmRotation {
     Current,

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/spine/multiline-policy.log
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/spine/multiline-policy.log
@@ -1,0 +1,2 @@
+<![LOG[Policy request completed for assignment
+{11111111-1111-1111-1111-111111111111}]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="NT AUTHORITY\SYSTEM" type="1" thread="42" file="policyagent.cpp">

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -600,6 +600,33 @@ fn evidence_public_message_projection_redacts_local_and_upn_identities_without_p
 }
 
 #[test]
+fn evidence_public_message_projection_redacts_colon_delimited_windows_identities() {
+    for sensitive in [r"LAB\SyntheticUser", r".\LocalUser"] {
+        let raw_message = format!(
+            r#"Caller:{sensitive}; Path C:\Windows\CCM\Logs\PolicyAgent.log; Relative .\Cache\Policy.bin; UNC \\LAB-CM01\SMS_CCM\Logs\MP.log; status=71"#
+        );
+        let text = format!(
+            r#"<![LOG[{raw_message}]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+        );
+
+        let evidence = normalize_ccm_artifact(client_policy_artifact(), &text);
+        let message = &evidence[0].message;
+        let json = serde_json::to_string(&evidence).unwrap();
+
+        assert!(!message.contains(sensitive), "{sensitive} leaked");
+        assert_public_json_omits(&json, sensitive);
+        for safe in [
+            r"C:\Windows\CCM\Logs\PolicyAgent.log",
+            r".\Cache\Policy.bin",
+            r"\\LAB-CM01\SMS_CCM\Logs\MP.log",
+            "status=71",
+        ] {
+            assert!(message.contains(safe), "{safe} was falsely redacted");
+        }
+    }
+}
+
+#[test]
 fn serde_roles_are_string_backed_and_future_tolerant() {
     assert_eq!(
         serde_json::to_string(&SccmRole::ManagementPoint).unwrap(),

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -93,15 +93,55 @@ fn public_ccm_malformed_continuation_stays_plain() {
 
 #[test]
 fn public_ccm_record_without_offset_keeps_legacy_projection() {
-    let text = r#"<![LOG[No source offset]LOG]!><time="10:00:00.000" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#;
+    // A nonzero seven-digit fraction proves that the parser does not steal
+    // the final fractional digit as a signless timezone offset.
+    let text = r#"<![LOG[No source offset]LOG]!><time="10:00:00.1234567" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#;
     let (entries, errors) =
         cmtraceopen_parser::parser::ccm::parse_content(text, "PolicyAgent.log", None);
+    let evidence = normalize_ccm_artifact(client_policy_artifact(), text);
 
     assert_eq!(errors, 0);
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].format, LogFormat::Ccm);
     assert!(entries[0].timestamp.is_some());
+    assert_eq!(
+        entries[0].timestamp_display.as_deref(),
+        Some("07-30-2026 10:00:00.123")
+    );
     assert_eq!(entries[0].timezone_offset, Some(0));
+    assert_eq!(evidence.len(), 1);
+    assert_eq!(
+        evidence[0].timestamp.original_display.as_deref(),
+        Some("07-30-2026 10:00:00.1234567")
+    );
+    assert_eq!(evidence[0].timestamp.offset_minutes, None);
+    assert_eq!(
+        evidence[0].timestamp.ordering_state,
+        SccmTimeOrderingState::OffsetMissing
+    );
+    assert_eq!(evidence[0].timestamp.utc_millis, None);
+}
+
+#[test]
+fn signless_ccm_offset_remains_explicit_for_public_and_evidence_paths() {
+    // CMTrace's documented `%03u%d` grammar permits the decimal offset to
+    // omit a sign: three millisecond digits followed by the offset.
+    let text = r#"<![LOG[Signless source offset]LOG]!><time="10:00:00.000240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#;
+    let (entries, errors) =
+        cmtraceopen_parser::parser::ccm::parse_content(text, "PolicyAgent.log", None);
+    let evidence = normalize_ccm_artifact(client_policy_artifact(), text);
+
+    assert_eq!(errors, 0);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].format, LogFormat::Ccm);
+    assert_eq!(entries[0].timezone_offset, Some(240));
+    assert_eq!(evidence.len(), 1);
+    assert_eq!(evidence[0].timestamp.offset_minutes, Some(240));
+    assert_eq!(
+        evidence[0].timestamp.ordering_state,
+        SccmTimeOrderingState::NormalizedUtc
+    );
+    assert!(evidence[0].timestamp.utc_millis.is_some());
 }
 
 #[test]
@@ -135,7 +175,7 @@ fn evidence_uses_one_logical_record_and_normalized_utc_ordering() {
 fn evidence_missing_or_invalid_time_provenance_is_not_comparable() {
     let cases = [
         (
-            r#"<![LOG[No source offset]LOG]!><time="10:00:00.000" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#,
+            r#"<![LOG[No source offset]LOG]!><time="10:00:00.1234567" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#,
             SccmTimeOrderingState::OffsetMissing,
             None,
         ),
@@ -175,21 +215,16 @@ fn evidence_export_is_deterministic_redacted_and_non_mutating() {
     assert_eq!(first, second);
     assert!(!first_json.contains(r"NT AUTHORITY\\SYSTEM"));
     assert!(!first_json.contains(r"C:\\Windows\\CCM\\Logs"));
-    let handle = first[0]
-        .execution_context
-        .as_ref()
-        .expect("non-empty raw context receives a redacted handle");
-    assert_eq!(handle.scheme, "sccm-context-fnv1a64-v1");
-    assert_eq!(handle.value.len(), 16);
+    assert_eq!(
+        first[0].execution_context, None,
+        "public export omits unkeyed context handles by default"
+    );
 
     let alternate = r#"<![LOG[Synthetic user context]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="LAB\SyntheticUser" type="1" thread="42" file="policyagent.cpp">"#;
     let alternate_evidence = normalize_ccm_artifact(client_policy_artifact(), alternate);
     let alternate_json = serde_json::to_string(&alternate_evidence).unwrap();
     assert!(!alternate_json.contains(r"LAB\\SyntheticUser"));
-    assert_ne!(
-        alternate_evidence[0].execution_context,
-        first[0].execution_context
-    );
+    assert_eq!(alternate_evidence[0].execution_context, None);
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -21,6 +21,34 @@ fn client_policy_artifact() -> SccmArtifact {
     }
 }
 
+fn json_value_contains_sensitive(value: &serde_json::Value, sensitive: &str) -> bool {
+    match value {
+        serde_json::Value::String(value) => value.contains(sensitive),
+        serde_json::Value::Array(values) => values
+            .iter()
+            .any(|value| json_value_contains_sensitive(value, sensitive)),
+        serde_json::Value::Object(values) => values
+            .values()
+            .any(|value| json_value_contains_sensitive(value, sensitive)),
+        _ => false,
+    }
+}
+
+fn public_json_contains_sensitive(json: &str, sensitive: &str) -> bool {
+    let decoded: serde_json::Value = serde_json::from_str(json).unwrap();
+    let encoded = serde_json::to_string(sensitive).unwrap();
+    let escaped = &encoded[1..encoded.len() - 1];
+
+    json_value_contains_sensitive(&decoded, sensitive) || json.contains(escaped)
+}
+
+fn assert_public_json_omits(json: &str, sensitive: &str) {
+    assert!(
+        !public_json_contains_sensitive(json, sensitive),
+        "{sensitive} leaked in decoded or escaped public JSON"
+    );
+}
+
 #[test]
 fn sccm_contract_is_public_and_versioned() {
     assert_eq!(SCCM_DIAGNOSTICS_SCHEMA_VERSION, 1);
@@ -288,8 +316,8 @@ fn evidence_export_is_deterministic_redacted_and_non_mutating() {
 
     assert_eq!(first, before_export);
     assert_eq!(first, second);
-    assert!(!first_json.contains(r"NT AUTHORITY\\SYSTEM"));
-    assert!(!first_json.contains(r"C:\\Windows\\CCM\\Logs"));
+    assert_public_json_omits(&first_json, r"NT AUTHORITY\SYSTEM");
+    assert_public_json_omits(&first_json, r"C:\Windows\CCM\Logs");
     assert_eq!(
         first[0].execution_context, None,
         "public export omits unkeyed context handles by default"
@@ -298,8 +326,17 @@ fn evidence_export_is_deterministic_redacted_and_non_mutating() {
     let alternate = r#"<![LOG[Synthetic user context]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="LAB\SyntheticUser" type="1" thread="42" file="policyagent.cpp">"#;
     let alternate_evidence = normalize_ccm_artifact(client_policy_artifact(), alternate);
     let alternate_json = serde_json::to_string(&alternate_evidence).unwrap();
-    assert!(!alternate_json.contains(r"LAB\\SyntheticUser"));
+    assert_public_json_omits(&alternate_json, r"LAB\SyntheticUser");
     assert_eq!(alternate_evidence[0].execution_context, None);
+}
+
+#[test]
+fn public_json_sensitive_assertion_detects_serde_escaped_backslashes() {
+    let leaked = serde_json::json!([{"message": r"LAB\SyntheticUser"}]);
+    let json = serde_json::to_string(&leaked).unwrap();
+
+    assert!(json.contains(r"LAB\\SyntheticUser"));
+    assert!(public_json_contains_sensitive(&json, r"LAB\SyntheticUser"));
 }
 
 #[test]
@@ -327,7 +364,7 @@ fn evidence_public_message_projection_redacts_sensitive_markers_and_preserves_sa
             !message.contains(sensitive),
             "{sensitive} leaked in message"
         );
-        assert!(!json.contains(sensitive), "{sensitive} leaked in JSON");
+        assert_public_json_omits(&json, sensitive);
     }
     assert!(message.contains("[redacted:sccm-public-message-v1]"));
 }
@@ -425,15 +462,56 @@ fn evidence_public_message_projection_redacts_whitespace_delimited_credentials()
             !message.contains(sensitive),
             "{sensitive} leaked in projected message for {raw_message}"
         );
-        assert!(
-            !json.contains(sensitive),
-            "{sensitive} leaked in JSON for {raw_message}"
-        );
+        assert_public_json_omits(&json, sensitive);
         assert!(
             message.contains("[redacted:sccm-public-message-v1]"),
             "{raw_message} was not classified as sensitive"
         );
     }
+}
+
+#[test]
+fn evidence_public_message_projection_redacts_quoted_structured_keys() {
+    let cases = [
+        (
+            r#"payload={"token":"synthetic-json-token","user":"SyntheticJsonUser"} status=71"#,
+            ["synthetic-json-token", "SyntheticJsonUser"],
+            "status=71",
+        ),
+        (
+            "payload={'password':'synthetic-json-password','user':'SyntheticSingleUser'} hr=0x80070005",
+            ["synthetic-json-password", "SyntheticSingleUser"],
+            "hr=0x80070005",
+        ),
+    ];
+
+    for (raw_message, sensitive_values, safe) in cases {
+        let text = format!(
+            r#"<![LOG[{raw_message}]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+        );
+        let evidence = normalize_ccm_artifact(client_policy_artifact(), &text);
+        let message = &evidence[0].message;
+        let json = serde_json::to_string(&evidence).unwrap();
+
+        assert!(message.contains(safe), "{safe} was swallowed");
+        for sensitive in sensitive_values {
+            assert!(!message.contains(sensitive), "{sensitive} leaked");
+            assert_public_json_omits(&json, sensitive);
+        }
+    }
+}
+
+#[test]
+fn evidence_public_message_projection_bounds_query_values_at_ampersand() {
+    let text = r#"<![LOG[url=https://example.invalid/?token=synthetic-query-token&status=71]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#;
+
+    let evidence = normalize_ccm_artifact(client_policy_artifact(), text);
+    let message = &evidence[0].message;
+    let json = serde_json::to_string(&evidence).unwrap();
+
+    assert!(!message.contains("synthetic-query-token"));
+    assert_public_json_omits(&json, "synthetic-query-token");
+    assert!(message.contains("&status=71"));
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -1,4 +1,4 @@
-use cmtraceopen_parser::models::log_entry::ParserKind;
+use cmtraceopen_parser::models::log_entry::{LogFormat, ParserKind};
 use cmtraceopen_parser::parser::detect::detect_parser;
 use cmtraceopen_parser::sccm::{
     classify_artifact_name, declared_source_catalog, SccmArtifact, SccmArtifactFamily,
@@ -20,6 +20,73 @@ fn sccm_contract_is_public_and_versioned() {
         SccmFindingClass::InsufficientEvidence.as_str(),
         "insufficientEvidence"
     );
+}
+
+#[test]
+fn public_ccm_multiline_projection_stays_compatible() {
+    let text = include_str!("fixtures/sccm/spine/multiline-policy.log");
+    let (entries, errors) =
+        cmtraceopen_parser::parser::ccm::parse_content(text, "PolicyAgent.log", None);
+    assert_eq!(errors, 0);
+    assert_eq!(
+        entries.len(),
+        1,
+        "ordinary public CCM output stays unchanged"
+    );
+    assert_eq!(entries[0].line_number, 1);
+    assert_eq!(entries[0].format, LogFormat::Ccm);
+    assert_eq!(entries[0].timezone_offset, Some(-240));
+    assert!(entries[0]
+        .message
+        .contains("{11111111-1111-1111-1111-111111111111}"));
+
+    let public_json = serde_json::to_value(&entries[0]).unwrap();
+    assert!(public_json.get("context").is_none());
+    assert!(!serde_json::to_string(&public_json)
+        .unwrap()
+        .contains(r"NT AUTHORITY\\SYSTEM"));
+}
+
+#[test]
+fn public_ccm_single_line_projection_matches_line_parser() {
+    let text = r#"<![LOG[Synthetic policy record]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="LAB\SyntheticUser" type="1" thread="42" file="policyagent.cpp">"#;
+    let (content_entries, content_errors) =
+        cmtraceopen_parser::parser::ccm::parse_content(text, "PolicyAgent.log", None);
+    let (line_entries, line_errors) =
+        cmtraceopen_parser::parser::ccm::parse_lines(&[text], "PolicyAgent.log");
+
+    assert_eq!(content_errors, line_errors);
+    assert_eq!(
+        serde_json::to_vec(&content_entries).unwrap(),
+        serde_json::to_vec(&line_entries).unwrap()
+    );
+}
+
+#[test]
+fn public_ccm_malformed_continuation_stays_plain() {
+    let text = "<![LOG[unfinished record\ncontinuation without attributes";
+    let (entries, errors) =
+        cmtraceopen_parser::parser::ccm::parse_content(text, "PolicyAgent.log", None);
+
+    assert_eq!(errors, 2);
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].format, LogFormat::Plain);
+    assert_eq!(entries[0].line_number, 1);
+    assert_eq!(entries[1].format, LogFormat::Plain);
+    assert_eq!(entries[1].line_number, 2);
+}
+
+#[test]
+fn public_ccm_record_without_offset_keeps_legacy_projection() {
+    let text = r#"<![LOG[No source offset]LOG]!><time="10:00:00.000" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#;
+    let (entries, errors) =
+        cmtraceopen_parser::parser::ccm::parse_content(text, "PolicyAgent.log", None);
+
+    assert_eq!(errors, 0);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].format, LogFormat::Ccm);
+    assert!(entries[0].timestamp.is_some());
+    assert_eq!(entries[0].timezone_offset, Some(0));
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -1,10 +1,25 @@
 use cmtraceopen_parser::models::log_entry::{LogFormat, ParserKind};
 use cmtraceopen_parser::parser::detect::detect_parser;
 use cmtraceopen_parser::sccm::{
-    classify_artifact_name, declared_source_catalog, SccmArtifact, SccmArtifactFamily,
-    SccmCoverageState, SccmFindingClass, SccmRole, SccmRotation, SccmUnknownRotation,
-    SCCM_DIAGNOSTICS_SCHEMA_VERSION,
+    classify_artifact_name, declared_source_catalog, normalize_ccm_artifact, SccmArtifact,
+    SccmArtifactFamily, SccmCoverageState, SccmFindingClass, SccmRole, SccmRotation,
+    SccmTimeOrderingState, SccmUnknownRotation, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
 };
+
+fn client_policy_artifact() -> SccmArtifact {
+    SccmArtifact {
+        artifact_id: "client-policy-agent".into(),
+        display_name: "PolicyAgent.log".into(),
+        original_path: Some(r"C:\Windows\CCM\Logs\PolicyAgent.log".into()),
+        host: Some("LAB-CLIENT-01".into()),
+        role: SccmRole::Client,
+        configmgr_version: Some("5.00.9128.1007".into()),
+        collected_at_utc: Some("2026-07-30T15:00:00Z".into()),
+        rotation: SccmRotation::Current,
+        coverage: SccmCoverageState::Captured,
+        encoding: Some("utf-8".into()),
+    }
+}
 
 #[test]
 fn sccm_contract_is_public_and_versioned() {
@@ -87,6 +102,94 @@ fn public_ccm_record_without_offset_keeps_legacy_projection() {
     assert_eq!(entries[0].format, LogFormat::Ccm);
     assert!(entries[0].timestamp.is_some());
     assert_eq!(entries[0].timezone_offset, Some(0));
+}
+
+#[test]
+fn evidence_uses_one_logical_record_and_normalized_utc_ordering() {
+    let text = include_str!("fixtures/sccm/spine/multiline-policy.log");
+    let evidence = normalize_ccm_artifact(client_policy_artifact(), text);
+
+    assert_eq!(evidence.len(), 1);
+    assert_eq!(evidence[0].evidence_id, "client-policy-agent:1-2");
+    assert_eq!(evidence[0].reference.entry_id, "client-policy-agent:1-2");
+    assert_eq!(evidence[0].reference.artifact_id, "client-policy-agent");
+    assert_eq!(evidence[0].reference.line_start, Some(1));
+    assert_eq!(evidence[0].reference.line_end, Some(2));
+    assert_eq!(
+        evidence[0].ccm_source_file.as_deref(),
+        Some("policyagent.cpp")
+    );
+    assert_eq!(
+        evidence[0].timestamp.original_display.as_deref(),
+        Some("07-30-2026 10:00:00.000")
+    );
+    assert_eq!(evidence[0].timestamp.offset_minutes, Some(-240));
+    assert_eq!(
+        evidence[0].timestamp.ordering_state,
+        SccmTimeOrderingState::NormalizedUtc
+    );
+    assert!(evidence[0].timestamp.utc_millis.is_some());
+}
+
+#[test]
+fn evidence_missing_or_invalid_time_provenance_is_not_comparable() {
+    let cases = [
+        (
+            r#"<![LOG[No source offset]LOG]!><time="10:00:00.000" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#,
+            SccmTimeOrderingState::OffsetMissing,
+            None,
+        ),
+        (
+            r#"<![LOG[Invalid source offset]LOG]!><time="10:00:00.000+99999" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#,
+            SccmTimeOrderingState::OffsetInvalid,
+            Some(99999),
+        ),
+        (
+            r#"<![LOG[Invalid local date]LOG]!><time="10:00:00.000-240" date="13-40-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#,
+            SccmTimeOrderingState::TimestampMissing,
+            Some(-240),
+        ),
+    ];
+
+    for (text, expected_state, expected_offset) in cases {
+        let evidence = normalize_ccm_artifact(client_policy_artifact(), text);
+        assert_eq!(evidence.len(), 1, "{expected_state:?}");
+        assert_eq!(
+            evidence[0].timestamp.ordering_state, expected_state,
+            "{text}"
+        );
+        assert_eq!(evidence[0].timestamp.offset_minutes, expected_offset);
+        assert_eq!(evidence[0].timestamp.utc_millis, None);
+    }
+}
+
+#[test]
+fn evidence_export_is_deterministic_redacted_and_non_mutating() {
+    let text = include_str!("fixtures/sccm/spine/multiline-policy.log");
+    let first = normalize_ccm_artifact(client_policy_artifact(), text);
+    let before_export = first.clone();
+    let first_json = serde_json::to_string(&first).unwrap();
+    let second = normalize_ccm_artifact(client_policy_artifact(), text);
+
+    assert_eq!(first, before_export);
+    assert_eq!(first, second);
+    assert!(!first_json.contains(r"NT AUTHORITY\\SYSTEM"));
+    assert!(!first_json.contains(r"C:\\Windows\\CCM\\Logs"));
+    let handle = first[0]
+        .execution_context
+        .as_ref()
+        .expect("non-empty raw context receives a redacted handle");
+    assert_eq!(handle.scheme, "sccm-context-fnv1a64-v1");
+    assert_eq!(handle.value.len(), 16);
+
+    let alternate = r#"<![LOG[Synthetic user context]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="LAB\SyntheticUser" type="1" thread="42" file="policyagent.cpp">"#;
+    let alternate_evidence = normalize_ccm_artifact(client_policy_artifact(), alternate);
+    let alternate_json = serde_json::to_string(&alternate_evidence).unwrap();
+    assert!(!alternate_json.contains(r"LAB\\SyntheticUser"));
+    assert_ne!(
+        alternate_evidence[0].execution_context,
+        first[0].execution_context
+    );
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -300,6 +300,153 @@ fn evidence_public_message_projection_redacts_unterminated_sensitive_values_to_e
 }
 
 #[test]
+fn evidence_public_message_projection_redacts_whitespace_delimited_credentials() {
+    let cases = [
+        (
+            "Authorization Bearer synthetic-auth-token",
+            "synthetic-auth-token",
+        ),
+        (
+            r#"Authorization Bearer "synthetic quoted auth token""#,
+            "synthetic quoted auth token",
+        ),
+        (
+            "Bearer synthetic-standalone-token",
+            "synthetic-standalone-token",
+        ),
+        (
+            "Bearer 'synthetic quoted bearer token'",
+            "synthetic quoted bearer token",
+        ),
+        (
+            "client_secret synthetic-client-secret",
+            "synthetic-client-secret",
+        ),
+        (
+            r#"client_secret "synthetic quoted client secret""#,
+            "synthetic quoted client secret",
+        ),
+        ("sig synthetic-signature", "synthetic-signature"),
+        (
+            "clientToken synthetic-client-token",
+            "synthetic-client-token",
+        ),
+        ("credential synthetic-credential", "synthetic-credential"),
+        (
+            "credential 'synthetic quoted credential'",
+            "synthetic quoted credential",
+        ),
+    ];
+
+    for (raw_message, sensitive) in cases {
+        let text = format!(
+            r#"<![LOG[{raw_message}]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+        );
+        let evidence = normalize_ccm_artifact(client_policy_artifact(), &text);
+        let message = &evidence[0].message;
+        let json = serde_json::to_string(&evidence).unwrap();
+
+        assert!(
+            !message.contains(sensitive),
+            "{sensitive} leaked in projected message for {raw_message}"
+        );
+        assert!(
+            !json.contains(sensitive),
+            "{sensitive} leaked in JSON for {raw_message}"
+        );
+        assert!(
+            message.contains("[redacted:sccm-public-message-v1]"),
+            "{raw_message} was not classified as sensitive"
+        );
+    }
+}
+
+#[test]
+fn evidence_public_message_projection_fails_closed_for_unterminated_whitespace_values() {
+    let cases = [
+        (
+            r#"Authorization Bearer "synthetic-unterminated-auth"#,
+            "synthetic-unterminated-auth",
+        ),
+        (
+            "Bearer 'synthetic-unterminated-bearer",
+            "synthetic-unterminated-bearer",
+        ),
+        (
+            r#"client_secret "synthetic-unterminated-client-secret"#,
+            "synthetic-unterminated-client-secret",
+        ),
+        (
+            "credential 'synthetic-unterminated-credential",
+            "synthetic-unterminated-credential",
+        ),
+    ];
+
+    for (raw_message, sensitive) in cases {
+        let text = format!(
+            r#"<![LOG[Policy hr=0x80070005 {raw_message}]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+        );
+        let evidence = normalize_ccm_artifact(client_policy_artifact(), &text);
+        let message = &evidence[0].message;
+
+        assert!(message.contains("hr=0x80070005"), "{raw_message}");
+        assert!(
+            message.ends_with("[redacted:sccm-public-message-v1]"),
+            "{raw_message}"
+        );
+        assert!(!message.contains(sensitive), "{sensitive} leaked");
+    }
+}
+
+#[test]
+fn evidence_public_message_projection_bounds_unquoted_values_before_safe_evidence() {
+    let assignment_id = "{ABCDEFAB-0000-0000-0000-000000000001}";
+    let text = format!(
+        r#"<![LOG[client_secret=synthetic-client-secret hr=0x80070005 sig synthetic-signature Policy id={assignment_id} clientToken:synthetic-client-token Path C:\Windows\CCM\Logs\PolicyAgent.log credential synthetic-credential status=71]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+    );
+
+    let evidence = normalize_ccm_artifact(client_policy_artifact(), &text);
+    let message = &evidence[0].message;
+
+    for sensitive in [
+        "synthetic-client-secret",
+        "synthetic-signature",
+        "synthetic-client-token",
+        "synthetic-credential",
+    ] {
+        assert!(!message.contains(sensitive), "{sensitive} leaked");
+    }
+    for safe in [
+        "hr=0x80070005",
+        assignment_id,
+        r"C:\Windows\CCM\Logs\PolicyAgent.log",
+        "status=71",
+    ] {
+        assert!(message.contains(safe), "{safe} was swallowed");
+    }
+}
+
+#[test]
+fn evidence_public_message_projection_redacts_local_and_upn_identities_without_path_noise() {
+    let text = r#"<![LOG[Caller .\LocalUser; UPN Synthetic.User@contoso.example; package package@1.2.3; Path C:\Windows\CCM\Logs\PolicyAgent.log; Relative .\Cache\Policy.bin; UNC \\LAB-CM01\SMS_CCM\Logs\MP.log]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#;
+
+    let evidence = normalize_ccm_artifact(client_policy_artifact(), text);
+    let message = &evidence[0].message;
+
+    for sensitive in [r".\LocalUser", "Synthetic.User@contoso.example"] {
+        assert!(!message.contains(sensitive), "{sensitive} leaked");
+    }
+    for safe in [
+        "package@1.2.3",
+        r"C:\Windows\CCM\Logs\PolicyAgent.log",
+        r".\Cache\Policy.bin",
+        r"\\LAB-CM01\SMS_CCM\Logs\MP.log",
+    ] {
+        assert!(message.contains(safe), "{safe} was falsely redacted");
+    }
+}
+
+#[test]
 fn serde_roles_are_string_backed_and_future_tolerant() {
     assert_eq!(
         serde_json::to_string(&SccmRole::ManagementPoint).unwrap(),

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -92,40 +92,115 @@ fn public_ccm_malformed_continuation_stays_plain() {
 }
 
 #[test]
-fn public_ccm_record_without_offset_keeps_legacy_projection() {
-    // A nonzero seven-digit fraction proves that the parser does not steal
-    // the final fractional digit as a signless timezone offset.
-    let text = r#"<![LOG[No source offset]LOG]!><time="10:00:00.1234567" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#;
-    let (entries, errors) =
-        cmtraceopen_parser::parser::ccm::parse_content(text, "PolicyAgent.log", None);
-    let evidence = normalize_ccm_artifact(client_policy_artifact(), text);
+fn public_ccm_digit_only_timestamp_tails_match_pre_spine_baseline() {
+    // Commit 463133d's public regex greedily assigned all but the final digit
+    // to milliseconds and the final digit to timezoneOffset. Preserve that
+    // observable LogEntry behavior while SCCM provenance interprets the same
+    // captured tail independently.
+    let cases = [
+        (
+            "000",
+            "07-30-2026 10:00:00.000",
+            0,
+            0,
+            "07-30-2026 10:00:00.000",
+            None,
+            SccmTimeOrderingState::OffsetMissing,
+        ),
+        (
+            "123",
+            "07-30-2026 10:00:00.012",
+            12,
+            3,
+            "07-30-2026 10:00:00.123",
+            None,
+            SccmTimeOrderingState::OffsetMissing,
+        ),
+        (
+            "000240",
+            "07-30-2026 10:00:00.000",
+            0,
+            0,
+            "07-30-2026 10:00:00.000",
+            Some(240),
+            SccmTimeOrderingState::NormalizedUtc,
+        ),
+        (
+            "1234567",
+            "07-30-2026 10:00:00.123",
+            123,
+            7,
+            "07-30-2026 10:00:00.1234567",
+            None,
+            SccmTimeOrderingState::OffsetMissing,
+        ),
+    ];
 
-    assert_eq!(errors, 0);
-    assert_eq!(entries.len(), 1);
-    assert_eq!(entries[0].format, LogFormat::Ccm);
-    assert!(entries[0].timestamp.is_some());
-    assert_eq!(
-        entries[0].timestamp_display.as_deref(),
-        Some("07-30-2026 10:00:00.123")
-    );
-    assert_eq!(entries[0].timezone_offset, Some(0));
-    assert_eq!(evidence.len(), 1);
-    assert_eq!(
-        evidence[0].timestamp.original_display.as_deref(),
-        Some("07-30-2026 10:00:00.1234567")
-    );
-    assert_eq!(evidence[0].timestamp.offset_minutes, None);
-    assert_eq!(
-        evidence[0].timestamp.ordering_state,
-        SccmTimeOrderingState::OffsetMissing
-    );
-    assert_eq!(evidence[0].timestamp.utc_millis, None);
+    for (
+        time_tail,
+        public_display,
+        public_millis,
+        public_offset,
+        evidence_display,
+        evidence_offset,
+        evidence_state,
+    ) in cases
+    {
+        let text = format!(
+            r#"<![LOG[Tail {time_tail}]LOG]!><time="10:00:00.{time_tail}" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+        );
+        let (entries, errors) =
+            cmtraceopen_parser::parser::ccm::parse_content(&text, "PolicyAgent.log", None);
+        let evidence = normalize_ccm_artifact(client_policy_artifact(), &text);
+        let expected_public_timestamp = chrono::NaiveDate::from_ymd_opt(2026, 7, 30)
+            .unwrap()
+            .and_hms_milli_opt(10, 0, 0, public_millis)
+            .unwrap()
+            .and_utc()
+            .timestamp_millis()
+            - i64::from(public_offset) * 60_000;
+
+        assert_eq!(errors, 0, "{time_tail}");
+        assert_eq!(entries.len(), 1, "{time_tail}");
+        assert_eq!(entries[0].format, LogFormat::Ccm, "{time_tail}");
+        assert_eq!(
+            entries[0].timestamp_display.as_deref(),
+            Some(public_display),
+            "{time_tail}"
+        );
+        assert_eq!(
+            entries[0].timezone_offset,
+            Some(public_offset),
+            "{time_tail}"
+        );
+        assert_eq!(
+            entries[0].timestamp,
+            Some(expected_public_timestamp),
+            "{time_tail}"
+        );
+        assert_eq!(evidence.len(), 1, "{time_tail}");
+        assert_eq!(
+            evidence[0].timestamp.original_display.as_deref(),
+            Some(evidence_display),
+            "{time_tail}"
+        );
+        assert_eq!(
+            evidence[0].timestamp.offset_minutes, evidence_offset,
+            "{time_tail}"
+        );
+        assert_eq!(
+            evidence[0].timestamp.ordering_state, evidence_state,
+            "{time_tail}"
+        );
+    }
 }
 
 #[test]
-fn signless_ccm_offset_remains_explicit_for_public_and_evidence_paths() {
+fn signless_ccm_offset_is_enriched_only_in_sccm_provenance() {
     // CMTrace's documented `%03u%d` grammar permits the decimal offset to
-    // omit a sign: three millisecond digits followed by the offset.
+    // omit a sign: three millisecond digits followed by the offset. The
+    // public LogEntry keeps its pre-spine projection; only the additive SCCM
+    // timestamp provenance receives the corrected interpretation.
     let text = r#"<![LOG[Signless source offset]LOG]!><time="10:00:00.000240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#;
     let (entries, errors) =
         cmtraceopen_parser::parser::ccm::parse_content(text, "PolicyAgent.log", None);
@@ -134,7 +209,7 @@ fn signless_ccm_offset_remains_explicit_for_public_and_evidence_paths() {
     assert_eq!(errors, 0);
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].format, LogFormat::Ccm);
-    assert_eq!(entries[0].timezone_offset, Some(240));
+    assert_eq!(entries[0].timezone_offset, Some(0));
     assert_eq!(evidence.len(), 1);
     assert_eq!(evidence[0].timestamp.offset_minutes, Some(240));
     assert_eq!(

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -228,6 +228,78 @@ fn evidence_export_is_deterministic_redacted_and_non_mutating() {
 }
 
 #[test]
+fn evidence_public_message_projection_redacts_sensitive_markers_and_preserves_safe_tokens() {
+    let assignment_id = "{ABCDEFAB-0000-0000-0000-000000000001}";
+    let text = format!(
+        r#"<![LOG[Policy id={assignment_id} failed hr=0x80070005 user=LAB\SyntheticUser credential="synthetic credential with spaces" token=synthetic-secret]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+    );
+
+    let first = normalize_ccm_artifact(client_policy_artifact(), &text);
+    let second = normalize_ccm_artifact(client_policy_artifact(), &text);
+    let message = &first[0].message;
+    let json = serde_json::to_string(&first).unwrap();
+
+    assert_eq!(first, second);
+    assert!(message.starts_with("[sccm-public-message-v1] "));
+    assert!(message.contains(assignment_id));
+    assert!(message.contains("hr=0x80070005"));
+    for sensitive in [
+        r"LAB\SyntheticUser",
+        "synthetic credential with spaces",
+        "synthetic-secret",
+    ] {
+        assert!(
+            !message.contains(sensitive),
+            "{sensitive} leaked in message"
+        );
+        assert!(!json.contains(sensitive), "{sensitive} leaked in JSON");
+    }
+    assert!(message.contains("[redacted:sccm-public-message-v1]"));
+}
+
+#[test]
+fn evidence_public_message_projection_fails_closed_without_path_or_code_false_positives() {
+    let assignment_id = "{ABCDEFAB-0000-0000-0000-000000000001}";
+    let text = format!(
+        r#"<![LOG[Caller LAB\SyntheticUser; Authorization: Bearer synthetic-bearer; client_secret="synthetic; leaked-credential-fragment"; sig=synthetic-signature; clientToken=synthetic-client-token; Path C:\Windows\CCM\Logs\PolicyAgent.log Policy id={assignment_id} status=71]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+    );
+
+    let evidence = normalize_ccm_artifact(client_policy_artifact(), &text);
+    let message = &evidence[0].message;
+
+    assert!(message.starts_with("[sccm-public-message-v1] "));
+    assert!(message.contains(r"C:\Windows\CCM\Logs\PolicyAgent.log"));
+    assert!(message.contains(assignment_id));
+    assert!(message.contains("status=71"));
+    for sensitive in [
+        r"LAB\SyntheticUser",
+        "synthetic-bearer",
+        "leaked-credential-fragment",
+        "synthetic-signature",
+        "synthetic-client-token",
+    ] {
+        assert!(!message.contains(sensitive), "{sensitive} leaked");
+    }
+}
+
+#[test]
+fn evidence_public_message_projection_redacts_unterminated_sensitive_values_to_end() {
+    let assignment_id = "{ABCDEFAB-0000-0000-0000-000000000001}";
+    let text = format!(
+        r#"<![LOG[Policy id={assignment_id} hr=0x80070005 client_secret="synthetic; leaked-unterminated-tail]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+    );
+
+    let evidence = normalize_ccm_artifact(client_policy_artifact(), &text);
+    let message = &evidence[0].message;
+
+    assert!(message.starts_with("[sccm-public-message-v1] "));
+    assert!(message.contains(assignment_id));
+    assert!(message.contains("hr=0x80070005"));
+    assert!(message.ends_with("[redacted:sccm-public-message-v1]"));
+    assert!(!message.contains("leaked-unterminated-tail"));
+}
+
+#[test]
 fn serde_roles_are_string_backed_and_future_tolerant() {
     assert_eq!(
         serde_json::to_string(&SccmRole::ManagementPoint).unwrap(),


### PR DESCRIPTION
## Summary

Part of #318. This Task 4 shared-interface slice:

- factors one crate-private logical CCM record scanner while preserving the public `LogEntry` projection and raw CCM grammar
- adds deterministic SCCM evidence references with exact line ranges, source provenance, and explicit normalized/missing/invalid timestamp states
- preserves legacy public timestamp semantics while retaining corrected provenance only in the internal SCCM envelope
- keeps raw CCM execution context crate-private and exports deterministic redacted evidence
- hardens public evidence against credentials, structured/query secrets, domain/local/UPN identities, and serialized-JSON escapes while preserving approved HRESULT/GUID/path/status evidence

## Contract boundaries

- `cmtraceopen-parser` remains pure Rust and wasm32-compatible
- no `ParserKind::Sccm`, Windows I/O, registry, WMI, Tauri, network, database, or live collection dependency
- public `LogEntry` shape and observable legacy projection remain compatible
- no workflow signals, keys, reducers, or cross-side correlation are included; Task 5 remains downstream
- no native Windows acceptance is claimed

## TDD and review corrections

The slice began red on the missing evidence normalizer, logical scanner, and timestamp-provenance contract. Successive exact-head reviews then drove focused red→green cases for missing/invalid offsets, public-context omission, whitespace/quoted/structured/query secrets, bounded safe trailing evidence, exact legacy timestamp projection, serialization-aware identity checks, and colon-delimited domain/local identities. Drive, relative, and UNC paths remain intact.

## Verification at `94148d909e976cea39e0b99306eddb0e8badd1e6`

- exact stack — 8 issue-scoped commits, 7 files; original 7-commit restack range-diff is unchanged plus the colon correction
- privacy 10/10; evidence 13/13; public CCM 4/4; CCM units 13/13
- dual-build baseline equality for `.000`, `.123`, `.000240`, and `.1234567`
- full parser — 615/615
- strict parser Clippy — pass
- wasm32 parser check — pass
- `npx tsc --noEmit` — pass
- owned rustfmt and `git diff --check` — pass

CodeRabbit performed an exact-head substantive static review at `94148d9` and found no additional blocker, while explicitly recording that its sandbox could not run the test matrix or load the historical baseline. Independent exact-head runtime review is the complementary merge gate.

## Merge order

Phase A is already merged on `codex/parser-family-skeleton`. This Task 4 slice is the next shared-interface gate. Task 5 signal extraction remains blocked until this PR passes exact-head review and merges.

Part of #318.