### PR TITLE
feat(sccm): add versioned correlation keys

### DIFF
--- a/crates/cmtraceopen-parser/src/sccm/keys.rs
+++ b/crates/cmtraceopen-parser/src/sccm/keys.rs
@@ -1,0 +1,425 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use super::models::{
+    SccmCorrelationKey, SccmCorrelationKeyKind, SccmEvidence, SccmExtractionGap,
+    SccmExtractionGapKind, SccmExtractionProfile, SccmExtractionProfileMaturity, SccmKeyConfidence,
+    SccmKeyExtractionResult,
+};
+
+pub const SCCM_EXPERIMENTAL_KEY_PROFILE_ID: &str = "sccm-keys-5.00.9128-experimental-v1";
+const EXPERIMENTAL_VERSION_PREFIX: &str = "5.00.9128.";
+
+impl SccmExtractionProfile {
+    pub fn for_version(configmgr_version: Option<&str>) -> Self {
+        let selected_configmgr_version = configmgr_version
+            .map(str::trim)
+            .filter(|version| !version.is_empty())
+            .map(str::to_owned);
+
+        match selected_configmgr_version {
+            Some(version)
+                if is_canonical_configmgr_version(&version)
+                    && version.starts_with(EXPERIMENTAL_VERSION_PREFIX) =>
+            {
+                Self {
+                    profile_id: SCCM_EXPERIMENTAL_KEY_PROFILE_ID.to_owned(),
+                    configmgr_version_prefixes: vec![EXPERIMENTAL_VERSION_PREFIX.to_owned()],
+                    validated_artifact_families: Vec::new(),
+                    selected_configmgr_version: Some(version),
+                    maturity: SccmExtractionProfileMaturity::Experimental,
+                }
+            }
+            Some(version) => Self {
+                profile_id: "sccm-keys-unvalidated-version-v1".to_owned(),
+                configmgr_version_prefixes: Vec::new(),
+                validated_artifact_families: Vec::new(),
+                selected_configmgr_version: Some(version),
+                maturity: SccmExtractionProfileMaturity::Unvalidated,
+            },
+            None => Self {
+                profile_id: "sccm-keys-version-missing-v1".to_owned(),
+                configmgr_version_prefixes: Vec::new(),
+                validated_artifact_families: Vec::new(),
+                selected_configmgr_version: None,
+                maturity: SccmExtractionProfileMaturity::Unvalidated,
+            },
+        }
+    }
+}
+
+struct KeyPattern {
+    kind: SccmCorrelationKeyKind,
+    regex: Regex,
+}
+
+#[derive(Debug)]
+struct KeyCandidate<'a> {
+    kind: SccmCorrelationKeyKind,
+    raw: &'a str,
+    start: usize,
+    end: usize,
+}
+
+fn key_patterns() -> &'static [KeyPattern] {
+    static CELL: OnceLock<Vec<KeyPattern>> = OnceLock::new();
+    CELL.get_or_init(|| {
+        [
+            (
+                SccmCorrelationKeyKind::AssignmentId,
+                r"(?i:\b(?:assignment|policy)[ \t]*id)[ \t]*=[ \t]*(?P<value>\{?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}?[A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::ClientGuid,
+                r"(?i:\bclient[ \t]*guid)[ \t]*=[ \t]*(?P<value>(?i:guid:)?\{?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}?[A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::PackageId,
+                r"(?i:\bpackage[ \t]*id)[ \t]*=[ \t]*(?P<value>[A-Za-z0-9]{8}[A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::ContentId,
+                r"(?i:\bcontent[ \t]*id)[ \t]*=[ \t]*(?P<value>[A-Za-z0-9][A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::SiteCode,
+                r"(?i:\bsite[ \t]*code)[ \t]*=[ \t]*(?P<value>[A-Za-z0-9]{3}[A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::ServerHost,
+                r"(?i:\bserver[ \t]*host)[ \t]*=[ \t]*(?P<value>[A-Za-z0-9][A-Za-z0-9._-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::CiId,
+                r"(?i:\b(?:ci|configuration[ \t]+item)[ \t]*id)[ \t]*=[ \t]*(?P<value>[0-9]+[A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::UpdateId,
+                r"(?i:\bupdate[ \t]*id)[ \t]*=[ \t]*(?P<value>\{?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}?[A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::KbId,
+                r"(?i:\b(?:kb|knowledge[ \t]+base)(?:[ \t]*id)?)[ \t]*=[ \t]*(?P<value>(?i:kb)?[0-9]+[A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::BitsJobId,
+                r"(?i:\bbits[ \t]*job[ \t]*id)[ \t]*=[ \t]*(?P<value>\{?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}?[A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::TaskSequenceExecutionId,
+                r"(?i:\btask[ \t]*sequence[ \t]*execution[ \t]*id)[ \t]*=[ \t]*(?P<value>\{?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}?[A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::RequestId,
+                r"(?i:\brequest[ \t]*id)[ \t]*=[ \t]*(?P<value>\{?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}?[A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::TopicId,
+                r"(?i:\btopic[ \t]*id)[ \t]*=[ \t]*(?P<value>\{?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}?[A-Za-z0-9_.-]*)",
+            ),
+            (
+                SccmCorrelationKeyKind::StateMessageId,
+                r"(?i:\bstate[ \t]*message[ \t]*id)[ \t]*=[ \t]*(?P<value>[0-9]+[A-Za-z0-9_.-]*)",
+            ),
+        ]
+        .into_iter()
+        .map(|(kind, pattern)| KeyPattern {
+            kind,
+            regex: Regex::new(pattern).expect("SCCM key regex must compile"),
+        })
+        .collect()
+    })
+}
+
+pub fn normalize_key(kind: SccmCorrelationKeyKind, raw: &str) -> SccmCorrelationKey {
+    let (normalized, confidence) = normalize_value(&kind, raw);
+    SccmCorrelationKey {
+        kind,
+        raw: raw.to_owned(),
+        normalized,
+        confidence,
+        extraction_profile_id: None,
+        evidence: None,
+        start: None,
+        end: None,
+    }
+}
+
+pub fn extract_keys(
+    evidence: &SccmEvidence,
+    profile: &SccmExtractionProfile,
+) -> SccmKeyExtractionResult {
+    let candidates = find_candidates(&evidence.message);
+    let mut result = SccmKeyExtractionResult {
+        profile_id: profile.profile_id.clone(),
+        keys: Vec::new(),
+        gaps: Vec::new(),
+    };
+
+    if let Some(kind) = profile_gap_kind(profile) {
+        if candidates.is_empty() {
+            result.gaps.push(gap_for(kind, profile, evidence, None));
+        } else {
+            result.gaps.extend(
+                candidates
+                    .iter()
+                    .map(|candidate| gap_for(kind.clone(), profile, evidence, Some(candidate))),
+            );
+        }
+        return result;
+    }
+
+    result.gaps.push(gap_for(
+        SccmExtractionGapKind::ExperimentalProfile,
+        profile,
+        evidence,
+        None,
+    ));
+
+    for candidate in candidates {
+        let mut key = normalize_key(candidate.kind.clone(), candidate.raw);
+        if key.confidence != SccmKeyConfidence::Exact {
+            result.gaps.push(gap_for(
+                SccmExtractionGapKind::MalformedCandidate,
+                profile,
+                evidence,
+                Some(&candidate),
+            ));
+            continue;
+        }
+
+        key.confidence = SccmKeyConfidence::Low;
+        key.extraction_profile_id = Some(profile.profile_id.clone());
+        key.evidence = Some(evidence.reference.clone());
+        key.start = Some(candidate.start);
+        key.end = Some(candidate.end);
+        result.keys.push(key);
+    }
+
+    result
+}
+
+fn profile_gap_kind(profile: &SccmExtractionProfile) -> Option<SccmExtractionGapKind> {
+    if profile.selected_configmgr_version.is_none() {
+        return Some(SccmExtractionGapKind::MissingVersion);
+    }
+
+    match profile.maturity {
+        SccmExtractionProfileMaturity::Unvalidated => {
+            Some(SccmExtractionGapKind::UnvalidatedVersion)
+        }
+        SccmExtractionProfileMaturity::Experimental if is_builtin_experimental(profile) => None,
+        SccmExtractionProfileMaturity::Experimental | SccmExtractionProfileMaturity::Stable => {
+            Some(SccmExtractionGapKind::UnvalidatedProfile)
+        }
+    }
+}
+
+fn is_builtin_experimental(profile: &SccmExtractionProfile) -> bool {
+    profile.profile_id == SCCM_EXPERIMENTAL_KEY_PROFILE_ID
+        && profile.configmgr_version_prefixes == [EXPERIMENTAL_VERSION_PREFIX]
+        && profile.validated_artifact_families.is_empty()
+        && profile
+            .selected_configmgr_version
+            .as_deref()
+            .is_some_and(|version| {
+                is_canonical_configmgr_version(version)
+                    && version.starts_with(EXPERIMENTAL_VERSION_PREFIX)
+            })
+}
+
+fn is_canonical_configmgr_version(version: &str) -> bool {
+    let mut component_count = 0;
+    for component in version.split('.') {
+        component_count += 1;
+        if component.is_empty() || !component.bytes().all(|byte| byte.is_ascii_digit()) {
+            return false;
+        }
+    }
+    component_count == 4
+}
+
+fn find_candidates(message: &str) -> Vec<KeyCandidate<'_>> {
+    let mut candidates = key_patterns()
+        .iter()
+        .flat_map(|pattern| {
+            pattern.regex.captures_iter(message).filter_map(|captures| {
+                let value = captures.name("value")?;
+                let start = message[..value.start()].encode_utf16().count();
+                Some(KeyCandidate {
+                    kind: pattern.kind.clone(),
+                    raw: value.as_str(),
+                    start,
+                    end: start + value.as_str().encode_utf16().count(),
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+
+    candidates.sort_by_key(|candidate| {
+        (
+            candidate.start,
+            key_kind_order(&candidate.kind),
+            candidate.end,
+        )
+    });
+    candidates.dedup_by(|right, left| {
+        right.kind == left.kind
+            && right.raw == left.raw
+            && right.start == left.start
+            && right.end == left.end
+    });
+    candidates
+}
+
+fn gap_for(
+    kind: SccmExtractionGapKind,
+    profile: &SccmExtractionProfile,
+    evidence: &SccmEvidence,
+    candidate: Option<&KeyCandidate<'_>>,
+) -> SccmExtractionGap {
+    SccmExtractionGap {
+        kind,
+        profile_id: profile.profile_id.clone(),
+        selected_configmgr_version: profile.selected_configmgr_version.clone(),
+        candidate_kind: candidate.map(|candidate| candidate.kind.clone()),
+        candidate_raw: candidate.map(|candidate| candidate.raw.to_owned()),
+        evidence: evidence.reference.clone(),
+    }
+}
+
+fn normalize_value(kind: &SccmCorrelationKeyKind, raw: &str) -> (String, SccmKeyConfidence) {
+    let trimmed = raw.trim();
+    let normalized = match kind {
+        SccmCorrelationKeyKind::AssignmentId
+        | SccmCorrelationKeyKind::ClientGuid
+        | SccmCorrelationKeyKind::UpdateId
+        | SccmCorrelationKeyKind::BitsJobId
+        | SccmCorrelationKeyKind::TaskSequenceExecutionId
+        | SccmCorrelationKeyKind::RequestId
+        | SccmCorrelationKeyKind::TopicId => normalize_guid(trimmed),
+        SccmCorrelationKeyKind::PackageId => {
+            is_fixed_alphanumeric(trimmed, 8).then(|| trimmed.to_ascii_uppercase())
+        }
+        SccmCorrelationKeyKind::ContentId => {
+            is_opaque_id(trimmed).then(|| trimmed.to_ascii_lowercase())
+        }
+        SccmCorrelationKeyKind::SiteCode => {
+            is_fixed_alphanumeric(trimmed, 3).then(|| trimmed.to_ascii_uppercase())
+        }
+        SccmCorrelationKeyKind::ServerHost => normalize_server_host(trimmed),
+        SccmCorrelationKeyKind::CiId | SccmCorrelationKeyKind::StateMessageId => {
+            normalize_decimal(trimmed)
+        }
+        SccmCorrelationKeyKind::KbId => normalize_kb_id(trimmed),
+    };
+
+    normalized.map_or_else(
+        || (trimmed.to_ascii_lowercase(), SccmKeyConfidence::Low),
+        |normalized| (normalized, SccmKeyConfidence::Exact),
+    )
+}
+
+fn normalize_guid(raw: &str) -> Option<String> {
+    let without_prefix = raw
+        .get(..5)
+        .filter(|prefix| prefix.eq_ignore_ascii_case("guid:"))
+        .map_or(raw, |_| &raw[5..]);
+    let without_braces = match (
+        without_prefix.strip_prefix('{'),
+        without_prefix.strip_suffix('}'),
+    ) {
+        (Some(_), None) | (None, Some(_)) => return None,
+        (Some(_), Some(_)) => &without_prefix[1..without_prefix.len() - 1],
+        (None, None) => without_prefix,
+    };
+    let bytes = without_braces.as_bytes();
+    let valid = bytes.len() == 36
+        && bytes.iter().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => *byte == b'-',
+            _ => byte.is_ascii_hexdigit(),
+        });
+    valid.then(|| without_braces.to_ascii_lowercase())
+}
+
+fn is_fixed_alphanumeric(value: &str, width: usize) -> bool {
+    value.len() == width && value.bytes().all(|byte| byte.is_ascii_alphanumeric())
+}
+
+fn is_opaque_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'-'))
+        && value
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_alphanumeric)
+        && value
+            .as_bytes()
+            .last()
+            .is_some_and(u8::is_ascii_alphanumeric)
+}
+
+fn normalize_server_host(value: &str) -> Option<String> {
+    let host = value.strip_suffix('.').unwrap_or(value);
+    let valid = !host.is_empty()
+        && host.len() <= 253
+        && host.split('.').all(|label| {
+            !label.is_empty()
+                && label.len() <= 63
+                && label
+                    .as_bytes()
+                    .first()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                && label
+                    .as_bytes()
+                    .last()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                && label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        });
+    valid.then(|| host.to_ascii_lowercase())
+}
+
+fn normalize_decimal(value: &str) -> Option<String> {
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let normalized = value.trim_start_matches('0');
+    Some(if normalized.is_empty() {
+        "0".to_owned()
+    } else {
+        normalized.to_owned()
+    })
+}
+
+fn normalize_kb_id(value: &str) -> Option<String> {
+    let digits = value
+        .get(..2)
+        .filter(|prefix| prefix.eq_ignore_ascii_case("kb"))
+        .map_or(value, |_| &value[2..]);
+    normalize_decimal(digits).map(|digits| format!("KB{digits}"))
+}
+
+fn key_kind_order(kind: &SccmCorrelationKeyKind) -> u8 {
+    match kind {
+        SccmCorrelationKeyKind::AssignmentId => 0,
+        SccmCorrelationKeyKind::ClientGuid => 1,
+        SccmCorrelationKeyKind::PackageId => 2,
+        SccmCorrelationKeyKind::ContentId => 3,
+        SccmCorrelationKeyKind::SiteCode => 4,
+        SccmCorrelationKeyKind::ServerHost => 5,
+        SccmCorrelationKeyKind::CiId => 6,
+        SccmCorrelationKeyKind::UpdateId => 7,
+        SccmCorrelationKeyKind::KbId => 8,
+        SccmCorrelationKeyKind::BitsJobId => 9,
+        SccmCorrelationKeyKind::TaskSequenceExecutionId => 10,
+        SccmCorrelationKeyKind::RequestId => 11,
+        SccmCorrelationKeyKind::TopicId => 12,
+        SccmCorrelationKeyKind::StateMessageId => 13,
+    }
+}

--- a/crates/cmtraceopen-parser/src/sccm/keys.rs
+++ b/crates/cmtraceopen-parser/src/sccm/keys.rs
@@ -246,12 +246,14 @@ fn find_candidates(message: &str) -> Vec<KeyCandidate<'_>> {
         .flat_map(|pattern| {
             pattern.regex.captures_iter(message).filter_map(|captures| {
                 let value = captures.name("value")?;
+                let raw_end = candidate_token_end(message, value.end());
+                let raw = &message[value.start()..raw_end];
                 let start = message[..value.start()].encode_utf16().count();
                 Some(KeyCandidate {
                     kind: pattern.kind.clone(),
-                    raw: value.as_str(),
+                    raw,
                     start,
-                    end: start + value.as_str().encode_utf16().count(),
+                    end: start + raw.encode_utf16().count(),
                 })
             })
         })
@@ -271,6 +273,19 @@ fn find_candidates(message: &str) -> Vec<KeyCandidate<'_>> {
             && right.end == left.end
     });
     candidates
+}
+
+fn candidate_token_end(message: &str, captured_end: usize) -> usize {
+    message[captured_end..]
+        .char_indices()
+        .find_map(|(offset, character)| {
+            is_key_token_boundary(character).then_some(captured_end + offset)
+        })
+        .unwrap_or(message.len())
+}
+
+fn is_key_token_boundary(character: char) -> bool {
+    character.is_whitespace() || matches!(character, ',' | ';' | '&')
 }
 
 fn gap_for(

--- a/crates/cmtraceopen-parser/src/sccm/keys.rs
+++ b/crates/cmtraceopen-parser/src/sccm/keys.rs
@@ -245,6 +245,10 @@ fn find_candidates(message: &str) -> Vec<KeyCandidate<'_>> {
         .iter()
         .flat_map(|pattern| {
             pattern.regex.captures_iter(message).filter_map(|captures| {
+                let matched = captures.get(0)?;
+                if !is_key_label_start(message, matched.start()) {
+                    return None;
+                }
                 let value = captures.name("value")?;
                 let raw_end = candidate_token_end(message, value.end());
                 let raw = &message[value.start()..raw_end];
@@ -273,6 +277,14 @@ fn find_candidates(message: &str) -> Vec<KeyCandidate<'_>> {
             && right.end == left.end
     });
     candidates
+}
+
+fn is_key_label_start(message: &str, label_start: usize) -> bool {
+    label_start == 0
+        || message[..label_start]
+            .chars()
+            .next_back()
+            .is_some_and(is_key_token_boundary)
 }
 
 fn candidate_token_end(message: &str, captured_end: usize) -> usize {

--- a/crates/cmtraceopen-parser/src/sccm/mod.rs
+++ b/crates/cmtraceopen-parser/src/sccm/mod.rs
@@ -1,11 +1,13 @@
 pub mod catalog;
 mod evidence;
 mod ingest;
+mod keys;
 pub mod models;
 mod rotation;
 mod signals;
 
 pub use catalog::*;
 pub use ingest::*;
+pub use keys::*;
 pub use models::*;
 pub use signals::*;

--- a/crates/cmtraceopen-parser/src/sccm/models.rs
+++ b/crates/cmtraceopen-parser/src/sccm/models.rs
@@ -2,6 +2,7 @@ use serde::ser::{Error as _, SerializeStruct};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
+use super::catalog::SccmArtifactFamily;
 use super::rotation::{is_canonical_rotation_number, is_canonical_rotation_timestamp};
 
 pub const SCCM_DIAGNOSTICS_SCHEMA_VERSION: u32 = 1;
@@ -142,6 +143,93 @@ pub struct SccmEvidence {
     pub message: String,
     pub timestamp: SccmTimestamp,
     pub execution_context: Option<SccmSensitiveHandle>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmCorrelationKeyKind {
+    AssignmentId,
+    ClientGuid,
+    PackageId,
+    ContentId,
+    SiteCode,
+    ServerHost,
+    CiId,
+    UpdateId,
+    KbId,
+    BitsJobId,
+    TaskSequenceExecutionId,
+    RequestId,
+    TopicId,
+    StateMessageId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmKeyConfidence {
+    Low,
+    Strong,
+    Exact,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmCorrelationKey {
+    pub kind: SccmCorrelationKeyKind,
+    pub raw: String,
+    pub normalized: String,
+    pub confidence: SccmKeyConfidence,
+    pub extraction_profile_id: Option<String>,
+    pub evidence: Option<SccmEvidenceRef>,
+    pub start: Option<usize>,
+    pub end: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmExtractionProfileMaturity {
+    Unvalidated,
+    Experimental,
+    Stable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmExtractionProfile {
+    pub profile_id: String,
+    pub configmgr_version_prefixes: Vec<String>,
+    pub validated_artifact_families: Vec<SccmArtifactFamily>,
+    pub selected_configmgr_version: Option<String>,
+    pub maturity: SccmExtractionProfileMaturity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmExtractionGapKind {
+    MissingVersion,
+    UnvalidatedVersion,
+    UnvalidatedProfile,
+    ExperimentalProfile,
+    MalformedCandidate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmExtractionGap {
+    pub kind: SccmExtractionGapKind,
+    pub profile_id: String,
+    pub selected_configmgr_version: Option<String>,
+    pub candidate_kind: Option<SccmCorrelationKeyKind>,
+    pub candidate_raw: Option<String>,
+    pub evidence: SccmEvidenceRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmKeyExtractionResult {
+    pub profile_id: String,
+    pub keys: Vec<SccmCorrelationKey>,
+    pub gaps: Vec<SccmExtractionGap>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -1,10 +1,12 @@
 use cmtraceopen_parser::models::log_entry::{LogFormat, ParserKind};
 use cmtraceopen_parser::parser::detect::detect_parser;
 use cmtraceopen_parser::sccm::{
-    classify_artifact_name, declared_source_catalog, extract_signals, normalize_ccm_artifact,
-    SccmArtifact, SccmArtifactFamily, SccmCoverageState, SccmFindingClass, SccmRole, SccmRotation,
-    SccmSignal, SccmSignalKind, SccmTimeOrderingState, SccmUnknownRotation,
-    SCCM_DIAGNOSTICS_SCHEMA_VERSION,
+    classify_artifact_name, declared_source_catalog, extract_keys, extract_signals,
+    normalize_ccm_artifact, normalize_key, SccmArtifact, SccmArtifactFamily,
+    SccmCorrelationKeyKind, SccmCoverageState, SccmEvidence, SccmEvidenceRef,
+    SccmExtractionGapKind, SccmExtractionProfile, SccmExtractionProfileMaturity, SccmFindingClass,
+    SccmKeyConfidence, SccmKeyExtractionResult, SccmRole, SccmRotation, SccmSignal, SccmSignalKind,
+    SccmTimeOrderingState, SccmTimestamp, SccmUnknownRotation, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
 };
 
 fn client_policy_artifact() -> SccmArtifact {
@@ -19,6 +21,29 @@ fn client_policy_artifact() -> SccmArtifact {
         rotation: SccmRotation::Current,
         coverage: SccmCoverageState::Captured,
         encoding: Some("utf-8".into()),
+    }
+}
+
+fn evidence_with_message(message: &str) -> SccmEvidence {
+    SccmEvidence {
+        evidence_id: "client-policy-agent:1-1".into(),
+        reference: SccmEvidenceRef {
+            artifact_id: "client-policy-agent".into(),
+            entry_id: "client-policy-agent:1-1".into(),
+            line_start: Some(1),
+            line_end: Some(1),
+        },
+        role: SccmRole::Client,
+        component: Some("PolicyAgent".into()),
+        ccm_source_file: Some("policyagent.cpp".into()),
+        message: message.into(),
+        timestamp: SccmTimestamp {
+            original_display: None,
+            offset_minutes: None,
+            utc_millis: None,
+            ordering_state: SccmTimeOrderingState::TimestampMissing,
+        },
+        execution_context: None,
     }
 }
 
@@ -246,6 +271,342 @@ fn signal_extractor_is_deterministic_and_serializes_camel_case() {
     assert_eq!(kind_json, r#""gle""#);
     let decoded_kind: SccmSignalKind = serde_json::from_str(&kind_json).unwrap();
     assert_eq!(decoded_kind, SccmSignalKind::Gle);
+}
+
+#[test]
+fn key_normalization_is_stable_across_case_and_brace_variants() {
+    let left = normalize_key(
+        SccmCorrelationKeyKind::AssignmentId,
+        "{ABCDEFAB-0000-0000-0000-000000000001}",
+    );
+    let right = normalize_key(
+        SccmCorrelationKeyKind::AssignmentId,
+        "abcdefab-0000-0000-0000-000000000001",
+    );
+
+    assert_eq!(left.normalized, right.normalized);
+    assert_eq!(left.confidence, SccmKeyConfidence::Exact);
+}
+
+#[test]
+fn key_normalization_covers_each_declared_lexical_kind() {
+    let cases = [
+        (
+            SccmCorrelationKeyKind::AssignmentId,
+            "{ABCDEFAB-0000-0000-0000-000000000001}",
+            "abcdefab-0000-0000-0000-000000000001",
+        ),
+        (
+            SccmCorrelationKeyKind::ClientGuid,
+            "GUID:{ABCDEFAB-0000-0000-0000-000000000002}",
+            "abcdefab-0000-0000-0000-000000000002",
+        ),
+        (SccmCorrelationKeyKind::PackageId, "lab00001", "LAB00001"),
+        (
+            SccmCorrelationKeyKind::ContentId,
+            "Content_ABC-123",
+            "content_abc-123",
+        ),
+        (SccmCorrelationKeyKind::SiteCode, "lab", "LAB"),
+        (
+            SccmCorrelationKeyKind::ServerHost,
+            "MP01.LAB.LOCAL.",
+            "mp01.lab.local",
+        ),
+        (SccmCorrelationKeyKind::CiId, "00042", "42"),
+        (
+            SccmCorrelationKeyKind::UpdateId,
+            "{ABCDEFAB-0000-0000-0000-000000000003}",
+            "abcdefab-0000-0000-0000-000000000003",
+        ),
+        (SccmCorrelationKeyKind::KbId, "kb5034441", "KB5034441"),
+        (
+            SccmCorrelationKeyKind::BitsJobId,
+            "{ABCDEFAB-0000-0000-0000-000000000004}",
+            "abcdefab-0000-0000-0000-000000000004",
+        ),
+        (
+            SccmCorrelationKeyKind::TaskSequenceExecutionId,
+            "{ABCDEFAB-0000-0000-0000-000000000005}",
+            "abcdefab-0000-0000-0000-000000000005",
+        ),
+        (
+            SccmCorrelationKeyKind::RequestId,
+            "{ABCDEFAB-0000-0000-0000-000000000006}",
+            "abcdefab-0000-0000-0000-000000000006",
+        ),
+        (
+            SccmCorrelationKeyKind::TopicId,
+            "{ABCDEFAB-0000-0000-0000-000000000007}",
+            "abcdefab-0000-0000-0000-000000000007",
+        ),
+        (SccmCorrelationKeyKind::StateMessageId, "00071", "71"),
+    ];
+
+    for (kind, raw, expected) in cases {
+        let key = normalize_key(kind, raw);
+        assert_eq!(key.normalized, expected, "{raw}");
+        assert_eq!(key.confidence, SccmKeyConfidence::Exact, "{raw}");
+    }
+}
+
+#[test]
+fn key_normalization_malformed_values_are_low_confidence_only() {
+    for (kind, raw) in [
+        (SccmCorrelationKeyKind::AssignmentId, "{not-a-guid}"),
+        (SccmCorrelationKeyKind::PackageId, "LAB001"),
+        (SccmCorrelationKeyKind::ServerHost, "bad..host"),
+        (SccmCorrelationKeyKind::KbId, "KB-not-numeric"),
+    ] {
+        assert_eq!(
+            normalize_key(kind, raw).confidence,
+            SccmKeyConfidence::Low,
+            "{raw}"
+        );
+    }
+}
+
+#[test]
+fn key_extraction_unvalidated_version_cannot_emit_exact_extracted_key() {
+    let result = extract_keys(
+        &evidence_with_message("Policy id={ABCDEFAB-0000-0000-0000-000000000001}"),
+        &SccmExtractionProfile::for_version(Some("unobserved-version")),
+    );
+
+    assert!(result.keys.is_empty());
+    assert_eq!(
+        result.gaps[0].kind,
+        SccmExtractionGapKind::UnvalidatedVersion
+    );
+    assert_eq!(
+        result.gaps[0].candidate_raw.as_deref(),
+        Some("{ABCDEFAB-0000-0000-0000-000000000001}")
+    );
+}
+
+#[test]
+fn key_extraction_missing_version_is_an_explicit_gap_not_a_key() {
+    let result = extract_keys(
+        &evidence_with_message("package id=LAB00001"),
+        &SccmExtractionProfile::for_version(None),
+    );
+
+    assert!(result.keys.is_empty());
+    assert_eq!(result.gaps[0].kind, SccmExtractionGapKind::MissingVersion);
+    assert_eq!(result.gaps[0].candidate_raw.as_deref(), Some("LAB00001"));
+}
+
+#[test]
+fn key_extraction_unvalidated_and_missing_versions_preserve_every_candidate_gap() {
+    let evidence = evidence_with_message(
+        "package id=LAB00001; site code=LAB; \
+         assignment id={ABCDEFAB-0000-0000-0000-000000000001}",
+    );
+
+    for (profile, expected_gap_kind) in [
+        (
+            SccmExtractionProfile::for_version(Some("unobserved-version")),
+            SccmExtractionGapKind::UnvalidatedVersion,
+        ),
+        (
+            SccmExtractionProfile::for_version(None),
+            SccmExtractionGapKind::MissingVersion,
+        ),
+    ] {
+        let first = extract_keys(&evidence, &profile);
+        let second = extract_keys(&evidence, &profile);
+
+        assert_eq!(first, second);
+        assert!(first.keys.is_empty());
+        assert_eq!(first.gaps.len(), 3);
+        assert!(first.gaps.iter().all(|gap| gap.kind == expected_gap_kind));
+        assert_eq!(
+            first
+                .gaps
+                .iter()
+                .map(|gap| (gap.candidate_kind.clone(), gap.candidate_raw.as_deref()))
+                .collect::<Vec<_>>(),
+            vec![
+                (Some(SccmCorrelationKeyKind::PackageId), Some("LAB00001")),
+                (Some(SccmCorrelationKeyKind::SiteCode), Some("LAB")),
+                (
+                    Some(SccmCorrelationKeyKind::AssignmentId),
+                    Some("{ABCDEFAB-0000-0000-0000-000000000001}")
+                ),
+            ]
+        );
+        assert!(first
+            .gaps
+            .iter()
+            .all(|gap| gap.evidence == evidence.reference));
+    }
+}
+
+#[test]
+fn key_extraction_rejects_truncated_prefixes_from_invalid_structured_values() {
+    let overlong_content_id = "a".repeat(129);
+    let invalid_guid = "{ABCDEFAB-0000-0000-0000-000000000001}extra";
+    let invalid_host = "mp01.lab.local_suffix";
+    let evidence = evidence_with_message(&format!(
+        "assignment id={invalid_guid}; content id={overlong_content_id}; \
+         server host={invalid_host}"
+    ));
+
+    let result = extract_keys(
+        &evidence,
+        &SccmExtractionProfile::for_version(Some("5.00.9128.1007")),
+    );
+
+    assert!(result.keys.is_empty());
+    assert_eq!(
+        result
+            .gaps
+            .iter()
+            .filter(|gap| gap.kind == SccmExtractionGapKind::MalformedCandidate)
+            .map(|gap| gap.candidate_raw.as_deref())
+            .collect::<Vec<_>>(),
+        vec![
+            Some(invalid_guid),
+            Some(overlong_content_id.as_str()),
+            Some(invalid_host),
+        ]
+    );
+}
+
+#[test]
+fn key_profile_single_observed_version_stays_experimental_and_low_confidence() {
+    let profile = SccmExtractionProfile::for_version(Some("5.00.9128.1007"));
+    let evidence = evidence_with_message(
+        "Policy id={ABCDEFAB-0000-0000-0000-000000000001}; \
+         package id=LAB00001; site code=LAB",
+    );
+    let result = extract_keys(&evidence, &profile);
+
+    assert_eq!(
+        profile.maturity,
+        SccmExtractionProfileMaturity::Experimental
+    );
+    assert_eq!(profile.configmgr_version_prefixes, vec!["5.00.9128."]);
+    assert!(profile.validated_artifact_families.is_empty());
+    assert_eq!(result.keys.len(), 3);
+    assert!(result
+        .keys
+        .iter()
+        .all(|key| key.confidence == SccmKeyConfidence::Low));
+    assert!(result.keys.iter().all(|key| {
+        !matches!(
+            key.confidence,
+            SccmKeyConfidence::Strong | SccmKeyConfidence::Exact
+        )
+    }));
+    assert_eq!(
+        result.gaps[0].kind,
+        SccmExtractionGapKind::ExperimentalProfile
+    );
+    assert_eq!(
+        SccmExtractionProfile::for_version(Some("5.00.9135.1000")).maturity,
+        SccmExtractionProfileMaturity::Unvalidated
+    );
+}
+
+#[test]
+fn key_profile_version_selection_rejects_malformed_or_prefix_collision_versions() {
+    for version in ["5.00.9128.not-observed", "5.00.91280.1007", "5.00.9128"] {
+        assert_eq!(
+            SccmExtractionProfile::for_version(Some(version)).maturity,
+            SccmExtractionProfileMaturity::Unvalidated,
+            "{version}"
+        );
+    }
+}
+
+#[test]
+fn key_extraction_covers_declared_labels_in_message_order() {
+    let evidence = evidence_with_message(
+        "assignment id={ABCDEFAB-0000-0000-0000-000000000001}; \
+         client guid=GUID:{ABCDEFAB-0000-0000-0000-000000000002}; \
+         package id=LAB00001; content id=Content_ABC-123; site code=lab; \
+         server host=MP01.LAB.LOCAL.; ci id=00042; \
+         update id={ABCDEFAB-0000-0000-0000-000000000003}; kb id=KB5034441; \
+         bits job id={ABCDEFAB-0000-0000-0000-000000000004}; \
+         task sequence execution id={ABCDEFAB-0000-0000-0000-000000000005}; \
+         request id={ABCDEFAB-0000-0000-0000-000000000006}; \
+         topic id={ABCDEFAB-0000-0000-0000-000000000007}; state message id=00071",
+    );
+    let result = extract_keys(
+        &evidence,
+        &SccmExtractionProfile::for_version(Some("5.00.9128.1007")),
+    );
+
+    assert_eq!(
+        result
+            .keys
+            .iter()
+            .map(|key| key.kind.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            SccmCorrelationKeyKind::AssignmentId,
+            SccmCorrelationKeyKind::ClientGuid,
+            SccmCorrelationKeyKind::PackageId,
+            SccmCorrelationKeyKind::ContentId,
+            SccmCorrelationKeyKind::SiteCode,
+            SccmCorrelationKeyKind::ServerHost,
+            SccmCorrelationKeyKind::CiId,
+            SccmCorrelationKeyKind::UpdateId,
+            SccmCorrelationKeyKind::KbId,
+            SccmCorrelationKeyKind::BitsJobId,
+            SccmCorrelationKeyKind::TaskSequenceExecutionId,
+            SccmCorrelationKeyKind::RequestId,
+            SccmCorrelationKeyKind::TopicId,
+            SccmCorrelationKeyKind::StateMessageId,
+        ]
+    );
+}
+
+#[test]
+fn key_profile_forged_stable_profile_cannot_emit_strong_or_exact_keys() {
+    let mut profile = SccmExtractionProfile::for_version(Some("5.00.9128.1007"));
+    profile.maturity = SccmExtractionProfileMaturity::Stable;
+
+    let result = extract_keys(&evidence_with_message("package id=LAB00001"), &profile);
+
+    assert!(result.keys.is_empty());
+    assert_eq!(
+        result.gaps[0].kind,
+        SccmExtractionGapKind::UnvalidatedProfile
+    );
+}
+
+#[test]
+fn key_profile_and_extraction_result_have_deterministic_json_round_trips() {
+    let profile = SccmExtractionProfile::for_version(Some("5.00.9128.1007"));
+    let evidence = evidence_with_message("Policy id={ABCDEFAB-0000-0000-0000-000000000001}");
+    let first = extract_keys(&evidence, &profile);
+    let second = extract_keys(&evidence, &profile);
+
+    assert_eq!(first, second);
+    assert_eq!(
+        serde_json::to_value(&profile).unwrap(),
+        serde_json::json!({
+            "profileId": "sccm-keys-5.00.9128-experimental-v1",
+            "configmgrVersionPrefixes": ["5.00.9128."],
+            "validatedArtifactFamilies": [],
+            "selectedConfigmgrVersion": "5.00.9128.1007",
+            "maturity": "experimental"
+        })
+    );
+
+    let profile_json = serde_json::to_string(&profile).unwrap();
+    assert_eq!(
+        serde_json::from_str::<SccmExtractionProfile>(&profile_json).unwrap(),
+        profile
+    );
+
+    let result_json = serde_json::to_string(&first).unwrap();
+    assert_eq!(
+        serde_json::from_str::<SccmKeyExtractionResult>(&result_json).unwrap(),
+        first
+    );
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -474,6 +474,131 @@ fn key_extraction_rejects_truncated_prefixes_from_invalid_structured_values() {
 }
 
 #[test]
+fn key_extraction_requires_a_full_token_boundary_for_every_declared_kind() {
+    let cases = [
+        (
+            SccmCorrelationKeyKind::AssignmentId,
+            "assignment id={ABCDEFAB-0000-0000-0000-000000000001}}",
+            "{ABCDEFAB-0000-0000-0000-000000000001}}",
+        ),
+        (
+            SccmCorrelationKeyKind::ClientGuid,
+            "client guid=GUID:{ABCDEFAB-0000-0000-0000-000000000002}/continued",
+            "GUID:{ABCDEFAB-0000-0000-0000-000000000002}/continued",
+        ),
+        (
+            SccmCorrelationKeyKind::PackageId,
+            "package id=LAB00001é",
+            "LAB00001é",
+        ),
+        (
+            SccmCorrelationKeyKind::ContentId,
+            "content id=ContentABC/continued",
+            "ContentABC/continued",
+        ),
+        (
+            SccmCorrelationKeyKind::SiteCode,
+            "site code=LAB:continued",
+            "LAB:continued",
+        ),
+        (
+            SccmCorrelationKeyKind::ServerHost,
+            "server host=mp01.lab.localé",
+            "mp01.lab.localé",
+        ),
+        (
+            SccmCorrelationKeyKind::CiId,
+            "ci id=42+continued",
+            "42+continued",
+        ),
+        (
+            SccmCorrelationKeyKind::UpdateId,
+            "update id={ABCDEFAB-0000-0000-0000-000000000003}:continued",
+            "{ABCDEFAB-0000-0000-0000-000000000003}:continued",
+        ),
+        (
+            SccmCorrelationKeyKind::KbId,
+            "kb id=KB5034441/continued",
+            "KB5034441/continued",
+        ),
+        (
+            SccmCorrelationKeyKind::BitsJobId,
+            "bits job id={ABCDEFAB-0000-0000-0000-000000000004}+continued",
+            "{ABCDEFAB-0000-0000-0000-000000000004}+continued",
+        ),
+        (
+            SccmCorrelationKeyKind::TaskSequenceExecutionId,
+            "task sequence execution id={ABCDEFAB-0000-0000-0000-000000000005}}",
+            "{ABCDEFAB-0000-0000-0000-000000000005}}",
+        ),
+        (
+            SccmCorrelationKeyKind::RequestId,
+            "request id={ABCDEFAB-0000-0000-0000-000000000006}/continued",
+            "{ABCDEFAB-0000-0000-0000-000000000006}/continued",
+        ),
+        (
+            SccmCorrelationKeyKind::TopicId,
+            "topic id={ABCDEFAB-0000-0000-0000-000000000007}:continued",
+            "{ABCDEFAB-0000-0000-0000-000000000007}:continued",
+        ),
+        (
+            SccmCorrelationKeyKind::StateMessageId,
+            "state message id=71é",
+            "71é",
+        ),
+    ];
+    let profile = SccmExtractionProfile::for_version(Some("5.00.9128.1007"));
+    let mut violations = Vec::new();
+
+    for (expected_kind, message, expected_raw) in cases {
+        let evidence = evidence_with_message(message);
+        let first = extract_keys(&evidence, &profile);
+        let second = extract_keys(&evidence, &profile);
+
+        assert_eq!(first, second, "{message}");
+        let malformed = first
+            .gaps
+            .iter()
+            .filter(|gap| gap.kind == SccmExtractionGapKind::MalformedCandidate)
+            .map(|gap| (gap.candidate_kind.clone(), gap.candidate_raw.as_deref()))
+            .collect::<Vec<_>>();
+        if !first.keys.is_empty() || malformed != vec![(Some(expected_kind), Some(expected_raw))] {
+            violations.push(format!("{message}: {first:?}"));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "truncated key prefixes were admitted:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn key_extraction_accepts_the_declared_full_token_boundaries() {
+    let profile = SccmExtractionProfile::for_version(Some("5.00.9128.1007"));
+
+    for message in [
+        "package id=LAB00001",
+        "package id=LAB00001 next",
+        "package id=LAB00001\nnext",
+        "package id=LAB00001,next",
+        "package id=LAB00001;next",
+        "package id=LAB00001&next",
+    ] {
+        let result = extract_keys(&evidence_with_message(message), &profile);
+
+        assert_eq!(result.keys.len(), 1, "{message:?}");
+        assert_eq!(result.keys[0].raw, "LAB00001", "{message:?}");
+        assert_eq!(result.keys[0].confidence, SccmKeyConfidence::Low);
+        assert!(result
+            .gaps
+            .iter()
+            .all(|gap| gap.kind != SccmExtractionGapKind::MalformedCandidate));
+    }
+}
+
+#[test]
 fn key_profile_single_observed_version_stays_experimental_and_low_confidence() {
     let profile = SccmExtractionProfile::for_version(Some("5.00.9128.1007"));
     let evidence = evidence_with_message(

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -575,22 +575,161 @@ fn key_extraction_requires_a_full_token_boundary_for_every_declared_kind() {
 }
 
 #[test]
+fn key_extraction_rejects_every_label_inside_a_preceding_malformed_token() {
+    let second_labels = [
+        (
+            SccmCorrelationKeyKind::AssignmentId,
+            "assignment id={ABCDEFAB-0000-0000-0000-000000000001}",
+        ),
+        (
+            SccmCorrelationKeyKind::ClientGuid,
+            "client guid=GUID:{ABCDEFAB-0000-0000-0000-000000000002}",
+        ),
+        (SccmCorrelationKeyKind::PackageId, "package id=LAB00002"),
+        (SccmCorrelationKeyKind::ContentId, "content id=ContentABC"),
+        (SccmCorrelationKeyKind::SiteCode, "site code=LAB"),
+        (
+            SccmCorrelationKeyKind::ServerHost,
+            "server host=mp01.lab.local",
+        ),
+        (SccmCorrelationKeyKind::CiId, "ci id=42"),
+        (
+            SccmCorrelationKeyKind::UpdateId,
+            "update id={ABCDEFAB-0000-0000-0000-000000000003}",
+        ),
+        (SccmCorrelationKeyKind::KbId, "kb id=KB5034441"),
+        (
+            SccmCorrelationKeyKind::BitsJobId,
+            "bits job id={ABCDEFAB-0000-0000-0000-000000000004}",
+        ),
+        (
+            SccmCorrelationKeyKind::TaskSequenceExecutionId,
+            "task sequence execution id={ABCDEFAB-0000-0000-0000-000000000005}",
+        ),
+        (
+            SccmCorrelationKeyKind::RequestId,
+            "request id={ABCDEFAB-0000-0000-0000-000000000006}",
+        ),
+        (
+            SccmCorrelationKeyKind::TopicId,
+            "topic id={ABCDEFAB-0000-0000-0000-000000000007}",
+        ),
+        (
+            SccmCorrelationKeyKind::StateMessageId,
+            "state message id=71",
+        ),
+    ];
+    let forbidden_delimiters = ["/", ":", "+"];
+    let profile = SccmExtractionProfile::for_version(Some("5.00.9128.1007"));
+    let mut violations = Vec::new();
+
+    for (index, (second_kind, second_label)) in second_labels.into_iter().enumerate() {
+        let delimiter = forbidden_delimiters[index % forbidden_delimiters.len()];
+        let message = format!("package id=LAB00001{delimiter}{second_label}");
+        let malformed_raw = format!(
+            "LAB00001{delimiter}{}",
+            second_label.split_whitespace().next().unwrap()
+        );
+        let evidence = evidence_with_message(&message);
+        let first = extract_keys(&evidence, &profile);
+        let second = extract_keys(&evidence, &profile);
+        let malformed = first
+            .gaps
+            .iter()
+            .filter(|gap| gap.kind == SccmExtractionGapKind::MalformedCandidate)
+            .map(|gap| {
+                (
+                    gap.candidate_kind.clone(),
+                    gap.candidate_raw.as_deref(),
+                    gap.evidence.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let expected_malformed = vec![(
+            Some(SccmCorrelationKeyKind::PackageId),
+            Some(malformed_raw.as_str()),
+            evidence.reference.clone(),
+        )];
+
+        if first != second || !first.keys.is_empty() || malformed != expected_malformed {
+            violations.push(format!("{second_kind:?}: {message}: {first:?}"));
+        }
+    }
+
+    for (message, malformed_kind, malformed_raw) in [
+        (
+            "assignment id={ABCDEFAB-0000-0000-0000-000000000001}}content id=ContentABC",
+            SccmCorrelationKeyKind::AssignmentId,
+            "{ABCDEFAB-0000-0000-0000-000000000001}}content",
+        ),
+        (
+            "package id=LAB00001écontent id=ContentABC",
+            SccmCorrelationKeyKind::PackageId,
+            "LAB00001écontent",
+        ),
+    ] {
+        let result = extract_keys(&evidence_with_message(message), &profile);
+        let malformed = result
+            .gaps
+            .iter()
+            .find(|gap| gap.kind == SccmExtractionGapKind::MalformedCandidate);
+        if !result.keys.is_empty()
+            || malformed.and_then(|gap| gap.candidate_kind.clone()) != Some(malformed_kind)
+            || malformed.and_then(|gap| gap.candidate_raw.as_deref()) != Some(malformed_raw)
+        {
+            violations.push(format!("{message}: {result:?}"));
+        }
+    }
+
+    let unvalidated_evidence = evidence_with_message("package id=LAB00001/content id=ContentABC");
+    let unvalidated = extract_keys(
+        &unvalidated_evidence,
+        &SccmExtractionProfile::for_version(Some("unobserved-version")),
+    );
+    if !unvalidated.keys.is_empty()
+        || unvalidated.gaps.len() != 1
+        || unvalidated.gaps[0].kind != SccmExtractionGapKind::UnvalidatedVersion
+        || unvalidated.gaps[0].candidate_kind != Some(SccmCorrelationKeyKind::PackageId)
+        || unvalidated.gaps[0].candidate_raw.as_deref() != Some("LAB00001/content")
+        || unvalidated.gaps[0].evidence != unvalidated_evidence.reference
+    {
+        violations.push(format!("unvalidated profile: {unvalidated:?}"));
+    }
+
+    assert!(
+        violations.is_empty(),
+        "labels escaped from malformed tokens:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn key_extraction_accepts_the_declared_full_token_boundaries() {
     let profile = SccmExtractionProfile::for_version(Some("5.00.9128.1007"));
 
-    for message in [
-        "package id=LAB00001",
-        "package id=LAB00001 next",
-        "package id=LAB00001\nnext",
-        "package id=LAB00001,next",
-        "package id=LAB00001;next",
-        "package id=LAB00001&next",
-    ] {
-        let result = extract_keys(&evidence_with_message(message), &profile);
+    for separator in [" ", "\n", "\t", ",", ";", "&"] {
+        let message = format!("😀 package id=LAB00001{separator}content id=ContentABC");
+        let result = extract_keys(&evidence_with_message(&message), &profile);
 
-        assert_eq!(result.keys.len(), 1, "{message:?}");
+        assert_eq!(result.keys.len(), 2, "{message:?}");
+        assert_eq!(result.keys[0].kind, SccmCorrelationKeyKind::PackageId);
         assert_eq!(result.keys[0].raw, "LAB00001", "{message:?}");
-        assert_eq!(result.keys[0].confidence, SccmKeyConfidence::Low);
+        assert_eq!(result.keys[1].kind, SccmCorrelationKeyKind::ContentId);
+        assert_eq!(result.keys[1].raw, "ContentABC", "{message:?}");
+        assert!(result
+            .keys
+            .iter()
+            .all(|key| key.confidence == SccmKeyConfidence::Low));
+        for key in &result.keys {
+            let byte_start = message.find(&key.raw).unwrap();
+            let expected_start = message[..byte_start].encode_utf16().count();
+            assert_eq!(key.start, Some(expected_start), "{message:?}");
+            assert_eq!(
+                key.end,
+                Some(expected_start + key.raw.encode_utf16().count()),
+                "{message:?}"
+            );
+        }
         assert!(result
             .gaps
             .iter()


### PR DESCRIPTION
## Scope

Implements Task 6 of the SCCM diagnostic spine for #318:

- adds the public correlation-key, extraction-profile, confidence, and coverage-gap contracts;
- normalizes all 14 declared SCCM lexical key families without adding a parser kind or duplicating CCM parsing;
- gates extraction by ConfigMgr version/profile maturity;
- keeps the single exercised profile experimental and caps every extracted key at Low confidence;
- rejects forged Stable profiles and malformed or prefix-collision version labels;
- preserves deterministic ordered candidate gaps for missing and unvalidated versions;
- requires a declared whole-token boundary both before a label and after its captured value.

No native collection, Windows I/O, findings/reducers, cross-side causal logic, `ParserKind::Sccm`, CCM grammar, `LogEntry`, or dependency changes are included.

## Review corrections

Independent review first found that a regex capture could stop before an unrecognized contiguous value suffix. Values such as `{GUID}}`, `LAB00001é`, or `hosté` could therefore emit a truncated Low key. The first correction made end-of-message, whitespace, comma, semicolon, or ampersand the only accepted value boundaries.

A fresh dynamic rereview then found the symmetric label-start flaw: per-label regex scans treated forbidden punctuation as a word boundary, so `package id=LAB00001/content id=ContentABC` could emit a nested ContentId even though the package token was malformed. Commit `e99cbab924da49d1b296459758307ba1ee8b110c` now applies the same explicit accepted-boundary contract to label starts. It does not special-case `/`, `:`, or `+`.

The test-first nested-label matrix covers all 14 declared second-label kinds across forbidden `/`, `:`, and `+` delimiters, plus Unicode and doubled-brace adjacency. It asserts zero leaked keys, one deterministic cited malformed PackageId gap, UTF-16 spans, and unvalidated-profile candidate behavior. The positive matrix pins accepted whitespace, newline, tab, comma, semicolon, and ampersand starts while retaining Low confidence.

## Restack evidence

Based on live `codex/parser-family-skeleton` at `a58eefdc2063f9e03899af882b0bcc35c9cc2bbd`.

```text
1:  79ca233 = 1:  4bb5473 feat(sccm): add versioned correlation keys
2:  7dd577f = 2:  c808848 fix(sccm): enforce correlation key boundaries
3:  -------- > 3:  e99cbab fix(sccm): reject nested correlation labels
```

## Verification on exact head `e99cbab924da49d1b296459758307ba1ee8b110c`

- RED: `cargo test -p cmtraceopen-parser --test sccm_spine_contract key_extraction_rejects_every_label_inside_a_preceding_malformed_token -- --exact --nocapture` reproduced leaked Low keys for all 14 second labels across `/`, `:`, and `+`, plus doubled-brace and unvalidated-profile leakage
- GREEN: the exact regression test passes
- `cargo test --locked -p cmtraceopen-parser --test sccm_spine_contract key_ -- --nocapture` — 15 passed
- `cargo test --locked -p cmtraceopen-parser` — 654 passed, 0 failed
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings` — passed
- `cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown` — passed
- `npx tsc --noEmit` — passed
- Rust 1.88 scoped `rustfmt --check` on all four owned files — passed
- exact-range `git diff --check a58eefdc2063f9e03899af882b0bcc35c9cc2bbd...HEAD` — passed
- `rustup run 1.88.0 cargo fmt --check --all` — repository baseline remains red in the same 17 unrelated pre-existing files; none are in this PR

## Review gate

Substantive exact-head CodeRabbit review and a fresh independent dynamic rereview completed on `e99cbab924da49d1b296459758307ba1ee8b110c`; both prior blocker threads are resolved. CodeRabbit’s missing-Serde warning was disproved by the existing manual implementations and runtime round trips, while its RegexSet note is a non-blocking unmeasured optimization. Common wrapping punctuation remains a conservative false-negative limitation of the experimental Low-confidence profile.

Refs #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SCCM correlation-key extraction across multiple key types.
  * Added normalization and validation for GUIDs, package IDs, site codes, hostnames, numeric IDs, and KB identifiers.
  * Added version-aware extraction profiles, including experimental ConfigMgr version support.
  * Extraction results now include confidence, evidence, offsets, ordering, and gap information.
  * Added serializable models for keys, profiles, confidence levels, and extraction results.

* **Tests**
  * Expanded coverage for normalization, validation, version gating, ordering, gap handling, confidence, and JSON round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->