### PR TITLE
feat(sccm): enforce evidence-backed findings

### DIFF
--- a/crates/cmtraceopen-parser/src/sccm/evidence.rs
+++ b/crates/cmtraceopen-parser/src/sccm/evidence.rs
@@ -28,6 +28,10 @@ fn sensitive_message_label_re() -> &'static Regex {
                     | (?:client|access|refresh|id|device|session)[\x20_-]?token
                     | api[\x20_-]?key
                     | account[\x20_-]?key
+                    | samaccountname
+                    | accountname
+                    | localuser
+                    | identity
                     | user[\x20_-]?principal[\x20_-]?name
                     | credential
                     | password
@@ -48,8 +52,10 @@ fn sensitive_message_label_re() -> &'static Regex {
 fn windows_identity_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
-        Regex::new(r"(?i)(?:\b(?:NT AUTHORITY|[A-Z0-9][A-Z0-9._-]*)|\.)\\[A-Z0-9][A-Z0-9._$-]*\b")
-            .expect("SCCM Windows identity regex must compile")
+        Regex::new(
+            r"(?i)(?:\b(?:NT AUTHORITY|[A-Z0-9][A-Z0-9._-]*)|\.)(?:\\)+[A-Z0-9][A-Z0-9._$-]*\b",
+        )
+        .expect("SCCM Windows identity regex must compile")
     })
 }
 
@@ -57,7 +63,14 @@ fn windows_user_path_identity_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
         Regex::new(
-            r"(?i)(?:^|[\\/])users[\\/](?P<identity>(?:NT AUTHORITY|[A-Z0-9][A-Z0-9._-]*|\.)\\[A-Z0-9][A-Z0-9._$-]*\b)",
+            r"(?ix)
+            (?:^|[\\/]+)
+            (?:users|profiles|home|documents[\x20_-]+and[\x20_-]+settings)
+            [\\/]+
+            (?P<identity>
+                (?:(?:NT[\x20]+AUTHORITY|[A-Z0-9][A-Z0-9._-]*|\.)[\\/]+)?
+                [A-Z0-9][A-Z0-9._$-]*\b
+            )",
         )
         .expect("SCCM Windows user-path identity regex must compile")
     })
@@ -76,11 +89,13 @@ fn email_identity_re() -> &'static Regex {
 /// codes and approved structured keys outside those values unchanged. It does
 /// not imply native collector validation.
 fn project_public_message_v1(raw: &str) -> String {
+    format!("[{PUBLIC_MESSAGE_PROFILE}] {}", project_public_text_v1(raw))
+}
+
+fn project_public_text_v1(raw: &str) -> String {
     let redacted = redact_sensitive_segments(raw);
     let identities_redacted = redact_windows_identities(&redacted);
-    let projected = redact_email_identities(&identities_redacted);
-
-    format!("[{PUBLIC_MESSAGE_PROFILE}] {projected}")
+    redact_email_identities(&identities_redacted)
 }
 
 fn redact_sensitive_segments(value: &str) -> String {
@@ -223,8 +238,8 @@ impl SccmRawEvidenceSnapshot {
             evidence_id: self.evidence_id.clone(),
             reference: self.reference.clone(),
             role: self.role.clone(),
-            component: self.component.clone(),
-            ccm_source_file: self.ccm_source_file.clone(),
+            component: self.component.as_deref().map(project_public_text_v1),
+            ccm_source_file: self.ccm_source_file.as_deref().map(project_public_text_v1),
             message: project_public_message_v1(&self.message),
             timestamp: self.timestamp.clone(),
             // Raw execution context remains available only to this

--- a/crates/cmtraceopen-parser/src/sccm/evidence.rs
+++ b/crates/cmtraceopen-parser/src/sccm/evidence.rs
@@ -53,6 +53,16 @@ fn windows_identity_re() -> &'static Regex {
     })
 }
 
+fn windows_user_path_identity_re() -> &'static Regex {
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    CELL.get_or_init(|| {
+        Regex::new(
+            r"(?i)(?:^|[\\/])users[\\/](?P<identity>(?:NT AUTHORITY|[A-Z0-9][A-Z0-9._-]*|\.)\\[A-Z0-9][A-Z0-9._$-]*\b)",
+        )
+        .expect("SCCM Windows user-path identity regex must compile")
+    })
+}
+
 fn email_identity_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
@@ -125,19 +135,37 @@ fn sensitive_value_end(value: &str, value_start: usize) -> usize {
 fn redact_windows_identities(value: &str) -> String {
     let mut projected = String::with_capacity(value.len());
     let mut copied_through = 0;
+    let mut identity_ranges = windows_identity_re()
+        .find_iter(value)
+        .filter_map(|matched| {
+            let preceding = value[..matched.start()].chars().next_back();
+            let following = value[matched.end()..].chars().next();
+            let begins_relative_path =
+                matched.as_str().starts_with(r".\") && matches!(following, Some('\\' | '/'));
+            (!matches!(preceding, Some('\\' | '/')) && !begins_relative_path)
+                .then_some((matched.start(), matched.end()))
+        })
+        .collect::<Vec<_>>();
+    identity_ranges.extend(
+        windows_user_path_identity_re()
+            .captures_iter(value)
+            .filter_map(|captures| {
+                captures
+                    .name("identity")
+                    .map(|matched| (matched.start(), matched.end()))
+            }),
+    );
+    identity_ranges.sort_unstable();
+    identity_ranges.dedup();
 
-    for matched in windows_identity_re().find_iter(value) {
-        let preceding = value[..matched.start()].chars().next_back();
-        let following = value[matched.end()..].chars().next();
-        let path_adjacent =
-            matches!(preceding, Some('\\' | '/')) || matches!(following, Some('\\' | '/'));
-        if path_adjacent {
+    for (start, end) in identity_ranges {
+        if start < copied_through {
             continue;
         }
 
-        projected.push_str(&value[copied_through..matched.start()]);
+        projected.push_str(&value[copied_through..start]);
         projected.push_str(PUBLIC_MESSAGE_REDACTION);
-        copied_through = matched.end();
+        copied_through = end;
     }
 
     projected.push_str(&value[copied_through..]);

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -1274,9 +1274,9 @@ fn has_passive_unbounded_confirmation_request(
                 return false;
             }
 
-            let subject = &tokens[1..auxiliary_index];
-            let has_broad_target = subject.iter().any(|token| is_broad_quantifier(token.text))
-                && subject.iter().any(|token| {
+            let body = &tokens[1..];
+            let has_broad_target = body.iter().any(|token| is_broad_quantifier(token.text))
+                && body.iter().any(|token| {
                     is_collection_target(token.text)
                         && !token_is_covered_by_identity(token, identity_ranges)
                 });

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -819,7 +819,14 @@ fn reason_scope_is_within_catalog_artifact(
         return false;
     }
 
-    request_clauses(reason).all(|clause| {
+    let clauses = request_clauses(reason).collect::<Vec<_>>();
+    let has_collection_directive = clauses.iter().any(|clause| {
+        tokenize_request_reason(clause)
+            .iter()
+            .any(|token| is_collection_action(token.text))
+    });
+
+    clauses.into_iter().all(|clause| {
         let tokens = tokenize_request_reason(clause);
         let identity_ranges = exact_collectable_identity_ranges(clause, authorization);
         let is_confirmation = tokens.first().is_some_and(|token| token.text == "confirm");
@@ -830,6 +837,12 @@ fn reason_scope_is_within_catalog_artifact(
             confirmation_clause_is_non_authorizing(&tokens, &identity_ranges)
         } else if contains_collection_directive {
             collection_clause_is_catalog_bounded(clause, &tokens, &identity_ranges)
+        } else if has_collection_directive {
+            // An authorized action cannot lend its identity to another
+            // strong-punctuation clause. Keep evidence context attached as a
+            // bounded narrative suffix instead of treating a second command
+            // as non-authorizing prose.
+            false
         } else {
             narrative_clause_has_no_collection_scope(&tokens)
         }
@@ -1080,7 +1093,7 @@ fn collection_action_has_exact_catalog_target(
     {
         trailing.next();
     }
-    let trailing = trailing.collect::<Vec<_>>();
+    let trailing = trailing.copied().collect::<Vec<_>>();
     if trailing.is_empty() {
         return true;
     }
@@ -1092,6 +1105,9 @@ fn collection_action_has_exact_catalog_target(
         return true;
     }
     if !is_collection_narrative_introducer(trailing[0].text) {
+        return false;
+    }
+    if !narrative_tokens_are_non_authorizing(clause, &trailing, identity_ranges) {
         return false;
     }
 
@@ -1257,6 +1273,99 @@ fn narrative_clause_has_no_collection_scope(tokens: &[RequestReasonToken<'_>]) -
                     "file" | "files" | "log" | "logs" | "record" | "records"
                 ))
     })
+}
+
+fn narrative_tokens_are_non_authorizing(
+    clause: &str,
+    tokens: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    narrative_clause_has_no_collection_scope(tokens)
+        && !has_unbound_dotted_target(clause, tokens, identity_ranges)
+        && !tokens
+            .iter()
+            .any(|token| is_collection_scope_nominal(token.text))
+        && !has_unbound_passive_artifact_request(tokens, identity_ranges)
+}
+
+fn is_collection_scope_nominal(token: &str) -> bool {
+    matches!(
+        token,
+        "collection" | "collections" | "inclusion" | "inclusions" | "traversal" | "traversals"
+    )
+}
+
+fn has_unbound_passive_artifact_request(
+    tokens: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    tokens.iter().enumerate().any(|(index, token)| {
+        is_passive_auxiliary(token.text)
+            && tokens.get(index + 1).is_some()
+            && !passive_subject_is_evidence(tokens, index + 1, identity_ranges)
+    })
+}
+
+fn passive_subject_is_evidence(
+    tokens: &[RequestReasonToken<'_>],
+    predicate_index: usize,
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    let auxiliary_index = tokens[..predicate_index]
+        .iter()
+        .rposition(|token| is_passive_auxiliary(token.text));
+    let Some(auxiliary_index) = auxiliary_index else {
+        return false;
+    };
+    let subject_start = tokens[..auxiliary_index]
+        .iter()
+        .rposition(|token| {
+            is_collection_narrative_introducer(token.text) || is_action_coordinator(token.text)
+        })
+        .map_or(0, |index| index + 1);
+
+    tokens[subject_start..auxiliary_index].iter().any(|token| {
+        token_is_covered_by_identity(token, identity_ranges)
+            || is_evidence_narrative_subject(token.text)
+    })
+}
+
+fn is_passive_auxiliary(token: &str) -> bool {
+    matches!(
+        token,
+        "are"
+            | "be"
+            | "been"
+            | "being"
+            | "is"
+            | "must"
+            | "need"
+            | "needs"
+            | "should"
+            | "was"
+            | "were"
+    )
+}
+
+fn is_evidence_narrative_subject(token: &str) -> bool {
+    matches!(
+        token,
+        "access"
+            | "assignment"
+            | "coverage"
+            | "error"
+            | "evaluation"
+            | "evidence"
+            | "failure"
+            | "finding"
+            | "outcome"
+            | "policy"
+            | "request"
+            | "response"
+            | "source"
+            | "state"
+            | "status"
+    )
 }
 
 fn is_wide_scope_token(token: &str) -> bool {

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -152,8 +152,7 @@ pub struct SccmArtifactRequest {
     pub reason: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SccmFinding {
     pub finding_id: String,
     pub class: SccmFindingClass,
@@ -168,6 +167,51 @@ pub struct SccmFinding {
     pub coverage_gaps: Vec<SccmFindingCoverageGap>,
     pub correlation_keys: Vec<SccmCorrelationKey>,
     pub next_artifacts: Vec<SccmArtifactRequest>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SccmFindingSerializeWire<'a> {
+    finding_id: &'a str,
+    class: &'a SccmFindingClass,
+    phase: &'a SccmPhase,
+    role: &'a SccmRole,
+    severity: &'a Severity,
+    confidence: &'a SccmConfidence,
+    title: &'a str,
+    summary: &'a str,
+    evidence: &'a [SccmEvidenceRef],
+    terminal_evidence: &'a [SccmTerminalEvidence],
+    coverage_gaps: &'a [SccmFindingCoverageGap],
+    correlation_keys: &'a [SccmCorrelationKey],
+    next_artifacts: &'a [SccmArtifactRequest],
+}
+
+impl Serialize for SccmFinding {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.validate().map_err(|error| {
+            S::Error::custom(format!("invalid SCCM finding contract: {error:?}"))
+        })?;
+        SccmFindingSerializeWire {
+            finding_id: &self.finding_id,
+            class: &self.class,
+            phase: &self.phase,
+            role: &self.role,
+            severity: &self.severity,
+            confidence: &self.confidence,
+            title: &self.title,
+            summary: &self.summary,
+            evidence: &self.evidence,
+            terminal_evidence: &self.terminal_evidence,
+            coverage_gaps: &self.coverage_gaps,
+            correlation_keys: &self.correlation_keys,
+            next_artifacts: &self.next_artifacts,
+        }
+        .serialize(serializer)
+    }
 }
 
 #[derive(Deserialize)]

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -1,0 +1,748 @@
+use std::cmp::Ordering;
+
+use serde::de::Error as _;
+use serde::ser::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::models::log_entry::Severity;
+
+use super::catalog::declared_source_catalog;
+use super::models::{
+    SccmCorrelationKey, SccmCorrelationKeyKind, SccmCoverageState, SccmEvidenceRef,
+    SccmFindingClass, SccmKeyConfidence, SccmRole,
+};
+
+pub const MAX_SCCM_ARTIFACT_REQUEST_REASON_CHARS: usize = 240;
+pub const MAX_SCCM_NEXT_ARTIFACT_REQUESTS: usize = 16;
+const MAX_SCCM_COVERAGE_GAP_ARTIFACT_ID_CHARS: usize = 256;
+const REGISTERED_STABLE_CORRELATION_PROFILE_IDS: &[&str] = &[];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmConfidence {
+    None,
+    Low,
+    Moderate,
+    High,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SccmPhase {
+    Policy,
+    Content,
+    Enforcement,
+    Unknown(String),
+}
+
+impl SccmPhase {
+    fn serialized_name(&self) -> &str {
+        match self {
+            Self::Policy => "policy",
+            Self::Content => "content",
+            Self::Enforcement => "enforcement",
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+impl Serialize for SccmPhase {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if matches!(self, Self::Unknown(value) if is_known_phase_name(value)) {
+            return Err(S::Error::custom(
+                "unknown SCCM phase must not shadow a declared phase",
+            ));
+        }
+        serializer.serialize_str(self.serialized_name())
+    }
+}
+
+impl<'de> Deserialize<'de> for SccmPhase {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(match String::deserialize(deserializer)? {
+            value if value == "policy" => Self::Policy,
+            value if value == "content" => Self::Content,
+            value if value == "enforcement" => Self::Enforcement,
+            value => Self::Unknown(value),
+        })
+    }
+}
+
+fn is_known_phase_name(value: &str) -> bool {
+    matches!(value, "policy" | "content" | "enforcement")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SccmTerminalEvidenceKind {
+    ObservedFailure,
+    Unknown(String),
+}
+
+impl SccmTerminalEvidenceKind {
+    fn serialized_name(&self) -> &str {
+        match self {
+            Self::ObservedFailure => "observedFailure",
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+impl Serialize for SccmTerminalEvidenceKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if matches!(self, Self::Unknown(value) if value == "observedFailure") {
+            return Err(S::Error::custom(
+                "unknown terminal evidence kind must not shadow observedFailure",
+            ));
+        }
+        serializer.serialize_str(self.serialized_name())
+    }
+}
+
+impl<'de> Deserialize<'de> for SccmTerminalEvidenceKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(match String::deserialize(deserializer)? {
+            value if value == "observedFailure" => Self::ObservedFailure,
+            value => Self::Unknown(value),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmTerminalEvidence {
+    pub reference: SccmEvidenceRef,
+    pub kind: SccmTerminalEvidenceKind,
+}
+
+impl SccmTerminalEvidence {
+    pub fn observed_failure(reference: SccmEvidenceRef) -> Self {
+        Self {
+            reference,
+            kind: SccmTerminalEvidenceKind::ObservedFailure,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmFindingCoverageGap {
+    pub artifact_id: String,
+    pub role: SccmRole,
+    pub coverage: SccmCoverageState,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmArtifactRequest {
+    pub logical_id: String,
+    pub role: SccmRole,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmFinding {
+    pub finding_id: String,
+    pub class: SccmFindingClass,
+    pub phase: SccmPhase,
+    pub role: SccmRole,
+    pub severity: Severity,
+    pub confidence: SccmConfidence,
+    pub title: String,
+    pub summary: String,
+    pub evidence: Vec<SccmEvidenceRef>,
+    pub terminal_evidence: Vec<SccmTerminalEvidence>,
+    pub coverage_gaps: Vec<SccmFindingCoverageGap>,
+    pub correlation_keys: Vec<SccmCorrelationKey>,
+    pub next_artifacts: Vec<SccmArtifactRequest>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SccmFindingWire {
+    finding_id: String,
+    class: SccmFindingClass,
+    phase: SccmPhase,
+    role: SccmRole,
+    severity: Severity,
+    confidence: SccmConfidence,
+    title: String,
+    summary: String,
+    evidence: Vec<SccmEvidenceRef>,
+    terminal_evidence: Vec<SccmTerminalEvidence>,
+    coverage_gaps: Vec<SccmFindingCoverageGap>,
+    correlation_keys: Vec<SccmCorrelationKey>,
+    next_artifacts: Vec<SccmArtifactRequest>,
+}
+
+impl<'de> Deserialize<'de> for SccmFinding {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = SccmFindingWire::deserialize(deserializer)?;
+        if wire.next_artifacts.len() > MAX_SCCM_NEXT_ARTIFACT_REQUESTS {
+            return Err(D::Error::custom("too many SCCM artifact requests"));
+        }
+        let mut finding = Self {
+            finding_id: wire.finding_id,
+            class: wire.class,
+            phase: wire.phase,
+            role: wire.role,
+            severity: wire.severity,
+            confidence: wire.confidence,
+            title: wire.title,
+            summary: wire.summary,
+            evidence: wire.evidence,
+            terminal_evidence: wire.terminal_evidence,
+            coverage_gaps: wire.coverage_gaps,
+            correlation_keys: wire.correlation_keys,
+            next_artifacts: wire.next_artifacts,
+        };
+        normalize_finding(&mut finding);
+        finding.validate().map_err(|error| {
+            D::Error::custom(format!("invalid SCCM finding contract: {error:?}"))
+        })?;
+        Ok(finding)
+    }
+}
+
+impl SccmFinding {
+    pub fn validate(&self) -> Result<(), SccmFindingValidationError> {
+        validate_required_text(self)?;
+        validate_coverage_gaps(&self.coverage_gaps)?;
+        validate_artifact_requests(&self.next_artifacts)?;
+
+        if self.class == SccmFindingClass::InsufficientEvidence && self.coverage_gaps.is_empty() {
+            return Err(SccmFindingValidationError::MissingCoverageGap);
+        }
+
+        if self.evidence.is_empty() && self.coverage_gaps.is_empty() {
+            return Err(SccmFindingValidationError::MissingEvidenceOrCoverageGap);
+        }
+
+        validate_terminal_evidence(&self.evidence, &self.terminal_evidence)?;
+        validate_correlation_key_evidence(&self.evidence, &self.correlation_keys)?;
+
+        if self.class == SccmFindingClass::InsufficientEvidence && self.next_artifacts.is_empty() {
+            return Err(SccmFindingValidationError::MissingNextArtifactRequest);
+        }
+
+        let has_terminal_failure = self
+            .terminal_evidence
+            .iter()
+            .any(|terminal| terminal.kind == SccmTerminalEvidenceKind::ObservedFailure);
+
+        if self.class == SccmFindingClass::ConfirmedFailure
+            && self.confidence == SccmConfidence::High
+            && !has_terminal_failure
+            && !has_profiled_key_corroboration(&self.correlation_keys)
+        {
+            return Err(SccmFindingValidationError::MissingTerminalEvidence);
+        }
+
+        if self.class == SccmFindingClass::LikelyContributor
+            && self.confidence == SccmConfidence::High
+            && !has_terminal_failure
+        {
+            return Err(SccmFindingValidationError::LikelyContributorConfidenceTooHigh);
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SccmFindingValidationError {
+    MissingRequiredField,
+    MissingEvidenceOrCoverageGap,
+    MissingTerminalEvidence,
+    InvalidTerminalEvidence,
+    TerminalEvidenceNotCited,
+    CorrelationKeyMissingEvidence,
+    CorrelationKeyEvidenceNotCited,
+    LikelyContributorConfidenceTooHigh,
+    MissingCoverageGap,
+    InvalidCoverageGap,
+    MissingNextArtifactRequest,
+    UndeclaredArtifactRequest,
+    ArtifactRequestRoleMismatch,
+    InvalidArtifactRequestReason,
+    TooManyArtifactRequests,
+}
+
+#[derive(Debug, Clone)]
+pub struct SccmFindingBuilder {
+    finding_id: String,
+    class: Option<SccmFindingClass>,
+    phase: Option<SccmPhase>,
+    role: Option<SccmRole>,
+    severity: Option<Severity>,
+    confidence: Option<SccmConfidence>,
+    title: String,
+    summary: String,
+    evidence: Vec<SccmEvidenceRef>,
+    terminal_evidence: Vec<SccmTerminalEvidence>,
+    coverage_gaps: Vec<SccmFindingCoverageGap>,
+    correlation_keys: Vec<SccmCorrelationKey>,
+    next_artifacts: Vec<SccmArtifactRequest>,
+}
+
+impl SccmFindingBuilder {
+    pub fn new(finding_id: impl Into<String>) -> Self {
+        let finding_id = finding_id.into();
+        Self {
+            title: finding_id.clone(),
+            summary: finding_id.clone(),
+            finding_id,
+            class: None,
+            phase: None,
+            role: None,
+            severity: None,
+            confidence: None,
+            evidence: Vec::new(),
+            terminal_evidence: Vec::new(),
+            coverage_gaps: Vec::new(),
+            correlation_keys: Vec::new(),
+            next_artifacts: Vec::new(),
+        }
+    }
+
+    pub fn class(mut self, class: SccmFindingClass) -> Self {
+        self.class = Some(class);
+        self
+    }
+
+    pub fn phase(mut self, phase: SccmPhase) -> Self {
+        self.phase = Some(phase);
+        self
+    }
+
+    pub fn role(mut self, role: SccmRole) -> Self {
+        self.role = Some(role);
+        self
+    }
+
+    pub fn severity(mut self, severity: Severity) -> Self {
+        self.severity = Some(severity);
+        self
+    }
+
+    pub fn confidence(mut self, confidence: SccmConfidence) -> Self {
+        self.confidence = Some(confidence);
+        self
+    }
+
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    pub fn summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = summary.into();
+        self
+    }
+
+    pub fn evidence(mut self, evidence: Vec<SccmEvidenceRef>) -> Self {
+        self.evidence = evidence;
+        self
+    }
+
+    pub fn terminal_evidence(mut self, terminal_evidence: Vec<SccmTerminalEvidence>) -> Self {
+        self.terminal_evidence = terminal_evidence;
+        self
+    }
+
+    pub fn coverage_gap(mut self, coverage_gap: SccmFindingCoverageGap) -> Self {
+        self.coverage_gaps.push(coverage_gap);
+        self
+    }
+
+    pub fn coverage_gaps(mut self, coverage_gaps: Vec<SccmFindingCoverageGap>) -> Self {
+        self.coverage_gaps = coverage_gaps;
+        self
+    }
+
+    pub fn correlation_keys(mut self, correlation_keys: Vec<SccmCorrelationKey>) -> Self {
+        self.correlation_keys = correlation_keys;
+        self
+    }
+
+    pub fn next_artifact(mut self, next_artifact: SccmArtifactRequest) -> Self {
+        self.next_artifacts.push(next_artifact);
+        self
+    }
+
+    pub fn next_artifacts(mut self, next_artifacts: Vec<SccmArtifactRequest>) -> Self {
+        self.next_artifacts = next_artifacts;
+        self
+    }
+
+    pub fn build(self) -> Result<SccmFinding, SccmFindingValidationError> {
+        if self.next_artifacts.len() > MAX_SCCM_NEXT_ARTIFACT_REQUESTS {
+            return Err(SccmFindingValidationError::TooManyArtifactRequests);
+        }
+
+        let mut finding = SccmFinding {
+            finding_id: self.finding_id,
+            class: self
+                .class
+                .ok_or(SccmFindingValidationError::MissingRequiredField)?,
+            phase: self
+                .phase
+                .ok_or(SccmFindingValidationError::MissingRequiredField)?,
+            role: self
+                .role
+                .ok_or(SccmFindingValidationError::MissingRequiredField)?,
+            severity: self
+                .severity
+                .ok_or(SccmFindingValidationError::MissingRequiredField)?,
+            confidence: self
+                .confidence
+                .ok_or(SccmFindingValidationError::MissingRequiredField)?,
+            title: self.title,
+            summary: self.summary,
+            evidence: self.evidence,
+            terminal_evidence: self.terminal_evidence,
+            coverage_gaps: self.coverage_gaps,
+            correlation_keys: self.correlation_keys,
+            next_artifacts: self.next_artifacts,
+        };
+        normalize_finding(&mut finding);
+        finding.validate()?;
+        Ok(finding)
+    }
+}
+
+fn validate_required_text(finding: &SccmFinding) -> Result<(), SccmFindingValidationError> {
+    if finding.finding_id.trim().is_empty()
+        || finding.title.trim().is_empty()
+        || finding.summary.trim().is_empty()
+        || matches!(&finding.phase, SccmPhase::Unknown(value) if value.trim().is_empty())
+    {
+        return Err(SccmFindingValidationError::MissingRequiredField);
+    }
+    Ok(())
+}
+
+fn validate_coverage_gaps(
+    coverage_gaps: &[SccmFindingCoverageGap],
+) -> Result<(), SccmFindingValidationError> {
+    if coverage_gaps.iter().any(|gap| {
+        gap.artifact_id.trim().is_empty()
+            || gap.artifact_id.chars().count() > MAX_SCCM_COVERAGE_GAP_ARTIFACT_ID_CHARS
+            || gap.coverage == SccmCoverageState::Captured
+    }) {
+        return Err(SccmFindingValidationError::InvalidCoverageGap);
+    }
+    Ok(())
+}
+
+fn validate_artifact_requests(
+    requests: &[SccmArtifactRequest],
+) -> Result<(), SccmFindingValidationError> {
+    if requests.len() > MAX_SCCM_NEXT_ARTIFACT_REQUESTS {
+        return Err(SccmFindingValidationError::TooManyArtifactRequests);
+    }
+
+    let catalog = declared_source_catalog();
+    for request in requests {
+        if !is_bounded_request_reason(&request.reason) {
+            return Err(SccmFindingValidationError::InvalidArtifactRequestReason);
+        }
+
+        let mut logical_matches = catalog
+            .iter()
+            .filter(|entry| entry.logical_name == request.logical_id);
+        let Some(first_match) = logical_matches.next() else {
+            return Err(SccmFindingValidationError::UndeclaredArtifactRequest);
+        };
+        if first_match.role != request.role
+            && !logical_matches.any(|entry| entry.role == request.role)
+        {
+            return Err(SccmFindingValidationError::ArtifactRequestRoleMismatch);
+        }
+    }
+    Ok(())
+}
+
+fn is_bounded_request_reason(reason: &str) -> bool {
+    let trimmed = reason.trim();
+    if trimmed.is_empty()
+        || trimmed.chars().count() > MAX_SCCM_ARTIFACT_REQUEST_REASON_CHARS
+        || trimmed.contains(['*', '?', '[', ']'])
+    {
+        return false;
+    }
+
+    let lowercase = trimmed.to_ascii_lowercase();
+    ![
+        "entire drive",
+        "whole drive",
+        "drive root",
+        "root drive",
+        "entire disk",
+        "whole disk",
+        "all files",
+        "recursive",
+    ]
+    .iter()
+    .any(|unbounded| lowercase.contains(unbounded))
+}
+
+fn validate_terminal_evidence(
+    evidence: &[SccmEvidenceRef],
+    terminal_evidence: &[SccmTerminalEvidence],
+) -> Result<(), SccmFindingValidationError> {
+    for terminal in terminal_evidence {
+        if !evidence.contains(&terminal.reference) {
+            return Err(SccmFindingValidationError::TerminalEvidenceNotCited);
+        }
+        if terminal.kind != SccmTerminalEvidenceKind::ObservedFailure {
+            return Err(SccmFindingValidationError::InvalidTerminalEvidence);
+        }
+    }
+    Ok(())
+}
+
+fn validate_correlation_key_evidence(
+    evidence: &[SccmEvidenceRef],
+    correlation_keys: &[SccmCorrelationKey],
+) -> Result<(), SccmFindingValidationError> {
+    for key in correlation_keys {
+        let Some(reference) = &key.evidence else {
+            return Err(SccmFindingValidationError::CorrelationKeyMissingEvidence);
+        };
+        if !evidence.contains(reference) {
+            return Err(SccmFindingValidationError::CorrelationKeyEvidenceNotCited);
+        }
+    }
+    Ok(())
+}
+
+fn has_profiled_key_corroboration(keys: &[SccmCorrelationKey]) -> bool {
+    for candidate in keys {
+        if !is_corroborating_key(candidate) {
+            continue;
+        }
+        let (Some(candidate_profile), Some(candidate_reference)) = (
+            candidate.extraction_profile_id.as_deref(),
+            candidate.evidence.as_ref(),
+        ) else {
+            continue;
+        };
+        let candidate_identity = evidence_identity(candidate_reference);
+        let mut distinct_identities = vec![candidate_identity];
+
+        for peer in keys {
+            if !is_corroborating_key(peer)
+                || peer.kind != candidate.kind
+                || peer.normalized != candidate.normalized
+                || peer.extraction_profile_id.as_deref() != Some(candidate_profile)
+            {
+                continue;
+            }
+            let Some(peer_reference) = peer.evidence.as_ref() else {
+                continue;
+            };
+            let peer_identity = evidence_identity(peer_reference);
+            if !distinct_identities.contains(&peer_identity) {
+                distinct_identities.push(peer_identity);
+            }
+        }
+
+        if distinct_identities.len() >= 2 {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_corroborating_key(key: &SccmCorrelationKey) -> bool {
+    matches!(
+        key.confidence,
+        SccmKeyConfidence::Strong | SccmKeyConfidence::Exact
+    ) && key
+        .extraction_profile_id
+        .as_deref()
+        .is_some_and(is_registered_stable_profile)
+        && !key.normalized.trim().is_empty()
+        && key.evidence.is_some()
+}
+
+fn is_registered_stable_profile(profile_id: &str) -> bool {
+    REGISTERED_STABLE_CORRELATION_PROFILE_IDS.contains(&profile_id)
+}
+
+fn evidence_identity(reference: &SccmEvidenceRef) -> (&str, &str) {
+    (&reference.artifact_id, &reference.entry_id)
+}
+
+fn normalize_finding(finding: &mut SccmFinding) {
+    finding.finding_id = finding.finding_id.trim().to_owned();
+    finding.title = finding.title.trim().to_owned();
+    finding.summary = finding.summary.trim().to_owned();
+    for gap in &mut finding.coverage_gaps {
+        gap.artifact_id = gap.artifact_id.trim().to_owned();
+    }
+    for request in &mut finding.next_artifacts {
+        request.logical_id = request.logical_id.trim().to_owned();
+        request.reason = request.reason.trim().to_owned();
+    }
+
+    finding.evidence.sort_by(compare_evidence_refs);
+    finding.evidence.dedup();
+
+    finding.terminal_evidence.sort_by(compare_terminal_evidence);
+    finding.terminal_evidence.dedup();
+
+    finding.coverage_gaps.sort_by(compare_coverage_gaps);
+    finding.coverage_gaps.dedup();
+
+    finding.correlation_keys.sort_by(compare_correlation_keys);
+    finding.correlation_keys.dedup();
+
+    finding.next_artifacts.sort_by(compare_artifact_requests);
+    finding.next_artifacts.dedup();
+}
+
+fn compare_evidence_refs(left: &SccmEvidenceRef, right: &SccmEvidenceRef) -> Ordering {
+    left.artifact_id
+        .cmp(&right.artifact_id)
+        .then_with(|| left.entry_id.cmp(&right.entry_id))
+        .then_with(|| left.line_start.cmp(&right.line_start))
+        .then_with(|| left.line_end.cmp(&right.line_end))
+}
+
+fn compare_terminal_evidence(
+    left: &SccmTerminalEvidence,
+    right: &SccmTerminalEvidence,
+) -> Ordering {
+    compare_evidence_refs(&left.reference, &right.reference).then_with(|| {
+        left.kind
+            .serialized_name()
+            .cmp(right.kind.serialized_name())
+    })
+}
+
+fn compare_coverage_gaps(
+    left: &SccmFindingCoverageGap,
+    right: &SccmFindingCoverageGap,
+) -> Ordering {
+    left.artifact_id
+        .cmp(&right.artifact_id)
+        .then_with(|| compare_roles(&left.role, &right.role))
+        .then_with(|| {
+            coverage_state_order(&left.coverage).cmp(&coverage_state_order(&right.coverage))
+        })
+}
+
+fn compare_correlation_keys(left: &SccmCorrelationKey, right: &SccmCorrelationKey) -> Ordering {
+    correlation_key_kind_order(&left.kind)
+        .cmp(&correlation_key_kind_order(&right.kind))
+        .then_with(|| left.normalized.cmp(&right.normalized))
+        .then_with(|| {
+            key_confidence_order(&left.confidence).cmp(&key_confidence_order(&right.confidence))
+        })
+        .then_with(|| left.extraction_profile_id.cmp(&right.extraction_profile_id))
+        .then_with(|| compare_optional_evidence_refs(&left.evidence, &right.evidence))
+        .then_with(|| left.raw.cmp(&right.raw))
+        .then_with(|| left.start.cmp(&right.start))
+        .then_with(|| left.end.cmp(&right.end))
+}
+
+fn compare_optional_evidence_refs(
+    left: &Option<SccmEvidenceRef>,
+    right: &Option<SccmEvidenceRef>,
+) -> Ordering {
+    match (left, right) {
+        (Some(left), Some(right)) => compare_evidence_refs(left, right),
+        (Some(_), None) => Ordering::Greater,
+        (None, Some(_)) => Ordering::Less,
+        (None, None) => Ordering::Equal,
+    }
+}
+
+fn compare_artifact_requests(left: &SccmArtifactRequest, right: &SccmArtifactRequest) -> Ordering {
+    left.logical_id
+        .cmp(&right.logical_id)
+        .then_with(|| compare_roles(&left.role, &right.role))
+        .then_with(|| left.reason.cmp(&right.reason))
+}
+
+fn compare_roles(left: &SccmRole, right: &SccmRole) -> Ordering {
+    role_order(left)
+        .cmp(&role_order(right))
+        .then_with(|| unknown_role_value(left).cmp(unknown_role_value(right)))
+}
+
+fn role_order(role: &SccmRole) -> u8 {
+    match role {
+        SccmRole::Client => 0,
+        SccmRole::SiteServer => 1,
+        SccmRole::ManagementPoint => 2,
+        SccmRole::DistributionPoint => 3,
+        SccmRole::SoftwareUpdatePoint => 4,
+        SccmRole::WsUs => 5,
+        SccmRole::Provider => 6,
+        SccmRole::AdminService => 7,
+        SccmRole::Unknown(_) => 8,
+    }
+}
+
+fn unknown_role_value(role: &SccmRole) -> &str {
+    match role {
+        SccmRole::Unknown(value) => value,
+        _ => "",
+    }
+}
+
+fn coverage_state_order(coverage: &SccmCoverageState) -> u8 {
+    match coverage {
+        SccmCoverageState::Captured => 0,
+        SccmCoverageState::Absent => 1,
+        SccmCoverageState::AccessDenied => 2,
+        SccmCoverageState::Capped => 3,
+        SccmCoverageState::Skipped => 4,
+        SccmCoverageState::Unsupported => 5,
+        SccmCoverageState::ParseFailed => 6,
+    }
+}
+
+fn correlation_key_kind_order(kind: &SccmCorrelationKeyKind) -> u8 {
+    match kind {
+        SccmCorrelationKeyKind::AssignmentId => 0,
+        SccmCorrelationKeyKind::ClientGuid => 1,
+        SccmCorrelationKeyKind::PackageId => 2,
+        SccmCorrelationKeyKind::ContentId => 3,
+        SccmCorrelationKeyKind::SiteCode => 4,
+        SccmCorrelationKeyKind::ServerHost => 5,
+        SccmCorrelationKeyKind::CiId => 6,
+        SccmCorrelationKeyKind::UpdateId => 7,
+        SccmCorrelationKeyKind::KbId => 8,
+        SccmCorrelationKeyKind::BitsJobId => 9,
+        SccmCorrelationKeyKind::TaskSequenceExecutionId => 10,
+        SccmCorrelationKeyKind::RequestId => 11,
+        SccmCorrelationKeyKind::TopicId => 12,
+        SccmCorrelationKeyKind::StateMessageId => 13,
+    }
+}
+
+fn key_confidence_order(confidence: &SccmKeyConfidence) -> u8 {
+    match confidence {
+        SccmKeyConfidence::Low => 0,
+        SccmKeyConfidence::Strong => 1,
+        SccmKeyConfidence::Exact => 2,
+    }
+}

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -46,6 +46,15 @@ impl SccmPhase {
             Self::Unknown(value) => value,
         }
     }
+
+    fn has_canonical_serialized_form(&self) -> bool {
+        match self {
+            Self::Unknown(value) => {
+                !value.is_empty() && value.trim() == value && !is_known_phase_name(value)
+            }
+            _ => true,
+        }
+    }
 }
 
 impl Serialize for SccmPhase {
@@ -53,9 +62,9 @@ impl Serialize for SccmPhase {
     where
         S: Serializer,
     {
-        if matches!(self, Self::Unknown(value) if is_known_phase_name(value)) {
+        if !self.has_canonical_serialized_form() {
             return Err(S::Error::custom(
-                "unknown SCCM phase must not shadow a declared phase",
+                "unknown SCCM phase must be canonical and must not shadow a declared phase",
             ));
         }
         serializer.serialize_str(self.serialized_name())
@@ -67,12 +76,18 @@ impl<'de> Deserialize<'de> for SccmPhase {
     where
         D: Deserializer<'de>,
     {
-        Ok(match String::deserialize(deserializer)? {
+        let phase = match String::deserialize(deserializer)? {
             value if value == "policy" => Self::Policy,
             value if value == "content" => Self::Content,
             value if value == "enforcement" => Self::Enforcement,
             value => Self::Unknown(value),
-        })
+        };
+        if !phase.has_canonical_serialized_form() {
+            return Err(D::Error::custom(
+                "unknown SCCM phase must be canonical and must not shadow a declared phase",
+            ));
+        }
+        Ok(phase)
     }
 }
 
@@ -193,6 +208,9 @@ impl Serialize for SccmFinding {
     where
         S: Serializer,
     {
+        self.validate().map_err(|error| {
+            S::Error::custom(format!("invalid SCCM finding contract: {error:?}"))
+        })?;
         let mut normalized = self.clone();
         normalize_finding(&mut normalized);
         normalized.validate().map_err(|error| {
@@ -580,11 +598,10 @@ impl SccmFindingBuilder {
 }
 
 fn validate_required_text(finding: &SccmFinding) -> Result<(), SccmFindingValidationError> {
-    if finding.finding_id.trim().is_empty()
+    if !is_canonical_opaque_id(&finding.finding_id)
         || finding.title.trim().is_empty()
         || finding.summary.trim().is_empty()
-        || matches!(&finding.phase, SccmPhase::Unknown(value) if value.trim().is_empty())
-        || matches!(&finding.phase, SccmPhase::Unknown(value) if is_known_phase_name(value))
+        || !finding.phase.has_canonical_serialized_form()
     {
         return Err(SccmFindingValidationError::MissingRequiredField);
     }
@@ -628,7 +645,7 @@ fn validate_all_evidence_references(
         )
     {
         validate_evidence_reference(reference)?;
-        let identity = (reference.artifact_id.trim(), reference.entry_id.trim());
+        let identity = (reference.artifact_id.as_str(), reference.entry_id.as_str());
         let range = (reference.line_start, reference.line_end);
         if ranges_by_identity
             .insert(identity, range)
@@ -648,8 +665,8 @@ fn validate_evidence_reference(
         (Some(start), Some(end)) => start > 0 && end >= start,
         _ => false,
     };
-    if reference.artifact_id.trim().is_empty()
-        || reference.entry_id.trim().is_empty()
+    if !is_canonical_opaque_id(&reference.artifact_id)
+        || !is_canonical_opaque_id(&reference.entry_id)
         || !valid_line_range
     {
         return Err(SccmFindingValidationError::InvalidEvidenceReference);
@@ -661,7 +678,7 @@ fn validate_coverage_gaps(
     coverage_gaps: &[SccmFindingCoverageGap],
 ) -> Result<(), SccmFindingValidationError> {
     if coverage_gaps.iter().any(|gap| {
-        gap.artifact_id.trim().is_empty()
+        !is_canonical_opaque_id(&gap.artifact_id)
             || gap.artifact_id.chars().count() > MAX_SCCM_COVERAGE_GAP_ARTIFACT_ID_CHARS
             || gap.coverage == SccmCoverageState::Captured
     }) {
@@ -679,6 +696,9 @@ fn validate_artifact_requests(
 
     let catalog = declared_source_catalog();
     for request in requests {
+        if !is_canonical_opaque_id(&request.logical_id) {
+            return Err(SccmFindingValidationError::UndeclaredArtifactRequest);
+        }
         if !is_bounded_request_reason(&request.reason) {
             return Err(SccmFindingValidationError::InvalidArtifactRequestReason);
         }
@@ -728,73 +748,143 @@ fn has_unbounded_request_scope(reason: &str) -> bool {
         .split(|character: char| !character.is_ascii_alphanumeric())
         .filter(|token| !token.is_empty())
         .collect::<Vec<_>>();
-    let has_token = |candidates: &[&str]| tokens.iter().any(|token| candidates.contains(token));
-    let is_wide_scope_token = |token: &str| {
-        matches!(
-            token,
-            "drivewide" | "diskwide" | "volumewide" | "filesystemwide" | "sitewide" | "systemwide"
-        )
-    };
-    let is_scope_token = |token: &str| {
-        matches!(
-            token,
-            "drive" | "disk" | "volume" | "filesystem" | "site" | "system"
-        )
-    };
-    let has_wide_scope = tokens.iter().any(|token| is_wide_scope_token(token))
+
+    tokens.iter().any(|token| is_compact_unbounded_scope(token))
         || tokens
-            .windows(2)
-            .any(|pair| is_scope_token(pair[0]) && pair[1] == "wide");
+            .iter()
+            .any(|token| matches!(*token, "glob" | "globs" | "globbing"))
+        || has_recursive_collection_scope(&tokens)
+        || has_wide_collection_scope(&tokens)
+        || has_root_collection_scope(&tokens)
+        || has_broad_collection_scope(&tokens)
+}
 
-    if has_wide_scope
-        || tokens.iter().any(|token| token.starts_with("recurs"))
-        || has_token(&["glob", "globs", "globbing"])
-    {
-        return true;
+fn is_collection_action(token: &str) -> bool {
+    matches!(
+        token,
+        "collect"
+            | "scan"
+            | "search"
+            | "walk"
+            | "traverse"
+            | "capture"
+            | "export"
+            | "gather"
+            | "inspect"
+            | "read"
+    )
+}
+
+fn is_collection_target(token: &str) -> bool {
+    matches!(
+        token,
+        "file"
+            | "files"
+            | "directory"
+            | "directories"
+            | "folder"
+            | "folders"
+            | "drive"
+            | "drives"
+            | "disk"
+            | "disks"
+            | "volume"
+            | "volumes"
+            | "filesystem"
+            | "filesystems"
+            | "log"
+            | "logs"
+            | "artifact"
+            | "artifacts"
+            | "evidence"
+    )
+}
+
+fn is_compact_unbounded_scope(token: &str) -> bool {
+    ["all", "every", "entire", "whole", "full", "complete"]
+        .iter()
+        .any(|prefix| token.strip_prefix(prefix).is_some_and(is_collection_target))
+}
+
+fn has_nearby_collection_action_before(tokens: &[&str], index: usize) -> bool {
+    let start = index.saturating_sub(4);
+    tokens[start..index]
+        .iter()
+        .any(|token| is_collection_action(token))
+}
+
+fn has_recursive_collection_scope(tokens: &[&str]) -> bool {
+    tokens.iter().enumerate().any(|(index, token)| {
+        token.starts_with("recurs")
+            && (has_nearby_collection_action_before(tokens, index)
+                || tokens
+                    .iter()
+                    .skip(index + 1)
+                    .take(2)
+                    .any(|candidate| is_collection_action(candidate)))
+    })
+}
+
+fn has_wide_collection_scope(tokens: &[&str]) -> bool {
+    tokens.iter().enumerate().any(|(index, token)| {
+        let compound = matches!(
+            *token,
+            "drivewide" | "diskwide" | "volumewide" | "filesystemwide" | "sitewide" | "systemwide"
+        ) && tokens
+            .get(index + 1)
+            .is_some_and(|target| is_collection_target(target));
+        let separated = matches!(
+            *token,
+            "drive" | "disk" | "volume" | "filesystem" | "site" | "system"
+        ) && tokens.get(index + 1) == Some(&"wide")
+            && tokens
+                .get(index + 2)
+                .is_some_and(|target| is_collection_target(target));
+
+        (compound || separated) && has_nearby_collection_action_before(tokens, index)
+    })
+}
+
+fn has_root_collection_scope(tokens: &[&str]) -> bool {
+    tokens.iter().enumerate().any(|(root_index, token)| {
+        if *token != "root" {
+            return false;
+        }
+        tokens.iter().enumerate().any(|(target_index, target)| {
+            is_collection_target(target)
+                && root_index.abs_diff(target_index) <= 2
+                && has_nearby_collection_action_before(tokens, root_index.min(target_index))
+        })
+    })
+}
+
+fn has_broad_collection_scope(tokens: &[&str]) -> bool {
+    for (action_index, action) in tokens.iter().enumerate() {
+        if !is_collection_action(action) {
+            continue;
+        }
+        for broad_index in (action_index + 1)..tokens.len().min(action_index + 4) {
+            if !matches!(
+                tokens[broad_index],
+                "all" | "every" | "entire" | "whole" | "full" | "complete"
+            ) {
+                continue;
+            }
+            for target_index in (broad_index + 1)..tokens.len().min(broad_index + 4) {
+                if !is_collection_target(tokens[target_index]) {
+                    continue;
+                }
+                if matches!(tokens[target_index], "disk" | "disks")
+                    && tokens
+                        .get(target_index + 1)
+                        .is_some_and(|descriptor| matches!(*descriptor, "imaging" | "encryption"))
+                {
+                    break;
+                }
+                return true;
+            }
+        }
     }
-
-    let has_broad_quantifier = has_token(&["all", "every", "entire", "whole", "full", "complete"]);
-    let has_filesystem_target = has_token(&[
-        "file",
-        "files",
-        "directory",
-        "directories",
-        "folder",
-        "folders",
-        "drive",
-        "drives",
-        "disk",
-        "disks",
-        "volume",
-        "volumes",
-        "filesystem",
-        "filesystems",
-    ]);
-    if has_broad_quantifier && has_filesystem_target {
-        return true;
-    }
-
-    let has_root_target = has_token(&["root"])
-        && has_token(&[
-            "directory",
-            "directories",
-            "folder",
-            "folders",
-            "drive",
-            "drives",
-            "disk",
-            "disks",
-            "volume",
-            "volumes",
-            "filesystem",
-            "filesystems",
-            "path",
-            "paths",
-        ]);
-    if has_root_target {
-        return true;
-    }
-
     false
 }
 
@@ -886,29 +976,14 @@ fn evidence_identity(reference: &SccmEvidenceRef) -> (&str, &str) {
     (&reference.artifact_id, &reference.entry_id)
 }
 
+fn is_canonical_opaque_id(value: &str) -> bool {
+    !value.is_empty() && value.trim() == value
+}
+
 fn normalize_finding(finding: &mut SccmFinding) {
-    finding.finding_id = finding.finding_id.trim().to_owned();
     finding.title = finding.title.trim().to_owned();
     finding.summary = finding.summary.trim().to_owned();
-    if let SccmPhase::Unknown(value) = &mut finding.phase {
-        *value = value.trim().to_owned();
-    }
-    for reference in &mut finding.evidence {
-        normalize_evidence_reference(reference);
-    }
-    for terminal in &mut finding.terminal_evidence {
-        normalize_evidence_reference(&mut terminal.reference);
-    }
-    for key in &mut finding.correlation_keys {
-        if let Some(reference) = &mut key.evidence {
-            normalize_evidence_reference(reference);
-        }
-    }
-    for gap in &mut finding.coverage_gaps {
-        gap.artifact_id = gap.artifact_id.trim().to_owned();
-    }
     for request in &mut finding.next_artifacts {
-        request.logical_id = request.logical_id.trim().to_owned();
         request.reason = request.reason.trim().to_owned();
     }
 
@@ -926,11 +1001,6 @@ fn normalize_finding(finding: &mut SccmFinding) {
 
     finding.next_artifacts.sort_by(compare_artifact_requests);
     finding.next_artifacts.dedup();
-}
-
-fn normalize_evidence_reference(reference: &mut SccmEvidenceRef) {
-    reference.artifact_id = reference.artifact_id.trim().to_owned();
-    reference.entry_id = reference.entry_id.trim().to_owned();
 }
 
 fn compare_evidence_refs(left: &SccmEvidenceRef, right: &SccmEvidenceRef) -> Ordering {

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -1295,6 +1295,9 @@ fn has_passive_unbounded_confirmation_request(
                     is_collection_target(token.text)
                         && !token_is_covered_by_identity(token, identity_ranges)
                 });
+            let has_explicit_bounded_state_observation = !broad_target_follows_auxiliary
+                && !identity_ranges.is_empty()
+                && predicate.iter().any(|token| token.text == "downloaded");
 
             matches!(auxiliary.text, "must" | "need" | "needs" | "should")
                 || broad_target_follows_auxiliary
@@ -1312,6 +1315,7 @@ fn has_passive_unbounded_confirmation_request(
                             | "required"
                     )
                 })
+                || !has_explicit_bounded_state_observation
         })
 }
 

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -677,12 +677,22 @@ fn validate_evidence_reference(
 fn validate_coverage_gaps(
     coverage_gaps: &[SccmFindingCoverageGap],
 ) -> Result<(), SccmFindingValidationError> {
-    if coverage_gaps.iter().any(|gap| {
-        !is_canonical_opaque_id(&gap.artifact_id)
+    let mut coverage_by_artifact: BTreeMap<&str, &SccmFindingCoverageGap> = BTreeMap::new();
+    for gap in coverage_gaps {
+        if !is_canonical_opaque_id(&gap.artifact_id)
             || gap.artifact_id.chars().count() > MAX_SCCM_COVERAGE_GAP_ARTIFACT_ID_CHARS
             || gap.coverage == SccmCoverageState::Captured
-    }) {
-        return Err(SccmFindingValidationError::InvalidCoverageGap);
+        {
+            return Err(SccmFindingValidationError::InvalidCoverageGap);
+        }
+
+        if let Some(previous) = coverage_by_artifact.get(gap.artifact_id.as_str()) {
+            if previous.role != gap.role || previous.coverage != gap.coverage {
+                return Err(SccmFindingValidationError::InvalidCoverageGap);
+            }
+        } else {
+            coverage_by_artifact.insert(gap.artifact_id.as_str(), gap);
+        }
     }
     Ok(())
 }
@@ -859,33 +869,47 @@ fn has_root_collection_scope(tokens: &[&str]) -> bool {
 }
 
 fn has_broad_collection_scope(tokens: &[&str]) -> bool {
-    for (action_index, action) in tokens.iter().enumerate() {
-        if !is_collection_action(action) {
-            continue;
-        }
-        for broad_index in (action_index + 1)..tokens.len().min(action_index + 4) {
-            if !matches!(
-                tokens[broad_index],
-                "all" | "every" | "entire" | "whole" | "full" | "complete"
-            ) {
-                continue;
-            }
-            for target_index in (broad_index + 1)..tokens.len().min(broad_index + 4) {
-                if !is_collection_target(tokens[target_index]) {
-                    continue;
-                }
-                if matches!(tokens[target_index], "disk" | "disks")
-                    && tokens
-                        .get(target_index + 1)
-                        .is_some_and(|descriptor| matches!(*descriptor, "imaging" | "encryption"))
-                {
-                    break;
-                }
-                return true;
-            }
-        }
-    }
-    false
+    let has_collection_target = tokens.iter().any(|token| is_collection_target(token));
+    has_collection_target
+        && tokens.iter().enumerate().any(|(index, token)| {
+            is_broad_quantifier(token) && !is_reviewed_bounded_narrative(tokens, index)
+        })
+}
+
+fn is_broad_quantifier(token: &str) -> bool {
+    matches!(
+        token,
+        "all" | "every" | "entire" | "whole" | "full" | "complete"
+    )
+}
+
+fn is_reviewed_bounded_narrative(tokens: &[&str], quantifier_index: usize) -> bool {
+    let quantifier = tokens[quantifier_index];
+    let bounded_disk_description = matches!(quantifier, "full" | "whole")
+        && tokens
+            .get(quantifier_index + 1)
+            .is_some_and(|target| matches!(*target, "disk" | "disks"))
+        && tokens
+            .get(quantifier_index + 2)
+            .is_some_and(|descriptor| matches!(*descriptor, "imaging" | "encryption"))
+        && has_specific_log_reference(tokens, quantifier_index + 3);
+    let downloaded_files_observation = quantifier == "all"
+        && tokens.get(quantifier_index + 1) == Some(&"files")
+        && tokens.get(quantifier_index + 2) == Some(&"were")
+        && tokens.get(quantifier_index + 3) == Some(&"downloaded")
+        && has_specific_log_reference(tokens, quantifier_index + 4);
+
+    bounded_disk_description || downloaded_files_observation
+}
+
+fn has_specific_log_reference(tokens: &[&str], start: usize) -> bool {
+    tokens[start..].windows(2).any(|pair| {
+        pair[1] == "log"
+            && !matches!(
+                pair[0],
+                "a" | "all" | "any" | "every" | "each" | "system" | "the"
+            )
+    })
 }
 
 fn validate_terminal_evidence(

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -709,9 +709,6 @@ fn validate_artifact_requests(
         if !is_canonical_opaque_id(&request.logical_id) {
             return Err(SccmFindingValidationError::UndeclaredArtifactRequest);
         }
-        if !is_bounded_request_reason(&request.reason) {
-            return Err(SccmFindingValidationError::InvalidArtifactRequestReason);
-        }
 
         let mut logical_matches = catalog
             .iter()
@@ -719,18 +716,34 @@ fn validate_artifact_requests(
         let Some(first_match) = logical_matches.next() else {
             return Err(SccmFindingValidationError::UndeclaredArtifactRequest);
         };
-        if first_match.role != request.role
-            && !logical_matches.any(|entry| entry.role == request.role)
-        {
+        let requested_source = if first_match.role == request.role {
+            first_match
+        } else if let Some(role_match) = logical_matches.find(|entry| entry.role == request.role) {
+            role_match
+        } else {
             return Err(SccmFindingValidationError::ArtifactRequestRoleMismatch);
+        };
+        if !is_bounded_request_reason(
+            &request.reason,
+            &requested_source.basename,
+            &requested_source.logical_name,
+        ) {
+            return Err(SccmFindingValidationError::InvalidArtifactRequestReason);
         }
     }
     Ok(())
 }
 
-fn is_bounded_request_reason(reason: &str) -> bool {
+fn is_bounded_request_reason(
+    reason: &str,
+    requested_basename: &str,
+    requested_logical_id: &str,
+) -> bool {
     let trimmed = reason.trim();
     if trimmed.is_empty()
+        || !trimmed
+            .chars()
+            .any(|character| character.is_ascii_alphanumeric())
         || trimmed.chars().count() > MAX_SCCM_ARTIFACT_REQUEST_REASON_CHARS
         || contains_rooted_path(trimmed)
         || trimmed.contains(['*', '?', '[', ']'])
@@ -738,7 +751,11 @@ fn is_bounded_request_reason(reason: &str) -> bool {
         return false;
     }
 
-    !has_unbounded_request_scope(&trimmed.to_ascii_lowercase())
+    let lowercase = trimmed.to_ascii_lowercase();
+    let clauses_are_bounded = request_clauses(&lowercase).all(|clause| {
+        !has_unbounded_request_scope(clause, requested_basename, requested_logical_id)
+    });
+    clauses_are_bounded
 }
 
 fn contains_rooted_path(reason: &str) -> bool {
@@ -753,8 +770,37 @@ fn contains_rooted_path(reason: &str) -> bool {
     })
 }
 
-fn has_unbounded_request_scope(reason: &str) -> bool {
-    let tokens = reason
+fn request_clauses(reason: &str) -> impl Iterator<Item = &str> {
+    let mut clauses = Vec::new();
+    let mut start = 0;
+    let mut characters = reason.char_indices().peekable();
+
+    while let Some((index, character)) = characters.next() {
+        let next = characters.peek().map(|(_, next)| *next);
+        let is_sentence_period =
+            character == '.' && next.is_none_or(|next| !next.is_ascii_alphanumeric());
+        if matches!(character, ';' | '\n' | '\r' | '!' | '?') || is_sentence_period {
+            let clause = reason[start..index].trim();
+            if !clause.is_empty() {
+                clauses.push(clause);
+            }
+            start = index + character.len_utf8();
+        }
+    }
+
+    let trailing = reason[start..].trim();
+    if !trailing.is_empty() {
+        clauses.push(trailing);
+    }
+    clauses.into_iter()
+}
+
+fn has_unbounded_request_scope(
+    clause: &str,
+    requested_basename: &str,
+    requested_logical_id: &str,
+) -> bool {
+    let tokens = clause
         .split(|character: char| !character.is_ascii_alphanumeric())
         .filter(|token| !token.is_empty())
         .collect::<Vec<_>>();
@@ -766,7 +812,7 @@ fn has_unbounded_request_scope(reason: &str) -> bool {
         || has_recursive_collection_scope(&tokens)
         || has_wide_collection_scope(&tokens)
         || has_root_collection_scope(&tokens)
-        || has_broad_collection_scope(&tokens)
+        || has_unscoped_broad_collection_scope(&tokens, requested_basename, requested_logical_id)
 }
 
 fn is_collection_action(token: &str) -> bool {
@@ -816,64 +862,70 @@ fn is_compact_unbounded_scope(token: &str) -> bool {
         .any(|prefix| token.strip_prefix(prefix).is_some_and(is_collection_target))
 }
 
-fn has_nearby_collection_action_before(tokens: &[&str], index: usize) -> bool {
-    let start = index.saturating_sub(4);
-    tokens[start..index]
-        .iter()
-        .any(|token| is_collection_action(token))
+fn is_collection_container(token: &str) -> bool {
+    matches!(
+        token,
+        "client"
+            | "device"
+            | "directory"
+            | "directories"
+            | "disk"
+            | "disks"
+            | "drive"
+            | "drives"
+            | "filesystem"
+            | "filesystems"
+            | "folder"
+            | "folders"
+            | "machine"
+            | "site"
+            | "system"
+            | "volume"
+            | "volumes"
+    )
+}
+
+fn is_collection_scope_subject(token: &str) -> bool {
+    is_collection_target(token) || matches!(token, "archive" | "collection" | "scope" | "traversal")
 }
 
 fn has_recursive_collection_scope(tokens: &[&str]) -> bool {
-    tokens.iter().enumerate().any(|(index, token)| {
-        token.starts_with("recurs")
-            && (has_nearby_collection_action_before(tokens, index)
-                || tokens
-                    .iter()
-                    .skip(index + 1)
-                    .take(2)
-                    .any(|candidate| is_collection_action(candidate)))
-    })
+    let mentions_recursion = tokens.iter().any(|token| token.starts_with("recurs"));
+    let describes_collection = tokens.iter().any(|token| {
+        is_collection_action(token)
+            || is_collection_container(token)
+            || matches!(*token, "collection" | "inclusion" | "traversal")
+    });
+    mentions_recursion && describes_collection
 }
 
 fn has_wide_collection_scope(tokens: &[&str]) -> bool {
     tokens.iter().enumerate().any(|(index, token)| {
-        let compound = matches!(
-            *token,
-            "drivewide" | "diskwide" | "volumewide" | "filesystemwide" | "sitewide" | "systemwide"
-        ) && tokens
-            .get(index + 1)
-            .is_some_and(|target| is_collection_target(target));
-        let separated = matches!(
-            *token,
-            "drive" | "disk" | "volume" | "filesystem" | "site" | "system"
-        ) && tokens.get(index + 1) == Some(&"wide")
+        let compound = token
+            .strip_suffix("wide")
+            .is_some_and(is_collection_container)
+            && tokens
+                .get(index + 1)
+                .is_some_and(|target| is_collection_scope_subject(target));
+        let separated = is_collection_container(token)
+            && tokens.get(index + 1) == Some(&"wide")
             && tokens
                 .get(index + 2)
-                .is_some_and(|target| is_collection_target(target));
+                .is_some_and(|target| is_collection_scope_subject(target));
 
-        (compound || separated) && has_nearby_collection_action_before(tokens, index)
+        compound || separated
     })
 }
 
 fn has_root_collection_scope(tokens: &[&str]) -> bool {
     tokens.iter().enumerate().any(|(root_index, token)| {
-        if *token != "root" {
+        if !token.starts_with("root") || tokens.get(root_index + 1) == Some(&"cause") {
             return false;
         }
-        tokens.iter().enumerate().any(|(target_index, target)| {
-            is_collection_target(target)
-                && root_index.abs_diff(target_index) <= 2
-                && has_nearby_collection_action_before(tokens, root_index.min(target_index))
+        tokens.iter().any(|candidate| {
+            is_collection_action(candidate) || is_collection_scope_subject(candidate)
         })
     })
-}
-
-fn has_broad_collection_scope(tokens: &[&str]) -> bool {
-    let has_collection_target = tokens.iter().any(|token| is_collection_target(token));
-    has_collection_target
-        && tokens.iter().enumerate().any(|(index, token)| {
-            is_broad_quantifier(token) && !is_reviewed_bounded_narrative(tokens, index)
-        })
 }
 
 fn is_broad_quantifier(token: &str) -> bool {
@@ -883,33 +935,136 @@ fn is_broad_quantifier(token: &str) -> bool {
     )
 }
 
-fn is_reviewed_bounded_narrative(tokens: &[&str], quantifier_index: usize) -> bool {
-    let quantifier = tokens[quantifier_index];
-    let bounded_disk_description = matches!(quantifier, "full" | "whole")
-        && tokens
-            .get(quantifier_index + 1)
-            .is_some_and(|target| matches!(*target, "disk" | "disks"))
-        && tokens
-            .get(quantifier_index + 2)
-            .is_some_and(|descriptor| matches!(*descriptor, "imaging" | "encryption"))
-        && has_specific_log_reference(tokens, quantifier_index + 3);
-    let downloaded_files_observation = quantifier == "all"
-        && tokens.get(quantifier_index + 1) == Some(&"files")
-        && tokens.get(quantifier_index + 2) == Some(&"were")
-        && tokens.get(quantifier_index + 3) == Some(&"downloaded")
-        && has_specific_log_reference(tokens, quantifier_index + 4);
+fn has_unscoped_broad_collection_scope(
+    tokens: &[&str],
+    requested_basename: &str,
+    requested_logical_id: &str,
+) -> bool {
+    tokens.iter().enumerate().any(|(quantifier_index, token)| {
+        if !is_broad_quantifier(token) {
+            return false;
+        }
 
-    bounded_disk_description || downloaded_files_observation
+        let (scope_start, scope_end) = broad_scope_segment(tokens, quantifier_index);
+        let scope = &tokens[scope_start..scope_end];
+        let targets = scope
+            .iter()
+            .enumerate()
+            .filter(|(_, candidate)| is_collection_target(candidate))
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        if targets.is_empty() {
+            return false;
+        }
+
+        let identity_ranges =
+            requested_artifact_identity_ranges(scope, requested_basename, requested_logical_id);
+        if identity_ranges.is_empty() || has_environment_collection_scope(scope) {
+            return true;
+        }
+
+        targets.into_iter().any(|target_index| {
+            !target_is_bounded_to_requested_artifact(
+                scope,
+                target_index,
+                &identity_ranges,
+                requested_logical_id,
+            )
+        })
+    })
 }
 
-fn has_specific_log_reference(tokens: &[&str], start: usize) -> bool {
-    tokens[start..].windows(2).any(|pair| {
-        pair[1] == "log"
-            && !matches!(
-                pair[0],
-                "a" | "all" | "any" | "every" | "each" | "system" | "the"
-            )
-    })
+fn broad_scope_segment(tokens: &[&str], quantifier_index: usize) -> (usize, usize) {
+    let is_boundary = |index: usize| {
+        matches!(tokens[index], "plus" | "also" | "then")
+            || (tokens[index] == "and"
+                && tokens
+                    .get(index + 1)
+                    .is_some_and(|next| is_broad_quantifier(next) || is_collection_action(next)))
+    };
+    let start = (0..quantifier_index)
+        .rev()
+        .find(|index| is_boundary(*index))
+        .map_or(0, |index| index + 1);
+    let end = ((quantifier_index + 1)..tokens.len())
+        .find(|index| is_boundary(*index))
+        .unwrap_or(tokens.len());
+    (start, end)
+}
+
+fn requested_artifact_identity_ranges(
+    tokens: &[&str],
+    requested_basename: &str,
+    requested_logical_id: &str,
+) -> Vec<(usize, usize)> {
+    let basename = normalize_catalog_identity(requested_basename);
+    let logical_id = normalize_catalog_identity(requested_logical_id);
+    let mut ranges = tokens
+        .iter()
+        .enumerate()
+        .filter(|(_, token)| **token == basename || **token == logical_id)
+        .map(|(index, _)| (index, index + 1))
+        .collect::<Vec<_>>();
+
+    if logical_id == "smsts" {
+        ranges.extend(tokens.windows(3).enumerate().filter_map(|(index, window)| {
+            (window == ["task", "sequence", "log"]).then_some((index, index + 3))
+        }));
+    }
+    ranges
+}
+
+fn normalize_catalog_identity(identity: &str) -> String {
+    identity
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn has_environment_collection_scope(tokens: &[&str]) -> bool {
+    tokens
+        .windows(2)
+        .any(|pair| is_collection_container(pair[0]) && is_collection_target(pair[1]))
+        || tokens.iter().enumerate().any(|(index, token)| {
+            matches!(*token, "across" | "from" | "on" | "throughout" | "under")
+                && tokens
+                    .iter()
+                    .skip(index + 1)
+                    .take(3)
+                    .any(|candidate| is_collection_container(candidate))
+        })
+}
+
+fn target_is_bounded_to_requested_artifact(
+    tokens: &[&str],
+    target_index: usize,
+    identity_ranges: &[(usize, usize)],
+    requested_logical_id: &str,
+) -> bool {
+    let identity_precedes_target = identity_ranges
+        .iter()
+        .any(|(start, end)| *start <= target_index && target_index.saturating_sub(*end) <= 2);
+    let is_state_observation = tokens.iter().any(|token| {
+        matches!(
+            *token,
+            "download" | "downloaded" | "encryption" | "image" | "imaging" | "state" | "status"
+        )
+    });
+
+    match tokens[target_index] {
+        "directory" | "directories" | "disk" | "disks" | "drive" | "drives" | "filesystem"
+        | "filesystems" | "folder" | "folders" | "volume" | "volumes" => {
+            is_state_observation
+                && (requested_logical_id.eq_ignore_ascii_case("smsts")
+                    || tokens
+                        .iter()
+                        .any(|token| matches!(*token, "encryption" | "status")))
+        }
+        "file" | "files" => identity_precedes_target || is_state_observation,
+        "logs" => identity_precedes_target,
+        _ => true,
+    }
 }
 
 fn validate_terminal_evidence(

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -367,6 +367,7 @@ impl<'de> Deserialize<'de> for SccmFinding {
 impl SccmFinding {
     pub fn validate(&self) -> Result<(), SccmFindingValidationError> {
         validate_required_text(self)?;
+        validate_all_evidence_references(self)?;
         validate_coverage_gaps(&self.coverage_gaps)?;
         validate_artifact_requests(&self.next_artifacts)?;
 
@@ -412,6 +413,7 @@ impl SccmFinding {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SccmFindingValidationError {
     MissingRequiredField,
+    InvalidEvidenceReference,
     MissingEvidenceOrCoverageGap,
     MissingTerminalEvidence,
     InvalidTerminalEvidence,
@@ -579,6 +581,47 @@ fn validate_required_text(finding: &SccmFinding) -> Result<(), SccmFindingValida
         || matches!(&finding.phase, SccmPhase::Unknown(value) if is_known_phase_name(value))
     {
         return Err(SccmFindingValidationError::MissingRequiredField);
+    }
+    Ok(())
+}
+
+fn validate_all_evidence_references(
+    finding: &SccmFinding,
+) -> Result<(), SccmFindingValidationError> {
+    for reference in finding
+        .evidence
+        .iter()
+        .chain(
+            finding
+                .terminal_evidence
+                .iter()
+                .map(|terminal| &terminal.reference),
+        )
+        .chain(
+            finding
+                .correlation_keys
+                .iter()
+                .filter_map(|key| key.evidence.as_ref()),
+        )
+    {
+        validate_evidence_reference(reference)?;
+    }
+    Ok(())
+}
+
+fn validate_evidence_reference(
+    reference: &SccmEvidenceRef,
+) -> Result<(), SccmFindingValidationError> {
+    let valid_line_range = match (reference.line_start, reference.line_end) {
+        (None, None) => true,
+        (Some(start), Some(end)) => start > 0 && end >= start,
+        _ => false,
+    };
+    if reference.artifact_id.trim().is_empty()
+        || reference.entry_id.trim().is_empty()
+        || !valid_line_range
+    {
+        return Err(SccmFindingValidationError::InvalidEvidenceReference);
     }
     Ok(())
 }

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -1287,8 +1287,18 @@ fn has_passive_unbounded_confirmation_request(
                 return false;
             }
 
+            let predicate = &tokens[auxiliary_index + 1..];
+            let broad_target_follows_auxiliary = predicate
+                .iter()
+                .any(|token| is_broad_quantifier(token.text))
+                && predicate.iter().any(|token| {
+                    is_collection_target(token.text)
+                        && !token_is_covered_by_identity(token, identity_ranges)
+                });
+
             matches!(auxiliary.text, "must" | "need" | "needs" | "should")
-                || tokens[auxiliary_index + 1..].iter().any(|token| {
+                || broad_target_follows_auxiliary
+                || predicate.iter().any(|token| {
                     matches!(
                         token.text,
                         "archived"

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -15,6 +15,8 @@ use super::models::{
 pub const MAX_SCCM_ARTIFACT_REQUEST_REASON_CHARS: usize = 240;
 pub const MAX_SCCM_NEXT_ARTIFACT_REQUESTS: usize = 16;
 const MAX_SCCM_COVERAGE_GAP_ARTIFACT_ID_CHARS: usize = 256;
+// Intentionally empty: no extraction profile is verified as stable enough to
+// authorize key-only High confidence. Adding one requires contract review.
 const REGISTERED_STABLE_CORRELATION_PROFILE_IDS: &[&str] = &[];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -179,11 +181,111 @@ struct SccmFindingWire {
     confidence: SccmConfidence,
     title: String,
     summary: String,
-    evidence: Vec<SccmEvidenceRef>,
-    terminal_evidence: Vec<SccmTerminalEvidence>,
-    coverage_gaps: Vec<SccmFindingCoverageGap>,
-    correlation_keys: Vec<SccmCorrelationKey>,
-    next_artifacts: Vec<SccmArtifactRequest>,
+    evidence: Vec<SccmEvidenceRefWire>,
+    terminal_evidence: Vec<SccmTerminalEvidenceWire>,
+    coverage_gaps: Vec<SccmFindingCoverageGapWire>,
+    correlation_keys: Vec<SccmCorrelationKeyWire>,
+    next_artifacts: Vec<SccmArtifactRequestWire>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SccmEvidenceRefWire {
+    artifact_id: String,
+    entry_id: String,
+    line_start: Option<u32>,
+    line_end: Option<u32>,
+}
+
+impl From<SccmEvidenceRefWire> for SccmEvidenceRef {
+    fn from(wire: SccmEvidenceRefWire) -> Self {
+        Self {
+            artifact_id: wire.artifact_id,
+            entry_id: wire.entry_id,
+            line_start: wire.line_start,
+            line_end: wire.line_end,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SccmTerminalEvidenceWire {
+    reference: SccmEvidenceRefWire,
+    kind: SccmTerminalEvidenceKind,
+}
+
+impl From<SccmTerminalEvidenceWire> for SccmTerminalEvidence {
+    fn from(wire: SccmTerminalEvidenceWire) -> Self {
+        Self {
+            reference: wire.reference.into(),
+            kind: wire.kind,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SccmFindingCoverageGapWire {
+    artifact_id: String,
+    role: SccmRole,
+    coverage: SccmCoverageState,
+}
+
+impl From<SccmFindingCoverageGapWire> for SccmFindingCoverageGap {
+    fn from(wire: SccmFindingCoverageGapWire) -> Self {
+        Self {
+            artifact_id: wire.artifact_id,
+            role: wire.role,
+            coverage: wire.coverage,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SccmCorrelationKeyWire {
+    kind: SccmCorrelationKeyKind,
+    raw: String,
+    normalized: String,
+    confidence: SccmKeyConfidence,
+    extraction_profile_id: Option<String>,
+    evidence: Option<SccmEvidenceRefWire>,
+    start: Option<usize>,
+    end: Option<usize>,
+}
+
+impl From<SccmCorrelationKeyWire> for SccmCorrelationKey {
+    fn from(wire: SccmCorrelationKeyWire) -> Self {
+        Self {
+            kind: wire.kind,
+            raw: wire.raw,
+            normalized: wire.normalized,
+            confidence: wire.confidence,
+            extraction_profile_id: wire.extraction_profile_id,
+            evidence: wire.evidence.map(Into::into),
+            start: wire.start,
+            end: wire.end,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SccmArtifactRequestWire {
+    logical_id: String,
+    role: SccmRole,
+    reason: String,
+}
+
+impl From<SccmArtifactRequestWire> for SccmArtifactRequest {
+    fn from(wire: SccmArtifactRequestWire) -> Self {
+        Self {
+            logical_id: wire.logical_id,
+            role: wire.role,
+            reason: wire.reason,
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for SccmFinding {
@@ -204,11 +306,11 @@ impl<'de> Deserialize<'de> for SccmFinding {
             confidence: wire.confidence,
             title: wire.title,
             summary: wire.summary,
-            evidence: wire.evidence,
-            terminal_evidence: wire.terminal_evidence,
-            coverage_gaps: wire.coverage_gaps,
-            correlation_keys: wire.correlation_keys,
-            next_artifacts: wire.next_artifacts,
+            evidence: wire.evidence.into_iter().map(Into::into).collect(),
+            terminal_evidence: wire.terminal_evidence.into_iter().map(Into::into).collect(),
+            coverage_gaps: wire.coverage_gaps.into_iter().map(Into::into).collect(),
+            correlation_keys: wire.correlation_keys.into_iter().map(Into::into).collect(),
+            next_artifacts: wire.next_artifacts.into_iter().map(Into::into).collect(),
         };
         normalize_finding(&mut finding);
         finding.validate().map_err(|error| {
@@ -430,6 +532,7 @@ fn validate_required_text(finding: &SccmFinding) -> Result<(), SccmFindingValida
         || finding.title.trim().is_empty()
         || finding.summary.trim().is_empty()
         || matches!(&finding.phase, SccmPhase::Unknown(value) if value.trim().is_empty())
+        || matches!(&finding.phase, SccmPhase::Unknown(value) if is_known_phase_name(value))
     {
         return Err(SccmFindingValidationError::MissingRequiredField);
     }

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -839,10 +839,9 @@ fn reason_scope_is_within_catalog_artifact(
             collection_clause_is_catalog_bounded(clause, &tokens, &identity_ranges)
         } else if has_collection_directive {
             // An authorized action cannot lend its identity to another
-            // strong-punctuation clause. Keep evidence context attached as a
-            // bounded narrative suffix instead of treating a second command
-            // as non-authorizing prose.
-            false
+            // strong-punctuation clause. Only independently safe evidence
+            // observations remain non-authorizing.
+            narrative_clause_is_safe_observation(clause, &tokens, &identity_ranges)
         } else {
             narrative_clause_has_no_collection_scope(&tokens)
         }
@@ -1275,6 +1274,21 @@ fn narrative_clause_has_no_collection_scope(tokens: &[RequestReasonToken<'_>]) -
     })
 }
 
+fn narrative_clause_is_safe_observation(
+    clause: &str,
+    tokens: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    narrative_tokens_are_non_authorizing(clause, tokens, identity_ranges)
+        && tokens.iter().any(|token| {
+            token_is_covered_by_identity(token, identity_ranges)
+                || is_evidence_narrative_subject(token.text)
+        })
+        && tokens
+            .iter()
+            .any(|token| is_evidence_narrative_predicate(token.text))
+}
+
 fn narrative_tokens_are_non_authorizing(
     clause: &str,
     tokens: &[RequestReasonToken<'_>],
@@ -1366,6 +1380,32 @@ fn is_evidence_narrative_subject(token: &str) -> bool {
             | "state"
             | "status"
     )
+}
+
+fn is_evidence_narrative_predicate(token: &str) -> bool {
+    is_passive_auxiliary(token)
+        || matches!(
+            token,
+            "available"
+                | "capped"
+                | "captured"
+                | "denied"
+                | "failed"
+                | "had"
+                | "has"
+                | "have"
+                | "malformed"
+                | "missing"
+                | "partial"
+                | "provided"
+                | "recorded"
+                | "reported"
+                | "required"
+                | "skipped"
+                | "succeeded"
+                | "unavailable"
+                | "unsupported"
+        )
 }
 
 fn is_wide_scope_token(token: &str) -> bool {

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::models::log_entry::Severity;
 
 use super::catalog::declared_source_catalog;
+use super::keys::normalize_key;
 use super::models::{
     SccmCorrelationKey, SccmCorrelationKeyKind, SccmCoverageState, SccmEvidenceRef,
     SccmFindingClass, SccmKeyConfidence, SccmRole,
@@ -459,6 +460,7 @@ pub enum SccmFindingValidationError {
     TerminalEvidenceNotCited,
     CorrelationKeyMissingEvidence,
     CorrelationKeyEvidenceNotCited,
+    InvalidCorrelationKey,
     LikelyContributorConfidenceTooHigh,
     MissingCoverageGap,
     InvalidCoverageGap,
@@ -1187,6 +1189,7 @@ fn confirmation_clause_is_non_authorizing(
         || tokens
             .iter()
             .any(|token| is_collection_scope_nominal(token.text))
+        || has_passive_unbounded_confirmation_request(tokens, identity_ranges)
         || !confirmation_tokens_match_defined_form(tokens, identity_ranges)
     {
         return false;
@@ -1257,6 +1260,46 @@ fn confirmation_clause_is_non_authorizing(
         }
     }
     true
+}
+
+fn has_passive_unbounded_confirmation_request(
+    tokens: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    tokens
+        .iter()
+        .enumerate()
+        .any(|(auxiliary_index, auxiliary)| {
+            if !is_passive_auxiliary(auxiliary.text) {
+                return false;
+            }
+
+            let subject = &tokens[1..auxiliary_index];
+            let has_broad_target = subject.iter().any(|token| is_broad_quantifier(token.text))
+                && subject.iter().any(|token| {
+                    is_collection_target(token.text)
+                        && !token_is_covered_by_identity(token, identity_ranges)
+                });
+            if !has_broad_target {
+                return false;
+            }
+
+            matches!(auxiliary.text, "must" | "need" | "needs" | "should")
+                || tokens[auxiliary_index + 1..].iter().any(|token| {
+                    matches!(
+                        token.text,
+                        "archived"
+                            | "captured"
+                            | "collected"
+                            | "copied"
+                            | "exported"
+                            | "gathered"
+                            | "included"
+                            | "provided"
+                            | "required"
+                    )
+                })
+        })
 }
 
 fn confirmation_tokens_match_defined_form(
@@ -1979,6 +2022,37 @@ fn validate_correlation_key_evidence(
     correlation_keys: &[SccmCorrelationKey],
 ) -> Result<(), SccmFindingValidationError> {
     for key in correlation_keys {
+        let normalized = normalize_key(key.kind.clone(), &key.raw);
+        let has_canonical_value = !key.raw.is_empty()
+            && key.raw.trim() == key.raw
+            && !key.normalized.is_empty()
+            && key.normalized.trim() == key.normalized
+            && normalized.confidence == SccmKeyConfidence::Exact
+            && normalized.normalized == key.normalized;
+        let has_valid_span = match (key.start, key.end) {
+            (None, None) => true,
+            (Some(start), Some(end)) => {
+                start < end && end - start == key.raw.encode_utf16().count()
+            }
+            _ => false,
+        };
+        let has_canonical_profile = key
+            .extraction_profile_id
+            .as_deref()
+            .is_none_or(is_canonical_opaque_id);
+        let has_valid_confidence = matches!(key.confidence, SccmKeyConfidence::Low)
+            || key
+                .extraction_profile_id
+                .as_deref()
+                .is_some_and(is_registered_stable_profile);
+        if !has_canonical_value
+            || !has_valid_span
+            || !has_canonical_profile
+            || !has_valid_confidence
+        {
+            return Err(SccmFindingValidationError::InvalidCorrelationKey);
+        }
+
         let Some(reference) = &key.evidence else {
             return Err(SccmFindingValidationError::CorrelationKeyMissingEvidence);
         };

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::collections::BTreeMap;
 
 use serde::de::Error as _;
 use serde::ser::Error as _;
@@ -192,23 +193,25 @@ impl Serialize for SccmFinding {
     where
         S: Serializer,
     {
-        self.validate().map_err(|error| {
+        let mut normalized = self.clone();
+        normalize_finding(&mut normalized);
+        normalized.validate().map_err(|error| {
             S::Error::custom(format!("invalid SCCM finding contract: {error:?}"))
         })?;
         SccmFindingSerializeWire {
-            finding_id: &self.finding_id,
-            class: &self.class,
-            phase: &self.phase,
-            role: &self.role,
-            severity: &self.severity,
-            confidence: &self.confidence,
-            title: &self.title,
-            summary: &self.summary,
-            evidence: &self.evidence,
-            terminal_evidence: &self.terminal_evidence,
-            coverage_gaps: &self.coverage_gaps,
-            correlation_keys: &self.correlation_keys,
-            next_artifacts: &self.next_artifacts,
+            finding_id: &normalized.finding_id,
+            class: &normalized.class,
+            phase: &normalized.phase,
+            role: &normalized.role,
+            severity: &normalized.severity,
+            confidence: &normalized.confidence,
+            title: &normalized.title,
+            summary: &normalized.summary,
+            evidence: &normalized.evidence,
+            terminal_evidence: &normalized.terminal_evidence,
+            coverage_gaps: &normalized.coverage_gaps,
+            correlation_keys: &normalized.correlation_keys,
+            next_artifacts: &normalized.next_artifacts,
         }
         .serialize(serializer)
     }
@@ -367,6 +370,7 @@ impl<'de> Deserialize<'de> for SccmFinding {
 impl SccmFinding {
     pub fn validate(&self) -> Result<(), SccmFindingValidationError> {
         validate_required_text(self)?;
+        validate_roles(self)?;
         validate_all_evidence_references(self)?;
         validate_coverage_gaps(&self.coverage_gaps)?;
         validate_artifact_requests(&self.next_artifacts)?;
@@ -413,7 +417,9 @@ impl SccmFinding {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SccmFindingValidationError {
     MissingRequiredField,
+    InvalidRole,
     InvalidEvidenceReference,
+    ConflictingEvidenceReference,
     MissingEvidenceOrCoverageGap,
     MissingTerminalEvidence,
     InvalidTerminalEvidence,
@@ -585,9 +591,26 @@ fn validate_required_text(finding: &SccmFinding) -> Result<(), SccmFindingValida
     Ok(())
 }
 
+fn validate_roles(finding: &SccmFinding) -> Result<(), SccmFindingValidationError> {
+    if !finding.role.has_canonical_serialized_form()
+        || finding
+            .coverage_gaps
+            .iter()
+            .any(|gap| !gap.role.has_canonical_serialized_form())
+        || finding
+            .next_artifacts
+            .iter()
+            .any(|request| !request.role.has_canonical_serialized_form())
+    {
+        return Err(SccmFindingValidationError::InvalidRole);
+    }
+    Ok(())
+}
+
 fn validate_all_evidence_references(
     finding: &SccmFinding,
 ) -> Result<(), SccmFindingValidationError> {
+    let mut ranges_by_identity = BTreeMap::new();
     for reference in finding
         .evidence
         .iter()
@@ -605,6 +628,14 @@ fn validate_all_evidence_references(
         )
     {
         validate_evidence_reference(reference)?;
+        let identity = (reference.artifact_id.trim(), reference.entry_id.trim());
+        let range = (reference.line_start, reference.line_end);
+        if ranges_by_identity
+            .insert(identity, range)
+            .is_some_and(|existing| existing != range)
+        {
+            return Err(SccmFindingValidationError::ConflictingEvidenceReference);
+        }
     }
     Ok(())
 }
@@ -676,19 +707,82 @@ fn is_bounded_request_reason(reason: &str) -> bool {
         return false;
     }
 
-    let lowercase = trimmed.to_ascii_lowercase();
-    ![
-        "entire drive",
-        "whole drive",
-        "drive root",
-        "root drive",
-        "entire disk",
-        "whole disk",
-        "all files",
-        "recursive",
-    ]
-    .iter()
-    .any(|unbounded| lowercase.contains(unbounded))
+    !has_unbounded_request_scope(&trimmed.to_ascii_lowercase())
+}
+
+fn has_unbounded_request_scope(reason: &str) -> bool {
+    let tokens = reason
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+    let has_token = |candidates: &[&str]| tokens.iter().any(|token| candidates.contains(token));
+    let is_wide_scope_token = |token: &str| {
+        matches!(
+            token,
+            "drivewide" | "diskwide" | "volumewide" | "filesystemwide" | "sitewide" | "systemwide"
+        )
+    };
+    let is_scope_token = |token: &str| {
+        matches!(
+            token,
+            "drive" | "disk" | "volume" | "filesystem" | "site" | "system"
+        )
+    };
+    let has_wide_scope = tokens.iter().any(|token| is_wide_scope_token(token))
+        || tokens
+            .windows(2)
+            .any(|pair| is_scope_token(pair[0]) && pair[1] == "wide");
+
+    if has_wide_scope
+        || tokens.iter().any(|token| token.starts_with("recurs"))
+        || has_token(&["glob", "globs", "globbing"])
+    {
+        return true;
+    }
+
+    let has_broad_quantifier = has_token(&["all", "every", "entire", "whole", "full", "complete"]);
+    let has_filesystem_target = has_token(&[
+        "file",
+        "files",
+        "directory",
+        "directories",
+        "folder",
+        "folders",
+        "drive",
+        "drives",
+        "disk",
+        "disks",
+        "volume",
+        "volumes",
+        "filesystem",
+        "filesystems",
+    ]);
+    if has_broad_quantifier && has_filesystem_target {
+        return true;
+    }
+
+    let has_root_target = has_token(&["root"])
+        && has_token(&[
+            "directory",
+            "directories",
+            "folder",
+            "folders",
+            "drive",
+            "drives",
+            "disk",
+            "disks",
+            "volume",
+            "volumes",
+            "filesystem",
+            "filesystems",
+            "path",
+            "paths",
+        ]);
+    if has_root_target {
+        return true;
+    }
+
+    false
 }
 
 fn validate_terminal_evidence(
@@ -783,6 +877,20 @@ fn normalize_finding(finding: &mut SccmFinding) {
     finding.finding_id = finding.finding_id.trim().to_owned();
     finding.title = finding.title.trim().to_owned();
     finding.summary = finding.summary.trim().to_owned();
+    if let SccmPhase::Unknown(value) = &mut finding.phase {
+        *value = value.trim().to_owned();
+    }
+    for reference in &mut finding.evidence {
+        normalize_evidence_reference(reference);
+    }
+    for terminal in &mut finding.terminal_evidence {
+        normalize_evidence_reference(&mut terminal.reference);
+    }
+    for key in &mut finding.correlation_keys {
+        if let Some(reference) = &mut key.evidence {
+            normalize_evidence_reference(reference);
+        }
+    }
     for gap in &mut finding.coverage_gaps {
         gap.artifact_id = gap.artifact_id.trim().to_owned();
     }
@@ -805,6 +913,11 @@ fn normalize_finding(finding: &mut SccmFinding) {
 
     finding.next_artifacts.sort_by(compare_artifact_requests);
     finding.next_artifacts.dedup();
+}
+
+fn normalize_evidence_reference(reference: &mut SccmEvidenceRef) {
+    reference.artifact_id = reference.artifact_id.trim().to_owned();
+    reference.entry_id = reference.entry_id.trim().to_owned();
 }
 
 fn compare_evidence_refs(left: &SccmEvidenceRef, right: &SccmEvidenceRef) -> Ordering {

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -108,6 +108,15 @@ impl SccmTerminalEvidenceKind {
             Self::Unknown(value) => value,
         }
     }
+
+    fn has_canonical_serialized_form(&self) -> bool {
+        match self {
+            Self::Unknown(value) => {
+                !value.is_empty() && value.trim() == value && value != "observedFailure"
+            }
+            Self::ObservedFailure => true,
+        }
+    }
 }
 
 impl Serialize for SccmTerminalEvidenceKind {
@@ -115,9 +124,9 @@ impl Serialize for SccmTerminalEvidenceKind {
     where
         S: Serializer,
     {
-        if matches!(self, Self::Unknown(value) if value == "observedFailure") {
+        if !self.has_canonical_serialized_form() {
             return Err(S::Error::custom(
-                "unknown terminal evidence kind must not shadow observedFailure",
+                "unknown terminal evidence kind must be canonical and must not shadow observedFailure",
             ));
         }
         serializer.serialize_str(self.serialized_name())
@@ -129,10 +138,16 @@ impl<'de> Deserialize<'de> for SccmTerminalEvidenceKind {
     where
         D: Deserializer<'de>,
     {
-        Ok(match String::deserialize(deserializer)? {
+        let kind = match String::deserialize(deserializer)? {
             value if value == "observedFailure" => Self::ObservedFailure,
             value => Self::Unknown(value),
-        })
+        };
+        if !kind.has_canonical_serialized_form() {
+            return Err(D::Error::custom(
+                "unknown terminal evidence kind must be canonical and must not shadow observedFailure",
+            ));
+        }
+        Ok(kind)
     }
 }
 
@@ -752,6 +767,14 @@ fn is_bounded_request_reason(
     }
 
     let lowercase = trimmed.to_ascii_lowercase();
+    let authorization = CatalogArtifactRequestScope {
+        basename: requested_basename,
+        logical_id: requested_logical_id,
+        task_sequence_alias: requested_logical_id.eq_ignore_ascii_case("smsts"),
+    };
+    if !reason_scope_is_within_catalog_artifact(&lowercase, &authorization) {
+        return false;
+    }
     let clauses_are_bounded = request_clauses(&lowercase).all(|clause| {
         !has_unbounded_request_scope(clause, requested_basename, requested_logical_id)
     });
@@ -768,6 +791,367 @@ fn contains_rooted_path(reason: &str) -> bool {
                     b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-' | b'.'
                 ))
     })
+}
+
+// The reason remains descriptive text: authorization comes only from the
+// catalog entry already selected by logical ID and role. Each clause is
+// evaluated independently so punctuation cannot lend a later modifier either
+// collection intent or an artifact identity from another clause.
+#[derive(Clone, Copy)]
+struct CatalogArtifactRequestScope<'a> {
+    basename: &'a str,
+    logical_id: &'a str,
+    task_sequence_alias: bool,
+}
+
+#[derive(Clone, Copy)]
+struct RequestReasonToken<'a> {
+    text: &'a str,
+    start: usize,
+    end: usize,
+}
+
+fn reason_scope_is_within_catalog_artifact(
+    reason: &str,
+    authorization: &CatalogArtifactRequestScope<'_>,
+) -> bool {
+    if has_unbounded_path_form(reason) {
+        return false;
+    }
+
+    request_clauses(reason).all(|clause| {
+        let tokens = tokenize_request_reason(clause);
+        let identity_ranges = exact_collectable_identity_ranges(clause, authorization);
+        let is_confirmation = tokens.first().is_some_and(|token| token.text == "confirm");
+        let contains_collection_directive =
+            tokens.iter().any(|token| is_collection_action(token.text));
+
+        if is_confirmation {
+            confirmation_clause_is_non_authorizing(&tokens, &identity_ranges)
+        } else if contains_collection_directive {
+            collection_clause_is_catalog_bounded(&tokens, &identity_ranges)
+        } else {
+            narrative_clause_has_no_collection_scope(&tokens)
+        }
+    })
+}
+
+fn has_unbounded_path_form(reason: &str) -> bool {
+    contains_rooted_path(reason)
+        || contains_drive_designator(reason)
+        || contains_environment_path(reason)
+        || reason
+            .as_bytes()
+            .windows(3)
+            .any(|window| matches!(window, b"../" | b"..\\"))
+}
+
+fn contains_drive_designator(reason: &str) -> bool {
+    let bytes = reason.as_bytes();
+    bytes.windows(2).enumerate().any(|(index, pair)| {
+        pair[0].is_ascii_alphabetic()
+            && pair[1] == b':'
+            && (index == 0
+                || !matches!(
+                    bytes[index - 1],
+                    b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_'
+                ))
+    })
+}
+
+fn contains_environment_path(reason: &str) -> bool {
+    let percent_offsets = reason
+        .match_indices('%')
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let has_percent_expansion = percent_offsets.windows(2).any(|pair| {
+        let variable = &reason[pair[0] + 1..pair[1]];
+        !variable.is_empty()
+            && variable
+                .chars()
+                .all(|character| character.is_ascii_alphanumeric() || character == '_')
+    });
+    has_percent_expansion || reason.contains("$env:")
+}
+
+fn tokenize_request_reason(reason: &str) -> Vec<RequestReasonToken<'_>> {
+    let mut tokens = Vec::new();
+    let mut token_start = None;
+
+    for (index, character) in reason.char_indices() {
+        if character.is_ascii_alphanumeric() || character == '_' {
+            token_start.get_or_insert(index);
+        } else if let Some(start) = token_start.take() {
+            tokens.push(RequestReasonToken {
+                text: &reason[start..index],
+                start,
+                end: index,
+            });
+        }
+    }
+    if let Some(start) = token_start {
+        tokens.push(RequestReasonToken {
+            text: &reason[start..],
+            start,
+            end: reason.len(),
+        });
+    }
+    tokens
+}
+
+fn exact_collectable_identity_ranges(
+    reason: &str,
+    authorization: &CatalogArtifactRequestScope<'_>,
+) -> Vec<(usize, usize)> {
+    let basename = catalog_log_stem(authorization.basename).to_ascii_lowercase();
+    let logical_id = authorization.logical_id.to_ascii_lowercase();
+    let mut aliases = vec![
+        format!("{basename}.log"),
+        format!("{logical_id}.log"),
+        format!("{basename} file"),
+        format!("{logical_id} file"),
+        format!("{basename} record"),
+        format!("{logical_id} record"),
+        format!("logs/{basename}.log"),
+        format!(r"logs\{basename}.log"),
+    ];
+    if authorization.task_sequence_alias {
+        aliases.extend([
+            "task sequence log".to_owned(),
+            "disk imaging task sequence log".to_owned(),
+            "disk-image task sequence log".to_owned(),
+        ]);
+    }
+    aliases.sort_by_key(|alias| std::cmp::Reverse(alias.len()));
+    aliases.dedup();
+
+    let mut ranges = aliases
+        .iter()
+        .flat_map(|alias| exact_alias_ranges(reason, alias))
+        .collect::<Vec<_>>();
+    for terminal_alias in [basename, logical_id] {
+        ranges.extend(exact_terminal_alias_ranges(reason, &terminal_alias));
+    }
+    ranges.sort_unstable();
+    ranges.dedup();
+    ranges
+}
+
+fn exact_alias_ranges(reason: &str, alias: &str) -> Vec<(usize, usize)> {
+    reason
+        .match_indices(alias)
+        .filter_map(|(start, matched)| {
+            let end = start + matched.len();
+            exact_identity_boundary(reason, start, end).then_some((start, end))
+        })
+        .collect()
+}
+
+fn exact_terminal_alias_ranges(reason: &str, alias: &str) -> Vec<(usize, usize)> {
+    reason
+        .match_indices(alias)
+        .filter_map(|(start, matched)| {
+            let end = start + matched.len();
+            (exact_identity_boundary(reason, start, end) && reason[end..].trim().is_empty())
+                .then_some((start, end))
+        })
+        .collect()
+}
+
+fn exact_identity_boundary(reason: &str, start: usize, end: usize) -> bool {
+    let before = reason[..start].chars().next_back();
+    let after = reason[end..].chars().next();
+    before.is_none_or(|character| !is_identity_continuation(character))
+        && after.is_none_or(|character| !is_identity_continuation(character))
+}
+
+fn catalog_log_stem(basename: &str) -> &str {
+    basename.strip_suffix(".log").unwrap_or(basename)
+}
+
+fn is_identity_continuation(character: char) -> bool {
+    character.is_ascii_alphanumeric()
+        || matches!(
+            character,
+            '_' | '-'
+                | '.'
+                | '\u{2010}'
+                | '\u{2011}'
+                | '\u{2012}'
+                | '\u{2013}'
+                | '\u{2014}'
+                | '\u{2015}'
+                | '\u{2212}'
+        )
+}
+
+fn collection_clause_is_catalog_bounded(
+    tokens: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    if identity_ranges.is_empty() {
+        return false;
+    }
+
+    tokens.iter().enumerate().all(|(index, token)| {
+        if token_is_covered_by_identity(token, identity_ranges) {
+            return true;
+        }
+        if is_external_collection_container(token.text)
+            || matches!(token.text, "data" | "everything")
+        {
+            return false;
+        }
+        if matches!(token.text, "file" | "files" | "log" | "logs") {
+            return token_is_adjacent_to_identity(tokens, index, identity_ranges);
+        }
+        true
+    })
+}
+
+fn confirmation_clause_is_non_authorizing(
+    tokens: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    let has_identity = !identity_ranges.is_empty();
+    let has_retry = tokens.iter().any(|token| token.text == "retry");
+    let has_root_cause = tokens
+        .windows(2)
+        .any(|pair| pair[0].text == "root" && pair[1].text == "cause");
+    let has_assignment_or_policy = tokens
+        .iter()
+        .any(|token| matches!(token.text, "assignment" | "policy"));
+    let has_state_observation = tokens.iter().any(|token| {
+        matches!(
+            token.text,
+            "download" | "downloaded" | "encryption" | "image" | "imaging" | "state" | "status"
+        )
+    });
+    let has_download_observation = tokens
+        .iter()
+        .any(|token| matches!(token.text, "downloaded" | "state" | "status"));
+
+    for token in tokens {
+        if is_collection_action(token.text)
+            && !(token.text == "download" && has_identity && has_download_observation)
+        {
+            return false;
+        }
+        if token.text.starts_with("recurs") && !(has_identity && has_retry) {
+            return false;
+        }
+        if token.text.starts_with("root") && !(has_identity && has_root_cause) {
+            return false;
+        }
+        if is_wide_scope_token(token.text) && !(has_identity && has_assignment_or_policy) {
+            return false;
+        }
+        if matches!(
+            token.text,
+            "directory"
+                | "directories"
+                | "drive"
+                | "drives"
+                | "filesystem"
+                | "filesystems"
+                | "folder"
+                | "folders"
+                | "volume"
+                | "volumes"
+                | "data"
+                | "everything"
+        ) {
+            return false;
+        }
+        if matches!(token.text, "disk" | "disks" | "file" | "files")
+            && !token_is_covered_by_identity(token, identity_ranges)
+            && !(has_identity && has_state_observation)
+        {
+            return false;
+        }
+        if matches!(
+            token.text,
+            "client" | "device" | "machine" | "site" | "system"
+        ) && !(has_identity && (has_assignment_or_policy || has_state_observation))
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn narrative_clause_has_no_collection_scope(tokens: &[RequestReasonToken<'_>]) -> bool {
+    let has_broad_scope = tokens.iter().any(|token| is_broad_quantifier(token.text));
+    !tokens.iter().any(|token| {
+        token.text.starts_with("recurs")
+            || token.text.starts_with("root")
+            || is_wide_scope_token(token.text)
+            || is_external_collection_container(token.text)
+            || matches!(token.text, "data" | "everything")
+            || (has_broad_scope
+                && matches!(
+                    token.text,
+                    "file" | "files" | "log" | "logs" | "record" | "records"
+                ))
+    })
+}
+
+fn is_wide_scope_token(token: &str) -> bool {
+    token == "wide"
+        || token
+            .strip_suffix("wide")
+            .is_some_and(|prefix| !prefix.is_empty())
+}
+
+fn is_external_collection_container(token: &str) -> bool {
+    matches!(
+        token,
+        "client"
+            | "clients"
+            | "device"
+            | "devices"
+            | "directory"
+            | "directories"
+            | "disk"
+            | "disks"
+            | "drive"
+            | "drives"
+            | "filesystem"
+            | "filesystems"
+            | "folder"
+            | "folders"
+            | "machine"
+            | "machines"
+            | "site"
+            | "sites"
+            | "system"
+            | "systems"
+            | "volume"
+            | "volumes"
+    )
+}
+
+fn token_is_covered_by_identity(
+    token: &RequestReasonToken<'_>,
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    identity_ranges
+        .iter()
+        .any(|(start, end)| token.start >= *start && token.end <= *end)
+}
+
+fn token_is_adjacent_to_identity(
+    tokens: &[RequestReasonToken<'_>],
+    token_index: usize,
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    token_index
+        .checked_sub(1)
+        .and_then(|index| tokens.get(index))
+        .is_some_and(|token| token_is_covered_by_identity(token, identity_ranges))
+        || tokens
+            .get(token_index + 1)
+            .is_some_and(|token| token_is_covered_by_identity(token, identity_ranges))
 }
 
 fn request_clauses(reason: &str) -> impl Iterator<Item = &str> {
@@ -801,7 +1185,7 @@ fn has_unbounded_request_scope(
     requested_logical_id: &str,
 ) -> bool {
     let tokens = clause
-        .split(|character: char| !character.is_ascii_alphanumeric())
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
         .filter(|token| !token.is_empty())
         .collect::<Vec<_>>();
 
@@ -818,16 +1202,21 @@ fn has_unbounded_request_scope(
 fn is_collection_action(token: &str) -> bool {
     matches!(
         token,
-        "collect"
+        "archive"
+            | "capture"
+            | "collect"
+            | "copy"
+            | "download"
+            | "enumerate"
+            | "export"
+            | "gather"
+            | "inspect"
+            | "obtain"
+            | "read"
             | "scan"
             | "search"
             | "walk"
             | "traverse"
-            | "capture"
-            | "export"
-            | "gather"
-            | "inspect"
-            | "read"
     )
 }
 
@@ -866,7 +1255,9 @@ fn is_collection_container(token: &str) -> bool {
     matches!(
         token,
         "client"
+            | "clients"
             | "device"
+            | "devices"
             | "directory"
             | "directories"
             | "disk"
@@ -878,8 +1269,11 @@ fn is_collection_container(token: &str) -> bool {
             | "folder"
             | "folders"
             | "machine"
+            | "machines"
             | "site"
+            | "sites"
             | "system"
+            | "systems"
             | "volume"
             | "volumes"
     )
@@ -997,7 +1391,7 @@ fn requested_artifact_identity_ranges(
     requested_basename: &str,
     requested_logical_id: &str,
 ) -> Vec<(usize, usize)> {
-    let basename = normalize_catalog_identity(requested_basename);
+    let basename = normalize_catalog_identity(catalog_log_stem(requested_basename));
     let logical_id = normalize_catalog_identity(requested_logical_id);
     let mut ranges = tokens
         .iter()
@@ -1017,7 +1411,7 @@ fn requested_artifact_identity_ranges(
 fn normalize_catalog_identity(identity: &str) -> String {
     identity
         .chars()
-        .filter(|character| character.is_ascii_alphanumeric())
+        .filter(|character| character.is_ascii_alphanumeric() || *character == '_')
         .flat_map(char::to_lowercase)
         .collect()
 }
@@ -1062,7 +1456,7 @@ fn target_is_bounded_to_requested_artifact(
                         .any(|token| matches!(*token, "encryption" | "status")))
         }
         "file" | "files" => identity_precedes_target || is_state_observation,
-        "logs" => identity_precedes_target,
+        "log" | "logs" => identity_precedes_target,
         _ => true,
     }
 }

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -819,14 +819,7 @@ fn reason_scope_is_within_catalog_artifact(
         return false;
     }
 
-    let clauses = request_clauses(reason).collect::<Vec<_>>();
-    let has_collection_directive = clauses.iter().any(|clause| {
-        tokenize_request_reason(clause)
-            .iter()
-            .any(|token| is_collection_action(token.text))
-    });
-
-    clauses.into_iter().all(|clause| {
+    request_clauses(reason).all(|clause| {
         let tokens = tokenize_request_reason(clause);
         let identity_ranges = exact_collectable_identity_ranges(clause, authorization);
         let is_confirmation = tokens.first().is_some_and(|token| token.text == "confirm");
@@ -837,13 +830,11 @@ fn reason_scope_is_within_catalog_artifact(
             confirmation_clause_is_non_authorizing(&tokens, &identity_ranges)
         } else if contains_collection_directive {
             collection_clause_is_catalog_bounded(clause, &tokens, &identity_ranges)
-        } else if has_collection_directive {
-            // An authorized action cannot lend its identity to another
-            // strong-punctuation clause. Only independently safe evidence
-            // observations remain non-authorizing.
-            narrative_clause_is_safe_observation(clause, &tokens, &identity_ranges)
         } else {
-            narrative_clause_has_no_collection_scope(&tokens)
+            // A clause without a recognized collection action is never an
+            // alternate authorization path. It must independently match the
+            // same positive, non-authorizing evidence grammar.
+            narrative_clause_is_safe_observation(clause, &tokens, &identity_ranges)
         }
     })
 }
@@ -1106,7 +1097,7 @@ fn collection_action_has_exact_catalog_target(
     if !is_collection_narrative_introducer(trailing[0].text) {
         return false;
     }
-    if !narrative_tokens_are_non_authorizing(clause, &trailing, identity_ranges) {
+    if !narrative_suffix_is_non_authorizing(clause, &trailing, identity_ranges) {
         return false;
     }
 
@@ -1280,13 +1271,93 @@ fn narrative_clause_is_safe_observation(
     identity_ranges: &[(usize, usize)],
 ) -> bool {
     narrative_tokens_are_non_authorizing(clause, tokens, identity_ranges)
-        && tokens.iter().any(|token| {
-            token_is_covered_by_identity(token, identity_ranges)
-                || is_evidence_narrative_subject(token.text)
-        })
+        && narrative_tokens_have_evidence_observation(tokens, identity_ranges)
+}
+
+fn narrative_suffix_is_non_authorizing(
+    clause: &str,
+    tokens: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    narrative_tokens_are_non_authorizing(clause, tokens, identity_ranges)
+        && (narrative_tokens_have_evidence_observation(tokens, identity_ranges)
+            || is_bounded_reference_suffix(tokens)
+            || is_bounded_bundle_suffix(tokens)
+            || is_bounded_completion_suffix(tokens))
+}
+
+fn narrative_tokens_have_evidence_observation(
+    tokens: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    tokens.iter().all(|token| {
+        token_is_covered_by_identity(token, identity_ranges)
+            || is_evidence_narrative_subject(token.text)
+            || is_evidence_narrative_predicate(token.text)
+            || is_collection_narrative_introducer(token.text)
+            || is_action_coordinator(token.text)
+            || matches!(
+                token.text,
+                "a" | "an" | "by" | "in" | "not" | "of" | "review" | "the" | "to"
+            )
+    }) && tokens.iter().any(|token| {
+        token_is_covered_by_identity(token, identity_ranges)
+            || is_evidence_narrative_subject(token.text)
+    }) && tokens
+        .iter()
+        .any(|token| is_evidence_narrative_predicate(token.text))
+}
+
+fn is_bounded_reference_suffix(tokens: &[RequestReasonToken<'_>]) -> bool {
+    tokens.first().is_some_and(|token| token.text == "cited")
+        && tokens.iter().any(|token| token.text == "by")
         && tokens
             .iter()
-            .any(|token| is_evidence_narrative_predicate(token.text))
+            .any(|token| matches!(token.text, "assignment" | "entry"))
+        && tokens.iter().all(|token| {
+            matches!(
+                token.text,
+                "a" | "an"
+                    | "assignment"
+                    | "by"
+                    | "cited"
+                    | "entry"
+                    | "exact"
+                    | "id"
+                    | "reference"
+                    | "requested"
+                    | "the"
+            )
+        })
+}
+
+fn is_bounded_bundle_suffix(tokens: &[RequestReasonToken<'_>]) -> bool {
+    tokens.first().is_some_and(|token| token.text == "from")
+        && tokens.iter().any(|token| token.text == "bounded")
+        && tokens.iter().any(|token| token.text == "bundle")
+        && tokens.iter().all(|token| {
+            matches!(
+                token.text,
+                "a" | "an" | "bounded" | "bundle" | "from" | "requested" | "the"
+            )
+        })
+}
+
+fn is_bounded_completion_suffix(tokens: &[RequestReasonToken<'_>]) -> bool {
+    tokens
+        .first()
+        .is_some_and(|token| matches!(token.text, "after" | "before"))
+        && tokens.iter().any(|token| token.text == "completion")
+        && tokens.iter().all(|token| {
+            token
+                .text
+                .chars()
+                .all(|character| character.is_ascii_digit())
+                || matches!(
+                    token.text,
+                    "after" | "and" | "before" | "completion" | "plus" | "then"
+                )
+        })
 }
 
 fn narrative_tokens_are_non_authorizing(

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -702,12 +702,25 @@ fn is_bounded_request_reason(reason: &str) -> bool {
     let trimmed = reason.trim();
     if trimmed.is_empty()
         || trimmed.chars().count() > MAX_SCCM_ARTIFACT_REQUEST_REASON_CHARS
+        || contains_rooted_path(trimmed)
         || trimmed.contains(['*', '?', '[', ']'])
     {
         return false;
     }
 
     !has_unbounded_request_scope(&trimmed.to_ascii_lowercase())
+}
+
+fn contains_rooted_path(reason: &str) -> bool {
+    let bytes = reason.as_bytes();
+    bytes.iter().enumerate().any(|(index, byte)| {
+        matches!(byte, b'/' | b'\\')
+            && (index == 0
+                || !matches!(
+                    bytes[index - 1],
+                    b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-' | b'.'
+                ))
+    })
 }
 
 fn has_unbounded_request_scope(reason: &str) -> bool {

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -989,7 +989,9 @@ fn collection_clause_is_catalog_bounded(
     tokens: &[RequestReasonToken<'_>],
     identity_ranges: &[(usize, usize)],
 ) -> bool {
-    if identity_ranges.is_empty() {
+    if identity_ranges.is_empty()
+        || !collection_actions_have_local_catalog_identity(tokens, identity_ranges)
+    {
         return false;
     }
 
@@ -1007,6 +1009,28 @@ fn collection_clause_is_catalog_bounded(
         }
         true
     })
+}
+
+fn collection_actions_have_local_catalog_identity(
+    tokens: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    let mut action_indices = tokens
+        .iter()
+        .enumerate()
+        .filter_map(|(index, token)| is_collection_action(token.text).then_some(index))
+        .peekable();
+
+    while let Some(action_index) = action_indices.next() {
+        let segment_end = action_indices.peek().copied().unwrap_or(tokens.len());
+        if !tokens[action_index..segment_end]
+            .iter()
+            .any(|token| token_is_covered_by_identity(token, identity_ranges))
+        {
+            return false;
+        }
+    }
+    true
 }
 
 fn confirmation_clause_is_non_authorizing(

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -1315,22 +1315,16 @@ fn has_unbound_passive_artifact_request(
 ) -> bool {
     tokens.iter().enumerate().any(|(index, token)| {
         is_passive_auxiliary(token.text)
-            && tokens.get(index + 1).is_some()
-            && !passive_subject_is_evidence(tokens, index + 1, identity_ranges)
+            && (!passive_subject_is_evidence(tokens, index, identity_ranges)
+                || !passive_predicate_is_evidence_state(tokens, index, identity_ranges))
     })
 }
 
 fn passive_subject_is_evidence(
     tokens: &[RequestReasonToken<'_>],
-    predicate_index: usize,
+    auxiliary_index: usize,
     identity_ranges: &[(usize, usize)],
 ) -> bool {
-    let auxiliary_index = tokens[..predicate_index]
-        .iter()
-        .rposition(|token| is_passive_auxiliary(token.text));
-    let Some(auxiliary_index) = auxiliary_index else {
-        return false;
-    };
     let subject_start = tokens[..auxiliary_index]
         .iter()
         .rposition(|token| {
@@ -1341,6 +1335,46 @@ fn passive_subject_is_evidence(
     tokens[subject_start..auxiliary_index].iter().any(|token| {
         token_is_covered_by_identity(token, identity_ranges)
             || is_evidence_narrative_subject(token.text)
+    })
+}
+
+fn passive_predicate_is_evidence_state(
+    tokens: &[RequestReasonToken<'_>],
+    auxiliary_index: usize,
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    let predicate = &tokens[auxiliary_index + 1..];
+    if predicate.is_empty() {
+        return false;
+    }
+
+    let has_exact_identity = predicate
+        .iter()
+        .any(|token| token_is_covered_by_identity(token, identity_ranges));
+    predicate.iter().all(|token| {
+        token_is_covered_by_identity(token, identity_ranges)
+            || is_evidence_narrative_subject(token.text)
+            || is_evidence_narrative_predicate(token.text)
+            || is_collection_narrative_introducer(token.text)
+            || is_action_coordinator(token.text)
+            || matches!(
+                token.text,
+                "a" | "an" | "by" | "in" | "not" | "of" | "the" | "to"
+            )
+            || (has_exact_identity
+                && matches!(
+                    token.text,
+                    "contain"
+                        | "contained"
+                        | "containing"
+                        | "contains"
+                        | "exact"
+                        | "include"
+                        | "included"
+                        | "includes"
+                        | "including"
+                        | "requested"
+                ))
     })
 }
 

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -827,7 +827,7 @@ fn reason_scope_is_within_catalog_artifact(
             tokens.iter().any(|token| is_collection_action(token.text));
 
         if is_confirmation {
-            confirmation_clause_is_non_authorizing(&tokens, &identity_ranges)
+            confirmation_clause_is_non_authorizing(clause, &tokens, &identity_ranges)
         } else if contains_collection_directive {
             collection_clause_is_catalog_bounded(clause, &tokens, &identity_ranges)
         } else {
@@ -1179,9 +1179,19 @@ fn has_unbound_dotted_target(
 }
 
 fn confirmation_clause_is_non_authorizing(
+    clause: &str,
     tokens: &[RequestReasonToken<'_>],
     identity_ranges: &[(usize, usize)],
 ) -> bool {
+    if has_unbound_dotted_target(clause, tokens, identity_ranges)
+        || tokens
+            .iter()
+            .any(|token| is_collection_scope_nominal(token.text))
+        || !confirmation_tokens_match_defined_form(tokens, identity_ranges)
+    {
+        return false;
+    }
+
     let has_identity = !identity_ranges.is_empty();
     let has_retry = tokens.iter().any(|token| token.text == "retry");
     let has_root_cause = tokens
@@ -1247,6 +1257,77 @@ fn confirmation_clause_is_non_authorizing(
         }
     }
     true
+}
+
+fn confirmation_tokens_match_defined_form(
+    tokens: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    let Some((confirmation, body)) = tokens.split_first() else {
+        return false;
+    };
+    if confirmation.text != "confirm" {
+        return false;
+    }
+
+    let has_subject = body.iter().any(|token| {
+        token_is_covered_by_identity(token, identity_ranges)
+            || is_evidence_narrative_subject(token.text)
+            || matches!(
+                token.text,
+                "behavior"
+                    | "cause"
+                    | "content"
+                    | "download"
+                    | "encryption"
+                    | "image"
+                    | "imaging"
+                    | "retry"
+            )
+    });
+    has_subject
+        && body.iter().all(|token| {
+            token_is_covered_by_identity(token, identity_ranges)
+                || is_evidence_narrative_subject(token.text)
+                || is_evidence_narrative_predicate(token.text)
+                || matches!(
+                    token.text,
+                    "a" | "all"
+                        | "as"
+                        | "behavior"
+                        | "bounded"
+                        | "by"
+                        | "cause"
+                        | "cited"
+                        | "client"
+                        | "code"
+                        | "complete"
+                        | "content"
+                        | "disk"
+                        | "download"
+                        | "downloaded"
+                        | "encryption"
+                        | "every"
+                        | "file"
+                        | "files"
+                        | "for"
+                        | "full"
+                        | "ids"
+                        | "image"
+                        | "imaging"
+                        | "in"
+                        | "not"
+                        | "of"
+                        | "record"
+                        | "recursive"
+                        | "retry"
+                        | "root"
+                        | "system"
+                        | "the"
+                        | "whole"
+                        | "wide"
+                )
+        })
 }
 
 fn narrative_clause_has_no_collection_scope(tokens: &[RequestReasonToken<'_>]) -> bool {

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -829,7 +829,7 @@ fn reason_scope_is_within_catalog_artifact(
         if is_confirmation {
             confirmation_clause_is_non_authorizing(&tokens, &identity_ranges)
         } else if contains_collection_directive {
-            collection_clause_is_catalog_bounded(&tokens, &identity_ranges)
+            collection_clause_is_catalog_bounded(clause, &tokens, &identity_ranges)
         } else {
             narrative_clause_has_no_collection_scope(&tokens)
         }
@@ -986,11 +986,12 @@ fn is_identity_continuation(character: char) -> bool {
 }
 
 fn collection_clause_is_catalog_bounded(
+    clause: &str,
     tokens: &[RequestReasonToken<'_>],
     identity_ranges: &[(usize, usize)],
 ) -> bool {
     if identity_ranges.is_empty()
-        || !collection_actions_have_local_catalog_identity(tokens, identity_ranges)
+        || !collection_actions_have_exact_catalog_targets(clause, tokens, identity_ranges)
     {
         return false;
     }
@@ -1011,7 +1012,8 @@ fn collection_clause_is_catalog_bounded(
     })
 }
 
-fn collection_actions_have_local_catalog_identity(
+fn collection_actions_have_exact_catalog_targets(
+    clause: &str,
     tokens: &[RequestReasonToken<'_>],
     identity_ranges: &[(usize, usize)],
 ) -> bool {
@@ -1023,14 +1025,151 @@ fn collection_actions_have_local_catalog_identity(
 
     while let Some(action_index) = action_indices.next() {
         let segment_end = action_indices.peek().copied().unwrap_or(tokens.len());
-        if !tokens[action_index..segment_end]
-            .iter()
-            .any(|token| token_is_covered_by_identity(token, identity_ranges))
-        {
+        let has_following_action = action_indices.peek().is_some();
+        if !collection_action_has_exact_catalog_target(
+            clause,
+            &tokens[action_index..segment_end],
+            identity_ranges,
+            has_following_action,
+        ) {
             return false;
         }
     }
     true
+}
+
+fn collection_action_has_exact_catalog_target(
+    clause: &str,
+    segment: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+    has_following_action: bool,
+) -> bool {
+    // Fail closed around the target shape:
+    // action + bounded modifiers + exact catalog identity + optional narrative.
+    // A catalog mention reached only after arbitrary target words is evidence
+    // context, not authorization for those earlier words.
+    let Some(action) = segment.first() else {
+        return false;
+    };
+    let segment_end = segment.last().map_or(action.end, |token| token.end);
+    let Some((target_start, target_end)) = identity_ranges
+        .iter()
+        .filter(|(start, end)| *start >= action.end && *end <= segment_end)
+        .min_by_key(|(start, end)| (*start, std::cmp::Reverse(*end)))
+        .copied()
+    else {
+        return false;
+    };
+
+    let leading_is_target_grammar = segment
+        .iter()
+        .skip(1)
+        .take_while(|token| token.end <= target_start)
+        .all(|token| is_catalog_target_modifier(token.text));
+    if !leading_is_target_grammar || has_unbound_dotted_target(clause, segment, identity_ranges) {
+        return false;
+    }
+
+    let mut trailing = segment
+        .iter()
+        .filter(|token| token.start >= target_end)
+        .peekable();
+    while trailing
+        .peek()
+        .is_some_and(|token| is_catalog_target_suffix(token.text))
+    {
+        trailing.next();
+    }
+    let trailing = trailing.collect::<Vec<_>>();
+    if trailing.is_empty() {
+        return true;
+    }
+    if has_following_action
+        && trailing
+            .iter()
+            .all(|token| is_action_coordinator(token.text))
+    {
+        return true;
+    }
+    if !is_collection_narrative_introducer(trailing[0].text) {
+        return false;
+    }
+
+    trailing.iter().enumerate().all(|(index, token)| {
+        if !is_action_coordinator(token.text) {
+            return true;
+        }
+        trailing
+            .get(index + 1)
+            .is_some_and(|next| is_safe_narrative_continuation(next.text))
+    })
+}
+
+fn is_catalog_target_modifier(token: &str) -> bool {
+    matches!(
+        token,
+        "a" | "all"
+            | "an"
+            | "cited"
+            | "complete"
+            | "current"
+            | "entire"
+            | "every"
+            | "exact"
+            | "full"
+            | "named"
+            | "of"
+            | "requested"
+            | "rotation"
+            | "rotations"
+            | "the"
+            | "whole"
+    )
+}
+
+fn is_catalog_target_suffix(token: &str) -> bool {
+    matches!(token, "entry" | "file" | "record")
+}
+
+fn is_collection_narrative_introducer(token: &str) -> bool {
+    matches!(
+        token,
+        "after"
+            | "as"
+            | "because"
+            | "before"
+            | "cited"
+            | "for"
+            | "from"
+            | "recorded"
+            | "reported"
+            | "since"
+            | "with"
+    )
+}
+
+fn is_action_coordinator(token: &str) -> bool {
+    matches!(token, "and" | "plus" | "then")
+}
+
+fn is_safe_narrative_continuation(token: &str) -> bool {
+    matches!(
+        token,
+        "after" | "as" | "because" | "before" | "for" | "from" | "since" | "with"
+    )
+}
+
+fn has_unbound_dotted_target(
+    clause: &str,
+    segment: &[RequestReasonToken<'_>],
+    identity_ranges: &[(usize, usize)],
+) -> bool {
+    segment.windows(2).any(|pair| {
+        clause[pair[0].end..pair[1].start].contains('.')
+            && !identity_ranges
+                .iter()
+                .any(|(start, end)| pair[0].start >= *start && pair[1].end <= *end)
+    })
 }
 
 fn confirmation_clause_is_non_authorizing(

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -413,7 +413,10 @@ impl SccmFinding {
             return Err(SccmFindingValidationError::MissingCoverageGap);
         }
 
-        if self.evidence.is_empty() && self.coverage_gaps.is_empty() {
+        if self.evidence.is_empty()
+            && (self.coverage_gaps.is_empty()
+                || self.class != SccmFindingClass::InsufficientEvidence)
+        {
             return Err(SccmFindingValidationError::MissingEvidenceOrCoverageGap);
         }
 
@@ -1580,6 +1583,9 @@ fn is_passive_auxiliary(token: &str) -> bool {
             | "be"
             | "been"
             | "being"
+            | "had"
+            | "has"
+            | "have"
             | "is"
             | "must"
             | "need"

--- a/crates/cmtraceopen-parser/src/sccm/mod.rs
+++ b/crates/cmtraceopen-parser/src/sccm/mod.rs
@@ -1,5 +1,6 @@
 pub mod catalog;
 mod evidence;
+mod findings;
 mod ingest;
 mod keys;
 pub mod models;
@@ -7,6 +8,7 @@ mod rotation;
 mod signals;
 
 pub use catalog::*;
+pub use findings::*;
 pub use ingest::*;
 pub use keys::*;
 pub use models::*;

--- a/crates/cmtraceopen-parser/src/sccm/models.rs
+++ b/crates/cmtraceopen-parser/src/sccm/models.rs
@@ -1,3 +1,4 @@
+use serde::de::Error as _;
 use serde::ser::{Error as _, SerializeStruct};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
@@ -6,6 +7,8 @@ use super::catalog::SccmArtifactFamily;
 use super::rotation::{is_canonical_rotation_number, is_canonical_rotation_timestamp};
 
 pub const SCCM_DIAGNOSTICS_SCHEMA_VERSION: u32 = 1;
+const INVALID_SCCM_ROLE_MESSAGE: &str =
+    "InvalidRole: unknown SCCM role must be canonical and must not shadow a declared role";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -46,6 +49,27 @@ impl SccmRole {
             Self::Unknown(value) => value,
         }
     }
+
+    pub(crate) fn has_canonical_serialized_form(&self) -> bool {
+        match self {
+            Self::Unknown(value) => {
+                !value.is_empty()
+                    && value.trim() == value
+                    && !matches!(
+                        value.as_str(),
+                        "client"
+                            | "siteServer"
+                            | "managementPoint"
+                            | "distributionPoint"
+                            | "softwareUpdatePoint"
+                            | "wsUs"
+                            | "provider"
+                            | "adminService"
+                    )
+            }
+            _ => true,
+        }
+    }
 }
 
 impl Serialize for SccmRole {
@@ -53,6 +77,9 @@ impl Serialize for SccmRole {
     where
         S: Serializer,
     {
+        if !self.has_canonical_serialized_form() {
+            return Err(S::Error::custom(INVALID_SCCM_ROLE_MESSAGE));
+        }
         serializer.serialize_str(self.serialized_name())
     }
 }
@@ -62,7 +89,7 @@ impl<'de> Deserialize<'de> for SccmRole {
     where
         D: Deserializer<'de>,
     {
-        Ok(match String::deserialize(deserializer)? {
+        let role = match String::deserialize(deserializer)? {
             value if value == "client" => Self::Client,
             value if value == "siteServer" => Self::SiteServer,
             value if value == "managementPoint" => Self::ManagementPoint,
@@ -72,7 +99,11 @@ impl<'de> Deserialize<'de> for SccmRole {
             value if value == "provider" => Self::Provider,
             value if value == "adminService" => Self::AdminService,
             value => Self::Unknown(value),
-        })
+        };
+        if !role.has_canonical_serialized_form() {
+            return Err(D::Error::custom(INVALID_SCCM_ROLE_MESSAGE));
+        }
+        Ok(role)
     }
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -382,7 +382,7 @@ const REVIEW_UNRECOGNIZED_CONFIRMATION_REQUEST_REASONS: [&str; 10] = [
     "Confirm PolicyAgent.log for fetching credentials.",
 ];
 
-const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 8] = [
+const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 12] = [
     "Confirm all files are required for status in PolicyAgent.log.",
     "Confirm every file must be provided for download status in PolicyAgent.log.",
     "Confirm the whole disk is required for imaging status in Smsts.log.",
@@ -391,6 +391,10 @@ const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 8] = [
     "Confirm Smsts.log imaging status must provide the full disk.",
     "Confirm PolicyAgent.log status must have all files provided.",
     "Confirm Smsts.log imaging status must have the full disk provided.",
+    "Confirm PolicyAgent.log status has all files provided.",
+    "Confirm PolicyAgent.log status has every file provided.",
+    "Confirm all files have provided status in PolicyAgent.log.",
+    "Confirm Smsts.log imaging status has the full disk provided.",
 ];
 
 const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
@@ -2651,6 +2655,91 @@ fn finding_evidence_less_claims_are_rejected() {
 }
 
 #[test]
+fn finding_access_denied_coverage_only_cannot_substantiate_an_outcome_class() {
+    let canonical = SccmFindingBuilder::new("access-denied-insufficient-evidence")
+        .class(SccmFindingClass::InsufficientEvidence)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .coverage_gap(finding_client_gap(
+            "client-policy-agent",
+            SccmCoverageState::AccessDenied,
+        ))
+        .next_artifact(finding_request(
+            "policyAgent",
+            SccmRole::Client,
+            "Policy evidence was not captured.",
+        ))
+        .build()
+        .unwrap();
+    let cases = [
+        (SccmFindingClass::Symptom, SccmConfidence::High, "symptom"),
+        (
+            SccmFindingClass::LikelyContributor,
+            SccmConfidence::Moderate,
+            "likelyContributor",
+        ),
+        (
+            SccmFindingClass::ConfirmedFailure,
+            SccmConfidence::Moderate,
+            "confirmedFailure",
+        ),
+        (
+            SccmFindingClass::BlockedOrDeferred,
+            SccmConfidence::Low,
+            "blockedOrDeferred",
+        ),
+    ];
+    let mut accepted = Vec::new();
+
+    for (class, confidence, label) in cases {
+        let builder = SccmFindingBuilder::new(format!("access-denied-builder-{label}"))
+            .class(class.clone())
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(confidence)
+            .coverage_gap(finding_client_gap(
+                "client-policy-agent",
+                SccmCoverageState::AccessDenied,
+            ))
+            .next_artifact(finding_request(
+                "policyAgent",
+                SccmRole::Client,
+                "Policy evidence was not captured.",
+            ))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::MissingEvidenceOrCoverageGap) {
+            accepted.push(format!("builder: {label}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.class = class;
+        direct.confidence = confidence;
+        if direct.validate().err() != Some(SccmFindingValidationError::MissingEvidenceOrCoverageGap)
+        {
+            accepted.push(format!("direct validate: {label}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {label}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["class"] = serde_json::json!(label);
+        json["confidence"] = serde_json::to_value(direct.confidence).unwrap();
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {label}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "coverage-only access denial substantiated outcome classes: {accepted:#?}"
+    );
+}
+
+#[test]
 fn finding_insufficient_evidence_requires_an_explicit_noncaptured_gap() {
     let request = finding_request(
         "policyAgent",
@@ -4707,6 +4796,50 @@ fn evidence_public_message_projection_redacts_path_adjacent_windows_identities()
     assert!(
         violations.is_empty(),
         "path-adjacent identity projection violations: {violations:#?}"
+    );
+}
+
+#[test]
+fn evidence_public_projection_redacts_identity_on_every_string_surface() {
+    let raw_message = r#"Profile C:\Profiles\LAB\SyntheticUser\profile.dat; Home \\server\home\LAB\SyntheticHomeUser\cache; Local C:\Profiles\.\LocalUser\profile.dat; account={"domain":"LAB","accountName":"SyntheticJsonUser"}; sam={"domain":"LAB","samAccountName":"SyntheticSamUser"}; localUser=LocalStructuredUser; status=71"#;
+    let text = format!(
+        r#"<![LOG[{raw_message}]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="LAB\ComponentUser" context="" type="1" thread="42" file="LAB\FileUser">"#
+    );
+    let first = normalize_ccm_artifact(client_policy_artifact(), &text);
+    let second = normalize_ccm_artifact(client_policy_artifact(), &text);
+    let json = serde_json::to_string(&first).unwrap();
+    let evidence = &first[0];
+
+    assert_eq!(first, second);
+    for sensitive in [
+        "SyntheticUser",
+        "SyntheticHomeUser",
+        "LocalUser",
+        "SyntheticJsonUser",
+        "SyntheticSamUser",
+        "LocalStructuredUser",
+        "ComponentUser",
+        "FileUser",
+    ] {
+        assert_public_json_omits(&json, sensitive);
+    }
+    assert!(evidence.message.contains("status=71"));
+    assert!(evidence
+        .message
+        .contains("[redacted:sccm-public-message-v1]"));
+    assert!(
+        evidence
+            .component
+            .as_deref()
+            .is_some_and(|value| value.contains("[redacted:sccm-public-message-v1]")),
+        "component identity was not classified"
+    );
+    assert!(
+        evidence
+            .ccm_source_file
+            .as_deref()
+            .is_some_and(|value| value.contains("[redacted:sccm-public-message-v1]")),
+        "CCM source-file identity was not classified"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -348,6 +348,12 @@ const REVIEW_NON_AUTHORIZING_COLLECTION_LANGUAGE_REASONS: [&str; 6] = [
     "Collect PolicyAgent.log after credentials were archived.",
 ];
 
+const REVIEW_SAFE_STRONG_PUNCTUATION_NARRATIVE_REASONS: [&str; 3] = [
+    "Collect PolicyAgent.log; policy evidence was not captured.",
+    "Collect PolicyAgent.log. The policy evaluation reported an error.",
+    "Collect PolicyAgent.log; the assignment error was reported.",
+];
+
 const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
     ("mpCliReg", "Collect the complete MP_CliReg.log file."),
     ("mpGetAuth", "Collect the complete MP_GetAuth.log file."),
@@ -2003,6 +2009,47 @@ fn finding_review_non_authorizing_collection_language_fails_at_every_public_boun
     assert!(
         accepted.is_empty(),
         "accepted non-authorizing collection language: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_safe_strong_punctuation_narratives_pass_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-safe-strong-narrative-parity");
+    let mut rejected = Vec::new();
+
+    for reason in REVIEW_SAFE_STRONG_PUNCTUATION_NARRATIVE_REASONS {
+        let builder = SccmFindingBuilder::new("review-safe-strong-narrative-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if let Err(error) = builder {
+            rejected.push(format!("builder ({error:?}): {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if let Err(error) = direct.validate() {
+            rejected.push(format!("direct validate ({error:?}): {reason}"));
+        }
+        if serde_json::to_value(&direct).is_err() {
+            rejected.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_err() {
+            rejected.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        rejected.is_empty(),
+        "rejected safe strong-punctuation narratives: {rejected:#?}"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -382,7 +382,7 @@ const REVIEW_UNRECOGNIZED_CONFIRMATION_REQUEST_REASONS: [&str; 10] = [
     "Confirm PolicyAgent.log for fetching credentials.",
 ];
 
-const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 23] = [
+const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 36] = [
     "Confirm all files are required for status in PolicyAgent.log.",
     "Confirm every file must be provided for download status in PolicyAgent.log.",
     "Confirm the whole disk is required for imaging status in Smsts.log.",
@@ -406,6 +406,19 @@ const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 23] = [
     "Confirm Smsts.log imaging status was the full disk.",
     "Confirm Smsts.log imaging status were the full disk.",
     "Confirm Smsts.log imaging status has the full disk.",
+    "Confirm every file had status in PolicyAgent.log.",
+    "Confirm every file has status in PolicyAgent.log.",
+    "Confirm all files have status in PolicyAgent.log.",
+    "Confirm all files are in PolicyAgent.log status.",
+    "Confirm all files be in PolicyAgent.log status.",
+    "Confirm all files have been in PolicyAgent.log status.",
+    "Confirm all files are being in PolicyAgent.log status.",
+    "Confirm the full disk is in Smsts.log imaging status.",
+    "Confirm the full disk was in Smsts.log imaging status.",
+    "Confirm the full disk were in Smsts.log imaging status.",
+    "Confirm the full disk has imaging status in Smsts.log.",
+    "Confirm all files, have status in PolicyAgent.log.",
+    "Confirm the full disk, has imaging status in Smsts.log.",
 ];
 
 const REVIEW_BOUNDED_AUXILIARY_CONFIRMATION_REASONS: [(&str, &str); 10] = [

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -319,6 +319,25 @@ const REVIEW_COORDINATED_UNQUALIFIED_ACTION_REASONS: [&str; 3] = [
     "Collect PolicyAgent.log plus export.",
 ];
 
+const REVIEW_UNBOUND_COLLECTION_TARGET_REASONS: [&str; 10] = [
+    "Collect secrets.txt because PolicyAgent.log reported an error.",
+    "Collect PolicyAgent.log and retrieve secrets.txt.",
+    "Collect credentials.json since PolicyAgent.log recorded a failure.",
+    "Collect evidence.zip after PolicyAgent.log reported a failure.",
+    "Collect credentials because PolicyAgent.log reported an error.",
+    "Collect PolicyAgent.log then retrieve credentials.json.",
+    "Collect PolicyAgent.log plus fetch credentials.json.",
+    "Collect PolicyAgent.log and preserve secrets.txt.",
+    "Collect PolicyAgent.log, retrieve secrets.txt.",
+    "Collect PolicyAgent.log and retrieve credentials.",
+];
+
+const REVIEW_SAFE_COLLECTION_NARRATIVE_REASONS: [&str; 3] = [
+    "Collect PolicyAgent.log because the policy evaluation reported an error.",
+    "Collect PolicyAgent.log for review of the reported assignment error.",
+    "Collect PolicyAgent.log after the reported policy error.",
+];
+
 const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
     ("mpCliReg", "Collect the complete MP_CliReg.log file."),
     ("mpGetAuth", "Collect the complete MP_GetAuth.log file."),
@@ -1849,6 +1868,89 @@ fn finding_review_coordinated_unqualified_actions_fail_at_every_public_boundary(
     assert!(
         accepted.is_empty(),
         "accepted coordinated unqualified action boundaries: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_unbound_collection_targets_fail_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-unbound-target-parity");
+    let mut accepted = Vec::new();
+
+    for reason in REVIEW_UNBOUND_COLLECTION_TARGET_REASONS {
+        let builder = SccmFindingBuilder::new("review-unbound-target-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted unbound collection target boundaries: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_safe_collection_narratives_pass_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-safe-narrative-parity");
+    let mut rejected = Vec::new();
+
+    for reason in REVIEW_SAFE_COLLECTION_NARRATIVE_REASONS {
+        let builder = SccmFindingBuilder::new("review-safe-narrative-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if let Err(error) = builder {
+            rejected.push(format!("builder ({error:?}): {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if let Err(error) = direct.validate() {
+            rejected.push(format!("direct validate ({error:?}): {reason}"));
+        }
+        if serde_json::to_value(&direct).is_err() {
+            rejected.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_err() {
+            rejected.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        rejected.is_empty(),
+        "rejected safe collection narratives: {rejected:#?}"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -382,6 +382,13 @@ const REVIEW_UNRECOGNIZED_CONFIRMATION_REQUEST_REASONS: [&str; 10] = [
     "Confirm PolicyAgent.log for fetching credentials.",
 ];
 
+const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 4] = [
+    "Confirm all files are required for status in PolicyAgent.log.",
+    "Confirm every file must be provided for download status in PolicyAgent.log.",
+    "Confirm the whole disk is required for imaging status in Smsts.log.",
+    "Confirm the full disk must be provided for imaging status in Smsts.log.",
+];
+
 const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
     ("mpCliReg", "Collect the complete MP_CliReg.log file."),
     ("mpGetAuth", "Collect the complete MP_GetAuth.log file."),
@@ -598,7 +605,7 @@ fn finding_rejects_unknown_phase_values_that_shadow_declared_names() {
 }
 
 #[test]
-fn finding_forged_unregistered_profile_never_authorizes_high_corroboration() {
+fn finding_forged_unregistered_profile_is_rejected() {
     let first = finding_evidence_ref("client-policy-agent", "policy:10-10");
     let second = finding_evidence_ref("mp-get-policy", "mp-policy:20-20");
     let result = SccmFindingBuilder::new("policy-request-failed")
@@ -630,12 +637,93 @@ fn finding_forged_unregistered_profile_never_authorizes_high_corroboration() {
 
     assert_eq!(
         result.unwrap_err(),
-        SccmFindingValidationError::MissingTerminalEvidence
+        SccmFindingValidationError::InvalidCorrelationKey
     );
 }
 
 #[test]
-fn finding_duplicate_one_ref_never_counts_as_two_ref_corroboration() {
+fn finding_review_invalid_profiled_keys_fail_at_every_public_boundary() {
+    let evidence = finding_evidence_ref("artifact-a", "entry-a");
+    let mut malformed = finding_key(
+        SccmCorrelationKeyKind::PackageId,
+        "",
+        "",
+        SccmKeyConfidence::Exact,
+        Some("sccm-keys-stable-v1"),
+        evidence.clone(),
+    );
+    malformed.start = Some(9);
+    malformed.end = Some(3);
+    let cases = [
+        (
+            "exact-without-profile",
+            finding_key(
+                SccmCorrelationKeyKind::AssignmentId,
+                "{ABCDEFAB-0000-0000-0000-000000000001}",
+                "abcdefab-0000-0000-0000-000000000001",
+                SccmKeyConfidence::Exact,
+                None,
+                evidence.clone(),
+            ),
+        ),
+        (
+            "strong-with-unknown-profile",
+            finding_key(
+                SccmCorrelationKeyKind::ContentId,
+                "ContentABC",
+                "contentabc",
+                SccmKeyConfidence::Strong,
+                Some("sccm-keys-unknown-v1"),
+                evidence.clone(),
+            ),
+        ),
+        ("malformed-values-and-spans", malformed),
+    ];
+    let canonical = finding_with_gap_and_request("review-invalid-key-parity");
+    let mut accepted = Vec::new();
+
+    for (label, key) in cases {
+        let builder = SccmFindingBuilder::new(format!("review-invalid-key-{label}"))
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![evidence.clone()])
+            .correlation_keys(vec![key.clone()])
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidCorrelationKey) {
+            accepted.push(format!(
+                "builder did not return InvalidCorrelationKey: {label}"
+            ));
+        }
+
+        let mut direct = canonical.clone();
+        direct.correlation_keys = vec![key.clone()];
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidCorrelationKey) {
+            accepted.push(format!(
+                "direct validate did not return InvalidCorrelationKey: {label}"
+            ));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {label}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["correlationKeys"] = serde_json::to_value([key]).unwrap();
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {label}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted invalid profiled keys: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_unregistered_exact_duplicate_keys_are_rejected() {
     let evidence = finding_evidence_ref("client-policy-agent", "policy:10-10");
     let key = finding_key(
         SccmCorrelationKeyKind::AssignmentId,
@@ -657,7 +745,7 @@ fn finding_duplicate_one_ref_never_counts_as_two_ref_corroboration() {
 
     assert_eq!(
         result.unwrap_err(),
-        SccmFindingValidationError::MissingTerminalEvidence
+        SccmFindingValidationError::InvalidCorrelationKey
     );
 }
 
@@ -682,7 +770,7 @@ fn finding_same_minute_keyless_evidence_never_counts_as_high_confidence() {
 }
 
 #[test]
-fn finding_mismatched_keys_or_profiles_never_corroborate_high_confidence() {
+fn finding_unregistered_strong_or_exact_key_profiles_are_rejected() {
     let first = finding_evidence_ref("client-content", "client-content:1-1");
     let second = finding_evidence_ref("server-content", "server-content:1-1");
     let cases = [
@@ -739,7 +827,7 @@ fn finding_mismatched_keys_or_profiles_never_corroborate_high_confidence() {
 
         assert_eq!(
             result.unwrap_err(),
-            SccmFindingValidationError::MissingTerminalEvidence,
+            SccmFindingValidationError::InvalidCorrelationKey,
             "{finding_id}"
         );
     }
@@ -2208,6 +2296,54 @@ fn finding_review_unrecognized_confirmation_requests_fail_at_every_public_bounda
 }
 
 #[test]
+fn finding_review_passive_unbounded_confirmation_requests_fail_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-passive-confirmation-parity");
+    let mut accepted = Vec::new();
+
+    for reason in REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS {
+        let logical_id = if reason.contains("Smsts.log") {
+            "smsts"
+        } else {
+            "policyAgent"
+        };
+        let builder = SccmFindingBuilder::new("review-passive-confirmation-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request(logical_id, SccmRole::Client, reason))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0] = finding_request(logical_id, SccmRole::Client, reason);
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0] =
+            serde_json::to_value(finding_request(logical_id, SccmRole::Client, reason)).unwrap();
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted passive unbounded confirmation requests: {accepted:#?}"
+    );
+}
+
+#[test]
 fn finding_review_exact_mp_identity_passes_every_public_boundary() {
     let canonical = finding_with_gap_and_request("review-exact-mp-identity-parity");
     let mut rejected = Vec::new();
@@ -2384,16 +2520,16 @@ fn finding_rejects_a_correlation_key_without_an_evidence_ref() {
 }
 
 #[test]
-fn finding_low_or_unprofiled_keys_never_corroborate_high_confidence() {
+fn finding_low_profiled_or_unprofiled_keys_never_corroborate_high_confidence() {
     let first = finding_evidence_ref("client-content", "client-content:1-1");
     let second = finding_evidence_ref("server-content", "server-content:1-1");
     let cases = [
         (
-            "low-keys",
+            "low-profiled-keys",
             Some("sccm-keys-experimental-v1"),
             SccmKeyConfidence::Low,
         ),
-        ("unprofiled-keys", None, SccmKeyConfidence::Exact),
+        ("low-unprofiled-keys", None, SccmKeyConfidence::Low),
     ];
 
     for (finding_id, profile, confidence) in cases {
@@ -4519,6 +4655,55 @@ fn evidence_public_message_projection_redacts_colon_delimited_windows_identities
             assert!(message.contains(safe), "{safe} was falsely redacted");
         }
     }
+}
+
+#[test]
+fn evidence_public_message_projection_redacts_path_adjacent_windows_identities() {
+    let cases: [(&str, &[&str]); 3] = [
+        (
+            r"Caller LAB\SyntheticUser\subdirectory",
+            &["Caller", "subdirectory"],
+        ),
+        (
+            r"Profile C:\Users\LAB\SyntheticUser\profile.dat",
+            &[r"C:\Users\", "profile.dat"],
+        ),
+        (
+            r"Home \\server\users\LAB\SyntheticUser\cache",
+            &[r"\\server\users\", "cache"],
+        ),
+    ];
+    let mut violations = Vec::new();
+
+    for (raw_message, safe_fragments) in cases {
+        let text = format!(
+            r#"<![LOG[{raw_message}]LOG]!><time="10:00:00.000-240" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+        );
+        let first = normalize_ccm_artifact(client_policy_artifact(), &text);
+        let second = normalize_ccm_artifact(client_policy_artifact(), &text);
+        let message = &first[0].message;
+        let json = serde_json::to_string(&first).unwrap();
+
+        assert_eq!(first, second, "{raw_message}");
+        if message.contains(r"LAB\SyntheticUser")
+            || public_json_contains_sensitive(&json, r"LAB\SyntheticUser")
+        {
+            violations.push(format!("identity leaked: {raw_message}"));
+        }
+        if !message.contains("[redacted:sccm-public-message-v1]") {
+            violations.push(format!("identity was not classified: {raw_message}"));
+        }
+        for safe in safe_fragments {
+            if !message.contains(safe) {
+                violations.push(format!("{safe} was swallowed: {raw_message}"));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "path-adjacent identity projection violations: {violations:#?}"
+    );
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -332,10 +332,20 @@ const REVIEW_UNBOUND_COLLECTION_TARGET_REASONS: [&str; 10] = [
     "Collect PolicyAgent.log and retrieve credentials.",
 ];
 
-const REVIEW_SAFE_COLLECTION_NARRATIVE_REASONS: [&str; 3] = [
+const REVIEW_SAFE_COLLECTION_NARRATIVE_REASONS: [&str; 4] = [
     "Collect PolicyAgent.log because the policy evaluation reported an error.",
     "Collect PolicyAgent.log for review of the reported assignment error.",
     "Collect PolicyAgent.log after the reported policy error.",
+    "Policy evidence was not captured.",
+];
+
+const REVIEW_NON_AUTHORIZING_COLLECTION_LANGUAGE_REASONS: [&str; 6] = [
+    "Collect PolicyAgent.log; retrieve secrets.txt.",
+    "Collect PolicyAgent.log. Fetch credentials.",
+    "Collect PolicyAgent.log; preserve secrets.txt.",
+    "Collect PolicyAgent.log for collection of credentials.",
+    "Collect PolicyAgent.log because secrets must be copied.",
+    "Collect PolicyAgent.log after credentials were archived.",
 ];
 
 const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
@@ -1951,6 +1961,48 @@ fn finding_review_safe_collection_narratives_pass_at_every_public_boundary() {
     assert!(
         rejected.is_empty(),
         "rejected safe collection narratives: {rejected:#?}"
+    );
+}
+
+#[test]
+fn finding_review_non_authorizing_collection_language_fails_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-non-authorizing-language-parity");
+    let mut accepted = Vec::new();
+
+    for reason in REVIEW_NON_AUTHORIZING_COLLECTION_LANGUAGE_REASONS {
+        let builder = SccmFindingBuilder::new("review-non-authorizing-language-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted non-authorizing collection language: {accepted:#?}"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -354,6 +354,12 @@ const REVIEW_SAFE_STRONG_PUNCTUATION_NARRATIVE_REASONS: [&str; 3] = [
     "Collect PolicyAgent.log; the assignment error was reported.",
 ];
 
+const REVIEW_EVIDENCE_SUBJECT_UNBOUND_PASSIVE_REASONS: [&str; 3] = [
+    "Collect PolicyAgent.log; policy evidence must include credentials.",
+    "Collect PolicyAgent.log; policy evidence needs credentials.",
+    "Collect PolicyAgent.log. Policy evidence needs to include secrets.",
+];
+
 const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
     ("mpCliReg", "Collect the complete MP_CliReg.log file."),
     ("mpGetAuth", "Collect the complete MP_GetAuth.log file."),
@@ -2050,6 +2056,48 @@ fn finding_review_safe_strong_punctuation_narratives_pass_at_every_public_bounda
     assert!(
         rejected.is_empty(),
         "rejected safe strong-punctuation narratives: {rejected:#?}"
+    );
+}
+
+#[test]
+fn finding_review_evidence_subject_cannot_authorize_passive_target_at_any_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-evidence-passive-target-parity");
+    let mut accepted = Vec::new();
+
+    for reason in REVIEW_EVIDENCE_SUBJECT_UNBOUND_PASSIVE_REASONS {
+        let builder = SccmFindingBuilder::new("review-evidence-passive-target-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted evidence-subject passive targets: {accepted:#?}"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -313,6 +313,12 @@ const REVIEW_UNQUALIFIED_COLLECTION_ACTION_REASONS: [&str; 15] = [
     "Walk the directory tree.",
 ];
 
+const REVIEW_COORDINATED_UNQUALIFIED_ACTION_REASONS: [&str; 3] = [
+    "Collect PolicyAgent.log and archive.",
+    "Collect PolicyAgent.log then scan.",
+    "Collect PolicyAgent.log plus export.",
+];
+
 const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
     ("mpCliReg", "Collect the complete MP_CliReg.log file."),
     ("mpGetAuth", "Collect the complete MP_GetAuth.log file."),
@@ -1801,6 +1807,48 @@ fn finding_review_unqualified_collection_actions_fail_at_every_public_boundary()
     assert!(
         accepted.is_empty(),
         "accepted unqualified collection action boundaries: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_coordinated_unqualified_actions_fail_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-coordinated-action-parity");
+    let mut accepted = Vec::new();
+
+    for reason in REVIEW_COORDINATED_UNQUALIFIED_ACTION_REASONS {
+        let builder = SccmFindingBuilder::new("review-coordinated-action-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted coordinated unqualified action boundaries: {accepted:#?}"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -360,6 +360,15 @@ const REVIEW_EVIDENCE_SUBJECT_UNBOUND_PASSIVE_REASONS: [&str; 3] = [
     "Collect PolicyAgent.log. Policy evidence needs to include secrets.",
 ];
 
+const REVIEW_STANDALONE_AND_INFLECTED_COLLECTION_REASONS: [&str; 6] = [
+    "Retrieve secrets.txt.",
+    "Fetch credentials.json.",
+    "Preserve secrets.txt.",
+    "Acquire credentials.json.",
+    "Collect PolicyAgent.log for fetching credentials.",
+    "Collect PolicyAgent.log after retrieving credentials.",
+];
+
 const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
     ("mpCliReg", "Collect the complete MP_CliReg.log file."),
     ("mpGetAuth", "Collect the complete MP_GetAuth.log file."),
@@ -2098,6 +2107,48 @@ fn finding_review_evidence_subject_cannot_authorize_passive_target_at_any_public
     assert!(
         accepted.is_empty(),
         "accepted evidence-subject passive targets: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_standalone_and_inflected_collection_requests_fail_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-standalone-inflected-parity");
+    let mut accepted = Vec::new();
+
+    for reason in REVIEW_STANDALONE_AND_INFLECTED_COLLECTION_REASONS {
+        let builder = SccmFindingBuilder::new("review-standalone-inflected-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted standalone or inflected collection requests: {accepted:#?}"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -117,6 +117,16 @@ fn finding_with_gap_and_request(finding_id: &str) -> SccmFinding {
         .unwrap()
 }
 
+const ROOTED_ARTIFACT_REQUEST_REASONS: [&str; 7] = [
+    r"Collect C:\ for related evidence.",
+    r"Collect C:\Windows\CCM\Logs\PolicyAgent.log.",
+    r"Collect C:/Windows/CCM/Logs/PolicyAgent.log.",
+    "Collect / for related evidence.",
+    "Collect /var/log/sccm/PolicyAgent.log.",
+    r"Collect \\server\share\PolicyAgent.log.",
+    "Collect //server/share/PolicyAgent.log.",
+];
+
 #[test]
 fn finding_confirmed_failure_requires_terminal_evidence() {
     let result = SccmFindingBuilder::new("app-enforcement-failed")
@@ -960,7 +970,7 @@ fn finding_artifact_requests_reject_structurally_unbounded_reasons() {
         r"Collect C:\Windows\CCM\Logs\*.log.",
     ];
 
-    for reason in reasons {
+    for reason in reasons.into_iter().chain(ROOTED_ARTIFACT_REQUEST_REASONS) {
         let result = SccmFindingBuilder::new("unbounded-structural-request")
             .class(SccmFindingClass::Symptom)
             .phase(SccmPhase::Policy)
@@ -971,7 +981,11 @@ fn finding_artifact_requests_reject_structurally_unbounded_reasons() {
             .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
             .build();
 
-        assert!(result.is_err(), "{reason}");
+        assert_eq!(
+            result.unwrap_err(),
+            SccmFindingValidationError::InvalidArtifactRequestReason,
+            "{reason}"
+        );
     }
 }
 
@@ -983,6 +997,8 @@ fn finding_artifact_requests_accept_specific_bounded_reasons() {
         "Confirm the root cause recorded by PolicyAgent.",
         "Confirm the disk status code recorded in PolicyAgent.log.",
         "Collect the disk imaging Task Sequence log.",
+        "Collect Logs/PolicyAgent.log from the bounded bundle.",
+        r"Collect Logs\PolicyAgent.log from the bounded bundle.",
     ] {
         SccmFindingBuilder::new("bounded-structural-request")
             .class(SccmFindingClass::Symptom)
@@ -1000,23 +1016,28 @@ fn finding_artifact_requests_accept_specific_bounded_reasons() {
 #[test]
 fn finding_artifact_request_bounds_apply_to_deserialization_and_serialization() {
     let finding = finding_with_gap_and_request("request-boundary-parity");
-    let mut json = serde_json::to_value(&finding).unwrap();
-    json["nextArtifacts"][0]["reason"] = serde_json::json!("Collect every file on the system.");
-    let deserialize_error = serde_json::from_value::<SccmFinding>(json)
-        .unwrap_err()
-        .to_string();
-    assert!(
-        deserialize_error.contains("InvalidArtifactRequestReason"),
-        "{deserialize_error}"
-    );
+    for reason in ROOTED_ARTIFACT_REQUEST_REASONS.into_iter().chain([
+        "Collect every file on the system.",
+        "Scan the full disk for related evidence.",
+    ]) {
+        let mut json = serde_json::to_value(&finding).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        let deserialize_error = serde_json::from_value::<SccmFinding>(json)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            deserialize_error.contains("InvalidArtifactRequestReason"),
+            "{reason}: {deserialize_error}"
+        );
 
-    let mut mutated = finding;
-    mutated.next_artifacts[0].reason = "Scan the full disk for related evidence.".into();
-    let serialize_error = serde_json::to_string(&mutated).unwrap_err().to_string();
-    assert!(
-        serialize_error.contains("InvalidArtifactRequestReason"),
-        "{serialize_error}"
-    );
+        let mut mutated = finding.clone();
+        mutated.next_artifacts[0].reason = reason.into();
+        let serialize_error = serde_json::to_string(&mutated).unwrap_err().to_string();
+        assert!(
+            serialize_error.contains("InvalidArtifactRequestReason"),
+            "{reason}: {serialize_error}"
+        );
+    }
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -135,6 +135,19 @@ const COMPACT_UNBOUNDED_ARTIFACT_REQUEST_REASONS: [&str; 5] = [
     "Collect every log on the system.",
 ];
 
+const ORDER_INDEPENDENT_UNBOUNDED_ARTIFACT_REQUEST_REASONS: [&str; 10] = [
+    "Every log on the system must be collected.",
+    "Request all files on the system.",
+    "Obtain every directory from the machine.",
+    "Copy the entire filesystem for review.",
+    "Enumerate all folders under the client.",
+    "Download all logs from the device.",
+    "Archive the whole disk.",
+    "All files from every directory are required.",
+    "Collect all of the files.",
+    "Scan every single directory.",
+];
+
 const BOUNDED_NARRATIVE_ARTIFACT_REQUEST_REASONS: [&str; 5] = [
     "Collect the full disk imaging Task Sequence log.",
     "Confirm the whole-disk encryption status recorded in PolicyAgent.log.",
@@ -1255,6 +1268,7 @@ fn finding_artifact_requests_reject_structurally_unbounded_reasons() {
         .into_iter()
         .chain(ROOTED_ARTIFACT_REQUEST_REASONS)
         .chain(COMPACT_UNBOUNDED_ARTIFACT_REQUEST_REASONS)
+        .chain(ORDER_INDEPENDENT_UNBOUNDED_ARTIFACT_REQUEST_REASONS)
     {
         let result = SccmFindingBuilder::new("unbounded-structural-request")
             .class(SccmFindingClass::Symptom)
@@ -1342,6 +1356,7 @@ fn finding_artifact_request_bounds_apply_to_deserialization_and_serialization() 
             "Scan the full disk for related evidence.",
         ])
         .chain(COMPACT_UNBOUNDED_ARTIFACT_REQUEST_REASONS)
+        .chain(ORDER_INDEPENDENT_UNBOUNDED_ARTIFACT_REQUEST_REASONS)
     {
         let mut direct = finding.clone();
         direct.next_artifacts[0].reason = reason.into();
@@ -1561,6 +1576,92 @@ fn finding_insufficient_evidence_requires_an_explicit_noncaptured_gap() {
         captured_is_not_a_gap.unwrap_err(),
         SccmFindingValidationError::InvalidCoverageGap
     );
+}
+
+#[test]
+fn finding_rejects_conflicting_coverage_for_one_artifact_identity() {
+    let first = finding_client_gap("client-policy-agent", SccmCoverageState::Absent);
+    let conflicts = [
+        (
+            "state",
+            vec![
+                first.clone(),
+                finding_client_gap("client-policy-agent", SccmCoverageState::AccessDenied),
+            ],
+        ),
+        (
+            "role",
+            vec![
+                first.clone(),
+                SccmFindingCoverageGap {
+                    artifact_id: "client-policy-agent".into(),
+                    role: SccmRole::ManagementPoint,
+                    coverage: SccmCoverageState::Absent,
+                },
+            ],
+        ),
+    ];
+    let mut accepted = Vec::new();
+
+    for (label, gaps) in conflicts {
+        let builder = SccmFindingBuilder::new(format!("conflicting-coverage-builder-{label}"))
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .coverage_gaps(gaps.clone())
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidCoverageGap) {
+            accepted.push(format!("builder: {label}"));
+        }
+
+        let mut direct =
+            finding_with_gap_and_request(&format!("conflicting-coverage-direct-{label}"));
+        direct.coverage_gaps = gaps.clone();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidCoverageGap) {
+            accepted.push(format!("direct validate: {label}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {label}"));
+        }
+
+        let mut json = serde_json::to_value(finding_with_gap_and_request(&format!(
+            "conflicting-coverage-json-{label}"
+        )))
+        .unwrap();
+        json["coverageGaps"] = serde_json::to_value(gaps).unwrap();
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {label}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted conflicting coverage: {accepted:#?}"
+    );
+
+    let duplicate = finding_client_gap("client-policy-agent", SccmCoverageState::AccessDenied);
+    let built = SccmFindingBuilder::new("duplicate-coverage-builder")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .coverage_gaps(vec![duplicate.clone(), duplicate.clone()])
+        .build()
+        .unwrap();
+    assert_eq!(built.coverage_gaps, vec![duplicate.clone()]);
+
+    let mut direct = built.clone();
+    direct.coverage_gaps = vec![duplicate.clone(), duplicate];
+    direct.validate().unwrap();
+    let serialized = serde_json::to_value(&direct).unwrap();
+    assert_eq!(serialized["coverageGaps"].as_array().unwrap().len(), 1);
+    let deserialized = serde_json::from_value::<SccmFinding>(serialized).unwrap();
+    assert_eq!(deserialized.coverage_gaps.len(), 1);
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -96,6 +96,27 @@ fn finding_request(logical_id: &str, role: SccmRole, reason: &str) -> SccmArtifa
     }
 }
 
+fn finding_with_gap_and_request(finding_id: &str) -> SccmFinding {
+    SccmFindingBuilder::new(finding_id)
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .coverage_gap(finding_client_gap(
+            "client-policy-agent",
+            SccmCoverageState::AccessDenied,
+        ))
+        .next_artifact(finding_request(
+            "policyAgent",
+            SccmRole::Client,
+            "Confirm the bounded policy request outcome.",
+        ))
+        .build()
+        .unwrap()
+}
+
 #[test]
 fn finding_confirmed_failure_requires_terminal_evidence() {
     let result = SccmFindingBuilder::new("app-enforcement-failed")
@@ -470,6 +491,532 @@ fn finding_evidence_reference_allows_an_unavailable_line_range() {
         .unwrap();
 
     serde_json::to_value(finding).unwrap();
+}
+
+#[test]
+fn finding_serialization_canonicalizes_public_collection_mutation() {
+    let first = finding_evidence_ref("artifact-a", "entry-a");
+    let second = finding_evidence_ref("artifact-b", "entry-b");
+    let mut finding = SccmFindingBuilder::new("mutated-order")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![first.clone(), second.clone()])
+        .terminal_evidence(vec![
+            SccmTerminalEvidence::observed_failure(first.clone()),
+            SccmTerminalEvidence::observed_failure(second.clone()),
+        ])
+        .coverage_gaps(vec![
+            finding_client_gap("artifact-gap-a", SccmCoverageState::AccessDenied),
+            finding_client_gap("artifact-gap-b", SccmCoverageState::Capped),
+        ])
+        .correlation_keys(vec![
+            finding_key(
+                SccmCorrelationKeyKind::AssignmentId,
+                "{ABCDEFAB-0000-0000-0000-000000000001}",
+                "abcdefab-0000-0000-0000-000000000001",
+                SccmKeyConfidence::Low,
+                Some("sccm-keys-experimental-v1"),
+                first,
+            ),
+            finding_key(
+                SccmCorrelationKeyKind::PackageId,
+                "LAB00001",
+                "LAB00001",
+                SccmKeyConfidence::Low,
+                Some("sccm-keys-experimental-v1"),
+                second,
+            ),
+        ])
+        .next_artifacts(vec![
+            finding_request(
+                "policyAgent",
+                SccmRole::Client,
+                "Confirm the bounded policy request outcome.",
+            ),
+            finding_request(
+                "policyEvaluator",
+                SccmRole::Client,
+                "Confirm the bounded policy evaluation outcome.",
+            ),
+        ])
+        .build()
+        .unwrap();
+
+    let expected = serde_json::to_value(&finding).unwrap();
+    fn scramble<T: Clone>(values: &mut Vec<T>) {
+        values.reverse();
+        values.push(values[0].clone());
+    }
+    scramble(&mut finding.evidence);
+    scramble(&mut finding.terminal_evidence);
+    scramble(&mut finding.coverage_gaps);
+    scramble(&mut finding.correlation_keys);
+    scramble(&mut finding.next_artifacts);
+
+    assert_eq!(serde_json::to_value(finding).unwrap(), expected);
+}
+
+#[test]
+fn finding_rejects_conflicting_ranges_for_one_logical_evidence_identity() {
+    let first = SccmEvidenceRef {
+        artifact_id: "artifact-a".into(),
+        entry_id: "entry-a".into(),
+        line_start: Some(1),
+        line_end: Some(1),
+    };
+    let conflicting = SccmEvidenceRef {
+        line_start: Some(2),
+        line_end: Some(2),
+        ..first.clone()
+    };
+    let top_level = SccmFindingBuilder::new("conflicting-top-level-ranges")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![first.clone(), conflicting.clone()])
+        .build();
+    let terminal = SccmFindingBuilder::new("conflicting-terminal-range")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![first.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(
+            conflicting.clone(),
+        )])
+        .build();
+    let key = SccmFindingBuilder::new("conflicting-key-range")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![first])
+        .correlation_keys(vec![finding_key(
+            SccmCorrelationKeyKind::AssignmentId,
+            "{ABCDEFAB-0000-0000-0000-000000000001}",
+            "abcdefab-0000-0000-0000-000000000001",
+            SccmKeyConfidence::Low,
+            Some("sccm-keys-experimental-v1"),
+            conflicting,
+        )])
+        .build();
+
+    for (label, result) in [
+        ("top-level", top_level),
+        ("terminal", terminal),
+        ("correlation-key", key),
+    ] {
+        assert_eq!(
+            result.unwrap_err(),
+            SccmFindingValidationError::ConflictingEvidenceReference,
+            "{label}"
+        );
+    }
+
+    let mut mutated = SccmFindingBuilder::new("mutated-conflicting-range")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![SccmEvidenceRef {
+            artifact_id: "artifact-a".into(),
+            entry_id: "entry-a".into(),
+            line_start: Some(1),
+            line_end: Some(1),
+        }])
+        .build()
+        .unwrap();
+    mutated.evidence.push(SccmEvidenceRef {
+        artifact_id: " artifact-a ".into(),
+        entry_id: " entry-a ".into(),
+        line_start: Some(2),
+        line_end: Some(2),
+    });
+    assert_eq!(
+        mutated.validate().unwrap_err(),
+        SccmFindingValidationError::ConflictingEvidenceReference
+    );
+}
+
+#[test]
+fn finding_deserialization_prioritizes_conflicting_evidence_identity_ranges() {
+    let evidence = finding_evidence_ref("artifact-a", "entry-a");
+    let finding = SccmFindingBuilder::new("conflicting-deserialized-range")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Enforcement)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![evidence.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(evidence)])
+        .build()
+        .unwrap();
+    let mut json = serde_json::to_value(finding).unwrap();
+    json["terminalEvidence"][0]["reference"]["lineStart"] = serde_json::json!(2);
+    json["terminalEvidence"][0]["reference"]["lineEnd"] = serde_json::json!(2);
+
+    let error = serde_json::from_value::<SccmFinding>(json)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("ConflictingEvidenceReference"), "{error}");
+}
+
+#[test]
+fn finding_serialization_prioritizes_conflicting_evidence_identity_ranges() {
+    let evidence = finding_evidence_ref("artifact-a", "entry-a");
+    let mut finding = SccmFindingBuilder::new("conflicting-serialized-range")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![evidence.clone()])
+        .correlation_keys(vec![finding_key(
+            SccmCorrelationKeyKind::AssignmentId,
+            "{ABCDEFAB-0000-0000-0000-000000000001}",
+            "abcdefab-0000-0000-0000-000000000001",
+            SccmKeyConfidence::Low,
+            Some("sccm-keys-experimental-v1"),
+            evidence,
+        )])
+        .build()
+        .unwrap();
+    let key_reference = finding.correlation_keys[0].evidence.as_mut().unwrap();
+    key_reference.line_start = Some(2);
+    key_reference.line_end = Some(2);
+
+    let error = serde_json::to_string(&finding).unwrap_err().to_string();
+    assert!(error.contains("ConflictingEvidenceReference"), "{error}");
+}
+
+#[test]
+fn finding_canonicalizes_evidence_identity_whitespace() {
+    let top_level = SccmEvidenceRef {
+        artifact_id: " artifact-a ".into(),
+        entry_id: " entry-a ".into(),
+        line_start: Some(1),
+        line_end: Some(1),
+    };
+    let terminal = SccmEvidenceRef {
+        artifact_id: "artifact-a ".into(),
+        entry_id: "entry-a".into(),
+        ..top_level.clone()
+    };
+    let key = SccmEvidenceRef {
+        artifact_id: " artifact-a".into(),
+        entry_id: " entry-a".into(),
+        ..top_level.clone()
+    };
+    let finding = SccmFindingBuilder::new("canonical-evidence-identity")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![top_level])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(terminal)])
+        .correlation_keys(vec![finding_key(
+            SccmCorrelationKeyKind::AssignmentId,
+            "{ABCDEFAB-0000-0000-0000-000000000001}",
+            "abcdefab-0000-0000-0000-000000000001",
+            SccmKeyConfidence::Low,
+            Some("sccm-keys-experimental-v1"),
+            key,
+        )])
+        .build()
+        .unwrap();
+
+    assert_eq!(finding.evidence[0].artifact_id, "artifact-a");
+    assert_eq!(finding.evidence[0].entry_id, "entry-a");
+    assert_eq!(finding.terminal_evidence[0].reference, finding.evidence[0]);
+    assert_eq!(
+        finding.correlation_keys[0].evidence.as_ref(),
+        Some(&finding.evidence[0])
+    );
+}
+
+#[test]
+fn finding_rejects_whitespace_wrapped_declared_phase_shadow() {
+    let result = SccmFindingBuilder::new("wrapped-phase-shadow")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Unknown(" policy ".into()))
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .build();
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn finding_deserialization_rejects_whitespace_wrapped_declared_phase_shadow() {
+    let finding = SccmFindingBuilder::new("deserialized-wrapped-phase-shadow")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .build()
+        .unwrap();
+    let mut json = serde_json::to_value(finding).unwrap();
+    json["phase"] = serde_json::json!(" policy ");
+
+    assert!(serde_json::from_value::<SccmFinding>(json).is_err());
+}
+
+#[test]
+fn finding_serialization_rejects_whitespace_wrapped_declared_phase_shadow() {
+    let mut finding = SccmFindingBuilder::new("serialized-wrapped-phase-shadow")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .build()
+        .unwrap();
+    finding.phase = SccmPhase::Unknown(" policy ".into());
+
+    assert!(serde_json::to_value(finding).is_err());
+}
+
+#[test]
+fn finding_canonicalizes_future_phase_whitespace() {
+    let finding = SccmFindingBuilder::new("canonical-future-phase")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Unknown(" futurePhase ".into()))
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .build()
+        .unwrap();
+
+    assert_eq!(finding.phase, SccmPhase::Unknown("futurePhase".into()));
+    assert_eq!(
+        serde_json::to_value(finding).unwrap()["phase"],
+        "futurePhase"
+    );
+}
+
+#[test]
+fn finding_role_unknown_values_cannot_shadow_declared_roles() {
+    for value in ["", " ", " futureRole "] {
+        assert!(
+            serde_json::to_string(&SccmRole::Unknown(value.into())).is_err(),
+            "{value:?}"
+        );
+        let wire = serde_json::to_string(value).unwrap();
+        assert!(
+            serde_json::from_str::<SccmRole>(&wire).is_err(),
+            "{value:?}"
+        );
+    }
+
+    for value in [
+        "client",
+        "siteServer",
+        "managementPoint",
+        "distributionPoint",
+        "softwareUpdatePoint",
+        "wsUs",
+        "provider",
+        "adminService",
+    ] {
+        assert!(
+            serde_json::to_string(&SccmRole::Unknown(value.into())).is_err(),
+            "{value:?}"
+        );
+    }
+
+    let future = SccmRole::Unknown("futureRole".into());
+    let wire = serde_json::to_string(&future).unwrap();
+    assert_eq!(serde_json::from_str::<SccmRole>(&wire).unwrap(), future);
+}
+
+#[test]
+fn finding_validates_finding_gap_and_request_roles_before_other_rules() {
+    let top_level = SccmFindingBuilder::new("invalid-top-level-role")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Unknown("client".into()))
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .build();
+    let gap = SccmFindingBuilder::new("invalid-gap-role")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .coverage_gap(SccmFindingCoverageGap {
+            artifact_id: "client-policy-agent".into(),
+            role: SccmRole::Unknown("client".into()),
+            coverage: SccmCoverageState::AccessDenied,
+        })
+        .build();
+    let request = SccmFindingBuilder::new("invalid-request-role")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .next_artifact(finding_request(
+            "policyAgent",
+            SccmRole::Unknown("client".into()),
+            "Confirm the bounded policy request outcome.",
+        ))
+        .build();
+
+    for (label, result) in [
+        ("finding", top_level),
+        ("coverage-gap", gap),
+        ("artifact-request", request),
+    ] {
+        assert_eq!(
+            result.unwrap_err(),
+            SccmFindingValidationError::InvalidRole,
+            "{label}"
+        );
+    }
+}
+
+#[test]
+fn finding_deserialization_validates_finding_gap_and_request_roles() {
+    let json =
+        serde_json::to_value(finding_with_gap_and_request("invalid-deserialized-role")).unwrap();
+    let mut cases = Vec::new();
+
+    let mut top_level = json.clone();
+    top_level["role"] = serde_json::json!(" client ");
+    cases.push(("finding", top_level));
+
+    let mut gap = json.clone();
+    gap["coverageGaps"][0]["role"] = serde_json::json!(" client ");
+    cases.push(("coverage-gap", gap));
+
+    let mut request = json;
+    request["nextArtifacts"][0]["role"] = serde_json::json!(" client ");
+    cases.push(("artifact-request", request));
+
+    for (label, case) in cases {
+        let error = serde_json::from_value::<SccmFinding>(case)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("InvalidRole"), "{label}: {error}");
+    }
+}
+
+#[test]
+fn finding_serialization_validates_finding_gap_and_request_roles() {
+    let finding = finding_with_gap_and_request("invalid-serialized-role");
+    let mut cases = Vec::new();
+
+    let mut top_level = finding.clone();
+    top_level.role = SccmRole::Unknown("client".into());
+    cases.push(("finding", top_level));
+
+    let mut gap = finding.clone();
+    gap.coverage_gaps[0].role = SccmRole::Unknown("client".into());
+    cases.push(("coverage-gap", gap));
+
+    let mut request = finding;
+    request.next_artifacts[0].role = SccmRole::Unknown("client".into());
+    cases.push(("artifact-request", request));
+
+    for (label, case) in cases {
+        let error = serde_json::to_string(&case).unwrap_err().to_string();
+        assert!(error.contains("InvalidRole"), "{label}: {error}");
+    }
+}
+
+#[test]
+fn finding_artifact_requests_reject_structurally_unbounded_reasons() {
+    let reasons = [
+        "Collect every file on the system.",
+        "Scan the full disk for related evidence.",
+        "Collect the complete C: drive.",
+        "Walk all directories under C:.",
+        "Collect drive-wide logs.",
+        "Collect drive wide logs.",
+        "Collect drivewide logs.",
+        "Collect sitewide logs.",
+        "Recursively collect PolicyAgent.log.",
+        "Collect from the filesystem root.",
+        "Use a glob for matching log files.",
+        r"Collect C:\Windows\CCM\Logs\*.log.",
+    ];
+
+    for reason in reasons {
+        let result = SccmFindingBuilder::new("unbounded-structural-request")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+
+        assert!(result.is_err(), "{reason}");
+    }
+}
+
+#[test]
+fn finding_artifact_requests_accept_specific_bounded_reasons() {
+    for reason in [
+        "Confirm the bounded policy request outcome.",
+        "Collect the PolicyAgent record cited by assignment A.",
+        "Confirm the root cause recorded by PolicyAgent.",
+        "Confirm the disk status code recorded in PolicyAgent.log.",
+        "Collect the disk imaging Task Sequence log.",
+    ] {
+        SccmFindingBuilder::new("bounded-structural-request")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build()
+            .unwrap();
+    }
+}
+
+#[test]
+fn finding_artifact_request_bounds_apply_to_deserialization_and_serialization() {
+    let finding = finding_with_gap_and_request("request-boundary-parity");
+    let mut json = serde_json::to_value(&finding).unwrap();
+    json["nextArtifacts"][0]["reason"] = serde_json::json!("Collect every file on the system.");
+    let deserialize_error = serde_json::from_value::<SccmFinding>(json)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        deserialize_error.contains("InvalidArtifactRequestReason"),
+        "{deserialize_error}"
+    );
+
+    let mut mutated = finding;
+    mutated.next_artifacts[0].reason = "Scan the full disk for related evidence.".into();
+    let serialize_error = serde_json::to_string(&mutated).unwrap_err().to_string();
+    assert!(
+        serialize_error.contains("InvalidArtifactRequestReason"),
+        "{serialize_error}"
+    );
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -161,6 +161,29 @@ fn finding_high_confirmed_failure_accepts_a_cited_terminal_failure() {
 }
 
 #[test]
+fn finding_rejects_unknown_phase_values_that_shadow_declared_names() {
+    for phase in ["policy", "content", "enforcement"] {
+        let result = SccmFindingBuilder::new(format!("shadowed-{phase}"))
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Unknown(phase.into()))
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref(
+                "client-policy-agent",
+                "policy:1-1",
+            )])
+            .build();
+
+        assert_eq!(
+            result.unwrap_err(),
+            SccmFindingValidationError::MissingRequiredField,
+            "{phase}"
+        );
+    }
+}
+
+#[test]
 fn finding_forged_unregistered_profile_never_authorizes_high_corroboration() {
     let first = finding_evidence_ref("client-policy-agent", "policy:10-10");
     let second = finding_evidence_ref("mp-get-policy", "mp-policy:20-20");
@@ -773,6 +796,83 @@ fn finding_deserialization_rejects_raw_execution_context_fields() {
     json["executionContext"] = serde_json::json!(r"LAB\SyntheticUser");
 
     assert!(serde_json::from_value::<SccmFinding>(json).is_err());
+}
+
+#[test]
+fn finding_deserialization_rejects_unknown_fields_recursively() {
+    let evidence = finding_evidence_ref("client-policy-agent", "policy:1-1");
+    let finding = SccmFindingBuilder::new("strict-finding-wire")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![evidence.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(
+            evidence.clone(),
+        )])
+        .coverage_gap(finding_client_gap(
+            "client-policy-agent",
+            SccmCoverageState::AccessDenied,
+        ))
+        .correlation_keys(vec![finding_key(
+            SccmCorrelationKeyKind::AssignmentId,
+            "{ABCDEFAB-0000-0000-0000-000000000001}",
+            "abcdefab-0000-0000-0000-000000000001",
+            SccmKeyConfidence::Low,
+            Some("sccm-keys-experimental-v1"),
+            evidence,
+        )])
+        .next_artifact(finding_request(
+            "policyAgent",
+            SccmRole::Client,
+            "Confirm the bounded policy request outcome.",
+        ))
+        .build()
+        .unwrap();
+    let json = serde_json::to_value(finding).unwrap();
+
+    let mut cases = Vec::new();
+
+    let mut nested_evidence = json.clone();
+    nested_evidence["evidence"][0]["executionContext"] = serde_json::json!(r"LAB\SyntheticUser");
+    cases.push(("evidence", nested_evidence));
+
+    let mut terminal_evidence = json.clone();
+    terminal_evidence["terminalEvidence"][0]["executionContext"] =
+        serde_json::json!(r"LAB\SyntheticUser");
+    cases.push(("terminal evidence", terminal_evidence));
+
+    let mut terminal_reference = json.clone();
+    terminal_reference["terminalEvidence"][0]["reference"]["executionContext"] =
+        serde_json::json!(r"LAB\SyntheticUser");
+    cases.push(("terminal reference", terminal_reference));
+
+    let mut coverage_gap = json.clone();
+    coverage_gap["coverageGaps"][0]["executionContext"] = serde_json::json!(r"LAB\SyntheticUser");
+    cases.push(("coverage gap", coverage_gap));
+
+    let mut correlation_key = json.clone();
+    correlation_key["correlationKeys"][0]["executionContext"] =
+        serde_json::json!(r"LAB\SyntheticUser");
+    cases.push(("correlation key", correlation_key));
+
+    let mut correlation_key_reference = json.clone();
+    correlation_key_reference["correlationKeys"][0]["evidence"]["executionContext"] =
+        serde_json::json!(r"LAB\SyntheticUser");
+    cases.push(("correlation key reference", correlation_key_reference));
+
+    let mut artifact_request = json;
+    artifact_request["nextArtifacts"][0]["executionContext"] =
+        serde_json::json!(r"LAB\SyntheticUser");
+    cases.push(("artifact request", artifact_request));
+
+    for (label, case) in cases {
+        assert!(
+            serde_json::from_value::<SccmFinding>(case).is_err(),
+            "{label} accepted an undeclared nested field"
+        );
+    }
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -1,12 +1,16 @@
-use cmtraceopen_parser::models::log_entry::{LogFormat, ParserKind};
+use cmtraceopen_parser::models::log_entry::{LogFormat, ParserKind, Severity};
 use cmtraceopen_parser::parser::detect::detect_parser;
 use cmtraceopen_parser::sccm::{
     classify_artifact_name, declared_source_catalog, extract_keys, extract_signals,
-    normalize_ccm_artifact, normalize_key, SccmArtifact, SccmArtifactFamily,
-    SccmCorrelationKeyKind, SccmCoverageState, SccmEvidence, SccmEvidenceRef,
-    SccmExtractionGapKind, SccmExtractionProfile, SccmExtractionProfileMaturity, SccmFindingClass,
-    SccmKeyConfidence, SccmKeyExtractionResult, SccmRole, SccmRotation, SccmSignal, SccmSignalKind,
-    SccmTimeOrderingState, SccmTimestamp, SccmUnknownRotation, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
+    normalize_ccm_artifact, normalize_key, SccmArtifact, SccmArtifactFamily, SccmArtifactRequest,
+    SccmConfidence, SccmCorrelationKey, SccmCorrelationKeyKind, SccmCoverageState, SccmEvidence,
+    SccmEvidenceRef, SccmExtractionGapKind, SccmExtractionProfile, SccmExtractionProfileMaturity,
+    SccmFinding, SccmFindingBuilder, SccmFindingClass, SccmFindingCoverageGap,
+    SccmFindingValidationError, SccmKeyConfidence, SccmKeyExtractionResult, SccmPhase, SccmRole,
+    SccmRotation, SccmSignal, SccmSignalKind, SccmTerminalEvidence, SccmTerminalEvidenceKind,
+    SccmTimeOrderingState, SccmTimestamp, SccmUnknownRotation,
+    MAX_SCCM_ARTIFACT_REQUEST_REASON_CHARS, MAX_SCCM_NEXT_ARTIFACT_REQUESTS,
+    SCCM_DIAGNOSTICS_SCHEMA_VERSION,
 };
 
 fn client_policy_artifact() -> SccmArtifact {
@@ -45,6 +49,836 @@ fn evidence_with_message(message: &str) -> SccmEvidence {
         },
         execution_context: None,
     }
+}
+
+fn finding_evidence_ref(artifact_id: &str, entry_id: &str) -> SccmEvidenceRef {
+    SccmEvidenceRef {
+        artifact_id: artifact_id.into(),
+        entry_id: entry_id.into(),
+        line_start: Some(1),
+        line_end: Some(1),
+    }
+}
+
+fn finding_key(
+    kind: SccmCorrelationKeyKind,
+    raw: &str,
+    normalized: &str,
+    confidence: SccmKeyConfidence,
+    extraction_profile_id: Option<&str>,
+    evidence: SccmEvidenceRef,
+) -> SccmCorrelationKey {
+    SccmCorrelationKey {
+        kind,
+        raw: raw.into(),
+        normalized: normalized.into(),
+        confidence,
+        extraction_profile_id: extraction_profile_id.map(str::to_owned),
+        evidence: Some(evidence),
+        start: None,
+        end: None,
+    }
+}
+
+fn finding_client_gap(artifact_id: &str, coverage: SccmCoverageState) -> SccmFindingCoverageGap {
+    SccmFindingCoverageGap {
+        artifact_id: artifact_id.into(),
+        role: SccmRole::Client,
+        coverage,
+    }
+}
+
+fn finding_request(logical_id: &str, role: SccmRole, reason: &str) -> SccmArtifactRequest {
+    SccmArtifactRequest {
+        logical_id: logical_id.into(),
+        role,
+        reason: reason.into(),
+    }
+}
+
+#[test]
+fn finding_confirmed_failure_requires_terminal_evidence() {
+    let result = SccmFindingBuilder::new("app-enforcement-failed")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Enforcement)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![finding_evidence_ref(
+            "client-app-enforce",
+            "client-app-enforce:1-1",
+        )])
+        .build();
+
+    assert_eq!(
+        result.unwrap_err(),
+        SccmFindingValidationError::MissingTerminalEvidence
+    );
+}
+
+#[test]
+fn finding_insufficient_evidence_requires_next_artifact_request() {
+    let result = SccmFindingBuilder::new("missing-policy-log")
+        .class(SccmFindingClass::InsufficientEvidence)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .coverage_gap(finding_client_gap(
+            "client-policy-agent",
+            SccmCoverageState::Absent,
+        ))
+        .build();
+
+    assert_eq!(
+        result.unwrap_err(),
+        SccmFindingValidationError::MissingNextArtifactRequest
+    );
+}
+
+#[test]
+fn finding_high_confirmed_failure_accepts_a_cited_terminal_failure() {
+    let evidence = finding_evidence_ref("client-app-enforce", "client-app-enforce:9-9");
+    let finding = SccmFindingBuilder::new("app-enforcement-failed")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Enforcement)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![evidence.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(
+            evidence.clone(),
+        )])
+        .build()
+        .unwrap();
+
+    assert_eq!(finding.evidence, vec![evidence.clone()]);
+    assert_eq!(finding.terminal_evidence[0].reference, evidence);
+    assert_eq!(
+        finding.terminal_evidence[0].kind,
+        SccmTerminalEvidenceKind::ObservedFailure
+    );
+}
+
+#[test]
+fn finding_forged_unregistered_profile_never_authorizes_high_corroboration() {
+    let first = finding_evidence_ref("client-policy-agent", "policy:10-10");
+    let second = finding_evidence_ref("mp-get-policy", "mp-policy:20-20");
+    let result = SccmFindingBuilder::new("policy-request-failed")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![second.clone(), first.clone()])
+        .correlation_keys(vec![
+            finding_key(
+                SccmCorrelationKeyKind::AssignmentId,
+                "{ABCDEFAB-0000-0000-0000-000000000001}",
+                "abcdefab-0000-0000-0000-000000000001",
+                SccmKeyConfidence::Exact,
+                Some("sccm-keys-stable-v1"),
+                first,
+            ),
+            finding_key(
+                SccmCorrelationKeyKind::AssignmentId,
+                "abcdefab-0000-0000-0000-000000000001",
+                "abcdefab-0000-0000-0000-000000000001",
+                SccmKeyConfidence::Strong,
+                Some("sccm-keys-stable-v1"),
+                second,
+            ),
+        ])
+        .build();
+
+    assert_eq!(
+        result.unwrap_err(),
+        SccmFindingValidationError::MissingTerminalEvidence
+    );
+}
+
+#[test]
+fn finding_duplicate_one_ref_never_counts_as_two_ref_corroboration() {
+    let evidence = finding_evidence_ref("client-policy-agent", "policy:10-10");
+    let key = finding_key(
+        SccmCorrelationKeyKind::AssignmentId,
+        "{ABCDEFAB-0000-0000-0000-000000000001}",
+        "abcdefab-0000-0000-0000-000000000001",
+        SccmKeyConfidence::Exact,
+        Some("sccm-keys-stable-v1"),
+        evidence.clone(),
+    );
+    let result = SccmFindingBuilder::new("duplicated-corroboration")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![evidence])
+        .correlation_keys(vec![key.clone(), key])
+        .build();
+
+    assert_eq!(
+        result.unwrap_err(),
+        SccmFindingValidationError::MissingTerminalEvidence
+    );
+}
+
+#[test]
+fn finding_same_minute_keyless_evidence_never_counts_as_high_confidence() {
+    let result = SccmFindingBuilder::new("same-minute-is-not-causation")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Content)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![
+            finding_evidence_ref("client-content", "client-content:12:00"),
+            finding_evidence_ref("server-content", "server-content:12:00"),
+        ])
+        .build();
+
+    assert_eq!(
+        result.unwrap_err(),
+        SccmFindingValidationError::MissingTerminalEvidence
+    );
+}
+
+#[test]
+fn finding_mismatched_keys_or_profiles_never_corroborate_high_confidence() {
+    let first = finding_evidence_ref("client-content", "client-content:1-1");
+    let second = finding_evidence_ref("server-content", "server-content:1-1");
+    let cases = [
+        (
+            "mismatched-normalized-keys",
+            finding_key(
+                SccmCorrelationKeyKind::ContentId,
+                "ContentABC",
+                "contentabc",
+                SccmKeyConfidence::Strong,
+                Some("sccm-keys-stable-v1"),
+                first.clone(),
+            ),
+            finding_key(
+                SccmCorrelationKeyKind::ContentId,
+                "ContentXYZ",
+                "contentxyz",
+                SccmKeyConfidence::Strong,
+                Some("sccm-keys-stable-v1"),
+                second.clone(),
+            ),
+        ),
+        (
+            "mismatched-key-profiles",
+            finding_key(
+                SccmCorrelationKeyKind::ContentId,
+                "ContentABC",
+                "contentabc",
+                SccmKeyConfidence::Strong,
+                Some("sccm-keys-stable-v1"),
+                first.clone(),
+            ),
+            finding_key(
+                SccmCorrelationKeyKind::ContentId,
+                "contentabc",
+                "contentabc",
+                SccmKeyConfidence::Exact,
+                Some("sccm-keys-stable-v2"),
+                second.clone(),
+            ),
+        ),
+    ];
+
+    for (finding_id, first_key, second_key) in cases {
+        let result = SccmFindingBuilder::new(finding_id)
+            .class(SccmFindingClass::ConfirmedFailure)
+            .phase(SccmPhase::Content)
+            .role(SccmRole::Client)
+            .severity(Severity::Error)
+            .confidence(SccmConfidence::High)
+            .evidence(vec![first.clone(), second.clone()])
+            .correlation_keys(vec![first_key, second_key])
+            .build();
+
+        assert_eq!(
+            result.unwrap_err(),
+            SccmFindingValidationError::MissingTerminalEvidence,
+            "{finding_id}"
+        );
+    }
+}
+
+#[test]
+fn finding_rejects_key_or_terminal_refs_that_are_not_cited() {
+    let cited = finding_evidence_ref("client-policy-agent", "policy:1-1");
+    let missing = finding_evidence_ref("client-policy-agent", "policy:2-2");
+
+    let key_result = SccmFindingBuilder::new("uncited-key")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![cited.clone()])
+        .correlation_keys(vec![finding_key(
+            SccmCorrelationKeyKind::AssignmentId,
+            "{ABCDEFAB-0000-0000-0000-000000000001}",
+            "abcdefab-0000-0000-0000-000000000001",
+            SccmKeyConfidence::Low,
+            Some("sccm-keys-experimental-v1"),
+            missing.clone(),
+        )])
+        .build();
+    assert_eq!(
+        key_result.unwrap_err(),
+        SccmFindingValidationError::CorrelationKeyEvidenceNotCited
+    );
+
+    let terminal_result = SccmFindingBuilder::new("uncited-terminal")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![cited])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(missing)])
+        .build();
+    assert_eq!(
+        terminal_result.unwrap_err(),
+        SccmFindingValidationError::TerminalEvidenceNotCited
+    );
+}
+
+#[test]
+fn finding_rejects_a_correlation_key_without_an_evidence_ref() {
+    let cited = finding_evidence_ref("client-policy-agent", "policy:1-1");
+    let mut key = finding_key(
+        SccmCorrelationKeyKind::AssignmentId,
+        "{ABCDEFAB-0000-0000-0000-000000000001}",
+        "abcdefab-0000-0000-0000-000000000001",
+        SccmKeyConfidence::Low,
+        Some("sccm-keys-experimental-v1"),
+        cited.clone(),
+    );
+    key.evidence = None;
+
+    let result = SccmFindingBuilder::new("missing-key-evidence")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![cited])
+        .correlation_keys(vec![key])
+        .build();
+
+    assert_eq!(
+        result.unwrap_err(),
+        SccmFindingValidationError::CorrelationKeyMissingEvidence
+    );
+}
+
+#[test]
+fn finding_low_or_unprofiled_keys_never_corroborate_high_confidence() {
+    let first = finding_evidence_ref("client-content", "client-content:1-1");
+    let second = finding_evidence_ref("server-content", "server-content:1-1");
+    let cases = [
+        (
+            "low-keys",
+            Some("sccm-keys-experimental-v1"),
+            SccmKeyConfidence::Low,
+        ),
+        ("unprofiled-keys", None, SccmKeyConfidence::Exact),
+    ];
+
+    for (finding_id, profile, confidence) in cases {
+        let result = SccmFindingBuilder::new(finding_id)
+            .class(SccmFindingClass::ConfirmedFailure)
+            .phase(SccmPhase::Content)
+            .role(SccmRole::Client)
+            .severity(Severity::Error)
+            .confidence(SccmConfidence::High)
+            .evidence(vec![first.clone(), second.clone()])
+            .correlation_keys(vec![
+                finding_key(
+                    SccmCorrelationKeyKind::ContentId,
+                    "ContentABC",
+                    "contentabc",
+                    confidence.clone(),
+                    profile,
+                    first.clone(),
+                ),
+                finding_key(
+                    SccmCorrelationKeyKind::ContentId,
+                    "contentabc",
+                    "contentabc",
+                    confidence.clone(),
+                    profile,
+                    second.clone(),
+                ),
+            ])
+            .build();
+
+        assert_eq!(
+            result.unwrap_err(),
+            SccmFindingValidationError::MissingTerminalEvidence,
+            "{finding_id}"
+        );
+    }
+}
+
+#[test]
+fn finding_rejects_forged_terminal_markers() {
+    let evidence = finding_evidence_ref("client-app-enforce", "client-app-enforce:1-1");
+    let result = SccmFindingBuilder::new("forged-terminal")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Enforcement)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![evidence.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence {
+            reference: evidence,
+            kind: SccmTerminalEvidenceKind::Unknown("observedFailure".into()),
+        }])
+        .build();
+
+    assert_eq!(
+        result.unwrap_err(),
+        SccmFindingValidationError::InvalidTerminalEvidence
+    );
+}
+
+#[test]
+fn finding_likely_contributor_is_capped_without_terminal_corroboration() {
+    let evidence = finding_evidence_ref("client-policy-agent", "policy:1-1");
+    let high = SccmFindingBuilder::new("likely-contributor-high")
+        .class(SccmFindingClass::LikelyContributor)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![evidence.clone()])
+        .build();
+    assert_eq!(
+        high.unwrap_err(),
+        SccmFindingValidationError::LikelyContributorConfidenceTooHigh
+    );
+
+    let moderate = SccmFindingBuilder::new("likely-contributor-moderate")
+        .class(SccmFindingClass::LikelyContributor)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Moderate)
+        .evidence(vec![evidence.clone()])
+        .build()
+        .unwrap();
+    assert_eq!(moderate.confidence, SccmConfidence::Moderate);
+
+    let terminal = SccmFindingBuilder::new("likely-contributor-terminal")
+        .class(SccmFindingClass::LikelyContributor)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![evidence.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(evidence)])
+        .build()
+        .unwrap();
+    assert_eq!(terminal.confidence, SccmConfidence::High);
+}
+
+#[test]
+fn finding_evidence_less_claims_are_rejected() {
+    let result = SccmFindingBuilder::new("unsupported-success-claim")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Success)
+        .confidence(SccmConfidence::High)
+        .build();
+
+    assert_eq!(
+        result.unwrap_err(),
+        SccmFindingValidationError::MissingEvidenceOrCoverageGap
+    );
+}
+
+#[test]
+fn finding_insufficient_evidence_requires_an_explicit_noncaptured_gap() {
+    let request = finding_request(
+        "policyAgent",
+        SccmRole::Client,
+        "Policy evidence was not captured.",
+    );
+    let missing_gap = SccmFindingBuilder::new("missing-gap")
+        .class(SccmFindingClass::InsufficientEvidence)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .next_artifact(request.clone())
+        .build();
+    assert_eq!(
+        missing_gap.unwrap_err(),
+        SccmFindingValidationError::MissingCoverageGap
+    );
+
+    let captured_is_not_a_gap = SccmFindingBuilder::new("captured-is-not-gap")
+        .class(SccmFindingClass::InsufficientEvidence)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .coverage_gap(finding_client_gap(
+            "client-policy-agent",
+            SccmCoverageState::Captured,
+        ))
+        .next_artifact(request)
+        .build();
+    assert_eq!(
+        captured_is_not_a_gap.unwrap_err(),
+        SccmFindingValidationError::InvalidCoverageGap
+    );
+}
+
+#[test]
+fn finding_artifact_requests_require_declared_logical_id_and_role() {
+    for invalid_id in [
+        "client-policy-agent",
+        r"C:\",
+        "D:/",
+        "/",
+        "*",
+        "**/*.log",
+        "whole disk",
+        "PolicyAgent.log",
+    ] {
+        let result = SccmFindingBuilder::new("invalid-request-id")
+            .class(SccmFindingClass::InsufficientEvidence)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .coverage_gap(finding_client_gap(
+                "client-policy-agent",
+                SccmCoverageState::Absent,
+            ))
+            .next_artifact(finding_request(
+                invalid_id,
+                SccmRole::Client,
+                "Policy evidence was not captured.",
+            ))
+            .build();
+        assert_eq!(
+            result.unwrap_err(),
+            SccmFindingValidationError::UndeclaredArtifactRequest,
+            "{invalid_id}"
+        );
+    }
+
+    let role_mismatch = SccmFindingBuilder::new("invalid-request-role")
+        .class(SccmFindingClass::InsufficientEvidence)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .coverage_gap(finding_client_gap(
+            "client-policy-agent",
+            SccmCoverageState::Absent,
+        ))
+        .next_artifact(finding_request(
+            "policyAgent",
+            SccmRole::ManagementPoint,
+            "Policy evidence was not captured.",
+        ))
+        .build();
+    assert_eq!(
+        role_mismatch.unwrap_err(),
+        SccmFindingValidationError::ArtifactRequestRoleMismatch
+    );
+}
+
+#[test]
+fn finding_artifact_requests_require_nonempty_bounded_reasons_and_count() {
+    for reason in ["", "   "] {
+        let result = SccmFindingBuilder::new("empty-request-reason")
+            .class(SccmFindingClass::InsufficientEvidence)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .coverage_gap(finding_client_gap(
+                "client-policy-agent",
+                SccmCoverageState::Absent,
+            ))
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        assert_eq!(
+            result.unwrap_err(),
+            SccmFindingValidationError::InvalidArtifactRequestReason
+        );
+    }
+
+    let overlong_reason = "x".repeat(MAX_SCCM_ARTIFACT_REQUEST_REASON_CHARS + 1);
+    let overlong = SccmFindingBuilder::new("overlong-request-reason")
+        .class(SccmFindingClass::InsufficientEvidence)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .coverage_gap(finding_client_gap(
+            "client-policy-agent",
+            SccmCoverageState::Absent,
+        ))
+        .next_artifact(finding_request(
+            "policyAgent",
+            SccmRole::Client,
+            &overlong_reason,
+        ))
+        .build();
+    assert_eq!(
+        overlong.unwrap_err(),
+        SccmFindingValidationError::InvalidArtifactRequestReason
+    );
+
+    let requests = (0..=MAX_SCCM_NEXT_ARTIFACT_REQUESTS)
+        .map(|index| {
+            finding_request(
+                "policyAgent",
+                SccmRole::Client,
+                &format!("Bounded request {index}"),
+            )
+        })
+        .collect();
+    let too_many = SccmFindingBuilder::new("too-many-requests")
+        .class(SccmFindingClass::InsufficientEvidence)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .coverage_gap(finding_client_gap(
+            "client-policy-agent",
+            SccmCoverageState::Absent,
+        ))
+        .next_artifacts(requests)
+        .build();
+    assert_eq!(
+        too_many.unwrap_err(),
+        SccmFindingValidationError::TooManyArtifactRequests
+    );
+}
+
+#[test]
+fn finding_artifact_requests_reject_unbounded_reason_language_and_globs() {
+    for reason in [
+        "Collect the entire drive.",
+        "Search the whole disk for related evidence.",
+        "Collect all files recursively.",
+        "Recursively scan the client logs.",
+        "Collect C:\\**\\*.log.",
+    ] {
+        let result = SccmFindingBuilder::new("unbounded-request-reason")
+            .class(SccmFindingClass::InsufficientEvidence)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .coverage_gap(finding_client_gap(
+                "client-policy-agent",
+                SccmCoverageState::Absent,
+            ))
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+
+        assert_eq!(
+            result.unwrap_err(),
+            SccmFindingValidationError::InvalidArtifactRequestReason,
+            "{reason}"
+        );
+    }
+}
+
+#[test]
+fn finding_deserialization_rejects_unsound_high_and_forged_terminal_state() {
+    let evidence = finding_evidence_ref("client-app-enforce", "client-app-enforce:1-1");
+    let sound = SccmFindingBuilder::new("sound-terminal")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Enforcement)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![evidence.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(evidence)])
+        .build()
+        .unwrap();
+
+    let mut keyless_high = serde_json::to_value(&sound).unwrap();
+    keyless_high["terminalEvidence"] = serde_json::json!([]);
+    assert!(serde_json::from_value::<SccmFinding>(keyless_high).is_err());
+
+    let mut forged_terminal = serde_json::to_value(&sound).unwrap();
+    forged_terminal["terminalEvidence"][0]["kind"] = serde_json::json!("forgedFailure");
+    assert!(serde_json::from_value::<SccmFinding>(forged_terminal).is_err());
+}
+
+#[test]
+fn finding_deserialization_sorts_and_deduplicates_terminal_evidence() {
+    let first = finding_evidence_ref("artifact-a", "entry-a");
+    let second = finding_evidence_ref("artifact-b", "entry-b");
+    let finding = SccmFindingBuilder::new("terminal-ordering")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Enforcement)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![first.clone(), second.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(first.clone())])
+        .build()
+        .unwrap();
+    let first_terminal =
+        serde_json::to_value(SccmTerminalEvidence::observed_failure(first)).unwrap();
+    let second_terminal =
+        serde_json::to_value(SccmTerminalEvidence::observed_failure(second)).unwrap();
+    let mut json = serde_json::to_value(finding).unwrap();
+    json["terminalEvidence"] =
+        serde_json::json!([second_terminal, first_terminal.clone(), first_terminal]);
+
+    let normalized: SccmFinding = serde_json::from_value(json).unwrap();
+    assert_eq!(normalized.terminal_evidence.len(), 2);
+    assert_eq!(
+        normalized.terminal_evidence[0].reference.artifact_id,
+        "artifact-a"
+    );
+    assert_eq!(
+        normalized.terminal_evidence[1].reference.artifact_id,
+        "artifact-b"
+    );
+}
+
+#[test]
+fn finding_deserialization_rejects_raw_execution_context_fields() {
+    let evidence = finding_evidence_ref("client-policy-agent", "policy:1-1");
+    let finding = SccmFindingBuilder::new("no-raw-context")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![evidence])
+        .build()
+        .unwrap();
+    let mut json = serde_json::to_value(finding).unwrap();
+    json["executionContext"] = serde_json::json!(r"LAB\SyntheticUser");
+
+    assert!(serde_json::from_value::<SccmFinding>(json).is_err());
+}
+
+#[test]
+fn finding_output_is_sorted_deduplicated_camel_case_and_round_trippable() {
+    let first = finding_evidence_ref("artifact-a", "entry-a");
+    let second = finding_evidence_ref("artifact-b", "entry-b");
+    let package_key = finding_key(
+        SccmCorrelationKeyKind::PackageId,
+        "LAB00001",
+        "LAB00001",
+        SccmKeyConfidence::Low,
+        Some("sccm-keys-experimental-v1"),
+        second.clone(),
+    );
+    let assignment_key = finding_key(
+        SccmCorrelationKeyKind::AssignmentId,
+        "{ABCDEFAB-0000-0000-0000-000000000001}",
+        "abcdefab-0000-0000-0000-000000000001",
+        SccmKeyConfidence::Low,
+        Some("sccm-keys-experimental-v1"),
+        first.clone(),
+    );
+
+    let finding = SccmFindingBuilder::new("blocked-policy")
+        .class(SccmFindingClass::BlockedOrDeferred)
+        .phase(SccmPhase::Unknown("futurePhase".into()))
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Moderate)
+        .title("Policy processing is blocked")
+        .summary("Synthetic evidence does not expose execution context.")
+        .evidence(vec![second.clone(), first.clone(), second.clone()])
+        .correlation_keys(vec![
+            package_key.clone(),
+            assignment_key.clone(),
+            package_key,
+        ])
+        .coverage_gaps(vec![
+            finding_client_gap("artifact-z", SccmCoverageState::Capped),
+            finding_client_gap("artifact-c", SccmCoverageState::AccessDenied),
+            finding_client_gap("artifact-z", SccmCoverageState::Capped),
+        ])
+        .next_artifacts(vec![
+            finding_request(
+                "policyEvaluator",
+                SccmRole::Client,
+                "Confirm the bounded policy evaluation outcome.",
+            ),
+            finding_request(
+                "policyAgent",
+                SccmRole::Client,
+                "Confirm the bounded policy request outcome.",
+            ),
+            finding_request(
+                "policyEvaluator",
+                SccmRole::Client,
+                "Confirm the bounded policy evaluation outcome.",
+            ),
+        ])
+        .build()
+        .unwrap();
+
+    assert_eq!(finding.evidence, vec![first, second]);
+    assert_eq!(
+        finding
+            .correlation_keys
+            .iter()
+            .map(|key| key.kind.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            SccmCorrelationKeyKind::AssignmentId,
+            SccmCorrelationKeyKind::PackageId,
+        ]
+    );
+    assert_eq!(
+        finding
+            .coverage_gaps
+            .iter()
+            .map(|gap| gap.artifact_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["artifact-c", "artifact-z"]
+    );
+    assert_eq!(
+        finding
+            .next_artifacts
+            .iter()
+            .map(|request| request.logical_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["policyAgent", "policyEvaluator"]
+    );
+
+    let json = serde_json::to_value(&finding).unwrap();
+    assert_eq!(json["findingId"], "blocked-policy");
+    assert_eq!(json["class"], "blockedOrDeferred");
+    assert_eq!(json["phase"], "futurePhase");
+    assert!(json.get("coverageGaps").is_some());
+    assert!(json.get("correlationKeys").is_some());
+    assert!(json.get("nextArtifacts").is_some());
+    assert!(json.get("executionContext").is_none());
+    assert!(!serde_json::to_string(&json)
+        .unwrap()
+        .contains("SyntheticUser"));
+
+    let round_trip: SccmFinding = serde_json::from_value(json).unwrap();
+    assert_eq!(round_trip, finding);
+    round_trip.validate().unwrap();
 }
 
 fn json_value_contains_sensitive(value: &serde_json::Value, sensitive: &str) -> bool {

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -382,11 +382,15 @@ const REVIEW_UNRECOGNIZED_CONFIRMATION_REQUEST_REASONS: [&str; 10] = [
     "Confirm PolicyAgent.log for fetching credentials.",
 ];
 
-const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 4] = [
+const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 8] = [
     "Confirm all files are required for status in PolicyAgent.log.",
     "Confirm every file must be provided for download status in PolicyAgent.log.",
     "Confirm the whole disk is required for imaging status in Smsts.log.",
     "Confirm the full disk must be provided for imaging status in Smsts.log.",
+    "Confirm PolicyAgent.log status must include all files.",
+    "Confirm Smsts.log imaging status must provide the full disk.",
+    "Confirm PolicyAgent.log status must have all files provided.",
+    "Confirm Smsts.log imaging status must have the full disk provided.",
 ];
 
 const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -236,6 +236,94 @@ const REVIEW_BOUNDED_NAMED_ARTIFACT_REQUESTS: [(&str, &str); 14] = [
     ),
 ];
 
+const REVIEW_EXPANDED_UNBOUNDED_ARTIFACT_REQUEST_REASONS: [&str; 49] = [
+    "Recursively; collect PolicyAgent.log.",
+    "Collect PolicyAgent.log. Recursively.",
+    "Collect PolicyAgent.log! Recursively.",
+    "Collect PolicyAgent.log; this request also applies recursively.",
+    "Collect PolicyAgent.log; use recursion.",
+    "Use recursion; collect PolicyAgent.log.",
+    "Collect PolicyAgent.log; recurse.",
+    "Recurse; collect PolicyAgent.log.",
+    "Collect PolicyAgent.log; scan the filesystem.",
+    "Scan the filesystem; collect PolicyAgent.log.",
+    "Collect PolicyAgent.log; traverse directories.",
+    "Collect PolicyAgent.log; enumerate the filesystem.",
+    "Collect PolicyAgent.log; archive the filesystem.",
+    "Collect PolicyAgent.log; search system logs.",
+    "Collect PolicyAgent.log; gather device logs.",
+    "Collect PolicyAgent.log; capture machine files.",
+    "Collect PolicyAgent.log; logs from the machine.",
+    "Collect PolicyAgent.log; across the filesystem.",
+    "Collect PolicyAgent.log; throughout the system.",
+    "Collect PolicyAgent.log; from root.",
+    "At root; collect PolicyAgent.log.",
+    "Collect PolicyAgent.log; device root.",
+    "Collect PolicyAgent.log; systemwide.",
+    "System-wide; collect PolicyAgent.log.",
+    "Collect PolicyAgent.log; sitewide.",
+    "Collect PolicyAgent.log; across all systems.",
+    "Collect PolicyAgent.log; from every machine.",
+    "Collect PolicyAgent.log; the entire system.",
+    "Collect PolicyAgent.log; all data.",
+    "Collect PolicyAgent.log; all records on the system.",
+    "Collect PolicyAgent.log; everything from the system.",
+    "Collect PolicyAgent.log; capture everything.",
+    "Collect PolicyAgent.log; download all data.",
+    "Collect PolicyAgent.log; collect related files.",
+    "Collect all disks, status is recorded in PolicyAgent.log.",
+    "Collect every drive, encryption status is recorded in PolicyAgent.log.",
+    "Collect all files, download status is recorded in PolicyAgent.log.",
+    "Collect the whole filesystem status from PolicyAgent.log.",
+    "Collect complete machine status files recorded in PolicyAgent.log.",
+    "Collect C:.",
+    "Collect D: for evidence.",
+    "Collect %SYSTEMROOT%.",
+    "Collect %WINDIR%.",
+    "Collect %SystemDrive%.",
+    "Collect $env:SystemRoot.",
+    "Collect ../PolicyAgent.log.",
+    r"Collect ..\PolicyAgent.log.",
+    "Collect Logs/../PolicyAgent.log.",
+    "Collect PolicyAgent.log; recursively.",
+];
+
+const REVIEW_LOOKALIKE_ARTIFACT_REQUEST_REASONS: [&str; 4] = [
+    "Collect every PolicyAgent-backup.log file.",
+    "Collect every PolicyAgent.log.backup file.",
+    "Collect every PolicyAgent—backup.log file.",
+    "Collect every PolicyAgent backup file.",
+];
+
+const REVIEW_UNQUALIFIED_COLLECTION_ACTION_REASONS: [&str; 15] = [
+    "Archive diagnostics.zip.",
+    "Capture the registry.",
+    "Collect unrelated.log.",
+    "Copy database.db.",
+    "Download package.bin.",
+    "Enumerate registry keys.",
+    "Export credentials.json.",
+    "Gather diagnostics.",
+    "Inspect arbitrary.txt.",
+    "Obtain secrets.txt.",
+    "Read config.ini.",
+    "Scan unrelated.log.",
+    "Search temp files.",
+    "Traverse cache.",
+    "Walk the directory tree.",
+];
+
+const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
+    ("mpCliReg", "Collect the complete MP_CliReg.log file."),
+    ("mpGetAuth", "Collect the complete MP_GetAuth.log file."),
+    ("mpGetPolicy", "Collect the complete MP_GetPolicy.log file."),
+    ("mpLocation", "Collect the complete MP_Location.log file."),
+    (
+        "mpRegistrationManager",
+        "Collect the complete MP_RegistrationManager.log file.",
+    ),
+];
+
 #[derive(Clone, Copy, Debug)]
 enum FindingEvidenceAliasSurface {
     TopLevel,
@@ -1193,6 +1281,32 @@ fn finding_phase_unknown_values_require_canonical_standalone_serde() {
 }
 
 #[test]
+fn finding_terminal_evidence_kind_unknown_values_require_canonical_standalone_serde() {
+    for value in ["", " ", " futureTerminalKind "] {
+        assert!(
+            serde_json::to_string(&SccmTerminalEvidenceKind::Unknown(value.into())).is_err(),
+            "serialized {value:?}"
+        );
+        let wire = serde_json::to_string(value).unwrap();
+        assert!(
+            serde_json::from_str::<SccmTerminalEvidenceKind>(&wire).is_err(),
+            "deserialized {value:?}"
+        );
+    }
+    assert!(
+        serde_json::to_string(&SccmTerminalEvidenceKind::Unknown("observedFailure".into()))
+            .is_err()
+    );
+
+    let future = SccmTerminalEvidenceKind::Unknown("futureTerminalKind".into());
+    let wire = serde_json::to_string(&future).unwrap();
+    assert_eq!(
+        serde_json::from_str::<SccmTerminalEvidenceKind>(&wire).unwrap(),
+        future
+    );
+}
+
+#[test]
 fn finding_role_unknown_values_cannot_shadow_declared_roles() {
     for value in ["", " ", " futureRole "] {
         assert!(
@@ -1561,6 +1675,279 @@ fn finding_review_bounded_named_artifact_matrix_passes_every_public_boundary() {
     assert!(
         rejected.is_empty(),
         "rejected reviewed bounded request boundaries: {rejected:#?}"
+    );
+}
+
+#[test]
+fn finding_review_expanded_unbounded_scope_fails_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-expanded-unbounded-scope-parity");
+    let mut accepted = Vec::new();
+
+    for reason in REVIEW_EXPANDED_UNBOUNDED_ARTIFACT_REQUEST_REASONS {
+        let builder = SccmFindingBuilder::new("review-expanded-unbounded-scope-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted expanded unbounded request boundaries: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_lookalike_identity_fails_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-lookalike-identity-parity");
+    let mut accepted = Vec::new();
+
+    for reason in REVIEW_LOOKALIKE_ARTIFACT_REQUEST_REASONS {
+        let builder = SccmFindingBuilder::new("review-lookalike-identity-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted lookalike artifact request boundaries: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_unqualified_collection_actions_fail_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-unqualified-action-parity");
+    let mut accepted = Vec::new();
+
+    for reason in REVIEW_UNQUALIFIED_COLLECTION_ACTION_REASONS {
+        let builder = SccmFindingBuilder::new("review-unqualified-action-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted unqualified collection action boundaries: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_exact_mp_identity_passes_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-exact-mp-identity-parity");
+    let mut rejected = Vec::new();
+
+    for (logical_id, reason) in REVIEW_EXACT_MP_ARTIFACT_REQUESTS {
+        let builder = SccmFindingBuilder::new("review-exact-mp-identity-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::ManagementPoint)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request(
+                logical_id,
+                SccmRole::ManagementPoint,
+                reason,
+            ))
+            .build();
+        if let Err(error) = builder {
+            rejected.push(format!("builder ({error:?}): {logical_id}: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0] = finding_request(logical_id, SccmRole::ManagementPoint, reason);
+        if let Err(error) = direct.validate() {
+            rejected.push(format!(
+                "direct validate ({error:?}): {logical_id}: {reason}"
+            ));
+        }
+        if serde_json::to_value(&direct).is_err() {
+            rejected.push(format!("serializer: {logical_id}: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0] = serde_json::to_value(finding_request(
+            logical_id,
+            SccmRole::ManagementPoint,
+            reason,
+        ))
+        .unwrap();
+        if serde_json::from_value::<SccmFinding>(json).is_err() {
+            rejected.push(format!("deserializer: {logical_id}: {reason}"));
+        }
+    }
+
+    assert!(
+        rejected.is_empty(),
+        "rejected exact MP artifact request boundaries: {rejected:#?}"
+    );
+}
+
+#[test]
+fn finding_review_every_exact_catalog_identity_passes_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-exact-catalog-identity-parity");
+    let mut rejected = Vec::new();
+
+    for source in declared_source_catalog() {
+        let reasons = [
+            format!("Collect the complete {} file.", source.basename),
+            format!("Collect the complete {}.log file.", source.logical_name),
+        ];
+
+        for reason in reasons {
+            let request = finding_request(&source.logical_name, source.role.clone(), &reason);
+            let builder = SccmFindingBuilder::new("review-exact-catalog-identity-builder")
+                .class(SccmFindingClass::Symptom)
+                .phase(SccmPhase::Policy)
+                .role(source.role.clone())
+                .severity(Severity::Warning)
+                .confidence(SccmConfidence::Low)
+                .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+                .next_artifact(request.clone())
+                .build();
+            if let Err(error) = builder {
+                rejected.push(format!(
+                    "builder ({error:?}): {}: {reason}",
+                    source.logical_name
+                ));
+            }
+
+            let mut direct = canonical.clone();
+            direct.next_artifacts[0] = request.clone();
+            if let Err(error) = direct.validate() {
+                rejected.push(format!(
+                    "direct validate ({error:?}): {}: {reason}",
+                    source.logical_name
+                ));
+            }
+            if serde_json::to_value(&direct).is_err() {
+                rejected.push(format!("serializer: {}: {reason}", source.logical_name));
+            }
+
+            let mut json = serde_json::to_value(&canonical).unwrap();
+            json["nextArtifacts"][0] = serde_json::to_value(request).unwrap();
+            if serde_json::from_value::<SccmFinding>(json).is_err() {
+                rejected.push(format!("deserializer: {}: {reason}", source.logical_name));
+            }
+        }
+    }
+
+    assert!(
+        rejected.is_empty(),
+        "rejected exact catalog artifact request boundaries: {rejected:#?}"
+    );
+}
+
+#[test]
+fn finding_review_percentages_are_not_environment_paths_at_every_public_boundary() {
+    let reason = "Collect PolicyAgent.log after 50% and before 60% completion.";
+    let canonical = finding_with_gap_and_request("review-percentage-path-parity");
+    let mut rejected = Vec::new();
+
+    let builder = SccmFindingBuilder::new("review-percentage-path-builder")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+        .build();
+    if let Err(error) = builder {
+        rejected.push(format!("builder ({error:?})"));
+    }
+
+    let mut direct = canonical.clone();
+    direct.next_artifacts[0].reason = reason.into();
+    if let Err(error) = direct.validate() {
+        rejected.push(format!("direct validate ({error:?})"));
+    }
+    if serde_json::to_value(&direct).is_err() {
+        rejected.push("serializer".into());
+    }
+
+    let mut json = serde_json::to_value(&canonical).unwrap();
+    json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+    if serde_json::from_value::<SccmFinding>(json).is_err() {
+        rejected.push("deserializer".into());
+    }
+
+    assert!(
+        rejected.is_empty(),
+        "rejected non-environment percentages: {rejected:#?}"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -747,6 +747,24 @@ fn finding_deserialization_rejects_unsound_high_and_forged_terminal_state() {
 }
 
 #[test]
+fn finding_serialization_rejects_post_build_invalid_mutation() {
+    let evidence = finding_evidence_ref("client-app-enforce", "client-app-enforce:1-1");
+    let mut finding = SccmFindingBuilder::new("mutated-confirmed-failure")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Enforcement)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![evidence.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(evidence)])
+        .build()
+        .unwrap();
+    finding.terminal_evidence.clear();
+
+    assert!(serde_json::to_value(finding).is_err());
+}
+
+#[test]
 fn finding_deserialization_sorts_and_deduplicates_terminal_evidence() {
     let first = finding_evidence_ref("artifact-a", "entry-a");
     let second = finding_evidence_ref("artifact-b", "entry-b");

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -373,6 +373,106 @@ fn finding_rejects_key_or_terminal_refs_that_are_not_cited() {
 }
 
 #[test]
+fn finding_nested_references_use_shared_identity_validation() {
+    let cited = finding_evidence_ref("client-policy-agent", "policy:1-1");
+    let invalid = SccmEvidenceRef {
+        artifact_id: " ".into(),
+        entry_id: "policy:2-2".into(),
+        line_start: Some(2),
+        line_end: Some(2),
+    };
+
+    let terminal_result = SccmFindingBuilder::new("invalid-terminal-reference")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![cited.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(
+            invalid.clone(),
+        )])
+        .build();
+    assert_eq!(
+        terminal_result.unwrap_err(),
+        SccmFindingValidationError::InvalidEvidenceReference
+    );
+
+    let key_result = SccmFindingBuilder::new("invalid-key-reference")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![cited])
+        .correlation_keys(vec![finding_key(
+            SccmCorrelationKeyKind::AssignmentId,
+            "{ABCDEFAB-0000-0000-0000-000000000001}",
+            "abcdefab-0000-0000-0000-000000000001",
+            SccmKeyConfidence::Low,
+            Some("sccm-keys-experimental-v1"),
+            invalid,
+        )])
+        .build();
+    assert_eq!(
+        key_result.unwrap_err(),
+        SccmFindingValidationError::InvalidEvidenceReference
+    );
+}
+
+#[test]
+fn finding_evidence_reference_line_ranges_are_integral() {
+    let cases = [
+        ("missing-end", Some(1), None),
+        ("missing-start", None, Some(1)),
+        ("zero-start", Some(0), Some(1)),
+        ("reversed", Some(2), Some(1)),
+    ];
+
+    for (label, line_start, line_end) in cases {
+        let result = SccmFindingBuilder::new(format!("invalid-range-{label}"))
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![SccmEvidenceRef {
+                artifact_id: "client-policy-agent".into(),
+                entry_id: "policy:1-1".into(),
+                line_start,
+                line_end,
+            }])
+            .build();
+
+        assert_eq!(
+            result.unwrap_err(),
+            SccmFindingValidationError::InvalidEvidenceReference,
+            "{label}"
+        );
+    }
+}
+
+#[test]
+fn finding_evidence_reference_allows_an_unavailable_line_range() {
+    let finding = SccmFindingBuilder::new("line-range-unavailable")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![SccmEvidenceRef {
+            artifact_id: "client-policy-agent".into(),
+            entry_id: "policy:logical-record".into(),
+            line_start: None,
+            line_end: None,
+        }])
+        .build()
+        .unwrap();
+
+    serde_json::to_value(finding).unwrap();
+}
+
+#[test]
 fn finding_rejects_a_correlation_key_without_an_evidence_ref() {
     let cited = finding_evidence_ref("client-policy-agent", "policy:1-1");
     let mut key = finding_key(
@@ -744,6 +844,73 @@ fn finding_deserialization_rejects_unsound_high_and_forged_terminal_state() {
     let mut forged_terminal = serde_json::to_value(&sound).unwrap();
     forged_terminal["terminalEvidence"][0]["kind"] = serde_json::json!("forgedFailure");
     assert!(serde_json::from_value::<SccmFinding>(forged_terminal).is_err());
+}
+
+#[test]
+fn finding_builder_rejects_blank_self_attesting_terminal_identity() {
+    let invalid = SccmEvidenceRef {
+        artifact_id: String::new(),
+        entry_id: "   ".into(),
+        line_start: None,
+        line_end: None,
+    };
+    let result = SccmFindingBuilder::new("blank-terminal-builder")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Enforcement)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![invalid.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(invalid)])
+        .build();
+
+    assert_eq!(
+        result.unwrap_err(),
+        SccmFindingValidationError::InvalidEvidenceReference
+    );
+}
+
+#[test]
+fn finding_deserialization_rejects_blank_self_attesting_terminal_identity() {
+    let evidence = finding_evidence_ref("client-app-enforce", "client-app-enforce:1-1");
+    let finding = SccmFindingBuilder::new("blank-terminal-deserialize")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Enforcement)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![evidence.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(evidence)])
+        .build()
+        .unwrap();
+    let mut json = serde_json::to_value(finding).unwrap();
+    json["evidence"][0]["artifactId"] = serde_json::json!(" ");
+    json["evidence"][0]["entryId"] = serde_json::json!("");
+    json["terminalEvidence"][0]["reference"]["artifactId"] = serde_json::json!(" ");
+    json["terminalEvidence"][0]["reference"]["entryId"] = serde_json::json!("");
+
+    assert!(serde_json::from_value::<SccmFinding>(json).is_err());
+}
+
+#[test]
+fn finding_serialization_rejects_blank_self_attesting_terminal_identity() {
+    let evidence = finding_evidence_ref("client-app-enforce", "client-app-enforce:1-1");
+    let mut finding = SccmFindingBuilder::new("blank-terminal-serialize")
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Enforcement)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![evidence.clone()])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(evidence)])
+        .build()
+        .unwrap();
+    finding.evidence[0].artifact_id = " ".into();
+    finding.evidence[0].entry_id.clear();
+    finding.terminal_evidence[0].reference.artifact_id = " ".into();
+    finding.terminal_evidence[0].reference.entry_id.clear();
+
+    assert!(serde_json::to_value(finding).is_err());
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -369,6 +369,19 @@ const REVIEW_STANDALONE_AND_INFLECTED_COLLECTION_REASONS: [&str; 6] = [
     "Collect PolicyAgent.log after retrieving credentials.",
 ];
 
+const REVIEW_UNRECOGNIZED_CONFIRMATION_REQUEST_REASONS: [&str; 10] = [
+    "Confirm retrieve secrets.txt.",
+    "Confirm acquire credentials.json.",
+    "Confirm fetch credentials.json.",
+    "Confirm preserve secrets.txt.",
+    "Confirm retrieving credentials.",
+    "Confirm fetching secrets.",
+    "Confirm preservation of secrets.txt.",
+    "Confirm collection of credentials.json.",
+    "Confirm PolicyAgent.log after retrieving credentials.",
+    "Confirm PolicyAgent.log for fetching credentials.",
+];
+
 const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
     ("mpCliReg", "Collect the complete MP_CliReg.log file."),
     ("mpGetAuth", "Collect the complete MP_GetAuth.log file."),
@@ -2149,6 +2162,48 @@ fn finding_review_standalone_and_inflected_collection_requests_fail_at_every_pub
     assert!(
         accepted.is_empty(),
         "accepted standalone or inflected collection requests: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_unrecognized_confirmation_requests_fail_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-confirmation-request-parity");
+    let mut accepted = Vec::new();
+
+    for reason in REVIEW_UNRECOGNIZED_CONFIRMATION_REQUEST_REASONS {
+        let builder = SccmFindingBuilder::new("review-confirmation-request-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted unrecognized confirmation requests: {accepted:#?}"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -127,6 +127,139 @@ const ROOTED_ARTIFACT_REQUEST_REASONS: [&str; 7] = [
     "Collect //server/share/PolicyAgent.log.",
 ];
 
+const COMPACT_UNBOUNDED_ARTIFACT_REQUEST_REASONS: [&str; 5] = [
+    "Collect allfiles.",
+    "Collect everydirectory.",
+    "Scan entiredisk.",
+    "Search wholefilesystem.",
+    "Collect every log on the system.",
+];
+
+const BOUNDED_NARRATIVE_ARTIFACT_REQUEST_REASONS: [&str; 5] = [
+    "Collect the full disk imaging Task Sequence log.",
+    "Confirm the whole-disk encryption status recorded in PolicyAgent.log.",
+    "Confirm the system-wide assignment recorded in PolicyAgent.log.",
+    "Confirm recursive retry behavior recorded in PolicyAgent.log.",
+    "Confirm all files were downloaded, as recorded in PolicyAgent.log.",
+];
+
+#[derive(Clone, Copy, Debug)]
+enum FindingEvidenceAliasSurface {
+    TopLevel,
+    Terminal,
+    CorrelationKey,
+}
+
+fn finding_with_evidence_alias(
+    finding_id: &str,
+    alias_surface: Option<FindingEvidenceAliasSurface>,
+) -> Result<SccmFinding, SccmFindingValidationError> {
+    let mut top_level = finding_evidence_ref("artifact-a", "entry-a");
+    let mut terminal = top_level.clone();
+    let mut key = top_level.clone();
+    match alias_surface {
+        Some(FindingEvidenceAliasSurface::TopLevel) => {
+            top_level.artifact_id = " artifact-a ".into();
+            top_level.entry_id = " entry-a ".into();
+        }
+        Some(FindingEvidenceAliasSurface::Terminal) => {
+            terminal.artifact_id = " artifact-a ".into();
+            terminal.entry_id = " entry-a ".into();
+        }
+        Some(FindingEvidenceAliasSurface::CorrelationKey) => {
+            key.artifact_id = " artifact-a ".into();
+            key.entry_id = " entry-a ".into();
+        }
+        None => {}
+    }
+
+    SccmFindingBuilder::new(finding_id)
+        .class(SccmFindingClass::ConfirmedFailure)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Error)
+        .confidence(SccmConfidence::High)
+        .evidence(vec![top_level])
+        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(terminal)])
+        .correlation_keys(vec![finding_key(
+            SccmCorrelationKeyKind::AssignmentId,
+            "{ABCDEFAB-0000-0000-0000-000000000001}",
+            "abcdefab-0000-0000-0000-000000000001",
+            SccmKeyConfidence::Low,
+            Some("sccm-keys-experimental-v1"),
+            key,
+        )])
+        .build()
+}
+
+fn apply_evidence_alias(finding: &mut SccmFinding, surface: FindingEvidenceAliasSurface) {
+    match surface {
+        FindingEvidenceAliasSurface::TopLevel => {
+            finding.evidence[0].artifact_id = " artifact-a ".into();
+            finding.evidence[0].entry_id = " entry-a ".into();
+        }
+        FindingEvidenceAliasSurface::Terminal => {
+            finding.terminal_evidence[0].reference.artifact_id = " artifact-a ".into();
+            finding.terminal_evidence[0].reference.entry_id = " entry-a ".into();
+        }
+        FindingEvidenceAliasSurface::CorrelationKey => {
+            let reference = finding.correlation_keys[0].evidence.as_mut().unwrap();
+            reference.artifact_id = " artifact-a ".into();
+            reference.entry_id = " entry-a ".into();
+        }
+    }
+}
+
+fn apply_evidence_alias_json(
+    finding: &mut serde_json::Value,
+    surface: FindingEvidenceAliasSurface,
+) {
+    match surface {
+        FindingEvidenceAliasSurface::TopLevel => {
+            finding["evidence"][0]["artifactId"] = serde_json::json!(" artifact-a ");
+            finding["evidence"][0]["entryId"] = serde_json::json!(" entry-a ");
+        }
+        FindingEvidenceAliasSurface::Terminal => {
+            finding["terminalEvidence"][0]["reference"]["artifactId"] =
+                serde_json::json!(" artifact-a ");
+            finding["terminalEvidence"][0]["reference"]["entryId"] = serde_json::json!(" entry-a ");
+        }
+        FindingEvidenceAliasSurface::CorrelationKey => {
+            finding["correlationKeys"][0]["evidence"]["artifactId"] =
+                serde_json::json!(" artifact-a ");
+            finding["correlationKeys"][0]["evidence"]["entryId"] = serde_json::json!(" entry-a ");
+        }
+    }
+}
+
+fn assert_evidence_alias_is_rejected(surface: FindingEvidenceAliasSurface) {
+    let mut mismatches = Vec::new();
+
+    if finding_with_evidence_alias("builder-evidence-alias", Some(surface)).err()
+        != Some(SccmFindingValidationError::InvalidEvidenceReference)
+    {
+        mismatches.push("builder did not return InvalidEvidenceReference");
+    }
+
+    let mut direct = finding_with_evidence_alias("direct-evidence-alias", None).unwrap();
+    apply_evidence_alias(&mut direct, surface);
+    if direct.validate().err() != Some(SccmFindingValidationError::InvalidEvidenceReference) {
+        mismatches.push("direct validate did not return InvalidEvidenceReference");
+    }
+    if serde_json::to_value(&direct).is_ok() {
+        mismatches.push("validating serializer accepted the alias");
+    }
+
+    let canonical = finding_with_evidence_alias("deserialized-evidence-alias", None).unwrap();
+    let mut json = serde_json::to_value(canonical).unwrap();
+    apply_evidence_alias_json(&mut json, surface);
+    if serde_json::from_value::<SccmFinding>(json).is_ok() {
+        mismatches.push("deserializer accepted the alias");
+    }
+
+    assert!(mismatches.is_empty(), "{surface:?}: {mismatches:?}");
+}
+
 #[test]
 fn finding_confirmed_failure_requires_terminal_evidence() {
     let result = SccmFindingBuilder::new("app-enforcement-failed")
@@ -652,7 +785,7 @@ fn finding_rejects_conflicting_ranges_for_one_logical_evidence_identity() {
     });
     assert_eq!(
         mutated.validate().unwrap_err(),
-        SccmFindingValidationError::ConflictingEvidenceReference
+        SccmFindingValidationError::InvalidEvidenceReference
     );
 }
 
@@ -708,49 +841,110 @@ fn finding_serialization_prioritizes_conflicting_evidence_identity_ranges() {
 }
 
 #[test]
-fn finding_canonicalizes_evidence_identity_whitespace() {
-    let top_level = SccmEvidenceRef {
-        artifact_id: " artifact-a ".into(),
-        entry_id: " entry-a ".into(),
-        line_start: Some(1),
-        line_end: Some(1),
-    };
-    let terminal = SccmEvidenceRef {
-        artifact_id: "artifact-a ".into(),
-        entry_id: "entry-a".into(),
-        ..top_level.clone()
-    };
-    let key = SccmEvidenceRef {
-        artifact_id: " artifact-a".into(),
-        entry_id: " entry-a".into(),
-        ..top_level.clone()
-    };
-    let finding = SccmFindingBuilder::new("canonical-evidence-identity")
-        .class(SccmFindingClass::ConfirmedFailure)
+fn finding_rejects_top_level_evidence_identity_whitespace_aliases() {
+    assert_evidence_alias_is_rejected(FindingEvidenceAliasSurface::TopLevel);
+}
+
+#[test]
+fn finding_rejects_terminal_evidence_identity_whitespace_aliases() {
+    assert_evidence_alias_is_rejected(FindingEvidenceAliasSurface::Terminal);
+}
+
+#[test]
+fn finding_rejects_correlation_key_evidence_identity_whitespace_aliases() {
+    assert_evidence_alias_is_rejected(FindingEvidenceAliasSurface::CorrelationKey);
+}
+
+#[test]
+fn finding_rejects_noncanonical_opaque_ids_across_public_boundaries() {
+    let mut mismatches = Vec::new();
+
+    if finding_with_evidence_alias(" finding-id ", None).err()
+        != Some(SccmFindingValidationError::MissingRequiredField)
+    {
+        mismatches.push("builder accepted a noncanonical finding ID");
+    }
+    let mut finding_id = finding_with_evidence_alias("finding-id", None).unwrap();
+    finding_id.finding_id = " finding-id ".into();
+    if finding_id.validate().err() != Some(SccmFindingValidationError::MissingRequiredField) {
+        mismatches.push("direct validate accepted a noncanonical finding ID");
+    }
+    if serde_json::to_value(&finding_id).is_ok() {
+        mismatches.push("serializer accepted a noncanonical finding ID");
+    }
+    let mut finding_id_json =
+        serde_json::to_value(finding_with_evidence_alias("finding-id-json", None).unwrap())
+            .unwrap();
+    finding_id_json["findingId"] = serde_json::json!(" finding-id-json ");
+    if serde_json::from_value::<SccmFinding>(finding_id_json).is_ok() {
+        mismatches.push("deserializer accepted a noncanonical finding ID");
+    }
+
+    let gap_builder = SccmFindingBuilder::new("noncanonical-gap-id")
+        .class(SccmFindingClass::Symptom)
         .phase(SccmPhase::Policy)
         .role(SccmRole::Client)
-        .severity(Severity::Error)
-        .confidence(SccmConfidence::High)
-        .evidence(vec![top_level])
-        .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(terminal)])
-        .correlation_keys(vec![finding_key(
-            SccmCorrelationKeyKind::AssignmentId,
-            "{ABCDEFAB-0000-0000-0000-000000000001}",
-            "abcdefab-0000-0000-0000-000000000001",
-            SccmKeyConfidence::Low,
-            Some("sccm-keys-experimental-v1"),
-            key,
-        )])
-        .build()
-        .unwrap();
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .coverage_gap(finding_client_gap(
+            " client-policy-agent ",
+            SccmCoverageState::AccessDenied,
+        ))
+        .build();
+    if gap_builder.err() != Some(SccmFindingValidationError::InvalidCoverageGap) {
+        mismatches.push("builder accepted a noncanonical coverage-gap artifact ID");
+    }
+    let mut gap = finding_with_gap_and_request("noncanonical-gap-direct");
+    gap.coverage_gaps[0].artifact_id = " client-policy-agent ".into();
+    if gap.validate().err() != Some(SccmFindingValidationError::InvalidCoverageGap) {
+        mismatches.push("direct validate accepted a noncanonical coverage-gap artifact ID");
+    }
+    if serde_json::to_value(&gap).is_ok() {
+        mismatches.push("serializer accepted a noncanonical coverage-gap artifact ID");
+    }
+    let mut gap_json =
+        serde_json::to_value(finding_with_gap_and_request("noncanonical-gap-json")).unwrap();
+    gap_json["coverageGaps"][0]["artifactId"] = serde_json::json!(" client-policy-agent ");
+    if serde_json::from_value::<SccmFinding>(gap_json).is_ok() {
+        mismatches.push("deserializer accepted a noncanonical coverage-gap artifact ID");
+    }
 
-    assert_eq!(finding.evidence[0].artifact_id, "artifact-a");
-    assert_eq!(finding.evidence[0].entry_id, "entry-a");
-    assert_eq!(finding.terminal_evidence[0].reference, finding.evidence[0]);
-    assert_eq!(
-        finding.correlation_keys[0].evidence.as_ref(),
-        Some(&finding.evidence[0])
-    );
+    let request_builder = SccmFindingBuilder::new("noncanonical-request-id")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .next_artifact(finding_request(
+            " policyAgent ",
+            SccmRole::Client,
+            " Confirm the bounded policy request outcome. ",
+        ))
+        .build();
+    if request_builder.err() != Some(SccmFindingValidationError::UndeclaredArtifactRequest) {
+        mismatches.push("builder accepted a noncanonical request logical ID");
+    }
+    let mut request = finding_with_gap_and_request("noncanonical-request-direct");
+    request.next_artifacts[0].logical_id = " policyAgent ".into();
+    request.next_artifacts[0].reason = " Confirm the bounded policy request outcome. ".into();
+    if request.validate().err() != Some(SccmFindingValidationError::UndeclaredArtifactRequest) {
+        mismatches.push("direct validate did not reject a noncanonical request logical ID");
+    }
+    if serde_json::to_value(&request).is_ok() {
+        mismatches.push("serializer accepted a noncanonical request logical ID");
+    }
+    let mut request_json =
+        serde_json::to_value(finding_with_gap_and_request("noncanonical-request-json")).unwrap();
+    request_json["nextArtifacts"][0]["logicalId"] = serde_json::json!(" policyAgent ");
+    request_json["nextArtifacts"][0]["reason"] =
+        serde_json::json!(" Confirm the bounded policy request outcome. ");
+    if serde_json::from_value::<SccmFinding>(request_json).is_ok() {
+        mismatches.push("deserializer accepted a noncanonical request logical ID");
+    }
+
+    assert!(mismatches.is_empty(), "{mismatches:#?}");
 }
 
 #[test]
@@ -764,7 +958,25 @@ fn finding_rejects_whitespace_wrapped_declared_phase_shadow() {
         .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
         .build();
 
-    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err(),
+        SccmFindingValidationError::MissingRequiredField
+    );
+
+    let mut mutated = SccmFindingBuilder::new("direct-wrapped-phase-shadow")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .build()
+        .unwrap();
+    mutated.phase = SccmPhase::Unknown(" policy ".into());
+    assert_eq!(
+        mutated.validate().unwrap_err(),
+        SccmFindingValidationError::MissingRequiredField
+    );
 }
 
 #[test]
@@ -801,18 +1013,86 @@ fn finding_serialization_rejects_whitespace_wrapped_declared_phase_shadow() {
 }
 
 #[test]
-fn finding_canonicalizes_future_phase_whitespace() {
-    let finding = SccmFindingBuilder::new("canonical-future-phase")
+fn finding_rejects_noncanonical_future_phase_whitespace() {
+    let result = SccmFindingBuilder::new("noncanonical-future-phase")
         .class(SccmFindingClass::Symptom)
         .phase(SccmPhase::Unknown(" futurePhase ".into()))
         .role(SccmRole::Client)
         .severity(Severity::Warning)
         .confidence(SccmConfidence::Low)
         .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .build();
+
+    assert_eq!(
+        result.unwrap_err(),
+        SccmFindingValidationError::MissingRequiredField
+    );
+
+    let mut mutated = SccmFindingBuilder::new("direct-noncanonical-future-phase")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Unknown("futurePhase".into()))
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
         .build()
         .unwrap();
+    mutated.phase = SccmPhase::Unknown(" futurePhase ".into());
+    assert_eq!(
+        mutated.validate().unwrap_err(),
+        SccmFindingValidationError::MissingRequiredField
+    );
+    assert!(serde_json::to_value(&mutated).is_err());
 
-    assert_eq!(finding.phase, SccmPhase::Unknown("futurePhase".into()));
+    let mut json = serde_json::to_value(
+        SccmFindingBuilder::new("deserialized-noncanonical-future-phase")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Unknown("futurePhase".into()))
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .build()
+            .unwrap(),
+    )
+    .unwrap();
+    json["phase"] = serde_json::json!(" futurePhase ");
+    assert!(serde_json::from_value::<SccmFinding>(json).is_err());
+}
+
+#[test]
+fn finding_phase_unknown_values_require_canonical_standalone_serde() {
+    for value in ["", " ", " policy ", " futurePhase "] {
+        assert!(
+            serde_json::to_string(&SccmPhase::Unknown(value.into())).is_err(),
+            "serialized {value:?}"
+        );
+        let wire = serde_json::to_string(value).unwrap();
+        assert!(
+            serde_json::from_str::<SccmPhase>(&wire).is_err(),
+            "deserialized {value:?}"
+        );
+    }
+    for value in ["policy", "content", "enforcement"] {
+        assert!(
+            serde_json::to_string(&SccmPhase::Unknown(value.into())).is_err(),
+            "shadowed {value:?}"
+        );
+    }
+
+    let phase = SccmPhase::Unknown("futurePhase".into());
+    let wire = serde_json::to_string(&phase).unwrap();
+    assert_eq!(serde_json::from_str::<SccmPhase>(&wire).unwrap(), phase);
+
+    let finding = SccmFindingBuilder::new("canonical-future-phase")
+        .class(SccmFindingClass::Symptom)
+        .phase(phase)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+        .build()
+        .unwrap();
     assert_eq!(
         serde_json::to_value(finding).unwrap()["phase"],
         "futurePhase"
@@ -969,8 +1249,13 @@ fn finding_artifact_requests_reject_structurally_unbounded_reasons() {
         "Use a glob for matching log files.",
         r"Collect C:\Windows\CCM\Logs\*.log.",
     ];
+    let mut accepted = Vec::new();
 
-    for reason in reasons.into_iter().chain(ROOTED_ARTIFACT_REQUEST_REASONS) {
+    for reason in reasons
+        .into_iter()
+        .chain(ROOTED_ARTIFACT_REQUEST_REASONS)
+        .chain(COMPACT_UNBOUNDED_ARTIFACT_REQUEST_REASONS)
+    {
         let result = SccmFindingBuilder::new("unbounded-structural-request")
             .class(SccmFindingClass::Symptom)
             .phase(SccmPhase::Policy)
@@ -981,17 +1266,20 @@ fn finding_artifact_requests_reject_structurally_unbounded_reasons() {
             .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
             .build();
 
-        assert_eq!(
-            result.unwrap_err(),
-            SccmFindingValidationError::InvalidArtifactRequestReason,
-            "{reason}"
-        );
+        if result.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(reason);
+        }
     }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted unbounded reasons: {accepted:#?}"
+    );
 }
 
 #[test]
 fn finding_artifact_requests_accept_specific_bounded_reasons() {
-    for reason in [
+    let existing = [
         "Confirm the bounded policy request outcome.",
         "Collect the PolicyAgent record cited by assignment A.",
         "Confirm the root cause recorded by PolicyAgent.",
@@ -999,8 +1287,15 @@ fn finding_artifact_requests_accept_specific_bounded_reasons() {
         "Collect the disk imaging Task Sequence log.",
         "Collect Logs/PolicyAgent.log from the bounded bundle.",
         r"Collect Logs\PolicyAgent.log from the bounded bundle.",
-    ] {
-        SccmFindingBuilder::new("bounded-structural-request")
+    ];
+    let canonical = finding_with_gap_and_request("bounded-reason-parity");
+    let mut rejected = Vec::new();
+
+    for reason in existing
+        .into_iter()
+        .chain(BOUNDED_NARRATIVE_ARTIFACT_REQUEST_REASONS)
+    {
+        if SccmFindingBuilder::new("bounded-structural-request")
             .class(SccmFindingClass::Symptom)
             .phase(SccmPhase::Policy)
             .role(SccmRole::Client)
@@ -1009,35 +1304,69 @@ fn finding_artifact_requests_accept_specific_bounded_reasons() {
             .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
             .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
             .build()
-            .unwrap();
+            .is_err()
+        {
+            rejected.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().is_err() {
+            rejected.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_err() {
+            rejected.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_err() {
+            rejected.push(format!("deserializer: {reason}"));
+        }
     }
+
+    assert!(
+        rejected.is_empty(),
+        "rejected bounded reasons: {rejected:#?}"
+    );
 }
 
 #[test]
 fn finding_artifact_request_bounds_apply_to_deserialization_and_serialization() {
     let finding = finding_with_gap_and_request("request-boundary-parity");
-    for reason in ROOTED_ARTIFACT_REQUEST_REASONS.into_iter().chain([
-        "Collect every file on the system.",
-        "Scan the full disk for related evidence.",
-    ]) {
+    let mut accepted = Vec::new();
+    for reason in ROOTED_ARTIFACT_REQUEST_REASONS
+        .into_iter()
+        .chain([
+            "Collect every file on the system.",
+            "Scan the full disk for related evidence.",
+        ])
+        .chain(COMPACT_UNBOUNDED_ARTIFACT_REQUEST_REASONS)
+    {
+        let mut direct = finding.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+
         let mut json = serde_json::to_value(&finding).unwrap();
         json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
-        let deserialize_error = serde_json::from_value::<SccmFinding>(json)
-            .unwrap_err()
-            .to_string();
-        assert!(
-            deserialize_error.contains("InvalidArtifactRequestReason"),
-            "{reason}: {deserialize_error}"
-        );
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
 
         let mut mutated = finding.clone();
         mutated.next_artifacts[0].reason = reason.into();
-        let serialize_error = serde_json::to_string(&mutated).unwrap_err().to_string();
-        assert!(
-            serialize_error.contains("InvalidArtifactRequestReason"),
-            "{reason}: {serialize_error}"
-        );
+        if serde_json::to_string(&mutated).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
     }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted unbounded request boundaries: {accepted:#?}"
+    );
 }
 
 #[test]
@@ -1359,6 +1688,46 @@ fn finding_artifact_requests_require_nonempty_bounded_reasons_and_count() {
         too_many.unwrap_err(),
         SccmFindingValidationError::TooManyArtifactRequests
     );
+}
+
+#[test]
+fn finding_artifact_request_raw_cardinality_precedes_exact_deduplication() {
+    let canonical = finding_with_gap_and_request("duplicate-request-cardinality");
+    let request = canonical.next_artifacts[0].clone();
+    let duplicated = vec![request; MAX_SCCM_NEXT_ARTIFACT_REQUESTS + 1];
+
+    let builder = SccmFindingBuilder::new("duplicate-request-builder")
+        .class(SccmFindingClass::InsufficientEvidence)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .coverage_gap(finding_client_gap(
+            "client-policy-agent",
+            SccmCoverageState::AccessDenied,
+        ))
+        .next_artifacts(duplicated.clone())
+        .build();
+    assert_eq!(
+        builder.unwrap_err(),
+        SccmFindingValidationError::TooManyArtifactRequests
+    );
+
+    let mut direct = canonical.clone();
+    direct.next_artifacts = duplicated;
+    assert_eq!(
+        direct.validate().unwrap_err(),
+        SccmFindingValidationError::TooManyArtifactRequests
+    );
+
+    let mut json = serde_json::to_value(canonical).unwrap();
+    let request_json = json["nextArtifacts"][0].clone();
+    json["nextArtifacts"] =
+        serde_json::Value::Array(vec![request_json; MAX_SCCM_NEXT_ARTIFACT_REQUESTS + 1]);
+    assert!(serde_json::from_value::<SccmFinding>(json).is_err());
+
+    let error = serde_json::to_string(&direct).unwrap_err().to_string();
+    assert!(error.contains("TooManyArtifactRequests"), "{error}");
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -135,7 +135,7 @@ const COMPACT_UNBOUNDED_ARTIFACT_REQUEST_REASONS: [&str; 5] = [
     "Collect every log on the system.",
 ];
 
-const ORDER_INDEPENDENT_UNBOUNDED_ARTIFACT_REQUEST_REASONS: [&str; 10] = [
+const ORDER_INDEPENDENT_UNBOUNDED_ARTIFACT_REQUEST_REASONS: [&str; 12] = [
     "Every log on the system must be collected.",
     "Request all files on the system.",
     "Obtain every directory from the machine.",
@@ -146,14 +146,94 @@ const ORDER_INDEPENDENT_UNBOUNDED_ARTIFACT_REQUEST_REASONS: [&str; 10] = [
     "All files from every directory are required.",
     "Collect all of the files.",
     "Scan every single directory.",
+    "Collect PolicyAgent.log plus logs at root.",
+    "Collect PolicyAgent.log plus systemwide collection scope.",
 ];
 
-const BOUNDED_NARRATIVE_ARTIFACT_REQUEST_REASONS: [&str; 5] = [
-    "Collect the full disk imaging Task Sequence log.",
-    "Confirm the whole-disk encryption status recorded in PolicyAgent.log.",
-    "Confirm the system-wide assignment recorded in PolicyAgent.log.",
-    "Confirm recursive retry behavior recorded in PolicyAgent.log.",
-    "Confirm all files were downloaded, as recorded in PolicyAgent.log.",
+const BOUNDED_NARRATIVE_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
+    ("smsts", "Collect the full disk imaging Task Sequence log."),
+    (
+        "policyAgent",
+        "Confirm the whole-disk encryption status recorded in PolicyAgent.log.",
+    ),
+    (
+        "policyAgent",
+        "Confirm the system-wide assignment recorded in PolicyAgent.log.",
+    ),
+    (
+        "policyAgent",
+        "Confirm recursive retry behavior recorded in PolicyAgent.log.",
+    ),
+    (
+        "policyAgent",
+        "Confirm all files were downloaded, as recorded in PolicyAgent.log.",
+    ),
+];
+
+const REVIEW_UNBOUNDED_ARTIFACT_REQUEST_REASONS: [&str; 19] = [
+    "System-wide logs are required.",
+    "Systemwide logs are required.",
+    "Drive-wide files are requested.",
+    "Logs from the filesystem root are required.",
+    "The filesystem root must be archived.",
+    "Recursive collection of system logs is required.",
+    "Recursive traversal of the filesystem is required.",
+    "All files were downloaded; collect them, as recorded in PolicyAgent.log.",
+    "Archive the whole disk; encryption is recorded in PolicyAgent.log.",
+    "Collect the full disk; imaging is recorded in Smsts.log.",
+    "Collect the full disk imaging Task Sequence log recursively across directories.",
+    "Collect the full disk imaging Task Sequence log and include recursive directory traversal.",
+    "Collect the full disk imaging Task Sequence log; include folders recursively.",
+    "Collect the full disk imaging Task Sequence log using recursion across folders.",
+    "Confirm all files were downloaded, as recorded in PolicyAgent.log, with recursive directory inclusion.",
+    "Confirm all files were downloaded, as recorded in PolicyAgent.log; recursive traversal across directories is also required.",
+    "Collect the full disk imaging Task Sequence log plus system-wide logs.",
+    "Collect the full disk imaging Task Sequence log plus systemwide logs.",
+    "Confirm all files were downloaded, as recorded in PolicyAgent.log, plus logs from the filesystem root.",
+];
+
+const REVIEW_BOUNDED_NAMED_ARTIFACT_REQUESTS: [(&str, &str); 14] = [
+    ("policyAgent", "Collect the complete PolicyAgent.log file."),
+    ("policyAgent", "Collect every cited PolicyAgent.log entry."),
+    (
+        "policyAgent",
+        "Confirm all assignment IDs in the cited PolicyAgent.log record.",
+    ),
+    (
+        "dataTransferService",
+        "Confirm complete file download status in DataTransferService.log.",
+    ),
+    ("policyAgent", "Collect all rotations of PolicyAgent.log."),
+    (
+        "policyAgent",
+        "Confirm every retry in PolicyAgent.log for assignment A.",
+    ),
+    (
+        "policyAgent",
+        "Collect the whole PolicyAgent.log record cited by entry A.",
+    ),
+    (
+        "policyAgent",
+        "Confirm the full client policy in PolicyAgent.log.",
+    ),
+    ("smsts", "Collect the complete Task Sequence log."),
+    (
+        "dataTransferService",
+        "Confirm all content files were downloaded, as recorded in DataTransferService.log.",
+    ),
+    (
+        "dataTransferService",
+        "Confirm all of the files were downloaded, as recorded in DataTransferService.log.",
+    ),
+    (
+        "dataTransferService",
+        "Confirm every file was downloaded, as recorded in DataTransferService.log.",
+    ),
+    ("smsts", "Confirm the full disk-image status in Smsts.log."),
+    (
+        "smsts",
+        "Collect the complete disk imaging Task Sequence log.",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug)]
@@ -1294,20 +1374,35 @@ fn finding_artifact_requests_reject_structurally_unbounded_reasons() {
 #[test]
 fn finding_artifact_requests_accept_specific_bounded_reasons() {
     let existing = [
-        "Confirm the bounded policy request outcome.",
-        "Collect the PolicyAgent record cited by assignment A.",
-        "Confirm the root cause recorded by PolicyAgent.",
-        "Confirm the disk status code recorded in PolicyAgent.log.",
-        "Collect the disk imaging Task Sequence log.",
-        "Collect Logs/PolicyAgent.log from the bounded bundle.",
-        r"Collect Logs\PolicyAgent.log from the bounded bundle.",
+        ("policyAgent", "Confirm the bounded policy request outcome."),
+        (
+            "policyAgent",
+            "Collect the PolicyAgent record cited by assignment A.",
+        ),
+        (
+            "policyAgent",
+            "Confirm the root cause recorded by PolicyAgent.",
+        ),
+        (
+            "policyAgent",
+            "Confirm the disk status code recorded in PolicyAgent.log.",
+        ),
+        ("smsts", "Collect the disk imaging Task Sequence log."),
+        (
+            "policyAgent",
+            "Collect Logs/PolicyAgent.log from the bounded bundle.",
+        ),
+        (
+            "policyAgent",
+            r"Collect Logs\PolicyAgent.log from the bounded bundle.",
+        ),
     ];
     let canonical = finding_with_gap_and_request("bounded-reason-parity");
     let mut rejected = Vec::new();
 
-    for reason in existing
+    for (logical_id, reason) in existing
         .into_iter()
-        .chain(BOUNDED_NARRATIVE_ARTIFACT_REQUEST_REASONS)
+        .chain(BOUNDED_NARRATIVE_ARTIFACT_REQUESTS)
     {
         if SccmFindingBuilder::new("bounded-structural-request")
             .class(SccmFindingClass::Symptom)
@@ -1316,7 +1411,7 @@ fn finding_artifact_requests_accept_specific_bounded_reasons() {
             .severity(Severity::Warning)
             .confidence(SccmConfidence::Low)
             .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
-            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .next_artifact(finding_request(logical_id, SccmRole::Client, reason))
             .build()
             .is_err()
         {
@@ -1324,7 +1419,7 @@ fn finding_artifact_requests_accept_specific_bounded_reasons() {
         }
 
         let mut direct = canonical.clone();
-        direct.next_artifacts[0].reason = reason.into();
+        direct.next_artifacts[0] = finding_request(logical_id, SccmRole::Client, reason);
         if direct.validate().is_err() {
             rejected.push(format!("direct validate: {reason}"));
         }
@@ -1333,7 +1428,8 @@ fn finding_artifact_requests_accept_specific_bounded_reasons() {
         }
 
         let mut json = serde_json::to_value(&canonical).unwrap();
-        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        json["nextArtifacts"][0] =
+            serde_json::to_value(finding_request(logical_id, SccmRole::Client, reason)).unwrap();
         if serde_json::from_value::<SccmFinding>(json).is_err() {
             rejected.push(format!("deserializer: {reason}"));
         }
@@ -1381,6 +1477,90 @@ fn finding_artifact_request_bounds_apply_to_deserialization_and_serialization() 
     assert!(
         accepted.is_empty(),
         "accepted unbounded request boundaries: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_unbounded_scope_matrix_fails_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-unbounded-scope-parity");
+    let mut accepted = Vec::new();
+
+    for reason in REVIEW_UNBOUNDED_ARTIFACT_REQUEST_REASONS {
+        let builder = SccmFindingBuilder::new("review-unbounded-scope-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request("policyAgent", SccmRole::Client, reason))
+            .build();
+        if builder.err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason) {
+            accepted.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0].reason = reason.into();
+        if direct.validate().err() != Some(SccmFindingValidationError::InvalidArtifactRequestReason)
+        {
+            accepted.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_ok() {
+            accepted.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0]["reason"] = serde_json::json!(reason);
+        if serde_json::from_value::<SccmFinding>(json).is_ok() {
+            accepted.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        accepted.is_empty(),
+        "accepted reviewed unbounded request boundaries: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_bounded_named_artifact_matrix_passes_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-bounded-scope-parity");
+    let mut rejected = Vec::new();
+
+    for (logical_id, reason) in REVIEW_BOUNDED_NAMED_ARTIFACT_REQUESTS {
+        let builder = SccmFindingBuilder::new("review-bounded-scope-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request(logical_id, SccmRole::Client, reason))
+            .build();
+        if builder.is_err() {
+            rejected.push(format!("builder: {logical_id}: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0] = finding_request(logical_id, SccmRole::Client, reason);
+        if direct.validate().is_err() {
+            rejected.push(format!("direct validate: {logical_id}: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_err() {
+            rejected.push(format!("serializer: {logical_id}: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0] =
+            serde_json::to_value(finding_request(logical_id, SccmRole::Client, reason)).unwrap();
+        if serde_json::from_value::<SccmFinding>(json).is_err() {
+            rejected.push(format!("deserializer: {logical_id}: {reason}"));
+        }
+    }
+
+    assert!(
+        rejected.is_empty(),
+        "rejected reviewed bounded request boundaries: {rejected:#?}"
     );
 }
 
@@ -1723,7 +1903,7 @@ fn finding_artifact_requests_require_declared_logical_id_and_role() {
 
 #[test]
 fn finding_artifact_requests_require_nonempty_bounded_reasons_and_count() {
-    for reason in ["", "   "] {
+    for reason in ["", "   ", ".", ";", "!?"] {
         let result = SccmFindingBuilder::new("empty-request-reason")
             .class(SccmFindingClass::InsufficientEvidence)
             .phase(SccmPhase::Policy)

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -382,7 +382,7 @@ const REVIEW_UNRECOGNIZED_CONFIRMATION_REQUEST_REASONS: [&str; 10] = [
     "Confirm PolicyAgent.log for fetching credentials.",
 ];
 
-const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 12] = [
+const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 23] = [
     "Confirm all files are required for status in PolicyAgent.log.",
     "Confirm every file must be provided for download status in PolicyAgent.log.",
     "Confirm the whole disk is required for imaging status in Smsts.log.",
@@ -395,6 +395,57 @@ const REVIEW_PASSIVE_UNBOUNDED_CONFIRMATION_REASONS: [&str; 12] = [
     "Confirm PolicyAgent.log status has every file provided.",
     "Confirm all files have provided status in PolicyAgent.log.",
     "Confirm Smsts.log imaging status has the full disk provided.",
+    "Confirm PolicyAgent.log status had every file.",
+    "Confirm PolicyAgent.log status has all files.",
+    "Confirm PolicyAgent.log status have every file.",
+    "Confirm PolicyAgent.log status are all files.",
+    "Confirm PolicyAgent.log status be all files.",
+    "Confirm PolicyAgent.log status been all files.",
+    "Confirm PolicyAgent.log status being all files.",
+    "Confirm Smsts.log imaging status is the full disk.",
+    "Confirm Smsts.log imaging status was the full disk.",
+    "Confirm Smsts.log imaging status were the full disk.",
+    "Confirm Smsts.log imaging status has the full disk.",
+];
+
+const REVIEW_BOUNDED_AUXILIARY_CONFIRMATION_REASONS: [(&str, &str); 10] = [
+    (
+        "policyAgent",
+        "Confirm PolicyAgent.log status had evidence.",
+    ),
+    (
+        "policyAgent",
+        "Confirm PolicyAgent.log status has evidence.",
+    ),
+    ("policyAgent", "Confirm PolicyAgent.log files have status."),
+    (
+        "policyAgent",
+        "Confirm PolicyAgent.log files are downloaded.",
+    ),
+    (
+        "policyAgent",
+        "Confirm PolicyAgent.log status should be available.",
+    ),
+    (
+        "policyAgent",
+        "Confirm PolicyAgent.log status has been available.",
+    ),
+    (
+        "policyAgent",
+        "Confirm PolicyAgent.log status is being reported.",
+    ),
+    (
+        "policyAgent",
+        "Confirm PolicyAgent.log status is available.",
+    ),
+    (
+        "policyAgent",
+        "Confirm PolicyAgent.log status was available.",
+    ),
+    (
+        "policyAgent",
+        "Confirm PolicyAgent.log files were downloaded.",
+    ),
 ];
 
 const REVIEW_EXACT_MP_ARTIFACT_REQUESTS: [(&str, &str); 5] = [
@@ -2348,6 +2399,48 @@ fn finding_review_passive_unbounded_confirmation_requests_fail_at_every_public_b
     assert!(
         accepted.is_empty(),
         "accepted passive unbounded confirmation requests: {accepted:#?}"
+    );
+}
+
+#[test]
+fn finding_review_bounded_auxiliary_confirmations_pass_at_every_public_boundary() {
+    let canonical = finding_with_gap_and_request("review-bounded-auxiliary-parity");
+    let mut rejected = Vec::new();
+
+    for (logical_id, reason) in REVIEW_BOUNDED_AUXILIARY_CONFIRMATION_REASONS {
+        let builder = SccmFindingBuilder::new("review-bounded-auxiliary-builder")
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![finding_evidence_ref("artifact-a", "entry-a")])
+            .next_artifact(finding_request(logical_id, SccmRole::Client, reason))
+            .build();
+        if builder.is_err() {
+            rejected.push(format!("builder: {reason}"));
+        }
+
+        let mut direct = canonical.clone();
+        direct.next_artifacts[0] = finding_request(logical_id, SccmRole::Client, reason);
+        if direct.validate().is_err() {
+            rejected.push(format!("direct validate: {reason}"));
+        }
+        if serde_json::to_value(&direct).is_err() {
+            rejected.push(format!("serializer: {reason}"));
+        }
+
+        let mut json = serde_json::to_value(&canonical).unwrap();
+        json["nextArtifacts"][0] =
+            serde_json::to_value(finding_request(logical_id, SccmRole::Client, reason)).unwrap();
+        if serde_json::from_value::<SccmFinding>(json).is_err() {
+            rejected.push(format!("deserializer: {reason}"));
+        }
+    }
+
+    assert!(
+        rejected.is_empty(),
+        "rejected bounded auxiliary confirmations: {rejected:#?}"
     );
 }
 


### PR DESCRIPTION
## Scope

Implements #318 Task 7 from the SCCM diagnostic-spine plan as a pure parser-crate finding builder and validator, on exact base `25b37333affde22b4ef8a19f4a5f3d89c082b599`.

- Adds public camelCase finding, confidence, phase, terminal-evidence, coverage-gap, and bounded artifact-request contracts.
- Requires cited observed terminal failure for High ConfirmedFailure today; no extraction profile is registered Stable.
- Caps LikelyContributor at Moderate without cited terminal failure.
- Requires InsufficientEvidence to carry a non-Captured coverage gap and a bounded next-artifact request.
- Selects the requested source by exact catalog logical ID and producer role; free-form reason text cannot broaden that authorization.
- Evaluates punctuation-separated clauses independently and gives every collection action a non-overlapping local segment.
- Parses each collection target fail-closed as bounded modifiers + requested exact catalog identity + an optional positively validated suffix.
- Requires every actionless clause to independently match positive evidence-observation grammar.
- Allows collection suffixes only when they match positive evidence-observation, cited-reference, bounded-bundle, or bounded-completion grammar.
- Requires `Confirm` clauses to match a finite positive confirmation vocabulary, include a confirmation subject or exact catalog identity, reject unbound dotted targets, and retain the existing bounded state-observation exceptions.
- Constrains passive evidence predicates to evidence-state terms or the requested exact identity.
- Rejects standalone, suffix, and confirmation unknown imperative/gerund/nominal collection shapes without expanding the finite collection-action verb list.
- Preserves declared separators such as the five `MP_*` basenames, accepts every declared catalog basename/logical alias, and rejects prefix/suffix/lookalike identities.
- Rejects recursive, root, wide/systemwide, drive/environment roots, traversal, rooted paths, globs, unqualified/coordinated-unqualified actions, external containers, and status/identity sanitization attempts.
- Treats one coverage-gap `artifactId` as one identity: conflicting role/state is rejected; exact duplicates deterministically deduplicate.
- Enforces canonical phase/role/terminal-kind/finding/evidence/request identities, raw request cardinality, strict nested wires, cited evidence, conservative confidence, and deterministic normalized output.

No native I/O, Tauri, Windows dependency, collection, reducer, correlation engine, `ParserKind`, CCM grammar, public `LogEntry`, workflow fixture, dependency, or live Windows acceptance change is included.

## Test-first evidence

Permanent four-boundary regressions cover builder, direct `validate()`, validating serialization, and deserialization:

- 49 additional unbounded reasons: **196 accepted boundaries RED → GREEN**.
- Four catalog lookalikes: **16 accepted boundaries RED → GREEN**.
- Five exact `MP_*` basenames: **20 false rejections RED → GREEN**.
- 15 unqualified collection actions: **60 accepted boundaries RED → GREEN**.
- Three coordinated action suffixes: **12 accepted boundaries RED → GREEN**.
- Two exact unbound-target reproductions plus eight target/order/connector/filename variants: **40 accepted boundaries RED → GREEN**.
- Six exact unrecognized/nominal/inflected collection-language probes: **24 accepted boundaries RED → GREEN**.
- Three evidence-subject passive-target probes: **12 accepted boundaries RED → GREEN**.
- Six standalone unknown-action and inflected-suffix probes: **24 accepted boundaries RED → GREEN**.
- Ten `Confirm` imperative/gerund/nominal/dotted-target variants from the latest CodeRabbit P1: **40 accepted boundaries RED → GREEN**.
- Four pre-auxiliary passive all-files/full-disk confirmation variants from the independent P1: **16 accepted boundaries RED → GREEN**.
- Two dynamically reproduced trailing-object variants (`must have all files provided` / `must have the full disk provided`): **8 accepted boundaries RED → GREEN**; the two literal CodeRabbit `must include` / `must provide` examples remain permanent already-green rejection controls.
- Three path-adjacent `DOMAIN\\User` payloads leaked through both the public evidence message and JSON RED → GREEN; deterministic redaction now preserves only the safe surrounding path fragments.
- Three unprofiled/unknown/malformed Strong/Exact key variants: **12 accepted boundaries RED → GREEN** across builder, direct validation, serialization, and deserialization.
- Existing bounded confirmation controls for policy/request outcome, download state, retry, assignment, root cause, disk imaging, and exact catalog identities remain GREEN at all four boundaries.
- Safe same-clause/standalone and strong-punctuation evidence narratives remain GREEN.
- All 48 declared sources by exact basename and logical alias remain GREEN.
- The prior 19-unbounded/14-bounded reviewed matrices and all earlier finding contracts remain GREEN.

## Verification on exact head `a515f33858be599759dd84e02353bc1f92f4a16f`

- `cargo +1.88.0 test --locked -p cmtraceopen-parser --test sccm_spine_contract finding_ -- --nocapture` — **71 passed, 0 failed**
- `cargo +1.88.0 test --locked -p cmtraceopen-parser` — **726 passed, 0 failed**
- `cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings` — passed
- `cargo +1.88.0 check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown` — passed
- `npx tsc --noEmit` — passed
- Rust 1.88 scoped `rustfmt --check` on the three changed files — passed
- `git diff --check`, `git diff --check ca7ee943794f0654c2502606088743ac0b9db7c0..a515f33858be599759dd84e02353bc1f92f4a16f`, and `git diff --check 25b37333affde22b4ef8a19f4a5f3d89c082b599..a515f33858be599759dd84e02353bc1f92f4a16f` — passed

Known unrelated baseline: repository-wide `cargo fmt --all -- --check` remains red only in the same 17 unrelated files, which this issue-owned slice does not modify. The repository-prescribed strict current-toolchain Clippy command above passes.

## Review gate

Independent review of `d6d5c697a4fa756078366bebe34b14519f5a0c5e` reproduced three P1 shared-contract failures: passive broad confirmation wording, path-adjacent Windows identity leakage, and unvalidated/malformed Strong/Exact finding keys: https://github.com/adamgell/cmtraceopen/pull/353#pullrequestreview-4825486265.

Commit `ca7ee943794f0654c2502606088743ac0b9db7c0` closes all three with permanent public-boundary regressions while preserving bounded confirmation, safe path fragments, Low-confidence unprofiled/unknown keys, parser purity, and wasm32 compatibility.

CodeRabbit's substantive review of that exact head accepted the key/redaction corrections and found a remaining confirmation-order P1: https://github.com/adamgell/cmtraceopen/pull/353#issuecomment-5139411954. Its two literal examples were already rejected; a dynamic equivalent using allowed tokens reproduced the actual root at all four boundaries. Commit `a515f33858be599759dd84e02353bc1f92f4a16f` now searches the whole confirmation body for an unbound broad target and closes the reproduced **8/8** trailing-object accepts without expanding the finite action vocabulary.

Hosted CodeRabbit completed a substantive review of exact range `25b37333affde22b4ef8a19f4a5f3d89c082b599..a515f33858be599759dd84e02353bc1f92f4a16f` with no blocking findings: https://github.com/adamgell/cmtraceopen/pull/353#issuecomment-5139439330. A different independent exact-head API/security review is still required before this PR may leave draft. A green status or approval attached to an older SHA is not sufficient. Historical blocker comments remain unresolved as review history.

Do not mark ready, merge, close #318, authorize downstream production reducers/correlation, or claim live Windows acceptance from this PR.

Refs #318