### PR TITLE
test(sccm): close issue 325 review gaps

### DIFF
--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/README.md
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/README.md
@@ -26,6 +26,13 @@ labels must agree across the sanitized path, fingerprint, and relative evidence
 path; retained-byte fields are exact for the declared capture state. Cited CCM
 fields and source-to-phase ownership are closed, evidence line ranges cannot
 overlap, and filesystem separators are normalized before manifest comparison.
+Artifact, transaction, and observation identities are bounded canonical
+lowercase tokens scoped to their active family (and scenario for artifacts).
+Source versions must be canonical tokens before profile-prefix selection, and
+one `(observation kind, artifact)` membership can appear only once. A
+`rotationSplit` observation additionally requires one common synthetic root,
+canonical basename, source version, and exact family key across its `current`
+and `.lo` fragments.
 
 Do not add real tenant, device, user, domain, path, package, baseline, or rule
 identifiers. Do not use these fixtures to admit production catalog sources

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/README.md
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/README.md
@@ -20,6 +20,13 @@ Every scenario contains:
 - optional `evidence/`: raw CCM transport records or deliberately incomplete
   synthetic input.
 
+The preparation validator treats each `(captureHost, sanitizedSourcePath,
+rotation)` tuple as one source identity in every scenario. Synthetic root
+labels must agree across the sanitized path, fingerprint, and relative evidence
+path; retained-byte fields are exact for the declared capture state. Cited CCM
+fields and source-to-phase ownership are closed, evidence line ranges cannot
+overlap, and filesystem separators are normalized before manifest comparison.
+
 Do not add real tenant, device, user, domain, path, package, baseline, or rule
 identifiers. Do not use these fixtures to admit production catalog sources
 until #318/#319 contracts and the relevant extraction profile have been

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/compliance/coverage-states/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/compliance/coverage-states/manifest.json
@@ -49,8 +49,8 @@
       "kind": "ccmLog",
       "captureState": "accessDenied",
       "originalBasename": "CITaskMgr.log",
-      "sanitizedSourcePath": "SYNTHETIC://root-a/CCM/Logs/CITaskMgr.log",
-      "pathFingerprint": "synthetic-compliance-coverage-states-access-denied-root-a",
+      "sanitizedSourcePath": "SYNTHETIC://root-b/CCM/Logs/CITaskMgr.log",
+      "pathFingerprint": "synthetic-compliance-coverage-states-access-denied-root-b",
       "rotation": {
         "kind": "current",
         "fragmentComplete": false

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/inventory/coverage-states/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/inventory/coverage-states/manifest.json
@@ -157,8 +157,8 @@
       "kind": "ccmLog",
       "captureState": "skipped",
       "originalBasename": "InventoryAgent.log",
-      "sanitizedSourcePath": "SYNTHETIC://root-a/CCM/Logs/InventoryAgent.log",
-      "pathFingerprint": "synthetic-inventory-coverage-states-skipped-root-a",
+      "sanitizedSourcePath": "SYNTHETIC://root-d/CCM/Logs/InventoryAgent.log",
+      "pathFingerprint": "synthetic-inventory-coverage-states-skipped-root-d",
       "rotation": {
         "kind": "current",
         "fragmentComplete": false
@@ -180,8 +180,8 @@
       "kind": "ccmLog",
       "captureState": "unsupported",
       "originalBasename": "InventoryProvider.log",
-      "sanitizedSourcePath": "SYNTHETIC://root-a/CCM/Logs/InventoryProvider.log",
-      "pathFingerprint": "synthetic-inventory-coverage-states-unsupported-root-a",
+      "sanitizedSourcePath": "SYNTHETIC://root-e/CCM/Logs/InventoryProvider.log",
+      "pathFingerprint": "synthetic-inventory-coverage-states-unsupported-root-e",
       "rotation": {
         "kind": "current",
         "fragmentComplete": false

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/inventory/rotation-boundary/evidence/client-inventory/root-a/current/InventoryAgent.log
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/inventory/rotation-boundary/evidence/client-inventory/root-a/current/InventoryAgent.log
@@ -1,0 +1,1 @@
+<![LOG[SYNTHETIC FIXTURE Family=inventory InventoryCycleId=INV-CYCLE-025 ResourceHandle=safe:resource:inventory-025 ReportId=INV-REPORT-025 Phase=Collect Disposition=Succeeded Terminal=false]LOG]!><time="01:25:01.000+000" date="7-30-2026" component="InventoryAgent" context="" type="1" thread="325" file="">

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/inventory/rotation-boundary/evidence/client-inventory/root-a/current/InventoryAgentProvider.log
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/inventory/rotation-boundary/evidence/client-inventory/root-a/current/InventoryAgentProvider.log
@@ -1,1 +1,0 @@
-<![LOG[SYNTHETIC FIXTURE Family=inventory InventoryCycleId=INV-CYCLE-025 ResourceHandle=safe:resource:inventory-025 ReportId=INV-REPORT-025 Phase=Report Disposition=Succeeded Terminal=true]LOG]!><time="01:25:01.000+000" date="7-30-2026" component="InventoryAgentProvider" context="" type="1" thread="325" file="">

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/inventory/rotation-boundary/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/inventory/rotation-boundary/expected.json
@@ -13,8 +13,8 @@
       "observationId": "inventory-rotation-split",
       "kind": "rotationSplit",
       "artifactIds": [
-        "inventory-rotation-boundary-agent-lo",
-        "inventory-rotation-boundary-report-current"
+        "inventory-rotation-boundary-agent-current",
+        "inventory-rotation-boundary-agent-lo"
       ],
       "confidenceCeiling": "low",
       "correlationEligible": false,
@@ -23,12 +23,12 @@
   ],
   "coverage": [
     {
-      "artifactId": "inventory-rotation-boundary-agent-lo",
+      "artifactId": "inventory-rotation-boundary-agent-current",
       "logicalArtifactId": "client-inventory",
       "state": "partial"
     },
     {
-      "artifactId": "inventory-rotation-boundary-report-current",
+      "artifactId": "inventory-rotation-boundary-agent-lo",
       "logicalArtifactId": "client-inventory",
       "state": "partial"
     }

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/inventory/rotation-boundary/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering/inventory/rotation-boundary/manifest.json
@@ -15,6 +15,34 @@
   },
   "artifacts": [
     {
+      "artifactId": "inventory-rotation-boundary-agent-current",
+      "designOnlyCatalog": {
+        "entryId": "client-inventory",
+        "groupMemberships": [
+          "client-inventory"
+        ]
+      },
+      "role": "client",
+      "kind": "ccmLog",
+      "captureState": "captured",
+      "originalBasename": "InventoryAgent.log",
+      "sanitizedSourcePath": "SYNTHETIC://root-a/CCM/Logs/InventoryAgent.log",
+      "pathFingerprint": "synthetic-inventory-rotation-boundary-agent-current-root-a",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": false
+      },
+      "sourceVersion": "5.00.TEST.325",
+      "capturedUtc": "2026-07-30T04:00:00Z",
+      "bytesCopied": 308,
+      "relativePath": "evidence/client-inventory/root-a/current/InventoryAgent.log",
+      "encoding": "utf-8",
+      "collectionLimit": {
+        "byteLimit": 4096,
+        "limitApplied": false
+      }
+    },
+    {
       "artifactId": "inventory-rotation-boundary-agent-lo",
       "designOnlyCatalog": {
         "entryId": "client-inventory",
@@ -36,34 +64,6 @@
       "capturedUtc": "2026-07-30T04:00:00Z",
       "bytesCopied": 308,
       "relativePath": "evidence/client-inventory/root-a/lo/InventoryAgent.log.lo",
-      "encoding": "utf-8",
-      "collectionLimit": {
-        "byteLimit": 4096,
-        "limitApplied": false
-      }
-    },
-    {
-      "artifactId": "inventory-rotation-boundary-report-current",
-      "designOnlyCatalog": {
-        "entryId": "client-inventory",
-        "groupMemberships": [
-          "client-inventory"
-        ]
-      },
-      "role": "client",
-      "kind": "ccmLog",
-      "captureState": "captured",
-      "originalBasename": "InventoryAgentProvider.log",
-      "sanitizedSourcePath": "SYNTHETIC://root-a/CCM/Logs/InventoryAgentProvider.log",
-      "pathFingerprint": "synthetic-inventory-rotation-boundary-report-current-root-a",
-      "rotation": {
-        "kind": "current",
-        "fragmentComplete": false
-      },
-      "sourceVersion": "5.00.TEST.325",
-      "capturedUtc": "2026-07-30T04:00:00Z",
-      "bytesCopied": 314,
-      "relativePath": "evidence/client-inventory/root-a/current/InventoryAgentProvider.log",
       "encoding": "utf-8",
       "collectionLimit": {
         "byteLimit": 4096,

--- a/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
@@ -1580,8 +1580,12 @@ fn validate_contract(
             observed_states.push(effective_state(artifact)?);
             observed_rotations.insert(required_string(&artifact["rotation"], "kind", artifact_id)?);
             observed_artifact_ids.insert(artifact_id.to_owned());
-            if kind == "unknownProfile" {
-                unknown_profile_observations.insert(artifact_id.to_owned());
+            if kind == "unknownProfile"
+                && !unknown_profile_observations.insert(artifact_id.to_owned())
+            {
+                return Err(format!(
+                    "{observation_id} is a duplicate unknown-profile observation for {artifact_id}"
+                ));
             }
             if kind == "invalidOffset" {
                 invalid_offset_observations.insert(artifact_id.to_owned());
@@ -3845,6 +3849,45 @@ fn review_blocker_unknown_versions_are_profile_gaps_for_every_coverage_state() {
     );
 
     assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn review_blocker_unknown_profile_observation_is_unique_per_artifact() {
+    let (scenario_root, mut manifest, mut expected) = load_contract("inventory", "coverage-states");
+    let artifact_id = "inventory-coverage-states-access-denied";
+    let artifact = manifest["artifacts"]
+        .as_array_mut()
+        .expect("artifacts are an array")
+        .iter_mut()
+        .find(|artifact| artifact["artifactId"] == artifact_id)
+        .expect("accessDenied artifact exists");
+    artifact["sourceVersion"] = json!("9.99.UNKNOWN");
+    expected["extractionProfile"]["selectionState"] = json!("mixedKnownAndUnknown");
+    for suffix in ["a", "b"] {
+        expected["sourceLocalObservations"]
+            .as_array_mut()
+            .expect("sourceLocalObservations are an array")
+            .push(json!({
+                "observationId": format!(
+                    "inventory-coverage-unknown-profile-{suffix}"
+                ),
+                "kind": "unknownProfile",
+                "artifactIds": [artifact_id],
+                "confidenceCeiling": "low",
+                "correlationEligible": false,
+                "claim": "Unknown source version has no selected extraction profile."
+            }));
+    }
+
+    assert_rejected_with(
+        "two canonical unknownProfile observations cite one artifact",
+        "inventory",
+        "coverage-states",
+        &scenario_root,
+        &manifest,
+        &expected,
+        "duplicate unknown-profile observation",
+    );
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
@@ -1114,8 +1114,23 @@ fn validate_contract(
         return Err("bundle identity is not the sanitized client fixture identity".to_owned());
     }
     let bundle_id = required_string(&manifest["bundle"], "bundleId", "bundle")?;
-    if !bundle_id.starts_with(&format!("sccm-325-{family}-")) {
-        return Err("bundleId is not issue/family scoped".to_owned());
+    let expected_bundle_id = format!("sccm-325-{family}-{scenario}");
+    if bundle_id != expected_bundle_id {
+        return Err("bundleId is not exact issue/family/scenario identity".to_owned());
+    }
+    for (field, expected_value) in [
+        (
+            "artifactOrder",
+            "designOnlyCatalog.entryId,pathFingerprint,rotationRank,originalBasename,artifactId",
+        ),
+        (
+            "rotationOrder",
+            "current,lo,numeric-ascending,timestamp-ascending",
+        ),
+    ] {
+        if required_string(&manifest["bundle"], field, "bundle")? != expected_value {
+            return Err(format!("bundle {field} is not the deterministic contract"));
+        }
     }
 
     let artifacts = manifest["artifacts"]
@@ -3502,6 +3517,49 @@ fn review_blocker_manifest_and_ccm_structured_vocabularies_are_closed() {
         validate_contract("inventory", "success", &scenario_root, &manifest, &expected),
         "artifact fields",
     );
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn review_blocker_bundle_identity_and_order_descriptors_are_closed() {
+    let (scenario_root, manifest, expected) = load_contract("inventory", "success");
+    let mutations = [
+        (
+            "foreign-scenario bundleId",
+            "bundleId",
+            json!("sccm-325-inventory-terminal-failures"),
+        ),
+        (
+            "arbitrary-suffix bundleId",
+            "bundleId",
+            json!("sccm-325-inventory-anything"),
+        ),
+        ("boolean artifactOrder", "artifactOrder", json!(false)),
+        (
+            "altered artifactOrder",
+            "artifactOrder",
+            json!("artifactId,originalBasename"),
+        ),
+        ("boolean rotationOrder", "rotationOrder", json!(false)),
+        (
+            "altered rotationOrder",
+            "rotationOrder",
+            json!("timestamp-descending,current"),
+        ),
+    ];
+    let mut failures = Vec::new();
+
+    for (label, field, value) in mutations {
+        let mut mutated = manifest.clone();
+        mutated["bundle"][field] = value;
+        collect_contract_rejection(
+            &mut failures,
+            label,
+            validate_contract("inventory", "success", &scenario_root, &mutated, &expected),
+            field,
+        );
+    }
 
     assert!(failures.is_empty(), "{}", failures.join("\n"));
 }

--- a/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
@@ -1240,12 +1240,24 @@ fn validate_contract(
             ));
         }
         require_exact_object_fields(artifact, &exact_artifact_fields, "artifact")?;
-        let relative_path = artifact["relativePath"].as_str();
-        if physical != relative_path.is_some() {
-            return Err(format!(
-                "{artifact_id} physical path does not match capture state {capture_state}"
-            ));
-        }
+        let relative_path = match (&artifact["relativePath"], physical) {
+            (Value::String(relative_path), true) => Some(relative_path.as_str()),
+            (Value::Null, false) => None,
+            _ => {
+                return Err(format!(
+                    "{artifact_id} relativePath type does not match capture state {capture_state}"
+                ))
+            }
+        };
+        let source_version = match &artifact["sourceVersion"] {
+            Value::String(source_version) => Some(source_version.as_str()),
+            Value::Null => None,
+            _ => {
+                return Err(format!(
+                    "{artifact_id} sourceVersion is neither a string nor null"
+                ))
+            }
+        };
 
         if let Some(relative_path) = relative_path {
             validate_relative_path(relative_path, artifact_id)?;
@@ -1333,7 +1345,7 @@ fn validate_contract(
             }
             referenced_files.insert(relative_path.to_owned());
 
-            if let Some(version) = artifact["sourceVersion"].as_str() {
+            if let Some(version) = source_version {
                 if !version.starts_with("5.00.TEST.") {
                     unknown_version_artifacts.insert(artifact_id.to_owned());
                 }
@@ -3615,6 +3627,124 @@ fn review_blocker_capture_state_provenance_is_closed() {
         ),
         "nonphysical state provenance",
     );
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn review_blocker_nonphysical_optional_field_json_types_are_closed() {
+    let (scenario_root, manifest, expected) = load_contract("inventory", "coverage-states");
+    let mut failures = Vec::new();
+    let mutations = vec![
+        (
+            "accessDenied.relativePath=false",
+            "accessDenied",
+            "relativePath",
+            json!(false),
+            "relativePath",
+        ),
+        (
+            "skipped.relativePath=0",
+            "skipped",
+            "relativePath",
+            json!(0),
+            "relativePath",
+        ),
+        (
+            "unsupported.relativePath=[]",
+            "unsupported",
+            "relativePath",
+            json!([]),
+            "relativePath",
+        ),
+        (
+            "absent.relativePath={}",
+            "absent",
+            "relativePath",
+            json!({}),
+            "relativePath",
+        ),
+        (
+            "accessDenied.sourceVersion=false",
+            "accessDenied",
+            "sourceVersion",
+            json!(false),
+            "sourceVersion",
+        ),
+        (
+            "skipped.sourceVersion={unexpected:true}",
+            "skipped",
+            "sourceVersion",
+            json!({"unexpected": true}),
+            "sourceVersion",
+        ),
+        (
+            "unsupported.sourceVersion=[]",
+            "unsupported",
+            "sourceVersion",
+            json!([]),
+            "sourceVersion",
+        ),
+        (
+            "accessDenied.sanitizedSourcePath=false",
+            "accessDenied",
+            "sanitizedSourcePath",
+            json!(false),
+            "sanitizedSourcePath",
+        ),
+        (
+            "skipped.pathFingerprint={}",
+            "skipped",
+            "pathFingerprint",
+            json!({}),
+            "pathFingerprint",
+        ),
+    ];
+
+    for (label, capture_state, field, value, required_error) in mutations {
+        let mut mutated = manifest.clone();
+        let artifact = mutated["artifacts"]
+            .as_array_mut()
+            .expect("artifacts are an array")
+            .iter_mut()
+            .find(|artifact| artifact["captureState"] == capture_state)
+            .unwrap_or_else(|| panic!("{capture_state} artifact exists"));
+        artifact[field] = value;
+        collect_contract_rejection(
+            &mut failures,
+            label,
+            validate_contract(
+                "inventory",
+                "coverage-states",
+                &scenario_root,
+                &mutated,
+                &expected,
+            ),
+            required_error,
+        );
+    }
+
+    for capture_state in ["accessDenied", "skipped", "unsupported"] {
+        let mut version_unknown = manifest.clone();
+        let artifact = version_unknown["artifacts"]
+            .as_array_mut()
+            .expect("artifacts are an array")
+            .iter_mut()
+            .find(|artifact| artifact["captureState"] == capture_state)
+            .unwrap_or_else(|| panic!("{capture_state} artifact exists"));
+        artifact["sourceVersion"] = Value::Null;
+        if let Err(error) = validate_contract(
+            "inventory",
+            "coverage-states",
+            &scenario_root,
+            &version_unknown,
+            &expected,
+        ) {
+            failures.push(format!(
+                "{capture_state}.sourceVersion=null: valid optional version was rejected: {error}"
+            ));
+        }
+    }
 
     assert!(failures.is_empty(), "{}", failures.join("\n"));
 }

--- a/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
@@ -1258,6 +1258,9 @@ fn validate_contract(
                 ))
             }
         };
+        if source_version.is_some_and(|version| !version.starts_with("5.00.TEST.")) {
+            unknown_version_artifacts.insert(artifact_id.to_owned());
+        }
 
         if let Some(relative_path) = relative_path {
             validate_relative_path(relative_path, artifact_id)?;
@@ -1345,11 +1348,7 @@ fn validate_contract(
             }
             referenced_files.insert(relative_path.to_owned());
 
-            if let Some(version) = source_version {
-                if !version.starts_with("5.00.TEST.") {
-                    unknown_version_artifacts.insert(artifact_id.to_owned());
-                }
-            } else {
+            if source_version.is_none() {
                 return Err(format!(
                     "{artifact_id} physical source has no sourceVersion"
                 ));
@@ -3745,6 +3744,105 @@ fn review_blocker_nonphysical_optional_field_json_types_are_closed() {
             ));
         }
     }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn review_blocker_unknown_versions_are_profile_gaps_for_every_coverage_state() {
+    let (scenario_root, manifest, expected) = load_contract("inventory", "coverage-states");
+    let mut failures = Vec::new();
+    let versioned_artifacts = manifest["artifacts"]
+        .as_array()
+        .expect("artifacts are an array")
+        .iter()
+        .filter_map(|artifact| {
+            artifact["sourceVersion"].as_str().map(|_| {
+                (
+                    artifact["artifactId"]
+                        .as_str()
+                        .expect("artifactId is a string")
+                        .to_owned(),
+                    artifact["captureState"]
+                        .as_str()
+                        .expect("captureState is a string")
+                        .to_owned(),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for (artifact_id, capture_state) in versioned_artifacts {
+        let mut unknown_manifest = manifest.clone();
+        let artifact = unknown_manifest["artifacts"]
+            .as_array_mut()
+            .expect("artifacts are an array")
+            .iter_mut()
+            .find(|artifact| artifact["artifactId"] == artifact_id)
+            .unwrap_or_else(|| panic!("{artifact_id} exists"));
+        artifact["sourceVersion"] = json!("9.99.UNKNOWN");
+
+        collect_contract_rejection(
+            &mut failures,
+            &format!("{capture_state} unknown version without profile gap"),
+            validate_contract(
+                "inventory",
+                "coverage-states",
+                &scenario_root,
+                &unknown_manifest,
+                &expected,
+            ),
+            "profile selection",
+        );
+
+        let mut gap_expected = expected.clone();
+        gap_expected["extractionProfile"]["selectionState"] = json!("mixedKnownAndUnknown");
+        gap_expected["sourceLocalObservations"]
+            .as_array_mut()
+            .expect("sourceLocalObservations are an array")
+            .push(json!({
+                "observationId": format!(
+                    "inventory-coverage-unknown-profile-{capture_state}"
+                ),
+                "kind": "unknownProfile",
+                "artifactIds": [artifact_id],
+                "confidenceCeiling": "low",
+                "correlationEligible": false,
+                "claim": "Unknown source version has no selected extraction profile."
+            }));
+        if let Err(error) = validate_contract(
+            "inventory",
+            "coverage-states",
+            &scenario_root,
+            &unknown_manifest,
+            &gap_expected,
+        ) {
+            failures.push(format!(
+                "{capture_state} unknown version with bounded profile gap was rejected: {error}"
+            ));
+        }
+    }
+
+    let mut absent_version = manifest.clone();
+    let absent = absent_version["artifacts"]
+        .as_array_mut()
+        .expect("artifacts are an array")
+        .iter_mut()
+        .find(|artifact| artifact["captureState"] == "absent")
+        .expect("absent artifact exists");
+    absent["sourceVersion"] = json!("9.99.UNKNOWN");
+    collect_contract_rejection(
+        &mut failures,
+        "absent source invents an unknown version",
+        validate_contract(
+            "inventory",
+            "coverage-states",
+            &scenario_root,
+            &absent_version,
+            &expected,
+        ),
+        "absent source invents path/version identity",
+    );
 
     assert!(failures.is_empty(), "{}", failures.join("\n"));
 }

--- a/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
@@ -36,7 +36,7 @@ const METERING_SCENARIOS: [&str; 6] = [
     "terminal-failures",
 ];
 
-const DOCUMENTED_CORPUS_DIGEST: &str = "409f976350ffbc05";
+const DOCUMENTED_CORPUS_DIGEST: &str = "26c8cf8aee0741a2";
 
 #[derive(Debug, PartialEq, Eq)]
 struct CorpusInventory {
@@ -446,6 +446,37 @@ fn required_string<'a>(value: &'a Value, field: &str, context: &str) -> Result<&
     value[field]
         .as_str()
         .ok_or_else(|| format!("{context} {field} is not a string"))
+}
+
+fn validate_canonical_id(value: &str, field: &str, required_prefix: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value.starts_with(required_prefix)
+        || value.ends_with('-')
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return Err(format!("{field} is not canonical for {required_prefix}"));
+    }
+    Ok(())
+}
+
+fn validate_source_version(version: &str, artifact_id: &str) -> Result<(), String> {
+    if version.is_empty()
+        || version.len() > 64
+        || version.split('.').any(|segment| {
+            segment.is_empty()
+                || segment.starts_with('-')
+                || segment.ends_with('-')
+                || !segment
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
+    {
+        return Err(format!("{artifact_id} sourceVersion is not canonical"));
+    }
+    Ok(())
 }
 
 fn require_exact_object_fields(
@@ -908,6 +939,72 @@ fn strict_ccm_structured_fields(
     Ok(fields)
 }
 
+fn rotation_lineage_key(
+    family: &str,
+    scenario_root: &Path,
+    artifact: &Value,
+) -> Result<String, String> {
+    let artifact_id = required_string(artifact, "artifactId", "rotation artifact")?;
+    let basename = required_string(artifact, "originalBasename", artifact_id)?;
+    let source_basename = basename.strip_suffix(".lo").unwrap_or(basename);
+    let source_version = required_string(artifact, "sourceVersion", artifact_id)?;
+    let sanitized_path = required_string(artifact, "sanitizedSourcePath", artifact_id)?;
+    let synthetic_root = sanitized_path
+        .strip_prefix("SYNTHETIC://")
+        .and_then(|path| path.split('/').next())
+        .ok_or_else(|| format!("{artifact_id} rotation source has no synthetic root"))?;
+    let relative_path = required_string(artifact, "relativePath", artifact_id)?;
+    let contents = std::fs::read_to_string(scenario_root.join(relative_path))
+        .map_err(|error| format!("{artifact_id} rotation evidence is readable: {error}"))?;
+    let additive_artifact = additive_artifact(artifact)?;
+    let required_fields = required_key_fields(family)?;
+    let mut exact_keys = BTreeSet::new();
+
+    for (index, line) in contents.lines().enumerate() {
+        let context = format!("{artifact_id}:{}", index + 1);
+        let normalized = normalize_ccm_artifact(additive_artifact.clone(), line);
+        if normalized.len() != 1
+            || normalized[0].reference.line_start != Some(1)
+            || normalized[0].reference.line_end != Some(1)
+        {
+            return Err(format!("{context} is not one complete CCM record"));
+        }
+        let fields = strict_ccm_structured_fields(line, &context)?;
+        validate_structured_field_vocabulary(&fields, &context)?;
+        validate_cited_record_semantics(&fields, source_basename, &context)?;
+        if fields.get("Family").map(String::as_str) != Some(family) {
+            return Err(format!("{context} Family is not exact"));
+        }
+        let mut key_values = Vec::new();
+        for field in required_fields {
+            let value = fields
+                .get(*field)
+                .ok_or_else(|| format!("{context} has no exact key field {field}"))?;
+            if value.is_empty()
+                || value.contains(['\n', '\r'])
+                || (field.ends_with("Handle") && !value.starts_with("safe:"))
+            {
+                return Err(format!("{context} exact key field {field} is unsafe/empty"));
+            }
+            key_values.push(value.as_str());
+        }
+        exact_keys.insert(key_values.join("\0"));
+    }
+    if exact_keys.len() != 1 {
+        return Err(format!(
+            "{artifact_id} rotation evidence has no single exact key"
+        ));
+    }
+
+    Ok(format!(
+        "{synthetic_root}\0{source_basename}\0{source_version}\0{}",
+        exact_keys
+            .into_iter()
+            .next()
+            .expect("one exact rotation key was checked")
+    ))
+}
+
 fn record_field_is(record: &CitedEvidenceRecord, field: &str, value: &str) -> bool {
     record
         .fields
@@ -1148,9 +1245,11 @@ fn validate_contract(
     let mut expected_coverage = BTreeMap::new();
     let mut unknown_version_artifacts = BTreeSet::new();
     let mut invalid_offset_artifacts = BTreeSet::new();
+    let artifact_id_prefix = format!("{family}-{scenario}-");
 
     for artifact in artifacts {
         let artifact_id = required_string(artifact, "artifactId", "artifact")?;
+        validate_canonical_id(artifact_id, "artifactId", &artifact_id_prefix)?;
         if artifacts_by_id
             .insert(artifact_id.to_owned(), artifact)
             .is_some()
@@ -1273,8 +1372,11 @@ fn validate_contract(
                 ))
             }
         };
-        if source_version.is_some_and(|version| !version.starts_with("5.00.TEST.")) {
-            unknown_version_artifacts.insert(artifact_id.to_owned());
+        if let Some(source_version) = source_version {
+            validate_source_version(source_version, artifact_id)?;
+            if !source_version.starts_with("5.00.TEST.") {
+                unknown_version_artifacts.insert(artifact_id.to_owned());
+            }
         }
 
         if let Some(relative_path) = relative_path {
@@ -1522,6 +1624,7 @@ fn validate_contract(
         .ok_or_else(|| "sourceLocalObservations is not an array".to_owned())?;
     require_canonical_string_field_order(observations, "observationId", "observation")?;
     let mut observation_ids = BTreeSet::new();
+    let mut observation_memberships = BTreeSet::new();
     let mut observed_artifact_ids = BTreeSet::new();
     let mut unknown_profile_observations = BTreeSet::new();
     let mut invalid_offset_observations = BTreeSet::new();
@@ -1539,6 +1642,7 @@ fn validate_contract(
             "observation",
         )?;
         let observation_id = required_string(observation, "observationId", "observation")?;
+        validate_canonical_id(observation_id, "observationId", &format!("{family}-"))?;
         if !observation_ids.insert(observation_id.to_owned()) {
             return Err(format!("duplicate observationId {observation_id}"));
         }
@@ -1574,6 +1678,7 @@ fn validate_contract(
         let mut previous_artifact_id = None;
         let mut observed_states = Vec::new();
         let mut observed_rotations = BTreeSet::new();
+        let mut observed_rotation_artifacts = Vec::new();
         for artifact_id in artifact_ids {
             let artifact_id = artifact_id
                 .as_str()
@@ -1594,25 +1699,56 @@ fn validate_contract(
                 .expect("artifact existence checked");
             observed_states.push(effective_state(artifact)?);
             observed_rotations.insert(required_string(&artifact["rotation"], "kind", artifact_id)?);
+            if kind == "rotationSplit" {
+                observed_rotation_artifacts.push(*artifact);
+            }
             observed_artifact_ids.insert(artifact_id.to_owned());
-            if kind == "unknownProfile"
-                && !unknown_profile_observations.insert(artifact_id.to_owned())
-            {
+            if !observation_memberships.insert((kind.to_owned(), artifact_id.to_owned())) {
+                let kind_label = match kind {
+                    "coverageGap" => "coverage-gap",
+                    "rotationSplit" => "rotation-split",
+                    "malformedRecord" => "malformed-record",
+                    "unknownProfile" => "unknown-profile",
+                    "invalidOffset" => "invalid-offset",
+                    _ => "unsupported",
+                };
                 return Err(format!(
-                    "{observation_id} is a duplicate unknown-profile observation for {artifact_id}"
+                    "{observation_id} is a duplicate source-local observation; duplicate {kind_label} observation for {artifact_id}"
                 ));
+            }
+            if kind == "unknownProfile" {
+                unknown_profile_observations.insert(artifact_id.to_owned());
             }
             if kind == "invalidOffset" {
                 invalid_offset_observations.insert(artifact_id.to_owned());
             }
         }
+        if kind == "rotationSplit" {
+            if observed_states.len() < 2
+                || observed_states.iter().any(|state| state != "partial")
+                || observed_rotations != ["current", "lo"].into_iter().collect::<BTreeSet<_>>()
+            {
+                return Err(format!(
+                    "{observation_id} rotationSplit is incompatible with cited artifact coverage/provenance"
+                ));
+            }
+            let observed_rotation_lineages = observed_rotation_artifacts
+                .into_iter()
+                .map(|artifact| {
+                    rotation_lineage_key(family, scenario_root, artifact).map_err(|error| {
+                        format!("{observation_id} rotationSplit lineage/key is invalid: {error}")
+                    })
+                })
+                .collect::<Result<BTreeSet<_>, _>>()?;
+            if observed_rotation_lineages.len() != 1 {
+                return Err(format!(
+                    "{observation_id} rotationSplit lineage/key is not common"
+                ));
+            }
+        }
         let incompatible = match kind {
             "coverageGap" => observed_states.iter().any(|state| state == "captured"),
-            "rotationSplit" => {
-                observed_states.len() < 2
-                    || observed_states.iter().any(|state| state != "partial")
-                    || observed_rotations != ["current", "lo"].into_iter().collect::<BTreeSet<_>>()
-            }
+            "rotationSplit" => false,
             "malformedRecord" => observed_states.iter().any(|state| state != "parseFailed"),
             "unknownProfile" => artifact_ids.iter().any(|artifact_id| {
                 !artifact_id
@@ -1677,6 +1813,7 @@ fn validate_contract(
             "transaction",
         )?;
         let transaction_id = required_string(transaction, "transactionId", "transaction")?;
+        validate_canonical_id(transaction_id, "transactionId", &format!("{family}-"))?;
         if !transaction_ids.insert(transaction_id.to_owned()) {
             return Err(format!("duplicate transactionId {transaction_id}"));
         }
@@ -2125,7 +2262,7 @@ fn corpus_inventory_is_deterministic_and_documented() {
             scenarios: 20,
             artifacts: 54,
             evidence_files: 42,
-            evidence_bytes: 16_820,
+            evidence_bytes: 16_814,
             capture_states: BTreeMap::from([
                 ("absent".to_owned(), 3),
                 ("accessDenied".to_owned(), 3),
@@ -3565,6 +3702,74 @@ fn review_blocker_bundle_identity_and_order_descriptors_are_closed() {
 }
 
 #[test]
+fn review_blocker_public_identities_are_nonempty_control_free_and_scoped() {
+    let mut failures = Vec::new();
+
+    for (label, replacement) in [
+        ("blank artifactId", ""),
+        ("control-bearing artifactId", "metering-success\nforeign"),
+        (
+            "foreign-family artifactId",
+            "inventory-success-report-current",
+        ),
+    ] {
+        let (scenario_root, mut manifest, mut expected) = load_contract("metering", "success");
+        manifest["artifacts"][0]["artifactId"] = json!(replacement);
+        manifest["artifacts"][0]["pathFingerprint"] =
+            json!(format!("synthetic-{replacement}-root-a"));
+        expected["coverage"][0]["artifactId"] = json!(replacement);
+        expected["transactions"][0]["evidence"][0]["artifactId"] = json!(replacement);
+        collect_contract_rejection(
+            &mut failures,
+            label,
+            validate_contract("metering", "success", &scenario_root, &manifest, &expected),
+            "artifactId is not canonical",
+        );
+    }
+
+    for (label, replacement) in [
+        ("blank transactionId", ""),
+        ("control-bearing transactionId", "metering-success\nforeign"),
+        ("foreign-family transactionId", "inventory-success"),
+    ] {
+        let (scenario_root, manifest, mut expected) = load_contract("metering", "success");
+        expected["transactions"][0]["transactionId"] = json!(replacement);
+        collect_contract_rejection(
+            &mut failures,
+            label,
+            validate_contract("metering", "success", &scenario_root, &manifest, &expected),
+            "transactionId is not canonical",
+        );
+    }
+
+    for (label, replacement) in [
+        ("blank observationId", ""),
+        (
+            "control-bearing observationId",
+            "metering-coverage-only\nforeign",
+        ),
+        ("foreign-family observationId", "inventory-coverage-only"),
+    ] {
+        let (scenario_root, manifest, mut expected) = load_contract("metering", "coverage-states");
+        expected["sourceLocalObservations"][0]["observationId"] = json!(replacement);
+        collect_contract_rejection(
+            &mut failures,
+            label,
+            validate_contract(
+                "metering",
+                "coverage-states",
+                &scenario_root,
+                &manifest,
+                &expected,
+            ),
+            "observationId is not canonical",
+        );
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
 fn review_blocker_sources_own_exact_phases_and_workflow_semantics() {
     let (temporary, manifest, mut expected) = copied_contract_with_evidence_replacements(
         "inventory",
@@ -3811,6 +4016,33 @@ fn review_blocker_nonphysical_optional_field_json_types_are_closed() {
 }
 
 #[test]
+fn review_blocker_source_versions_are_canonical_before_profile_selection() {
+    let (scenario_root, manifest, expected) = load_contract("metering", "success");
+    let mut failures = Vec::new();
+
+    for (label, source_version) in [
+        ("blank sourceVersion", ""),
+        (
+            "control-bearing sourceVersion",
+            "5.00.TEST.325\n9.99.UNKNOWN",
+        ),
+        ("whitespace-bearing sourceVersion", "5.00.TEST.325 "),
+        ("empty sourceVersion segment", "5.00.TEST..325"),
+    ] {
+        let mut mutated = manifest.clone();
+        mutated["artifacts"][0]["sourceVersion"] = json!(source_version);
+        collect_contract_rejection(
+            &mut failures,
+            label,
+            validate_contract("metering", "success", &scenario_root, &mutated, &expected),
+            "sourceVersion is not canonical",
+        );
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
 fn review_blocker_unknown_versions_are_profile_gaps_for_every_coverage_state() {
     let (scenario_root, manifest, expected) = load_contract("inventory", "coverage-states");
     let mut failures = Vec::new();
@@ -3864,7 +4096,7 @@ fn review_blocker_unknown_versions_are_profile_gaps_for_every_coverage_state() {
             .expect("sourceLocalObservations are an array")
             .push(json!({
                 "observationId": format!(
-                    "inventory-coverage-unknown-profile-{capture_state}"
+                    "inventory-coverage-unknown-profile-{artifact_id}"
                 ),
                 "kind": "unknownProfile",
                 "artifactIds": [artifact_id],
@@ -3904,6 +4136,180 @@ fn review_blocker_unknown_versions_are_profile_gaps_for_every_coverage_state() {
             &expected,
         ),
         "absent source invents path/version identity",
+    );
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn review_blocker_source_local_observation_memberships_are_unique_by_kind() {
+    let mut failures = Vec::new();
+
+    for (family, scenario, kind) in [
+        ("metering", "coverage-states", "coverageGap"),
+        (
+            "compliance",
+            "malformed-unknown-profile-invalid-offset",
+            "malformedRecord",
+        ),
+        (
+            "compliance",
+            "malformed-unknown-profile-invalid-offset",
+            "invalidOffset",
+        ),
+        ("metering", "rotation-boundary", "rotationSplit"),
+    ] {
+        let (scenario_root, manifest, mut expected) = load_contract(family, scenario);
+        let observations = expected["sourceLocalObservations"]
+            .as_array_mut()
+            .expect("sourceLocalObservations are an array");
+        let mut duplicate = observations
+            .iter()
+            .find(|observation| observation["kind"] == kind)
+            .unwrap_or_else(|| panic!("{family}/{scenario} contains {kind}"))
+            .clone();
+        let observation_id = duplicate["observationId"]
+            .as_str()
+            .expect("observationId is a string");
+        duplicate["observationId"] = json!(format!("{observation_id}-z"));
+        observations.push(duplicate);
+        observations.sort_by(|left, right| {
+            left["observationId"]
+                .as_str()
+                .cmp(&right["observationId"].as_str())
+        });
+
+        collect_contract_rejection(
+            &mut failures,
+            &format!("duplicate {kind} membership"),
+            validate_contract(family, scenario, &scenario_root, &manifest, &expected),
+            "duplicate source-local observation",
+        );
+    }
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn review_blocker_rotation_split_requires_one_source_lineage_and_exact_key() {
+    let mut failures = Vec::new();
+
+    let (inventory_source_root, mut inventory_manifest, inventory_expected) =
+        load_contract("inventory", "rotation-boundary");
+    let inventory_temporary =
+        TemporaryScenario::copy_from(&inventory_source_root, "rotation-basename-mismatch");
+    let inventory_artifact = &mut inventory_manifest["artifacts"][0];
+    let old_relative_path = inventory_artifact["relativePath"]
+        .as_str()
+        .expect("current inventory artifact relativePath is a string")
+        .to_owned();
+    let new_relative_path =
+        "evidence/client-inventory/root-a/current/InventoryAgentProvider.log".to_owned();
+    let new_full_path = inventory_temporary.root.join(&new_relative_path);
+    let provider_contents = "<![LOG[SYNTHETIC FIXTURE Family=inventory InventoryCycleId=INV-CYCLE-025 ResourceHandle=safe:resource:inventory-025 ReportId=INV-REPORT-025 Phase=Report Disposition=Succeeded Terminal=true]LOG]!><time=\"01:25:01.000+000\" date=\"7-30-2026\" component=\"InventoryAgentProvider\" context=\"\" type=\"1\" thread=\"325\" file=\"\">\n";
+    std::fs::remove_file(inventory_temporary.root.join(old_relative_path))
+        .expect("current inventory evidence can be replaced");
+    std::fs::write(&new_full_path, provider_contents)
+        .expect("mismatched provider evidence can be written");
+    inventory_artifact["originalBasename"] = json!("InventoryAgentProvider.log");
+    inventory_artifact["sanitizedSourcePath"] =
+        json!("SYNTHETIC://root-a/CCM/Logs/InventoryAgentProvider.log");
+    inventory_artifact["relativePath"] = json!(new_relative_path);
+    inventory_artifact["bytesCopied"] = json!(provider_contents.len() as u64);
+    collect_contract_rejection(
+        &mut failures,
+        "different canonical basenames form one rotation split",
+        validate_contract(
+            "inventory",
+            "rotation-boundary",
+            &inventory_temporary.root,
+            &inventory_manifest,
+            &inventory_expected,
+        ),
+        "rotationSplit lineage/key",
+    );
+
+    let (metering_root, mut version_manifest, mut version_expected) =
+        load_contract("metering", "rotation-boundary");
+    let unknown_artifact_id = "metering-rotation-boundary-report-lo";
+    version_manifest["artifacts"][1]["sourceVersion"] = json!("9.99.UNKNOWN");
+    version_expected["extractionProfile"]["selectionState"] = json!("mixedKnownAndUnknown");
+    version_expected["sourceLocalObservations"]
+        .as_array_mut()
+        .expect("sourceLocalObservations are an array")
+        .push(json!({
+            "observationId": "metering-rotation-unknown-profile",
+            "kind": "unknownProfile",
+            "artifactIds": [unknown_artifact_id],
+            "confidenceCeiling": "low",
+            "correlationEligible": false,
+            "claim": "Unknown source version has no selected extraction profile."
+        }));
+    collect_contract_rejection(
+        &mut failures,
+        "different source versions form one rotation split",
+        validate_contract(
+            "metering",
+            "rotation-boundary",
+            &metering_root,
+            &version_manifest,
+            &version_expected,
+        ),
+        "rotationSplit lineage/key",
+    );
+
+    let (temporary, key_manifest, key_expected) = copied_contract_with_evidence_replacements(
+        "metering",
+        "rotation-boundary",
+        "metering-rotation-boundary-report-current",
+        "rotation-key-mismatch",
+        &[("RuleId=RULE-025", "RuleId=RULE-999")],
+    );
+    collect_contract_rejection(
+        &mut failures,
+        "different exact keys form one rotation split",
+        validate_contract(
+            "metering",
+            "rotation-boundary",
+            &temporary.root,
+            &key_manifest,
+            &key_expected,
+        ),
+        "rotationSplit lineage/key",
+    );
+
+    let (source_root, mut root_manifest, root_expected) =
+        load_contract("metering", "rotation-boundary");
+    let temporary = TemporaryScenario::copy_from(&source_root, "rotation-root-mismatch");
+    let artifact = &mut root_manifest["artifacts"][1];
+    let old_relative_path = artifact["relativePath"]
+        .as_str()
+        .expect("lo artifact relativePath is a string")
+        .to_owned();
+    let new_relative_path = "evidence/client-metering/root-b/lo/SWMTRReportGen.log.lo".to_owned();
+    let new_full_path = temporary.root.join(&new_relative_path);
+    std::fs::create_dir_all(
+        new_full_path
+            .parent()
+            .expect("root-mismatch destination has a parent"),
+    )
+    .expect("root-mismatch destination can be created");
+    std::fs::rename(temporary.root.join(old_relative_path), &new_full_path)
+        .expect("lo evidence can move to a distinct synthetic root");
+    artifact["sanitizedSourcePath"] = json!("SYNTHETIC://root-b/CCM/Logs/SWMTRReportGen.log.lo");
+    artifact["pathFingerprint"] = json!("synthetic-metering-rotation-boundary-report-lo-root-b");
+    artifact["relativePath"] = json!(new_relative_path);
+    collect_contract_rejection(
+        &mut failures,
+        "different synthetic roots form one rotation split",
+        validate_contract(
+            "metering",
+            "rotation-boundary",
+            &temporary.root,
+            &root_manifest,
+            &root_expected,
+        ),
+        "rotationSplit lineage/key",
     );
 
     assert!(failures.is_empty(), "{}", failures.join("\n"));

--- a/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
@@ -3706,19 +3706,26 @@ fn review_blocker_public_identities_are_nonempty_control_free_and_scoped() {
     let mut failures = Vec::new();
 
     for (label, replacement) in [
-        ("blank artifactId", ""),
-        ("control-bearing artifactId", "metering-success\nforeign"),
+        ("blank artifactId", String::new()),
+        (
+            "control-bearing artifactId",
+            "metering-success\nforeign".to_owned(),
+        ),
         (
             "foreign-family artifactId",
-            "inventory-success-report-current",
+            "inventory-success-report-current".to_owned(),
+        ),
+        (
+            "overlong artifactId",
+            format!("metering-success-{}", "a".repeat(112)),
         ),
     ] {
         let (scenario_root, mut manifest, mut expected) = load_contract("metering", "success");
-        manifest["artifacts"][0]["artifactId"] = json!(replacement);
+        manifest["artifacts"][0]["artifactId"] = json!(&replacement);
         manifest["artifacts"][0]["pathFingerprint"] =
             json!(format!("synthetic-{replacement}-root-a"));
-        expected["coverage"][0]["artifactId"] = json!(replacement);
-        expected["transactions"][0]["evidence"][0]["artifactId"] = json!(replacement);
+        expected["coverage"][0]["artifactId"] = json!(&replacement);
+        expected["transactions"][0]["evidence"][0]["artifactId"] = json!(&replacement);
         collect_contract_rejection(
             &mut failures,
             label,
@@ -3728,12 +3735,22 @@ fn review_blocker_public_identities_are_nonempty_control_free_and_scoped() {
     }
 
     for (label, replacement) in [
-        ("blank transactionId", ""),
-        ("control-bearing transactionId", "metering-success\nforeign"),
-        ("foreign-family transactionId", "inventory-success"),
+        ("blank transactionId", String::new()),
+        (
+            "control-bearing transactionId",
+            "metering-success\nforeign".to_owned(),
+        ),
+        (
+            "foreign-family transactionId",
+            "inventory-success".to_owned(),
+        ),
+        (
+            "overlong transactionId",
+            format!("metering-{}", "a".repeat(120)),
+        ),
     ] {
         let (scenario_root, manifest, mut expected) = load_contract("metering", "success");
-        expected["transactions"][0]["transactionId"] = json!(replacement);
+        expected["transactions"][0]["transactionId"] = json!(&replacement);
         collect_contract_rejection(
             &mut failures,
             label,
@@ -3743,15 +3760,22 @@ fn review_blocker_public_identities_are_nonempty_control_free_and_scoped() {
     }
 
     for (label, replacement) in [
-        ("blank observationId", ""),
+        ("blank observationId", String::new()),
         (
             "control-bearing observationId",
-            "metering-coverage-only\nforeign",
+            "metering-coverage-only\nforeign".to_owned(),
         ),
-        ("foreign-family observationId", "inventory-coverage-only"),
+        (
+            "foreign-family observationId",
+            "inventory-coverage-only".to_owned(),
+        ),
+        (
+            "overlong observationId",
+            format!("metering-{}", "a".repeat(120)),
+        ),
     ] {
         let (scenario_root, manifest, mut expected) = load_contract("metering", "coverage-states");
-        expected["sourceLocalObservations"][0]["observationId"] = json!(replacement);
+        expected["sourceLocalObservations"][0]["observationId"] = json!(&replacement);
         collect_contract_rejection(
             &mut failures,
             label,

--- a/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_inventory_compliance_metering_fixture_contract.rs
@@ -197,6 +197,78 @@ fn admitted_phases(family: &str) -> Result<&'static [&'static str], String> {
     }
 }
 
+fn admitted_source_phases(
+    family: &str,
+    source_basename: &str,
+) -> Result<&'static [&'static str], String> {
+    match (family, source_basename) {
+        ("inventory", "InventoryAgent.log") => Ok(&["Collect"]),
+        ("inventory", "InventoryProvider.log") => Ok(&["Provider", "Serialize"]),
+        ("inventory", "InventoryAgentProvider.log") => Ok(&["Queue", "Report"]),
+        ("compliance", "CIAgent.log" | "CITaskMgr.log") => Ok(&["Evaluate"]),
+        ("compliance", "DCMAgent.log") => Ok(&["Remediate"]),
+        ("compliance", "DCMReporting.log") => Ok(&["Evaluate", "Report"]),
+        ("compliance", "StateMessage.log") => Ok(&["Report"]),
+        ("metering", "SWMTRReportGen.log") => Ok(&["Collect", "Aggregate", "Report"]),
+        _ => Err(format!(
+            "{source_basename} has no admitted {family} phase ownership"
+        )),
+    }
+}
+
+fn admitted_structured_fields(family: &str) -> Result<BTreeSet<&'static str>, String> {
+    let fields = match family {
+        "inventory" => &[
+            "Family",
+            "InventoryCycleId",
+            "ResourceHandle",
+            "ReportId",
+            "Phase",
+            "Disposition",
+            "Terminal",
+            "ErrorCode",
+            "Recovery",
+            "Ordering",
+            "Coverage",
+            "Rotation",
+        ][..],
+        "compliance" => &[
+            "Family",
+            "CiId",
+            "BaselineId",
+            "StateId",
+            "ResourceHandle",
+            "Phase",
+            "Disposition",
+            "Terminal",
+            "ResultType",
+            "ErrorCode",
+            "Recovery",
+            "Ordering",
+            "PostRemediation",
+            "Coverage",
+            "Rotation",
+        ][..],
+        "metering" => &[
+            "Family",
+            "MeteringCycleId",
+            "RuleId",
+            "ReportId",
+            "ResourceHandle",
+            "Phase",
+            "Disposition",
+            "Terminal",
+            "ErrorCode",
+            "Recovery",
+            "Ordering",
+            "Coverage",
+            "Rotation",
+        ][..],
+        other => return Err(format!("unsupported structured-field family {other}")),
+    };
+    Ok(fields.iter().copied().collect())
+}
+
 fn expected_logical_artifact(family: &str) -> Result<&'static str, String> {
     match family {
         "inventory" => Ok("client-inventory"),
@@ -204,6 +276,103 @@ fn expected_logical_artifact(family: &str) -> Result<&'static str, String> {
         "metering" => Ok("client-metering"),
         other => Err(format!("unsupported workflow family {other}")),
     }
+}
+
+fn validate_structured_field_vocabulary(
+    fields: &BTreeMap<String, String>,
+    context: &str,
+) -> Result<(), String> {
+    let family = fields
+        .get("Family")
+        .ok_or_else(|| format!("{context} has no structured Family field"))?;
+    let admitted = admitted_structured_fields(family)?;
+    for field in fields.keys() {
+        if !admitted.contains(field.as_str()) {
+            return Err(format!(
+                "{context} has unadmitted structured field {field} for {family}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_cited_record_semantics(
+    fields: &BTreeMap<String, String>,
+    source_basename: &str,
+    context: &str,
+) -> Result<(), String> {
+    let family = fields
+        .get("Family")
+        .ok_or_else(|| format!("{context} has no structured Family field"))?;
+    let phase = fields
+        .get("Phase")
+        .ok_or_else(|| format!("{context} has no structured Phase field"))?;
+    if !admitted_source_phases(family, source_basename)?.contains(&phase.as_str()) {
+        return Err(format!(
+            "{context} source {source_basename} does not own phase {phase}"
+        ));
+    }
+    let disposition = fields
+        .get("Disposition")
+        .ok_or_else(|| format!("{context} has no structured Disposition field"))?;
+    let terminal = fields
+        .get("Terminal")
+        .ok_or_else(|| format!("{context} has no structured Terminal field"))?;
+    if !matches!(terminal.as_str(), "true" | "false") {
+        return Err(format!("{context} has invalid Terminal={terminal}"));
+    }
+    if !matches!(
+        disposition.as_str(),
+        "Succeeded" | "Failed" | "Progress" | "Compliant" | "NonCompliant"
+    ) {
+        return Err(format!(
+            "{context} has unadmitted Disposition={disposition}"
+        ));
+    }
+
+    let evaluation_disposition = matches!(disposition.as_str(), "Compliant" | "NonCompliant");
+    if evaluation_disposition && (family != "compliance" || phase != "Evaluate") {
+        return Err(format!(
+            "{context} borrows compliance evaluation semantics outside compliance/Evaluate"
+        ));
+    }
+    if let Some(result_type) = fields.get("ResultType") {
+        if family != "compliance" || phase != "Evaluate" || result_type != "Evaluation" {
+            return Err(format!(
+                "{context} has unowned ResultType={result_type} semantics"
+            ));
+        }
+    }
+    if fields.contains_key("ErrorCode") && (disposition != "Failed" || terminal != "true") {
+        return Err(format!(
+            "{context} ErrorCode is not bound to a terminal failure"
+        ));
+    }
+    if fields.contains_key("Recovery") && (disposition != "Succeeded" || terminal != "true") {
+        return Err(format!(
+            "{context} Recovery is not bound to terminal success"
+        ));
+    }
+    if fields.contains_key("Ordering")
+        && (!matches!(disposition.as_str(), "Succeeded" | "Compliant") || terminal != "true")
+    {
+        return Err(format!(
+            "{context} Ordering is not bound to opposing terminal evidence"
+        ));
+    }
+    if let Some(post_remediation) = fields.get("PostRemediation") {
+        if family != "compliance"
+            || phase != "Report"
+            || disposition != "Succeeded"
+            || terminal != "true"
+            || post_remediation != "Compliant"
+        {
+            return Err(format!(
+                "{context} has unowned PostRemediation={post_remediation} semantics"
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn expected_profile(family: &str) -> Result<&'static str, String> {
@@ -379,6 +548,10 @@ fn walk_files(root: &Path) -> Result<Vec<PathBuf>, String> {
     Ok(files)
 }
 
+fn normalize_manifest_relative_path(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
 static TEMP_SCENARIO_SEQUENCE: AtomicUsize = AtomicUsize::new(0);
 
 struct TemporaryScenario {
@@ -525,6 +698,44 @@ fn validate_relative_path(relative_path: &str, artifact_id: &str) -> Result<(), 
         return Err(format!(
             "{artifact_id} relativePath is outside the evidence root"
         ));
+    }
+    Ok(())
+}
+
+fn validate_source_topology(
+    family: &str,
+    artifact_id: &str,
+    basename: &str,
+    rotation_kind: &str,
+    sanitized_path: &str,
+    fingerprint: &str,
+    relative_path: Option<&str>,
+) -> Result<(), String> {
+    let source_tail = sanitized_path
+        .strip_prefix("SYNTHETIC://")
+        .ok_or_else(|| format!("{artifact_id} source topology is not synthetic"))?;
+    let root = source_tail
+        .split('/')
+        .next()
+        .ok_or_else(|| format!("{artifact_id} source topology has no synthetic root"))?;
+    if !root.starts_with("root-")
+        || !root
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        || sanitized_path != format!("SYNTHETIC://{root}/CCM/Logs/{basename}")
+        || fingerprint != format!("synthetic-{artifact_id}-{root}")
+    {
+        return Err(format!(
+            "{artifact_id} source topology does not bind path/fingerprint root"
+        ));
+    }
+    if let Some(relative_path) = relative_path {
+        let expected = format!("evidence/client-{family}/{root}/{rotation_kind}/{basename}");
+        if relative_path != expected {
+            return Err(format!(
+                "{artifact_id} source topology does not bind relative path {relative_path}"
+            ));
+        }
     }
     Ok(())
 }
@@ -722,7 +933,11 @@ fn evidence_backed_last_successful_phase<'a>(
             let disposition = record.fields.get("Disposition")?.as_str();
             let completed = match disposition {
                 "Succeeded" => true,
-                "Compliant" | "NonCompliant" => record_field_is(record, "ResultType", "Evaluation"),
+                "Compliant" | "NonCompliant" => {
+                    record_field_is(record, "Family", "compliance")
+                        && record_field_is(record, "Phase", "Evaluate")
+                        && record_field_is(record, "ResultType", "Evaluation")
+                }
                 _ => false,
             };
             if !completed {
@@ -810,6 +1025,10 @@ fn evidence_record_texts(
             let source_version = required_string(artifact, "sourceVersion", artifact_id)?;
             let record_context = format!("{artifact_id}:{}", start + offset);
             let fields = strict_ccm_structured_fields(line, &record_context)?;
+            validate_structured_field_vocabulary(&fields, &record_context)?;
+            let basename = required_string(artifact, "originalBasename", artifact_id)?;
+            let source_basename = basename.strip_suffix(".lo").unwrap_or(basename);
+            validate_cited_record_semantics(&fields, source_basename, &record_context)?;
             records.push(CitedEvidenceRecord {
                 fields,
                 source_version: source_version.to_owned(),
@@ -832,6 +1051,32 @@ fn validate_contract(
     let phases = admitted_phases(family)?;
     let profile = expected_profile(family)?;
 
+    require_exact_object_fields(
+        manifest,
+        &[
+            "sccmManifestVersion",
+            "contractState",
+            "proposalOnly",
+            "syntheticFixture",
+            "scenario",
+            "workflowFamily",
+            "bundle",
+            "artifacts",
+        ],
+        "manifest",
+    )?;
+    require_exact_object_fields(
+        &manifest["bundle"],
+        &[
+            "bundleId",
+            "captureHost",
+            "role",
+            "siteCode",
+            "artifactOrder",
+            "rotationOrder",
+        ],
+        "bundle",
+    )?;
     require_exact_object_fields(
         expected,
         &[
@@ -882,7 +1127,7 @@ fn validate_contract(
     require_canonical_string_field_order(artifacts, "artifactId", "manifest artifact")?;
     let mut artifacts_by_id = BTreeMap::new();
     let mut relative_paths = BTreeSet::new();
-    let mut sanitized_paths = BTreeSet::new();
+    let mut physical_source_identities = BTreeSet::new();
     let mut path_fingerprints = BTreeSet::new();
     let mut referenced_files = BTreeSet::new();
     let mut expected_coverage = BTreeMap::new();
@@ -900,6 +1145,16 @@ fn validate_contract(
         if artifact["role"] != "client" || artifact["kind"] != "ccmLog" {
             return Err(format!("{artifact_id} is not a client CCM artifact"));
         }
+        require_exact_object_fields(
+            &artifact["designOnlyCatalog"],
+            &["entryId", "groupMemberships"],
+            &format!("{artifact_id} designOnlyCatalog"),
+        )?;
+        require_exact_object_fields(
+            &artifact["rotation"],
+            &["kind", "fragmentComplete"],
+            &format!("{artifact_id} rotation"),
+        )?;
         let captured_utc = required_string(artifact, "capturedUtc", artifact_id)?;
         let parsed_captured_utc = chrono::DateTime::parse_from_rfc3339(captured_utc)
             .map_err(|error| format!("{artifact_id} capturedUtc is invalid: {error}"))?;
@@ -946,6 +1201,45 @@ fn validate_contract(
         }
         let capture_state = required_string(artifact, "captureState", artifact_id)?;
         let physical = matches!(capture_state, "captured" | "capped" | "parseFailed");
+        let mut exact_artifact_fields = vec![
+            "artifactId",
+            "bytesCopied",
+            "captureState",
+            "capturedUtc",
+            "designOnlyCatalog",
+            "kind",
+            "originalBasename",
+            "pathFingerprint",
+            "relativePath",
+            "role",
+            "rotation",
+            "sanitizedSourcePath",
+            "sourceVersion",
+        ];
+        if physical {
+            exact_artifact_fields.extend(["collectionLimit", "encoding"]);
+        }
+        if capture_state == "capped" {
+            exact_artifact_fields.push("truncated");
+        }
+        if capture_state == "captured"
+            && (artifact["collectionLimit"]["limitApplied"] != false
+                || artifact.get("truncated").is_some())
+        {
+            return Err(format!(
+                "{artifact_id} captured state provenance claims a cap/truncation"
+            ));
+        }
+        if !physical
+            && (artifact.get("encoding").is_some()
+                || artifact.get("collectionLimit").is_some()
+                || artifact.get("truncated").is_some())
+        {
+            return Err(format!(
+                "{artifact_id} nonphysical state provenance invents retained-byte fields"
+            ));
+        }
+        require_exact_object_fields(artifact, &exact_artifact_fields, "artifact")?;
         let relative_path = artifact["relativePath"].as_str();
         if physical != relative_path.is_some() {
             return Err(format!(
@@ -980,10 +1274,15 @@ fn validate_contract(
             if artifact["encoding"] != "utf-8" || std::str::from_utf8(&bytes).is_err() {
                 return Err(format!("{artifact_id} is not declared and encoded UTF-8"));
             }
+            require_exact_object_fields(
+                &artifact["collectionLimit"],
+                &["byteLimit", "limitApplied"],
+                &format!("{artifact_id} collectionLimit"),
+            )?;
+            let byte_limit = artifact["collectionLimit"]["byteLimit"]
+                .as_u64()
+                .ok_or_else(|| format!("{artifact_id} byteLimit is not an integer"))?;
             if capture_state == "capped" {
-                let byte_limit = artifact["collectionLimit"]["byteLimit"]
-                    .as_u64()
-                    .ok_or_else(|| format!("{artifact_id} capped byteLimit is not an integer"))?;
                 if artifact["collectionLimit"]["limitApplied"] != true
                     || artifact["truncated"] != true
                     || artifact["rotation"]["fragmentComplete"] != false
@@ -993,6 +1292,13 @@ fn validate_contract(
                         "{artifact_id} capped state is not an inclusive exact prefix"
                     ));
                 }
+            } else if artifact["collectionLimit"]["limitApplied"] != false
+                || artifact.get("truncated").is_some()
+                || declared_bytes > byte_limit
+            {
+                return Err(format!(
+                    "{artifact_id} {capture_state} state provenance is not uncapped"
+                ));
             }
             if capture_state == "parseFailed" && artifact["rotation"]["fragmentComplete"] != false {
                 return Err(format!(
@@ -1000,20 +1306,29 @@ fn validate_contract(
                 ));
             }
             let sanitized_path = required_string(artifact, "sanitizedSourcePath", artifact_id)?;
-            if !sanitized_path.starts_with("SYNTHETIC://") || !sanitized_path.ends_with(basename) {
-                return Err(format!("{artifact_id} source path is not sanitized"));
-            }
-            if scenario == "same-minute-collision"
-                && !sanitized_paths.insert(sanitized_path.to_owned())
-            {
-                return Err(format!(
-                    "{artifact_id} has an aliased sanitized source path"
-                ));
-            }
             let fingerprint = required_string(artifact, "pathFingerprint", artifact_id)?;
             if fingerprint.is_empty() || !path_fingerprints.insert(fingerprint.to_owned()) {
                 return Err(format!(
                     "{artifact_id} has blank or aliased pathFingerprint"
+                ));
+            }
+            validate_source_topology(
+                family,
+                artifact_id,
+                basename,
+                rotation_kind,
+                sanitized_path,
+                fingerprint,
+                Some(relative_path),
+            )?;
+            let capture_host = required_string(&manifest["bundle"], "captureHost", "bundle")?;
+            if !physical_source_identities.insert((
+                capture_host.to_owned(),
+                sanitized_path.to_owned(),
+                rotation_kind.to_owned(),
+            )) {
+                return Err(format!(
+                    "{artifact_id} has duplicate physical source identity"
                 ));
             }
             referenced_files.insert(relative_path.to_owned());
@@ -1054,24 +1369,29 @@ fn validate_contract(
             }
             if capture_state != "absent" {
                 let sanitized_path = required_string(artifact, "sanitizedSourcePath", artifact_id)?;
-                if !sanitized_path.starts_with("SYNTHETIC://")
-                    || !sanitized_path.ends_with(basename)
-                {
-                    return Err(format!(
-                        "{artifact_id} attempted source path is unsanitized"
-                    ));
-                }
-                if scenario == "same-minute-collision"
-                    && !sanitized_paths.insert(sanitized_path.to_owned())
-                {
-                    return Err(format!(
-                        "{artifact_id} has an aliased sanitized source path"
-                    ));
-                }
                 let fingerprint = required_string(artifact, "pathFingerprint", artifact_id)?;
                 if fingerprint.is_empty() || !path_fingerprints.insert(fingerprint.to_owned()) {
                     return Err(format!(
                         "{artifact_id} has blank or aliased attempted-path fingerprint"
+                    ));
+                }
+                validate_source_topology(
+                    family,
+                    artifact_id,
+                    basename,
+                    rotation_kind,
+                    sanitized_path,
+                    fingerprint,
+                    None,
+                )?;
+                let capture_host = required_string(&manifest["bundle"], "captureHost", "bundle")?;
+                if !physical_source_identities.insert((
+                    capture_host.to_owned(),
+                    sanitized_path.to_owned(),
+                    rotation_kind.to_owned(),
+                )) {
+                    return Err(format!(
+                        "{artifact_id} has duplicate physical source identity"
                     ));
                 }
             }
@@ -1081,10 +1401,11 @@ fn validate_contract(
     let actual_files = walk_files(&scenario_root.join("evidence"))?
         .into_iter()
         .map(|path| {
-            path.strip_prefix(scenario_root)
+            let relative_path = path
+                .strip_prefix(scenario_root)
                 .expect("walk root is below scenario")
-                .to_string_lossy()
-                .into_owned()
+                .to_string_lossy();
+            normalize_manifest_relative_path(&relative_path)
         })
         .collect::<BTreeSet<_>>();
     if actual_files != referenced_files {
@@ -1304,6 +1625,7 @@ fn validate_contract(
         .ok_or_else(|| "transactions are not an array".to_owned())?;
     let mut transaction_ids = BTreeSet::new();
     let mut logical_transaction_identities = BTreeSet::new();
+    let mut cited_evidence_ranges: BTreeMap<String, Vec<(u64, u64)>> = BTreeMap::new();
     let mut previous_transaction_order: Option<(String, u64, u64, String)> = None;
     let mut scenario_semantics = Vec::new();
     for transaction in transactions {
@@ -1438,6 +1760,25 @@ fn validate_contract(
         }
         if evidence_order.windows(2).any(|pair| pair[0] >= pair[1]) {
             return Err(format!("{transaction_id} evidence order is not canonical"));
+        }
+        for (artifact_id, start, end) in &evidence_order {
+            if start == &0 || end < start {
+                return Err(format!(
+                    "{transaction_id} evidence range {start}-{end} is invalid"
+                ));
+            }
+            let prior_ranges = cited_evidence_ranges
+                .entry(artifact_id.clone())
+                .or_default();
+            if prior_ranges
+                .iter()
+                .any(|(prior_start, prior_end)| start <= prior_end && prior_start <= end)
+            {
+                return Err(format!(
+                    "{transaction_id} has overlapping evidence line identity {artifact_id}:{start}-{end}"
+                ));
+            }
+            prior_ranges.push((*start, *end));
         }
         let first_evidence = evidence_order
             .first()
@@ -1714,6 +2055,19 @@ fn assert_rejected_with(
         error.contains(required_error),
         "`{label}` was rejected for the wrong reason: {error}"
     );
+}
+
+fn collect_contract_rejection(
+    failures: &mut Vec<String>,
+    label: &str,
+    result: Result<(), String>,
+    required_error: &str,
+) {
+    match result {
+        Err(error) if error.contains(required_error) => {}
+        Err(error) => failures.push(format!("{label}: wrong rejection: {error}")),
+        Ok(()) => failures.push(format!("{label}: unsafe mutation was accepted")),
+    }
 }
 
 #[test]
@@ -2247,7 +2601,7 @@ fn exact_head_review_blocker_compliance_result_type_is_source_record_local() {
         "Disposition=NonCompliant Terminal=true]LOG]!><time=\"02:02:00.000+000\" ",
         "date=\"7-30-2026\" component=\"CIAgent\" context=\"\" type=\"1\" thread=\"325\" file=\"\">\n",
         "<![LOG[SYNTHETIC FIXTURE Family=compliance CiId=CI-002 BaselineId=BASELINE-002 ",
-        "StateId=STATE-002 ResourceHandle=safe:resource:compliance-002 Phase=Report ",
+        "StateId=STATE-002 ResourceHandle=safe:resource:compliance-002 Phase=Evaluate ",
         "Disposition=Progress Terminal=false ResultType=Evaluation]LOG]!>",
         "<time=\"02:02:01.000+000\" date=\"7-30-2026\" component=\"CIAgent\" ",
         "context=\"\" type=\"1\" thread=\"325\" file=\"\">\n",
@@ -2277,7 +2631,7 @@ fn exact_head_review_blocker_compliance_result_type_is_source_record_local() {
         &temporary.root,
         &manifest,
         &expected,
-        "source-record-local",
+        "compliance evaluation result is not source-record-local",
     );
 }
 
@@ -2471,7 +2825,7 @@ fn exact_head_review_blocker_transaction_identity_and_collision_topology_are_uni
         &scenario_root,
         &manifest,
         &expected,
-        "aliased sanitized source path",
+        "source topology",
     );
 }
 
@@ -2977,5 +3331,330 @@ fn invalid_timestamp_offsets_cannot_be_promoted_to_high_confidence() {
         &scenario_root,
         &manifest,
         &expected,
+    );
+}
+
+#[test]
+fn review_blocker_physical_identity_and_cross_root_topology_are_closed() {
+    let mut failures = Vec::new();
+    for (family, target_id, source_id) in [
+        (
+            "inventory",
+            "inventory-coverage-states-skipped",
+            "inventory-coverage-states-partial",
+        ),
+        (
+            "inventory",
+            "inventory-coverage-states-unsupported",
+            "inventory-coverage-states-access-denied",
+        ),
+        (
+            "compliance",
+            "compliance-coverage-states-access-denied",
+            "compliance-coverage-states-partial",
+        ),
+    ] {
+        let (scenario_root, mut manifest, expected) = load_contract(family, "coverage-states");
+        let artifacts = manifest["artifacts"]
+            .as_array_mut()
+            .expect("artifacts are an array");
+        let source_path = artifacts
+            .iter()
+            .find(|artifact| artifact["artifactId"] == source_id)
+            .expect("source artifact exists")["sanitizedSourcePath"]
+            .clone();
+        let source_root = source_path
+            .as_str()
+            .expect("source path is a string")
+            .strip_prefix("SYNTHETIC://")
+            .expect("source path is synthetic")
+            .split('/')
+            .next()
+            .expect("source path has a root")
+            .to_owned();
+        let target = artifacts
+            .iter_mut()
+            .find(|artifact| artifact["artifactId"] == target_id)
+            .expect("target artifact exists");
+        target["sanitizedSourcePath"] = source_path;
+        target["pathFingerprint"] = json!(format!("synthetic-{target_id}-{source_root}"));
+        collect_contract_rejection(
+            &mut failures,
+            &format!("{family} contradictory physical identity {target_id}/{source_id}"),
+            validate_contract(
+                family,
+                "coverage-states",
+                &scenario_root,
+                &manifest,
+                &expected,
+            ),
+            "duplicate physical source identity",
+        );
+    }
+
+    let (scenario_root, mut collapsed_manifest, expected) =
+        load_contract("inventory", "same-minute-collision");
+    collapsed_manifest["artifacts"][1]["sanitizedSourcePath"] =
+        json!("SYNTHETIC://root-a/alternate/CCM/Logs/InventoryAgentProvider.log");
+    collect_contract_rejection(
+        &mut failures,
+        "cross-root source collapsed beneath an alternate root-a path",
+        validate_contract(
+            "inventory",
+            "same-minute-collision",
+            &scenario_root,
+            &collapsed_manifest,
+            &expected,
+        ),
+        "source topology",
+    );
+
+    let (_, mut swapped_manifest, expected) = load_contract("inventory", "same-minute-collision");
+    let first_fingerprint = swapped_manifest["artifacts"][0]["pathFingerprint"].clone();
+    swapped_manifest["artifacts"][0]["pathFingerprint"] =
+        swapped_manifest["artifacts"][1]["pathFingerprint"].clone();
+    swapped_manifest["artifacts"][1]["pathFingerprint"] = first_fingerprint;
+    collect_contract_rejection(
+        &mut failures,
+        "cross-root fingerprints swapped between exact source handles",
+        validate_contract(
+            "inventory",
+            "same-minute-collision",
+            &scenario_root,
+            &swapped_manifest,
+            &expected,
+        ),
+        "source topology",
+    );
+
+    let (success_root, mut same_root_manifest, success_expected) =
+        load_contract("inventory", "success");
+    let first_fingerprint = same_root_manifest["artifacts"][0]["pathFingerprint"].clone();
+    same_root_manifest["artifacts"][0]["pathFingerprint"] =
+        same_root_manifest["artifacts"][1]["pathFingerprint"].clone();
+    same_root_manifest["artifacts"][1]["pathFingerprint"] = first_fingerprint;
+    collect_contract_rejection(
+        &mut failures,
+        "same-root fingerprints swapped between artifact handles",
+        validate_contract(
+            "inventory",
+            "success",
+            &success_root,
+            &same_root_manifest,
+            &success_expected,
+        ),
+        "source topology",
+    );
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn review_blocker_manifest_and_ccm_structured_vocabularies_are_closed() {
+    let mut failures = Vec::new();
+    for (label, injected_field) in [
+        ("server cause", "ServerCause=ManagementPoint"),
+        ("server role", "Role=server"),
+        ("foreign workflow", "Workflow=compliance"),
+    ] {
+        let replacement = format!("{injected_field} Phase=Report");
+        let (temporary, manifest, expected) = copied_contract_with_evidence_replacements(
+            "inventory",
+            "success",
+            "inventory-success-report-current",
+            label,
+            &[("Phase=Report", &replacement)],
+        );
+        collect_contract_rejection(
+            &mut failures,
+            &format!("unknown CCM field {injected_field}"),
+            validate_contract(
+                "inventory",
+                "success",
+                &temporary.root,
+                &manifest,
+                &expected,
+            ),
+            "unadmitted structured field",
+        );
+    }
+
+    let (scenario_root, mut manifest, expected) = load_contract("inventory", "success");
+    manifest["artifacts"][0]["serverCause"] = json!("ManagementPoint");
+    collect_contract_rejection(
+        &mut failures,
+        "undeclared SCCM manifest artifact serverCause",
+        validate_contract("inventory", "success", &scenario_root, &manifest, &expected),
+        "artifact fields",
+    );
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn review_blocker_sources_own_exact_phases_and_workflow_semantics() {
+    let (temporary, manifest, mut expected) = copied_contract_with_evidence_replacements(
+        "inventory",
+        "success",
+        "inventory-success-agent-current",
+        "agent-borrows-report-phase",
+        &[(
+            "Phase=Collect Disposition=Succeeded Terminal=false",
+            "Phase=Report Disposition=Succeeded Terminal=true",
+        )],
+    );
+    expected["transactions"][0]["evidence"] = json!([{
+        "artifactId": "inventory-success-agent-current",
+        "startLine": 1,
+        "endLine": 1
+    }]);
+    assert_rejected_with(
+        "InventoryAgent record relabeled as terminal Report success",
+        "inventory",
+        "success",
+        &temporary.root,
+        &manifest,
+        &expected,
+        "does not own phase",
+    );
+}
+
+#[test]
+fn review_blocker_inventory_does_not_borrow_compliance_completion_semantics() {
+    let (scenario_root, manifest, _) = load_contract("inventory", "success");
+    let artifacts = manifest["artifacts"]
+        .as_array()
+        .expect("artifacts are an array");
+    let artifacts_by_id = artifacts
+        .iter()
+        .map(|artifact| {
+            (
+                artifact["artifactId"]
+                    .as_str()
+                    .expect("artifactId is a string")
+                    .to_owned(),
+                artifact,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let evidence = json!([{
+        "artifactId": "inventory-success-agent-current",
+        "startLine": 1,
+        "endLine": 1
+    }]);
+    let mut records = evidence_record_texts(
+        &scenario_root,
+        &artifacts_by_id,
+        evidence.as_array().expect("evidence is an array"),
+    )
+    .expect("inventory collect evidence is readable");
+    records[0]
+        .fields
+        .insert("Disposition".to_owned(), "NonCompliant".to_owned());
+    records[0]
+        .fields
+        .insert("Terminal".to_owned(), "true".to_owned());
+    records[0]
+        .fields
+        .insert("ResultType".to_owned(), "Evaluation".to_owned());
+    assert_eq!(
+        evidence_backed_last_successful_phase(
+            &records,
+            admitted_phases("inventory").expect("inventory phases"),
+            "confirmedFailure",
+        ),
+        None,
+        "inventory must not infer a predecessor from compliance evaluation semantics"
+    );
+}
+
+#[test]
+fn review_blocker_capture_state_provenance_is_closed() {
+    let mut failures = Vec::new();
+
+    let (success_root, mut captured_manifest, success_expected) =
+        load_contract("inventory", "success");
+    captured_manifest["artifacts"][0]["collectionLimit"]["limitApplied"] = json!(true);
+    captured_manifest["artifacts"][0]["truncated"] = json!(true);
+    collect_contract_rejection(
+        &mut failures,
+        "captured source claims an applied truncating cap",
+        validate_contract(
+            "inventory",
+            "success",
+            &success_root,
+            &captured_manifest,
+            &success_expected,
+        ),
+        "captured state provenance",
+    );
+
+    let (coverage_root, mut nonphysical_manifest, coverage_expected) =
+        load_contract("inventory", "coverage-states");
+    let access_denied = nonphysical_manifest["artifacts"]
+        .as_array_mut()
+        .expect("artifacts are an array")
+        .iter_mut()
+        .find(|artifact| artifact["artifactId"] == "inventory-coverage-states-access-denied")
+        .expect("access-denied artifact exists");
+    access_denied["encoding"] = json!("utf-8");
+    access_denied["collectionLimit"] = json!({
+        "byteLimit": 0,
+        "limitApplied": true
+    });
+    access_denied["truncated"] = json!(true);
+    collect_contract_rejection(
+        &mut failures,
+        "accessDenied source invents encoding cap and truncation",
+        validate_contract(
+            "inventory",
+            "coverage-states",
+            &coverage_root,
+            &nonphysical_manifest,
+            &coverage_expected,
+        ),
+        "nonphysical state provenance",
+    );
+
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn review_blocker_evidence_line_identity_is_unique_and_nonoverlapping() {
+    let (scenario_root, manifest, expected) = load_contract("inventory", "recovery-contradictory");
+
+    let mut overlapping = expected.clone();
+    overlapping["transactions"][0]["evidence"][0]["endLine"] = json!(2);
+    assert_rejected_with(
+        "recovery cites ranges 1-2 and 2-2",
+        "inventory",
+        "recovery-contradictory",
+        &scenario_root,
+        &manifest,
+        &overlapping,
+        "overlapping evidence line",
+    );
+
+    let mut duplicated = expected;
+    duplicated["transactions"][0]["evidence"][1] =
+        duplicated["transactions"][0]["evidence"][0].clone();
+    assert_rejected(
+        "recovery duplicates the same physical evidence range",
+        "inventory",
+        "recovery-contradictory",
+        &scenario_root,
+        &manifest,
+        &duplicated,
+    );
+}
+
+#[test]
+fn review_blocker_windows_evidence_paths_use_manifest_separators() {
+    assert_eq!(
+        normalize_manifest_relative_path(
+            r"evidence\client-inventory\root-a\current\InventoryAgent.log"
+        ),
+        "evidence/client-inventory/root-a/current/InventoryAgent.log",
+        "actual evidence files must compare to manifest relativePath on Windows"
     );
 }

--- a/docs/sccm/preparation/issue-325-client-inventory-compliance-metering-corpus.md
+++ b/docs/sccm/preparation/issue-325-client-inventory-compliance-metering-corpus.md
@@ -30,6 +30,9 @@ in one complete, unambiguous CCM logical envelope. Required key and semantic
 fields cannot be duplicated or conflict, and phase/disposition/terminal/result
 semantics must come from the same source record. A field borrowed from another
 envelope, line, artifact, root, rotation, or workflow cannot complete a key.
+The structured CCM vocabulary is family-closed, and each admitted source owns
+only its reviewed phases; inventory cannot borrow compliance evaluation
+semantics to synthesize a predecessor.
 The profile identifiers in this corpus are deliberately test-only:
 
 - `sccm-client-inventory-5.00.test-v1`
@@ -77,7 +80,12 @@ The manifest is SCCM-specific preparation data and does not overload generic
 Nonphysical states have no evidence path and zero copied bytes. An absent source
 does not invent path, fingerprint, or version identity. Duplicate basenames from
 different roots remain separate when their sanitized paths, fingerprints, and
-relative paths are distinct.
+relative paths are distinct. One `(captureHost, sanitizedSourcePath, rotation)`
+tuple cannot be declared as contradictory capture states, and each synthetic
+root label must match its path fingerprint and physical relative path.
+`captured`/`parseFailed` rows have an unapplied cap and no truncation field;
+only `capped` rows may carry an applied cap plus truncation. Nonphysical rows
+cannot invent encoding, cap, or truncation provenance.
 
 The proposed #319 preparation schema keeps
 `rotation: {"kind": "current", "fragmentComplete": false}` on noncapture rows.
@@ -91,7 +99,8 @@ The expected contract keeps output deterministic and preparation-only:
 - every coverage row is an exact artifact-level projection of the manifest;
 - every transaction is bound to one unique workflow/profile/exact-key identity;
 - every evidence reference names a manifest artifact and valid line range, and
-  manifest artifacts plus output arrays use canonical stable ordering;
+  cited physical lines are globally unique and non-overlapping; manifest
+  artifacts plus output arrays use canonical stable ordering;
 - transaction citations contain complete raw CCM records whose additive SCCM
   timestamp provenance normalizes to UTC no later than the artifact's canonical
   `capturedUtc`;
@@ -130,12 +139,17 @@ of:
 
 - client-to-server role swaps and workflow/log-family source injection;
 - unsafe relative paths, incorrect byte counts, and cross-root fingerprint
-  aliasing;
+  aliasing, root collapse, fingerprint swaps, or contradictory source
+  identities;
+- capture-state schema drift such as applied caps on `captured` rows or retained
+  byte metadata on nonphysical rows;
 - cross-family key fields, uncited key values, and phase borrowing from another
   record;
 - embedded/look-alike key labels that contain an expected label as a substring;
-- duplicate/conflicting structured fields, nested CCM envelopes, and compliance
-  result types borrowed from another source record;
+- duplicate/conflicting or unknown structured fields, nested CCM envelopes,
+  source-to-phase violations, and compliance result types borrowed from another
+  source record;
+- overlapping or duplicate physical evidence-line identity;
 - uncited predecessor `lastSuccessfulPhase` claims on confirmed failures;
 - high-confidence output from an unknown source profile or invalid timestamp
   offset;
@@ -158,6 +172,9 @@ of:
 - reversed manifest, transaction, evidence, coverage, observation, or
   observation-artifact arrays;
 - missing, altered, or spurious next-artifact requests.
+
+The file projection also canonicalizes Windows `\` separators to manifest `/`
+separators before comparing the physical evidence set.
 
 This mutation layer is independent of the positive fixture assertions, so an
 internally consistent edit to both a manifest and its expected file cannot

--- a/docs/sccm/preparation/issue-325-client-inventory-compliance-metering-corpus.md
+++ b/docs/sccm/preparation/issue-325-client-inventory-compliance-metering-corpus.md
@@ -39,15 +39,16 @@ The profile identifiers in this corpus are deliberately test-only:
 - `sccm-client-compliance-5.00.test-v1`
 - `sccm-client-metering-5.00.test-v1`
 
-An unknown source version has no fallback profile. It remains a source-local,
-low-confidence observation and a coverage/profile gap.
+Source versions are bounded canonical tokens before any prefix-based profile
+selection. An unknown source version has no fallback profile. It remains a
+source-local, low-confidence observation and a coverage/profile gap.
 
 ## Fixture matrix
 
 The fixture root is
 `crates/cmtraceopen-parser/tests/fixtures/sccm/client/inventory-compliance-metering`.
 It contains 20 scenarios, 54 manifest artifacts, and 42 physical evidence files
-(16,820 bytes). The deterministic fixture digest is `409f976350ffbc05`.
+(16,814 bytes). The deterministic fixture digest is `26c8cf8aee0741a2`.
 
 | Family | Scenarios | Contract coverage |
 | --- | --- | --- |
@@ -68,7 +69,8 @@ The manifest is SCCM-specific preparation data and does not overload generic
 `ArtifactStatus` semantics. It preserves:
 
 - a synthetic bundle ID, client role, sanitized capture host, and site code;
-- exact physical artifact identity and logical workflow membership;
+- exact, bounded, control-free artifact identity scoped to its family/scenario
+  and logical workflow membership;
 - original basename, sanitized attempted source path, and path fingerprint;
 - current or `.lo` rotation identity and fragment completeness;
 - explicit `captured`, `absent`, `accessDenied`, `capped`, `skipped`,
@@ -112,7 +114,10 @@ The expected contract keeps output deterministic and preparation-only:
   invent next-artifact requests;
 - `findings` remains empty until production reducers are authorized;
 - source-local observations use a closed kind/artifact/claim schema, have a low
-  confidence ceiling, and are not correlation eligible;
+  confidence ceiling, are not correlation eligible, and cannot repeat one
+  `(kind, artifact)` membership under another observation ID;
+- `rotationSplit` requires `current` and `.lo` partial artifacts from one
+  synthetic root, canonical basename, source version, and exact family key;
 - next-artifact requests name one admitted logical group and basename, never an
   arbitrary path, drive, volume, wildcard, or recursive scan.
 
@@ -149,6 +154,12 @@ of:
 - duplicate/conflicting or unknown structured fields, nested CCM envelopes,
   source-to-phase violations, and compliance result types borrowed from another
   source record;
+- blank, control-bearing, overlong, or foreign-scope artifact, transaction, and
+  observation identities;
+- empty, control-bearing, whitespace-bearing, or malformed source-version
+  tokens before profile selection;
+- duplicate source-local `(kind, artifact)` memberships and rotation splits
+  whose root, canonical basename, version, or exact key differs;
 - overlapping or duplicate physical evidence-line identity;
 - uncited predecessor `lastSuccessfulPhase` claims on confirmed failures;
 - high-confidence output from an unknown source profile or invalid timestamp


### PR DESCRIPTION
## Scope

Stacked correction for draft PR #355 and issue #325. Exact base is `9746f5e2ea634583d6f98ba6ca4f6936ee48fa96`; corrected exact head is `c303e44ee2cde7eec21847fde3a2b868b29f56e2`. The original owner branch is unchanged.

This remains preparation-only and test-scoped. In addition to the earlier review closures, this head:

- rejects blank, control-bearing, overlong, or foreign-scope artifact, transaction, and observation IDs;
- validates canonical source-version tokens before any profile-prefix selection;
- rejects duplicate `(observation kind, artifact)` memberships even under distinct observation IDs;
- requires `rotationSplit` current/`.lo` artifacts to share one synthetic root, canonical basename, canonical source version, and exact family key;
- corrects the inventory rotation fixture so both fragments are one `InventoryAgent.log` lineage;
- preserves every prior conservative coverage, timestamp, collision, vocabulary, phase, bundle-order, and profile-gap gate.

No production catalog, reducer, native adapter, dependency, public model, `ParserKind`, raw CCM grammar, or `LogEntry` change is included. No live Windows acceptance is claimed.

## TDD evidence

Four permanent RED/GREEN contracts were added for the controlling independent review:

1. Public identity closure: nine blank/control/foreign mutations were accepted RED; canonical/scoped validation made them GREEN. CodeRabbit then identified the missing length-bound mutation, so canonical 129-byte mutations for all three ID classes were added and pass.
2. Source-version closure: newline-smuggled, trailing-whitespace, blank, and empty-segment versions were accepted RED; canonical token validation before prefix selection made them GREEN.
3. Source-local membership uniqueness: `coverageGap`, `malformedRecord`, `invalidOffset`, and `rotationSplit` duplicates under distinct IDs were accepted RED; unique `(kind, artifact)` membership made them GREEN.
4. Rotation lineage/key closure: basename, root, version, and exact-key mismatches were accepted RED; one common root/basename/version/key contract made them GREEN.

Nonphysical artifacts retain their original coverage state and cite no evidence file, retained bytes, physical identity, transaction, finding, or causal claim.

## Verification at `c303e44ee2cde7eec21847fde3a2b868b29f56e2`

- exact CodeRabbit follow-up regression: **1/1**
- focused #325 contract: **47/47**
- full Rust 1.88 parser: **701/701**
- repository-default strict Clippy: passed
- Rust 1.88 `wasm32-unknown-unknown`: passed
- `npx tsc --noEmit`: passed
- issue-owned Rust 1.88 `rustfmt --check`: passed
- fixture JSON: **40/40**
- `git diff --check`: passed
- authenticated local CodeRabbit 0.7.1 exact-range review: **0 findings** after its one actionable minor finding was fixed

Two plan-wide commands expose unrelated baselines and were not hidden: full `cargo fmt --check --all` reports existing formatting drift outside #325-owned files, and exact Rust 1.88 strict Clippy reports the same 59 pre-existing `clippy::uninlined-format-args` findings in unrelated parser source. The repository-default strict Clippy command is green.

## Review state

- controlling independent BLOCKED review: https://github.com/adamgell/cmtraceopen/pull/378#pullrequestreview-4825457060
- prior substantive hosted CodeRabbit review through `4e0d933`: no blocker: https://github.com/adamgell/cmtraceopen/pull/378#issuecomment-5139189724
- substantive hosted CodeRabbit static review of exact `4e0d933..c303e44`: **no blocking finding**: https://github.com/adamgell/cmtraceopen/pull/378#issuecomment-5139373034
- all inline review threads remain intentionally unresolved pending exact-head independent readback

Keep this PR draft and stacked. Issue #325 and epic #317 remain open. Production reducer work still depends on reviewed stable #318/#319 interfaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened SCCM inventory and compliance fixture validation for source identity, artifact ownership, metadata consistency, path handling, rotation lineage, and evidence ranges.
  * Added adversarial coverage for duplicate records, conflicting identities, invalid topology, overlapping evidence, and Windows path separators.
  * Updated fixture metadata, expected outputs, and rotation-boundary scenarios to reflect corrected artifact coverage.

* **Documentation**
  * Updated preparation guidance to document stricter validation and provenance requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
