### PR TITLE
feat(sccm): retain diagnostic signal tokens

### DIFF
--- a/crates/cmtraceopen-parser/src/sccm/mod.rs
+++ b/crates/cmtraceopen-parser/src/sccm/mod.rs
@@ -3,7 +3,9 @@ mod evidence;
 mod ingest;
 pub mod models;
 mod rotation;
+mod signals;
 
 pub use catalog::*;
 pub use ingest::*;
 pub use models::*;
+pub use signals::*;

--- a/crates/cmtraceopen-parser/src/sccm/signals.rs
+++ b/crates/cmtraceopen-parser/src/sccm/signals.rs
@@ -88,7 +88,7 @@ pub fn extract_signals(message: &str) -> Vec<SccmSignal> {
                 let raw = value.as_str();
                 let numeric = parse_numeric(raw);
                 let (error_description, error_category) = numeric
-                    .map(|_| lookup_error_code(raw))
+                    .map(|numeric| lookup_error_code(&format!("0x{numeric:08X}")))
                     .filter(|result| result.found)
                     .map(|result| (Some(result.description), Some(result.category)))
                     .unwrap_or((None, None));

--- a/crates/cmtraceopen-parser/src/sccm/signals.rs
+++ b/crates/cmtraceopen-parser/src/sccm/signals.rs
@@ -1,0 +1,135 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::error_db::lookup::lookup_error_code;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmSignalKind {
+    HResult,
+    Gle,
+    ExitCode,
+    ReturnCode,
+    Status,
+}
+
+/// A structured diagnostic token captured from an SCCM evidence message.
+///
+/// `start` and `end` are an end-exclusive range measured in UTF-16 code units,
+/// matching JavaScript string indexes rather than UTF-8 byte offsets.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSignal {
+    pub kind: SccmSignalKind,
+    pub raw: String,
+    pub numeric: Option<u32>,
+    pub start: usize,
+    pub end: usize,
+    pub error_description: Option<String>,
+    pub error_category: Option<String>,
+}
+
+struct SignalPattern {
+    kind: SccmSignalKind,
+    regex: Regex,
+}
+
+fn signal_patterns() -> &'static [SignalPattern] {
+    static CELL: OnceLock<Vec<SignalPattern>> = OnceLock::new();
+    CELL.get_or_init(|| {
+        [
+            (
+                SccmSignalKind::HResult,
+                r"(?i:\bhr)=(?P<value>0[xX][0-9A-Fa-f]{8})\b",
+            ),
+            (
+                SccmSignalKind::HResult,
+                r"(?i:\bHRESULT)[ \t]+(?P<value>0[xX][0-9A-Fa-f]{8})\b",
+            ),
+            (
+                SccmSignalKind::Gle,
+                r"(?i:\[gle)=(?P<value>0[xX][0-9A-Fa-f]{8})\]",
+            ),
+            (
+                SccmSignalKind::ExitCode,
+                r"(?i:\bexit[ \t]+code)[ \t]+(?P<value>[0-9]+)\b",
+            ),
+            (
+                SccmSignalKind::ExitCode,
+                r"(?i:\bexitcode)[ \t]*=[ \t]*(?P<value>[0-9]+)\b",
+            ),
+            (
+                SccmSignalKind::ReturnCode,
+                r"(?i:\breturn[ \t]+code)[ \t]+(?P<value>[0-9]+)\b",
+            ),
+            (SccmSignalKind::Status, r"(?i:\bstatus)=(?P<value>[0-9]+)\b"),
+        ]
+        .into_iter()
+        .map(|(kind, pattern)| SignalPattern {
+            kind,
+            regex: Regex::new(pattern).expect("SCCM signal regex must compile"),
+        })
+        .collect()
+    })
+}
+
+/// Extract structured SCCM diagnostic tokens in message order.
+///
+/// Capture does not depend on the embedded error database: unknown or
+/// out-of-range values are retained with absent numeric/enrichment fields.
+pub fn extract_signals(message: &str) -> Vec<SccmSignal> {
+    let mut signals = signal_patterns()
+        .iter()
+        .flat_map(|pattern| {
+            pattern.regex.captures_iter(message).filter_map(|captures| {
+                let value = captures.name("value")?;
+                let raw = value.as_str();
+                let numeric = parse_numeric(raw);
+                let (error_description, error_category) = numeric
+                    .map(|_| lookup_error_code(raw))
+                    .filter(|result| result.found)
+                    .map(|result| (Some(result.description), Some(result.category)))
+                    .unwrap_or((None, None));
+                let start = message[..value.start()].encode_utf16().count();
+                let end = start + raw.encode_utf16().count();
+
+                Some(SccmSignal {
+                    kind: pattern.kind.clone(),
+                    raw: raw.to_owned(),
+                    numeric,
+                    start,
+                    end,
+                    error_description,
+                    error_category,
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+
+    signals.sort_by_key(|signal| (signal.start, signal_kind_order(&signal.kind), signal.end));
+    signals.dedup_by(|right, left| {
+        right.kind == left.kind
+            && right.raw == left.raw
+            && right.start == left.start
+            && right.end == left.end
+    });
+    signals
+}
+
+fn parse_numeric(raw: &str) -> Option<u32> {
+    raw.strip_prefix("0x")
+        .or_else(|| raw.strip_prefix("0X"))
+        .map_or_else(|| raw.parse().ok(), |hex| u32::from_str_radix(hex, 16).ok())
+}
+
+fn signal_kind_order(kind: &SccmSignalKind) -> u8 {
+    match kind {
+        SccmSignalKind::HResult => 0,
+        SccmSignalKind::Gle => 1,
+        SccmSignalKind::ExitCode => 2,
+        SccmSignalKind::ReturnCode => 3,
+        SccmSignalKind::Status => 4,
+    }
+}

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -1,9 +1,9 @@
 use cmtraceopen_parser::models::log_entry::{LogFormat, ParserKind};
 use cmtraceopen_parser::parser::detect::detect_parser;
 use cmtraceopen_parser::sccm::{
-    classify_artifact_name, declared_source_catalog, normalize_ccm_artifact, SccmArtifact,
-    SccmArtifactFamily, SccmCoverageState, SccmFindingClass, SccmRole, SccmRotation,
-    SccmTimeOrderingState, SccmUnknownRotation, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
+    classify_artifact_name, declared_source_catalog, extract_signals, normalize_ccm_artifact,
+    SccmArtifact, SccmArtifactFamily, SccmCoverageState, SccmFindingClass, SccmRole, SccmRotation,
+    SccmSignalKind, SccmTimeOrderingState, SccmUnknownRotation, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
 };
 
 fn client_policy_artifact() -> SccmArtifact {
@@ -103,6 +103,103 @@ fn public_ccm_single_line_projection_matches_line_parser() {
         serde_json::to_vec(&content_entries).unwrap(),
         serde_json::to_vec(&line_entries).unwrap()
     );
+}
+
+#[test]
+fn signal_extractor_preserves_known_hresult_and_error_db_metadata() {
+    let signals = extract_signals("Download failed with hr=0x80070005");
+
+    assert_eq!(signals.len(), 1);
+    assert_eq!(signals[0].kind, SccmSignalKind::HResult);
+    assert_eq!(signals[0].raw, "0x80070005");
+    assert_eq!(signals[0].numeric, Some(0x80070005));
+    assert!(signals[0].error_description.is_some());
+    assert!(signals[0].error_category.is_some());
+}
+
+#[test]
+fn signal_extractor_preserves_unknown_exit_and_gle_values() {
+    let signals = extract_signals("exit code 1603; [gle=0xDEADBEEF]; status=71");
+
+    assert_eq!(
+        signals
+            .iter()
+            .map(|signal| (&signal.kind, signal.raw.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (&SccmSignalKind::ExitCode, "1603"),
+            (&SccmSignalKind::Gle, "0xDEADBEEF"),
+            (&SccmSignalKind::Status, "71"),
+        ]
+    );
+    assert!(signals
+        .iter()
+        .all(|signal| signal.error_description.is_none() || !signal.raw.is_empty()));
+    assert_eq!(signals[1].numeric, Some(0xDEADBEEF));
+    assert_eq!(signals[1].error_description, None);
+    assert_eq!(signals[1].error_category, None);
+}
+
+#[test]
+fn signal_extractor_supports_only_the_declared_structured_forms() {
+    let signals = extract_signals(
+        "HRESULT 0x80004005; exitCode = 1618; return code 3010; \
+         unstructured 0x80070005; id={80070005-1111-2222-3333-444444444444}",
+    );
+
+    assert_eq!(
+        signals
+            .iter()
+            .map(|signal| (&signal.kind, signal.raw.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (&SccmSignalKind::HResult, "0x80004005"),
+            (&SccmSignalKind::ExitCode, "1618"),
+            (&SccmSignalKind::ReturnCode, "3010"),
+        ]
+    );
+}
+
+#[test]
+fn signal_extractor_uses_utf16_spans_and_preserves_repeated_tokens() {
+    let message = "😀 hr=0x80070005 then hr=0x80070005";
+    let signals = extract_signals(message);
+
+    assert_eq!(signals.len(), 2);
+    assert_eq!(signals[0].raw, signals[1].raw);
+    assert_ne!(
+        (signals[0].start, signals[0].end),
+        (signals[1].start, signals[1].end)
+    );
+    assert_eq!((signals[0].start, signals[0].end), (6, 16));
+    assert_eq!(
+        message
+            .encode_utf16()
+            .skip(signals[0].start)
+            .take(signals[0].end - signals[0].start)
+            .collect::<Vec<_>>(),
+        "0x80070005".encode_utf16().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn signal_extractor_is_deterministic_and_serializes_camel_case() {
+    let message = "HRESULT 0x80004005; status=4294967296";
+    let first = extract_signals(message);
+    let second = extract_signals(message);
+
+    assert_eq!(first, second);
+    assert_eq!(first[1].raw, "4294967296");
+    assert_eq!(first[1].numeric, None);
+    assert_eq!(first[1].error_description, None);
+
+    let json = serde_json::to_value(&first).unwrap();
+    assert_eq!(json[0]["kind"], "hResult");
+    assert_eq!(json[0]["raw"], "0x80004005");
+    assert!(json[0]["errorDescription"].is_string());
+    assert!(json[0]["errorCategory"].is_string());
+    assert!(json[0]["start"].is_number());
+    assert!(json[0]["end"].is_number());
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -3,7 +3,8 @@ use cmtraceopen_parser::parser::detect::detect_parser;
 use cmtraceopen_parser::sccm::{
     classify_artifact_name, declared_source_catalog, extract_signals, normalize_ccm_artifact,
     SccmArtifact, SccmArtifactFamily, SccmCoverageState, SccmFindingClass, SccmRole, SccmRotation,
-    SccmSignalKind, SccmTimeOrderingState, SccmUnknownRotation, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
+    SccmSignal, SccmSignalKind, SccmTimeOrderingState, SccmUnknownRotation,
+    SCCM_DIAGNOSTICS_SCHEMA_VERSION,
 };
 
 fn client_policy_artifact() -> SccmArtifact {
@@ -135,9 +136,22 @@ fn signal_extractor_preserves_unknown_exit_and_gle_values() {
     assert!(signals
         .iter()
         .all(|signal| signal.error_description.is_none() || !signal.raw.is_empty()));
+    assert!(signals[0].error_description.is_some());
     assert_eq!(signals[1].numeric, Some(0xDEADBEEF));
     assert_eq!(signals[1].error_description, None);
     assert_eq!(signals[1].error_category, None);
+}
+
+#[test]
+fn signal_extractor_does_not_enrich_decimal_values_as_unprefixed_hex() {
+    let signals = extract_signals("status=80004005");
+
+    assert_eq!(signals.len(), 1);
+    assert_eq!(signals[0].kind, SccmSignalKind::Status);
+    assert_eq!(signals[0].raw, "80004005");
+    assert_eq!(signals[0].numeric, Some(80_004_005));
+    assert_eq!(signals[0].error_description, None);
+    assert_eq!(signals[0].error_category, None);
 }
 
 #[test]
@@ -200,6 +214,38 @@ fn signal_extractor_is_deterministic_and_serializes_camel_case() {
     assert!(json[0]["errorCategory"].is_string());
     assert!(json[0]["start"].is_number());
     assert!(json[0]["end"].is_number());
+    assert_eq!(
+        json,
+        serde_json::json!([
+            {
+                "kind": "hResult",
+                "raw": "0x80004005",
+                "numeric": 2_147_500_037_u32,
+                "start": 8,
+                "end": 18,
+                "errorDescription": "E_FAIL - Unspecified failure",
+                "errorCategory": "Windows"
+            },
+            {
+                "kind": "status",
+                "raw": "4294967296",
+                "numeric": null,
+                "start": 27,
+                "end": 37,
+                "errorDescription": null,
+                "errorCategory": null
+            }
+        ])
+    );
+
+    let decoded: Vec<SccmSignal> = serde_json::from_value(json.clone()).unwrap();
+    assert_eq!(decoded, first);
+    assert_eq!(serde_json::to_value(&decoded).unwrap(), json);
+
+    let kind_json = serde_json::to_string(&SccmSignalKind::Gle).unwrap();
+    assert_eq!(kind_json, r#""gle""#);
+    let decoded_kind: SccmSignalKind = serde_json::from_str(&kind_json).unwrap();
+    assert_eq!(decoded_kind, SccmSignalKind::Gle);
 }
 
 #[test]


### PR DESCRIPTION
## Scope

Implements the Task 5 signal-extraction slice of #318 only.

- adds public `SccmSignal` / `SccmSignalKind` contracts and `extract_signals(message)`
- captures only the declared `hr=`, `HRESULT`, `[gle=]`, exit-code, return-code, and status forms
- preserves raw tokens, optional `u32` values, end-exclusive UTF-16 source spans, message order, and repeated occurrences
- enriches only the already parsed numeric value through the existing embedded error database
- retains unknown and out-of-range values without inventing a cause
- ignores unstructured hex and GUID text

No Task 6 correlation keys, Task 7 findings, workflow reducers, Windows I/O, Tauri, database, network, parser-kind, or raw CCM grammar changes are included. Public `LogEntry` remains unchanged.

## Test-first evidence

Initial RED:

`cargo test -p cmtraceopen-parser --test sccm_spine_contract signal_extractor_ -- --nocapture`

Failed on unresolved public `extract_signals` and `SccmSignalKind`, before production implementation.

Independent review then found a base-ambiguity blocker at the prior head: decimal `status=80004005` parsed numerically as 80,004,005 but error enrichment reinterpreted the raw digits as hexadecimal `0x80004005` / `E_FAIL`.

Correction RED:

`cargo test -p cmtraceopen-parser --test sccm_spine_contract signal_extractor_does_not_enrich_decimal_values_as_unprefixed_hex -- --exact --nocapture`

Failed with `Some("E_FAIL - Unspecified failure")` instead of `None`.

Correction: error enrichment now looks up the already parsed numeric value through an explicit hexadecimal representation, so the token grammar chooses the numeric base exactly once. Intended prefixed HRESULT and decimal `1603` enrichment remain covered. The serde contract now has an exact deterministic JSON fixture plus `SccmSignal` and standalone `SccmSignalKind` round trips.

## Exact current state and verification

Current base: `c342e9467f570879506b5e42c37f61e05efe2912`

Current head: `68968194f4b85458592ce2522816ccd6842cb496`

The two Task 5 commits were rebased from the former `781fb9c6` base. `git range-diff` reports both commits patch-equivalent (`=`): `a6581d9` → `a784e96`, `a0f0a61` → `6896819`.

Fresh gates after the rebase:

- focused signal contract: 6 passed
- full parser: 631 passed, 0 failed (351 + 222 + 3 + 3 + 1 + 5 + 46)
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings`: pass
- `cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown`: pass
- `npx tsc --noEmit`: pass
- owned Rust 1.88 formatting: pass
- `git diff --check origin/codex/parser-family-skeleton..HEAD`: pass

Repository-wide formatting still has unrelated pre-existing ESP/Tauri drift; all three owned Task 5 files pass scoped Rust 1.88 formatting.

## Review state

The original independent blocker review is https://github.com/adamgell/cmtraceopen/pull/348#pullrequestreview-4823653799 and the exact-head correction reply is https://github.com/adamgell/cmtraceopen/pull/348#discussion_r3686634848.

CodeRabbit completed a fresh substantive static review of exact head `68968194f4b85458592ce2522816ccd6842cb496` against base `c342e9467f570879506b5e42c37f61e05efe2912` with **no source-supported findings**: https://github.com/adamgell/cmtraceopen/pull/348#issuecomment-5136860934. It specifically confirmed the numeric-base correction and deterministic serde contracts without inferring runtime proof.

Independent exact-head rereview passed at `68968194f4b85458592ce2522816ccd6842cb496`: https://github.com/adamgell/cmtraceopen/pull/348#pullrequestreview-4823726223. The PR is ready for the reviewed merge. Native Windows acceptance is not claimed or required for this pure parser slice. If the base advances again, the branch must be refreshed and all gates rerun.

Part of #318. Tracked under epic #317.
