### PR TITLE
feat(sccm): catalog advanced server role sources

### DIFF
--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/missing-required-field/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/missing-required-field/expected.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "1.0.0",
+  "valid": false,
+  "admittedToSemanticCatalog": false,
+  "issues": [
+    "missingField:ownerIssue"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/missing-required-field/source-card.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/missing-required-field/source-card.json
@@ -1,0 +1,72 @@
+{
+  "cardSchemaVersion": "1.0.0",
+  "cardId": "missing-owner-source",
+  "cardVersion": "1.0.0",
+  "family": "Synthetic malformed source missing required ownership",
+  "roleScope": [
+    "syntheticRole"
+  ],
+  "candidateBasenames": [
+    "SyntheticRole.log"
+  ],
+  "pathClasses": [
+    "configuredRoleLogRoot"
+  ],
+  "rawParserFamily": "ccm",
+  "sourceVersionScope": {
+    "state": "unknown",
+    "allowedPrefixes": []
+  },
+  "capture": {
+    "classification": "optional",
+    "maxBytes": 1024,
+    "accessPolicy": "leastPrivilegeNoEscalation",
+    "rotationPolicy": {
+      "kinds": [
+        "current"
+      ],
+      "maxFiles": 1
+    }
+  },
+  "privacy": {
+    "sensitivity": "low",
+    "classes": [],
+    "redactionRequired": false,
+    "publicProjection": [
+      "captureState",
+      "cardId",
+      "coverageState",
+      "roleScope"
+    ],
+    "rawSensitiveFieldProjection": []
+  },
+  "expectedHealthyEvidence": "A future validated synthetic rule would require an exact request key and explicit terminal success evidence.",
+  "terminalFailureEvidence": "A future validated synthetic rule would require an exact request key and explicit terminal failure evidence.",
+  "correlationPolicy": {
+    "keyState": "unvalidated",
+    "allowedKeyKinds": [],
+    "timeOnlyEligible": false,
+    "topologyRequired": true
+  },
+  "fixtureIds": [],
+  "promotion": {
+    "state": "candidate",
+    "observedEvidenceIds": [],
+    "implementationIssue": null,
+    "productionReducer": null,
+    "deferredReason": null
+  },
+  "semanticPolicy": {
+    "captureGuidanceOnly": true,
+    "canCreateTransactions": false,
+    "canCreateFailureFindings": false
+  },
+  "nextEvidence": [
+    "Add explicit issue ownership before this malformed source card can be accepted."
+  ],
+  "supersession": {
+    "state": "active",
+    "supersedes": [],
+    "supersededBy": null
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/redaction-required/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/redaction-required/expected.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "1.0.0",
+  "valid": false,
+  "admittedToSemanticCatalog": false,
+  "issues": [
+    "rawSensitiveProjectionForbidden",
+    "redactionRequired",
+    "unsafePublicProjection"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/redaction-required/source-card.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/redaction-required/source-card.json
@@ -1,0 +1,79 @@
+{
+  "cardSchemaVersion": "1.0.0",
+  "cardId": "unsafe-private-source",
+  "cardVersion": "1.0.0",
+  "family": "Synthetic private source with unsafe projection settings",
+  "roleScope": [
+    "syntheticRole"
+  ],
+  "candidateBasenames": [
+    "SyntheticPrivate.log"
+  ],
+  "pathClasses": [
+    "configuredRoleLogRoot"
+  ],
+  "rawParserFamily": "ccm",
+  "sourceVersionScope": {
+    "state": "unknown",
+    "allowedPrefixes": []
+  },
+  "capture": {
+    "classification": "optional",
+    "maxBytes": 1024,
+    "accessPolicy": "leastPrivilegeNoEscalation",
+    "rotationPolicy": {
+      "kinds": [
+        "current"
+      ],
+      "maxFiles": 1
+    }
+  },
+  "privacy": {
+    "sensitivity": "high",
+    "classes": [
+      "queryText",
+      "userIdentity"
+    ],
+    "redactionRequired": false,
+    "publicProjection": [
+      "captureState",
+      "cardId",
+      "coverageState",
+      "rawQueryText",
+      "roleScope"
+    ],
+    "rawSensitiveFieldProjection": [
+      "rawQueryText"
+    ]
+  },
+  "expectedHealthyEvidence": "A future validated synthetic rule would require an exact request key and explicit terminal success evidence.",
+  "terminalFailureEvidence": "A future validated synthetic rule would require an exact request key and explicit terminal failure evidence.",
+  "correlationPolicy": {
+    "keyState": "unvalidated",
+    "allowedKeyKinds": [],
+    "timeOnlyEligible": false,
+    "topologyRequired": true
+  },
+  "fixtureIds": [],
+  "ownerIssue": "#334",
+  "promotion": {
+    "state": "candidate",
+    "observedEvidenceIds": [],
+    "implementationIssue": null,
+    "productionReducer": null,
+    "deferredReason": null
+  },
+  "semanticPolicy": {
+    "captureGuidanceOnly": true,
+    "canCreateTransactions": false,
+    "canCreateFailureFindings": false
+  },
+  "nextEvidence": [
+    "Remove raw sensitive projection and require public-output redaction before accepting this source card."
+  ],
+  "supersession": {
+    "state": "active",
+    "supersedes": [],
+    "supersededBy": null
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/unvalidated-source/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/unvalidated-source/expected.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "1.0.0",
+  "valid": false,
+  "admittedToSemanticCatalog": false,
+  "issues": [
+    "candidateMetadataInvalid",
+    "unvalidatedSourceCannotDiagnose"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/unvalidated-source/source-card.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/unvalidated-source/source-card.json
@@ -1,0 +1,73 @@
+{
+  "cardSchemaVersion": "1.0.0",
+  "cardId": "unvalidated-production-source",
+  "cardVersion": "1.0.0",
+  "family": "Synthetic unvalidated source attempting semantic admission",
+  "roleScope": [
+    "syntheticRole"
+  ],
+  "candidateBasenames": [
+    "SyntheticRole.log"
+  ],
+  "pathClasses": [
+    "configuredRoleLogRoot"
+  ],
+  "rawParserFamily": "ccm",
+  "sourceVersionScope": {
+    "state": "unknown",
+    "allowedPrefixes": []
+  },
+  "capture": {
+    "classification": "optional",
+    "maxBytes": 1024,
+    "accessPolicy": "leastPrivilegeNoEscalation",
+    "rotationPolicy": {
+      "kinds": [
+        "current"
+      ],
+      "maxFiles": 1
+    }
+  },
+  "privacy": {
+    "sensitivity": "low",
+    "classes": [],
+    "redactionRequired": false,
+    "publicProjection": [
+      "captureState",
+      "cardId",
+      "coverageState",
+      "roleScope"
+    ],
+    "rawSensitiveFieldProjection": []
+  },
+  "expectedHealthyEvidence": "A future validated synthetic rule would require an exact request key and explicit terminal success evidence.",
+  "terminalFailureEvidence": "A future validated synthetic rule would require an exact request key and explicit terminal failure evidence.",
+  "correlationPolicy": {
+    "keyState": "unvalidated",
+    "allowedKeyKinds": [],
+    "timeOnlyEligible": false,
+    "topologyRequired": true
+  },
+  "fixtureIds": [],
+  "ownerIssue": "#334",
+  "promotion": {
+    "state": "candidate",
+    "observedEvidenceIds": [],
+    "implementationIssue": null,
+    "productionReducer": "sccm.server.synthetic.reduce",
+    "deferredReason": null
+  },
+  "semanticPolicy": {
+    "captureGuidanceOnly": false,
+    "canCreateTransactions": true,
+    "canCreateFailureFindings": true
+  },
+  "nextEvidence": [
+    "Remove semantic claims and collect the complete observed, fixture, key, and implementation evidence chain."
+  ],
+  "supersession": {
+    "state": "active",
+    "supersedes": [],
+    "supersededBy": null
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/valid/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/valid/expected.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": "1.0.0",
+  "valid": true,
+  "admittedToSemanticCatalog": false,
+  "issues": []
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/valid/source-card.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/catalog-fixtures/valid/source-card.json
@@ -1,0 +1,73 @@
+{
+  "cardSchemaVersion": "1.0.0",
+  "cardId": "valid-candidate-source",
+  "cardVersion": "1.0.0",
+  "family": "Synthetic valid candidate source for admission testing",
+  "roleScope": [
+    "syntheticRole"
+  ],
+  "candidateBasenames": [
+    "SyntheticRole.log"
+  ],
+  "pathClasses": [
+    "configuredRoleLogRoot"
+  ],
+  "rawParserFamily": "ccm",
+  "sourceVersionScope": {
+    "state": "unknown",
+    "allowedPrefixes": []
+  },
+  "capture": {
+    "classification": "optional",
+    "maxBytes": 1024,
+    "accessPolicy": "leastPrivilegeNoEscalation",
+    "rotationPolicy": {
+      "kinds": [
+        "current"
+      ],
+      "maxFiles": 1
+    }
+  },
+  "privacy": {
+    "sensitivity": "low",
+    "classes": [],
+    "redactionRequired": false,
+    "publicProjection": [
+      "captureState",
+      "cardId",
+      "coverageState",
+      "roleScope"
+    ],
+    "rawSensitiveFieldProjection": []
+  },
+  "expectedHealthyEvidence": "A future validated synthetic rule would require an exact request key and an explicit terminal success record.",
+  "terminalFailureEvidence": "A future validated synthetic rule would require an exact request key and explicit terminal failure evidence.",
+  "correlationPolicy": {
+    "keyState": "unvalidated",
+    "allowedKeyKinds": [],
+    "timeOnlyEligible": false,
+    "topologyRequired": true
+  },
+  "fixtureIds": [],
+  "ownerIssue": "#334",
+  "promotion": {
+    "state": "candidate",
+    "observedEvidenceIds": [],
+    "implementationIssue": null,
+    "productionReducer": null,
+    "deferredReason": null
+  },
+  "semanticPolicy": {
+    "captureGuidanceOnly": true,
+    "canCreateTransactions": false,
+    "canCreateFailureFindings": false
+  },
+  "nextEvidence": [
+    "Record sanitized role, configured-path, and version provenance before promoting this synthetic source."
+  ],
+  "supersession": {
+    "state": "active",
+    "supersedes": [],
+    "supersededBy": null
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/certificate-enrollment-pki.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/certificate-enrollment-pki.json
@@ -1,0 +1,80 @@
+{
+  "cardSchemaVersion": "1.0.0",
+  "cardId": "certificate-enrollment-pki",
+  "cardVersion": "1.0.0",
+  "family": "Certificate enrollment and PKI role diagnostics",
+  "roleScope": [
+    "certificateRegistrationPoint"
+  ],
+  "candidateBasenames": [
+    "crp.log"
+  ],
+  "pathClasses": [
+    "configuredRoleLogRoot",
+    "siteServerLogs"
+  ],
+  "rawParserFamily": "ccm",
+  "sourceVersionScope": {
+    "state": "unknown",
+    "allowedPrefixes": []
+  },
+  "capture": {
+    "classification": "optional",
+    "maxBytes": 4194304,
+    "accessPolicy": "leastPrivilegeNoEscalation",
+    "rotationPolicy": {
+      "kinds": [
+        "current",
+        "lo_"
+      ],
+      "maxFiles": 2
+    }
+  },
+  "privacy": {
+    "sensitivity": "high",
+    "classes": [
+      "certificateIdentity",
+      "deviceIdentity",
+      "subjectName"
+    ],
+    "redactionRequired": true,
+    "publicProjection": [
+      "captureState",
+      "cardId",
+      "coverageState",
+      "roleScope"
+    ],
+    "rawSensitiveFieldProjection": []
+  },
+  "expectedHealthyEvidence": "A future validated rule must cite a bounded enrollment request and its terminal certificate-registration disposition from the same role instance.",
+  "terminalFailureEvidence": "A future terminal rule must cite an explicit certificate-registration failure and must not infer failure from a missing file, access denial, or time proximity.",
+  "correlationPolicy": {
+    "keyState": "unvalidated",
+    "allowedKeyKinds": [],
+    "timeOnlyEligible": false,
+    "topologyRequired": true
+  },
+  "fixtureIds": [],
+  "ownerIssue": "#334",
+  "promotion": {
+    "state": "candidate",
+    "observedEvidenceIds": [],
+    "implementationIssue": null,
+    "productionReducer": null,
+    "deferredReason": null
+  },
+  "semanticPolicy": {
+    "captureGuidanceOnly": true,
+    "canCreateTransactions": false,
+    "canCreateFailureFindings": false
+  },
+  "nextEvidence": [
+    "Record sanitized configured-role and source-version provenance from an authorized development server.",
+    "Design success, terminal-failure, privacy, incomplete-capture, and rotation fixtures before proposing a reducer."
+  ],
+  "supersession": {
+    "state": "active",
+    "supersedes": [],
+    "supersededBy": null
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/client-notification-bgb.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/client-notification-bgb.json
@@ -1,0 +1,81 @@
+{
+  "cardSchemaVersion": "1.0.0",
+  "cardId": "client-notification-bgb",
+  "cardVersion": "1.0.0",
+  "family": "Server-side client notification and BGB diagnostics",
+  "roleScope": [
+    "clientNotificationServer",
+    "managementPoint"
+  ],
+  "candidateBasenames": [
+    "BgbServer.log"
+  ],
+  "pathClasses": [
+    "configuredRoleLogRoot",
+    "siteServerLogs"
+  ],
+  "rawParserFamily": "ccm",
+  "sourceVersionScope": {
+    "state": "unknown",
+    "allowedPrefixes": []
+  },
+  "capture": {
+    "classification": "optional",
+    "maxBytes": 4194304,
+    "accessPolicy": "leastPrivilegeNoEscalation",
+    "rotationPolicy": {
+      "kinds": [
+        "current",
+        "lo_"
+      ],
+      "maxFiles": 2
+    }
+  },
+  "privacy": {
+    "sensitivity": "high",
+    "classes": [
+      "deviceIdentity",
+      "notificationPayload",
+      "userIdentity"
+    ],
+    "redactionRequired": true,
+    "publicProjection": [
+      "captureState",
+      "cardId",
+      "coverageState",
+      "roleScope"
+    ],
+    "rawSensitiveFieldProjection": []
+  },
+  "expectedHealthyEvidence": "A future validated rule must cite a server-side notification request and terminal acknowledgement with an exact, sanitized notification key.",
+  "terminalFailureEvidence": "A future terminal rule must cite an explicit server-side rejection or delivery exhaustion and distinguish it from client-side notification evidence.",
+  "correlationPolicy": {
+    "keyState": "unvalidated",
+    "allowedKeyKinds": [],
+    "timeOnlyEligible": false,
+    "topologyRequired": true
+  },
+  "fixtureIds": [],
+  "ownerIssue": "#334",
+  "promotion": {
+    "state": "candidate",
+    "observedEvidenceIds": [],
+    "implementationIssue": null,
+    "productionReducer": null,
+    "deferredReason": null
+  },
+  "semanticPolicy": {
+    "captureGuidanceOnly": true,
+    "canCreateTransactions": false,
+    "canCreateFailureFindings": false
+  },
+  "nextEvidence": [
+    "Record sanitized server-role, configured-path, and source-version provenance without assuming the candidate basename exists.",
+    "Validate server versus client notification keys using independent synthetic fixtures before defining any correlation."
+  ],
+  "supersession": {
+    "state": "active",
+    "supersedes": [],
+    "supersededBy": null
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/cloud-service-connection.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/cloud-service-connection.json
@@ -1,0 +1,83 @@
+{
+  "cardSchemaVersion": "1.0.0",
+  "cardId": "cloud-service-connection",
+  "cardVersion": "1.0.0",
+  "family": "Cloud and service-connection role diagnostics",
+  "roleScope": [
+    "cloudManagementGatewayConnectionPoint",
+    "serviceConnectionPoint"
+  ],
+  "candidateBasenames": [
+    "CloudMgr.log",
+    "SMS_Cloud_ProxyConnector.log"
+  ],
+  "pathClasses": [
+    "configuredRoleLogRoot",
+    "siteServerLogs"
+  ],
+  "rawParserFamily": "ccm",
+  "sourceVersionScope": {
+    "state": "unknown",
+    "allowedPrefixes": []
+  },
+  "capture": {
+    "classification": "optional",
+    "maxBytes": 4194304,
+    "accessPolicy": "leastPrivilegeNoEscalation",
+    "rotationPolicy": {
+      "kinds": [
+        "current",
+        "lo_"
+      ],
+      "maxFiles": 2
+    }
+  },
+  "privacy": {
+    "sensitivity": "high",
+    "classes": [
+      "certificateIdentity",
+      "cloudEndpoint",
+      "tenantIdentity",
+      "tokenMaterial"
+    ],
+    "redactionRequired": true,
+    "publicProjection": [
+      "captureState",
+      "cardId",
+      "coverageState",
+      "roleScope"
+    ],
+    "rawSensitiveFieldProjection": []
+  },
+  "expectedHealthyEvidence": "A future validated rule must cite a configured cloud operation and explicit terminal service response while retaining only redacted endpoint identity.",
+  "terminalFailureEvidence": "A future terminal rule must cite a corroborated service-connection failure; connectivity gaps, skipped collection, and timestamps alone remain coverage states.",
+  "correlationPolicy": {
+    "keyState": "unvalidated",
+    "allowedKeyKinds": [],
+    "timeOnlyEligible": false,
+    "topologyRequired": true
+  },
+  "fixtureIds": [],
+  "ownerIssue": "#334",
+  "promotion": {
+    "state": "candidate",
+    "observedEvidenceIds": [],
+    "implementationIssue": null,
+    "productionReducer": null,
+    "deferredReason": null
+  },
+  "semanticPolicy": {
+    "captureGuidanceOnly": true,
+    "canCreateTransactions": false,
+    "canCreateFailureFindings": false
+  },
+  "nextEvidence": [
+    "Observe an authorized configured role and capture only sanitized basename, path-class, version, and coverage provenance.",
+    "Complete privacy review for tenant, endpoint, certificate, token, and user-like data before authoring scenario fixtures."
+  ],
+  "supersession": {
+    "state": "active",
+    "supersedes": [],
+    "supersededBy": null
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/osd-pxe.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/osd-pxe.json
@@ -1,0 +1,82 @@
+{
+  "cardSchemaVersion": "1.0.0",
+  "cardId": "osd-pxe",
+  "cardVersion": "1.0.0",
+  "family": "Operating-system deployment and PXE role diagnostics",
+  "roleScope": [
+    "distributionPointPxe",
+    "siteServer"
+  ],
+  "candidateBasenames": [
+    "smspxe.log"
+  ],
+  "pathClasses": [
+    "configuredRoleLogRoot",
+    "siteServerLogs"
+  ],
+  "rawParserFamily": "ccm",
+  "sourceVersionScope": {
+    "state": "unknown",
+    "allowedPrefixes": []
+  },
+  "capture": {
+    "classification": "optional",
+    "maxBytes": 4194304,
+    "accessPolicy": "leastPrivilegeNoEscalation",
+    "rotationPolicy": {
+      "kinds": [
+        "current",
+        "lo_"
+      ],
+      "maxFiles": 2
+    }
+  },
+  "privacy": {
+    "sensitivity": "high",
+    "classes": [
+      "deviceIdentity",
+      "macAddress",
+      "networkIdentity",
+      "resourceIdentity"
+    ],
+    "redactionRequired": true,
+    "publicProjection": [
+      "captureState",
+      "cardId",
+      "coverageState",
+      "roleScope"
+    ],
+    "rawSensitiveFieldProjection": []
+  },
+  "expectedHealthyEvidence": "A future validated rule must cite an exact PXE request identity, compatible distribution-point topology, and explicit boot-service disposition.",
+  "terminalFailureEvidence": "A future terminal rule must cite an explicit PXE rejection or terminal service error and cannot infer failure from an absent default path.",
+  "correlationPolicy": {
+    "keyState": "unvalidated",
+    "allowedKeyKinds": [],
+    "timeOnlyEligible": false,
+    "topologyRequired": true
+  },
+  "fixtureIds": [],
+  "ownerIssue": "#334",
+  "promotion": {
+    "state": "candidate",
+    "observedEvidenceIds": [],
+    "implementationIssue": null,
+    "productionReducer": null,
+    "deferredReason": null
+  },
+  "semanticPolicy": {
+    "captureGuidanceOnly": true,
+    "canCreateTransactions": false,
+    "canCreateFailureFindings": false
+  },
+  "nextEvidence": [
+    "Record configured PXE-role and path-class provenance from a sanitized authorized server before asserting source availability.",
+    "Design privacy-safe success, rejection, topology-mismatch, rotation, malformed, and incomplete source fixtures."
+  ],
+  "supersession": {
+    "state": "active",
+    "supersedes": [],
+    "supersededBy": null
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/reporting.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/reporting.json
@@ -1,0 +1,82 @@
+{
+  "cardSchemaVersion": "1.0.0",
+  "cardId": "reporting",
+  "cardVersion": "1.0.0",
+  "family": "Reporting services role diagnostics",
+  "roleScope": [
+    "reportingServicesPoint"
+  ],
+  "candidateBasenames": [
+    "srsrp.log"
+  ],
+  "pathClasses": [
+    "configuredRoleLogRoot",
+    "reportServerLogs",
+    "siteServerLogs"
+  ],
+  "rawParserFamily": "ccm",
+  "sourceVersionScope": {
+    "state": "unknown",
+    "allowedPrefixes": []
+  },
+  "capture": {
+    "classification": "optional",
+    "maxBytes": 4194304,
+    "accessPolicy": "leastPrivilegeNoEscalation",
+    "rotationPolicy": {
+      "kinds": [
+        "current",
+        "lo_"
+      ],
+      "maxFiles": 2
+    }
+  },
+  "privacy": {
+    "sensitivity": "high",
+    "classes": [
+      "dataSourceIdentity",
+      "reportIdentity",
+      "serviceAccountIdentity",
+      "userIdentity"
+    ],
+    "redactionRequired": true,
+    "publicProjection": [
+      "captureState",
+      "cardId",
+      "coverageState",
+      "roleScope"
+    ],
+    "rawSensitiveFieldProjection": []
+  },
+  "expectedHealthyEvidence": "A future validated rule must cite a reporting-role operation and explicit terminal configuration or service outcome from a compatible role instance.",
+  "terminalFailureEvidence": "A future terminal rule must cite an explicit reporting-role failure while keeping queries, report names, accounts, and data-source details private.",
+  "correlationPolicy": {
+    "keyState": "unvalidated",
+    "allowedKeyKinds": [],
+    "timeOnlyEligible": false,
+    "topologyRequired": true
+  },
+  "fixtureIds": [],
+  "ownerIssue": "#334",
+  "promotion": {
+    "state": "candidate",
+    "observedEvidenceIds": [],
+    "implementationIssue": null,
+    "productionReducer": null,
+    "deferredReason": null
+  },
+  "semanticPolicy": {
+    "captureGuidanceOnly": true,
+    "canCreateTransactions": false,
+    "canCreateFailureFindings": false
+  },
+  "nextEvidence": [
+    "Observe a configured reporting role and record sanitized source-version and configured-path provenance.",
+    "Define bounded redaction fixtures for report, query, account, endpoint, and data-source identity before any semantic rule."
+  ],
+  "supersession": {
+    "state": "active",
+    "supersedes": [],
+    "supersededBy": null
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/sql-database-export.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/advanced_roles/source-cards/sql-database-export.json
@@ -1,0 +1,79 @@
+{
+  "cardSchemaVersion": "1.0.0",
+  "cardId": "sql-database-export",
+  "cardVersion": "1.0.0",
+  "family": "SQL database and supplementary export diagnostics",
+  "roleScope": [
+    "siteDatabaseServer"
+  ],
+  "candidateBasenames": [
+    "site-database-export.json"
+  ],
+  "pathClasses": [
+    "operatorProvidedDatabaseSupplement"
+  ],
+  "rawParserFamily": "unsupported",
+  "sourceVersionScope": {
+    "state": "unknown",
+    "allowedPrefixes": []
+  },
+  "capture": {
+    "classification": "optional",
+    "maxBytes": 1048576,
+    "accessPolicy": "explicitOperatorExport",
+    "rotationPolicy": {
+      "kinds": [
+        "snapshot"
+      ],
+      "maxFiles": 1
+    }
+  },
+  "privacy": {
+    "sensitivity": "high",
+    "classes": [
+      "databaseIdentity",
+      "deviceIdentity",
+      "queryText",
+      "userIdentity"
+    ],
+    "redactionRequired": true,
+    "publicProjection": [
+      "captureState",
+      "cardId",
+      "coverageState",
+      "roleScope"
+    ],
+    "rawSensitiveFieldProjection": []
+  },
+  "expectedHealthyEvidence": "No healthy semantic evidence is supported in this phase; an explicit operator export may only be retained as bounded coverage data.",
+  "terminalFailureEvidence": "No terminal database finding is supported in this phase; missing, denied, malformed, or partial exports remain coverage states only.",
+  "correlationPolicy": {
+    "keyState": "unvalidated",
+    "allowedKeyKinds": [],
+    "timeOnlyEligible": false,
+    "topologyRequired": true
+  },
+  "fixtureIds": [],
+  "ownerIssue": "#334",
+  "promotion": {
+    "state": "deferred",
+    "observedEvidenceIds": [],
+    "implementationIssue": null,
+    "productionReducer": null,
+    "deferredReason": "Database and export parsing needs a separately approved source contract, privacy model, and bounded operator workflow."
+  },
+  "semanticPolicy": {
+    "captureGuidanceOnly": true,
+    "canCreateTransactions": false,
+    "canCreateFailureFindings": false
+  },
+  "nextEvidence": [
+    "Approve a dedicated database-supplement contract with data minimization and explicit operator authorization.",
+    "Create sanitized schema, privacy, cap, unsupported-version, malformed, and partial-export fixtures in a separate implementation issue."
+  ],
+  "supersession": {
+    "state": "active",
+    "supersedes": [],
+    "supersededBy": null
+  }
+}

--- a/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
@@ -452,6 +452,15 @@ fn validate_card(card: &SourceCard) -> Validation {
         {
             issues.push("deprecatedCardRequiresSuccessor".to_owned());
         }
+        SupersessionState::Deprecated
+            if card
+                .supersession
+                .superseded_by
+                .as_deref()
+                .is_some_and(|successor| !is_card_id(successor) || successor == card.card_id) =>
+        {
+            issues.push("supersessionSuccessorInvalid".to_owned());
+        }
         _ => {}
     }
 
@@ -518,6 +527,12 @@ fn validate_card(card: &SourceCard) -> Validation {
         }
         PromotionState::Unknown(_) => issues.push("unknownPromotionState".to_owned()),
     }
+    if matches!(card.promotion.state, PromotionState::RuleValidated)
+        && (card.correlation_policy.key_state != KeyState::Validated
+            || !nonempty_sorted(&card.correlation_policy.allowed_key_kinds))
+    {
+        issues.push("ruleValidatedKeyPolicyInvalid".to_owned());
+    }
 
     let guidance_only = matches!(
         card.promotion.state,
@@ -542,13 +557,36 @@ fn validate_card(card: &SourceCard) -> Validation {
 
     issues.sort();
     issues.dedup();
-    let admitted_to_semantic_catalog =
-        issues.is_empty() && matches!(card.promotion.state, PromotionState::RuleValidated);
+    let admitted_to_semantic_catalog = issues.is_empty()
+        && matches!(card.promotion.state, PromotionState::RuleValidated)
+        && card.supersession.state == SupersessionState::Active;
     Validation {
         valid: issues.is_empty(),
         admitted_to_semantic_catalog,
         issues,
     }
+}
+
+fn validate_card_with_inventory(card: &SourceCard, inventory: &BTreeSet<String>) -> Validation {
+    let mut validation = validate_card(card);
+    if card.supersession.state == SupersessionState::Deprecated
+        && card
+            .supersession
+            .superseded_by
+            .as_ref()
+            .is_some_and(|successor| !inventory.contains(successor))
+    {
+        validation
+            .issues
+            .push("supersessionSuccessorMissing".to_owned());
+    }
+    validation.issues.sort();
+    validation.issues.dedup();
+    validation.valid = validation.issues.is_empty();
+    validation.admitted_to_semantic_catalog = validation.valid
+        && matches!(card.promotion.state, PromotionState::RuleValidated)
+        && card.supersession.state == SupersessionState::Active;
+    validation
 }
 
 fn validate_path(path: &Path) -> Validation {
@@ -585,11 +623,24 @@ fn advanced_role_source_card_inventory_is_exact_and_sorted() {
 #[test]
 fn candidate_catalog_is_typed_private_and_not_semantically_admitted() {
     let root = corpus_root().join("source-cards");
+    let cards = SOURCE_CARDS
+        .iter()
+        .map(|filename| {
+            load_card(&root.join(filename)).unwrap_or_else(|error| panic!("{filename}: {error}"))
+        })
+        .collect::<Vec<_>>();
+    let inventory = cards
+        .iter()
+        .map(|card| card.card_id.clone())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        inventory.len(),
+        cards.len(),
+        "source-card IDs must be unique"
+    );
     let mut card_ids = Vec::new();
-    for filename in SOURCE_CARDS {
-        let path = root.join(filename);
-        let card = load_card(&path).unwrap_or_else(|error| panic!("{filename}: {error}"));
-        let validation = validate_card(&card);
+    for (filename, card) in SOURCE_CARDS.into_iter().zip(cards) {
+        let validation = validate_card_with_inventory(&card, &inventory);
         assert!(
             validation.valid,
             "{filename}: {}",
@@ -693,14 +744,38 @@ fn deprecation_requires_an_explicit_successor_and_never_panics() {
         .issues
         .contains(&"deprecatedCardRequiresSuccessor".to_owned()));
 
+    card.source_version_scope.state = SourceVersionState::Scoped;
+    card.source_version_scope.allowed_prefixes = vec!["5.00.".to_owned()];
+    card.correlation_policy.key_state = KeyState::Validated;
+    card.correlation_policy.allowed_key_kinds = vec!["requestId".to_owned()];
+    card.fixture_ids = vec!["advanced-role-rule-success".to_owned()];
+    card.promotion.state = PromotionState::RuleValidated;
+    card.promotion.observed_evidence_ids = vec!["sanitized-lab-role-path-version-001".to_owned()];
+    card.promotion.implementation_issue = Some("#400".to_owned());
+    card.promotion.production_reducer = Some("sccm.server.synthetic.reduce".to_owned());
+    card.semantic_policy.capture_guidance_only = false;
+    card.semantic_policy.can_create_transactions = true;
+    card.semantic_policy.can_create_failure_findings = true;
+    card.supersession.superseded_by = Some("missing-successor".to_owned());
+    let inventory = [card.card_id.clone()].into_iter().collect();
+    let dangling = validate_card_with_inventory(&card, &inventory);
+    assert!(dangling
+        .issues
+        .contains(&"supersessionSuccessorMissing".to_owned()));
+    assert!(!dangling.admitted_to_semantic_catalog);
+
     card.supersession.superseded_by = Some("advanced-role-successor".to_owned());
-    let valid = validate_card(&card);
+    let inventory = [card.card_id.clone(), "advanced-role-successor".to_owned()]
+        .into_iter()
+        .collect();
+    let valid = validate_card_with_inventory(&card, &inventory);
     assert!(!valid
         .issues
-        .contains(&"deprecatedCardRequiresSuccessor".to_owned()));
+        .contains(&"supersessionSuccessorMissing".to_owned()));
+    assert!(valid.valid, "an existing successor keeps the card valid");
     assert!(
         !valid.admitted_to_semantic_catalog,
-        "deprecation metadata cannot promote a candidate source"
+        "deprecation metadata cannot admit even a RuleValidated source"
     );
 }
 
@@ -737,4 +812,11 @@ fn only_a_fully_linked_rule_validated_card_is_semantically_admitted() {
     let blocked = validate_card(&card);
     assert_eq!(blocked.issues, ["ruleValidatedMetadataInvalid"]);
     assert!(!blocked.admitted_to_semantic_catalog);
+
+    card.promotion.implementation_issue = Some("#400".to_owned());
+    card.correlation_policy.key_state = KeyState::Unvalidated;
+    card.correlation_policy.allowed_key_kinds.clear();
+    let unvalidated_key = validate_card(&card);
+    assert_eq!(unvalidated_key.issues, ["ruleValidatedKeyPolicyInvalid"]);
+    assert!(!unvalidated_key.admitted_to_semantic_catalog);
 }

--- a/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
@@ -1,0 +1,740 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use serde_json::Value;
+
+const CARD_SCHEMA_VERSION: &str = "1.0.0";
+const SOURCE_CARDS: [&str; 6] = [
+    "certificate-enrollment-pki.json",
+    "client-notification-bgb.json",
+    "cloud-service-connection.json",
+    "osd-pxe.json",
+    "reporting.json",
+    "sql-database-export.json",
+];
+const CATALOG_FIXTURES: [&str; 4] = [
+    "missing-required-field",
+    "redaction-required",
+    "unvalidated-source",
+    "valid",
+];
+const REQUIRED_FIELDS: [&str; 20] = [
+    "cardSchemaVersion",
+    "cardId",
+    "cardVersion",
+    "family",
+    "roleScope",
+    "candidateBasenames",
+    "pathClasses",
+    "rawParserFamily",
+    "sourceVersionScope",
+    "capture",
+    "privacy",
+    "expectedHealthyEvidence",
+    "terminalFailureEvidence",
+    "correlationPolicy",
+    "fixtureIds",
+    "ownerIssue",
+    "promotion",
+    "semanticPolicy",
+    "nextEvidence",
+    "supersession",
+];
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SourceCard {
+    card_schema_version: String,
+    card_id: String,
+    card_version: String,
+    family: String,
+    role_scope: Vec<String>,
+    candidate_basenames: Vec<String>,
+    path_classes: Vec<String>,
+    raw_parser_family: RawParserFamily,
+    source_version_scope: SourceVersionScope,
+    capture: CapturePolicy,
+    privacy: PrivacyPolicy,
+    expected_healthy_evidence: String,
+    terminal_failure_evidence: String,
+    correlation_policy: CorrelationPolicy,
+    fixture_ids: Vec<String>,
+    owner_issue: String,
+    promotion: Promotion,
+    semantic_policy: SemanticPolicy,
+    next_evidence: Vec<String>,
+    supersession: Supersession,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum RawParserFamily {
+    Ccm,
+    Unsupported,
+    Unknown(String),
+}
+
+impl<'de> Deserialize<'de> for RawParserFamily {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(match value.as_str() {
+            "ccm" => Self::Ccm,
+            "unsupported" => Self::Unsupported,
+            _ => Self::Unknown(value),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SourceVersionScope {
+    state: SourceVersionState,
+    allowed_prefixes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+enum SourceVersionState {
+    Unknown,
+    Scoped,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CapturePolicy {
+    classification: CaptureClassification,
+    max_bytes: u64,
+    access_policy: AccessPolicy,
+    rotation_policy: RotationPolicy,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+enum CaptureClassification {
+    Mandatory,
+    Optional,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+enum AccessPolicy {
+    LeastPrivilegeNoEscalation,
+    ExplicitOperatorExport,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RotationPolicy {
+    kinds: Vec<String>,
+    max_files: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PrivacyPolicy {
+    sensitivity: PrivacySensitivity,
+    classes: Vec<String>,
+    redaction_required: bool,
+    public_projection: Vec<String>,
+    raw_sensitive_field_projection: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+#[serde(rename_all = "camelCase")]
+enum PrivacySensitivity {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CorrelationPolicy {
+    key_state: KeyState,
+    allowed_key_kinds: Vec<String>,
+    time_only_eligible: bool,
+    topology_required: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+enum KeyState {
+    Unvalidated,
+    Validated,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum PromotionState {
+    Candidate,
+    Observed,
+    FixtureValidated,
+    RuleValidated,
+    Deferred,
+    Unknown(String),
+}
+
+impl<'de> Deserialize<'de> for PromotionState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(match value.as_str() {
+            "candidate" => Self::Candidate,
+            "observed" => Self::Observed,
+            "fixtureValidated" => Self::FixtureValidated,
+            "ruleValidated" => Self::RuleValidated,
+            "deferred" => Self::Deferred,
+            _ => Self::Unknown(value),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Promotion {
+    state: PromotionState,
+    observed_evidence_ids: Vec<String>,
+    implementation_issue: Option<String>,
+    production_reducer: Option<String>,
+    deferred_reason: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SemanticPolicy {
+    capture_guidance_only: bool,
+    can_create_transactions: bool,
+    can_create_failure_findings: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Supersession {
+    state: SupersessionState,
+    supersedes: Vec<String>,
+    superseded_by: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+enum SupersessionState {
+    Active,
+    Deprecated,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ExpectedValidation {
+    schema_version: String,
+    valid: bool,
+    admitted_to_semantic_catalog: bool,
+    issues: Vec<String>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct Validation {
+    valid: bool,
+    admitted_to_semantic_catalog: bool,
+    issues: Vec<String>,
+}
+
+fn corpus_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sccm/server/advanced_roles")
+}
+
+fn read_json(path: &Path) -> Value {
+    let contents = fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("{} is readable: {error}", path.display()));
+    serde_json::from_str(&contents)
+        .unwrap_or_else(|error| panic!("{} contains valid JSON: {error}", path.display()))
+}
+
+fn load_card(path: &Path) -> Result<SourceCard, String> {
+    let value = read_json(path);
+    let object = value
+        .as_object()
+        .ok_or_else(|| "schemaDeserializeFailed:rootMustBeObject".to_owned())?;
+    let missing = REQUIRED_FIELDS
+        .iter()
+        .find(|field| !object.contains_key(**field));
+    if let Some(field) = missing {
+        return Err(format!("missingField:{field}"));
+    }
+
+    serde_json::from_value(value).map_err(|error| {
+        let message = error.to_string();
+        if let Some(field) = message
+            .strip_prefix("unknown field `")
+            .and_then(|value| value.split('`').next())
+        {
+            format!("unknownField:{field}")
+        } else {
+            format!("schemaDeserializeFailed:{message}")
+        }
+    })
+}
+
+fn is_sorted_unique(values: &[String]) -> bool {
+    values.windows(2).all(|pair| pair[0] < pair[1])
+}
+
+fn is_card_id(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        && !value.starts_with('-')
+        && !value.ends_with('-')
+        && !value.contains("--")
+}
+
+fn is_version(value: &str) -> bool {
+    let parts = value.split('.').collect::<Vec<_>>();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+fn is_issue(value: &str) -> bool {
+    value.strip_prefix('#').is_some_and(|digits| {
+        !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+    })
+}
+
+fn nonempty_sorted(values: &[String]) -> bool {
+    !values.is_empty()
+        && is_sorted_unique(values)
+        && values.iter().all(|value| !value.trim().is_empty())
+}
+
+fn validate_card(card: &SourceCard) -> Validation {
+    let mut issues = Vec::new();
+
+    if card.card_schema_version != CARD_SCHEMA_VERSION {
+        issues.push("schemaVersionUnsupported".to_owned());
+    }
+    if !is_card_id(&card.card_id) {
+        issues.push("invalidCardId".to_owned());
+    }
+    if !is_version(&card.card_version) {
+        issues.push("invalidCardVersion".to_owned());
+    }
+    if card.family.trim().len() < 12 {
+        issues.push("familyDescriptionTooShort".to_owned());
+    }
+    if !nonempty_sorted(&card.role_scope) {
+        issues.push("roleScopeMustBeSortedUnique".to_owned());
+    }
+    if !nonempty_sorted(&card.candidate_basenames)
+        || card.candidate_basenames.iter().any(|basename| {
+            basename.contains(['/', '\\', '*'])
+                || basename == "."
+                || basename == ".."
+                || basename.trim() != basename
+        })
+    {
+        issues.push("candidateBasenamesInvalid".to_owned());
+    }
+    if !nonempty_sorted(&card.path_classes) {
+        issues.push("pathClassesMustBeSortedUnique".to_owned());
+    }
+    if let RawParserFamily::Unknown(_) = &card.raw_parser_family {
+        issues.push("unknownRawParserFamily".to_owned());
+    }
+    match card.source_version_scope.state {
+        SourceVersionState::Unknown if !card.source_version_scope.allowed_prefixes.is_empty() => {
+            issues.push("unknownVersionCannotDeclarePrefixes".to_owned());
+        }
+        SourceVersionState::Scoped
+            if !nonempty_sorted(&card.source_version_scope.allowed_prefixes) =>
+        {
+            issues.push("scopedVersionRequiresSortedPrefixes".to_owned());
+        }
+        _ => {}
+    }
+    if card.capture.max_bytes == 0 || card.capture.max_bytes > 16 * 1024 * 1024 {
+        issues.push("captureMaxBytesOutOfRange".to_owned());
+    }
+    let allowed_rotation_kinds = ["current", "lo_", "snapshot", "timestamped"];
+    if !nonempty_sorted(&card.capture.rotation_policy.kinds)
+        || card
+            .capture
+            .rotation_policy
+            .kinds
+            .iter()
+            .any(|kind| !allowed_rotation_kinds.contains(&kind.as_str()))
+        || card.capture.rotation_policy.max_files == 0
+        || card.capture.rotation_policy.max_files > 4
+    {
+        issues.push("rotationPolicyInvalid".to_owned());
+    }
+    if !is_sorted_unique(&card.privacy.classes) || !nonempty_sorted(&card.privacy.public_projection)
+    {
+        issues.push("privacyClassesOrProjectionUnsorted".to_owned());
+    }
+    let allowed_public_projection = ["captureState", "cardId", "coverageState", "roleScope"];
+    if card
+        .privacy
+        .public_projection
+        .iter()
+        .any(|field| !allowed_public_projection.contains(&field.as_str()))
+    {
+        issues.push("unsafePublicProjection".to_owned());
+    }
+    if (!card.privacy.classes.is_empty() || card.privacy.sensitivity >= PrivacySensitivity::Medium)
+        && !card.privacy.redaction_required
+    {
+        issues.push("redactionRequired".to_owned());
+    }
+    if !card.privacy.raw_sensitive_field_projection.is_empty() {
+        issues.push("rawSensitiveProjectionForbidden".to_owned());
+    }
+    let descriptions = [
+        &card.expected_healthy_evidence,
+        &card.terminal_failure_evidence,
+    ];
+    if descriptions.iter().any(|description| {
+        description.trim().len() < 40
+            || description
+                .to_ascii_lowercase()
+                .contains("parse log and identify errors")
+    }) {
+        issues.push("evidenceDescriptionNotSpecific".to_owned());
+    }
+    if card.correlation_policy.time_only_eligible {
+        issues.push("timeOnlyCorrelationForbidden".to_owned());
+    }
+    if !card.correlation_policy.topology_required {
+        issues.push("topologyRequirementMissing".to_owned());
+    }
+    if card.correlation_policy.key_state == KeyState::Unvalidated
+        && !card.correlation_policy.allowed_key_kinds.is_empty()
+    {
+        issues.push("unvalidatedKeysCannotBeDeclared".to_owned());
+    }
+    if card.correlation_policy.key_state == KeyState::Validated
+        && !nonempty_sorted(&card.correlation_policy.allowed_key_kinds)
+    {
+        issues.push("validatedKeysMustBeSorted".to_owned());
+    }
+    if !is_issue(&card.owner_issue) {
+        issues.push("ownerIssueInvalid".to_owned());
+    }
+    if !is_sorted_unique(&card.fixture_ids) {
+        issues.push("fixtureIdsMustBeSortedUnique".to_owned());
+    }
+    if !is_sorted_unique(&card.promotion.observed_evidence_ids) {
+        issues.push("observedEvidenceIdsMustBeSortedUnique".to_owned());
+    }
+    if card.next_evidence.is_empty() || card.next_evidence.iter().any(|item| item.trim().len() < 30)
+    {
+        issues.push("nextEvidenceNotSpecific".to_owned());
+    }
+    if !is_sorted_unique(&card.supersession.supersedes) {
+        issues.push("supersedesMustBeSortedUnique".to_owned());
+    }
+    match card.supersession.state {
+        SupersessionState::Active if card.supersession.superseded_by.is_some() => {
+            issues.push("activeCardCannotBeSuperseded".to_owned());
+        }
+        SupersessionState::Deprecated
+            if card
+                .supersession
+                .superseded_by
+                .as_deref()
+                .is_none_or(str::is_empty) =>
+        {
+            issues.push("deprecatedCardRequiresSuccessor".to_owned());
+        }
+        _ => {}
+    }
+
+    match &card.promotion.state {
+        PromotionState::Candidate => {
+            if !card.promotion.observed_evidence_ids.is_empty()
+                || card.promotion.implementation_issue.is_some()
+                || card.promotion.production_reducer.is_some()
+                || card.promotion.deferred_reason.is_some()
+            {
+                issues.push("candidateMetadataInvalid".to_owned());
+            }
+        }
+        PromotionState::Observed => {
+            if card.promotion.observed_evidence_ids.is_empty()
+                || card.promotion.implementation_issue.is_some()
+                || card.promotion.production_reducer.is_some()
+                || card.promotion.deferred_reason.is_some()
+            {
+                issues.push("observedMetadataInvalid".to_owned());
+            }
+        }
+        PromotionState::FixtureValidated => {
+            if card.promotion.observed_evidence_ids.is_empty()
+                || card.fixture_ids.is_empty()
+                || card.promotion.implementation_issue.is_some()
+                || card.promotion.production_reducer.is_some()
+                || card.promotion.deferred_reason.is_some()
+            {
+                issues.push("fixtureValidatedMetadataInvalid".to_owned());
+            }
+        }
+        PromotionState::RuleValidated => {
+            if card.promotion.observed_evidence_ids.is_empty()
+                || card.fixture_ids.is_empty()
+                || card
+                    .promotion
+                    .implementation_issue
+                    .as_deref()
+                    .is_none_or(|issue| !is_issue(issue))
+                || card
+                    .promotion
+                    .production_reducer
+                    .as_deref()
+                    .is_none_or(str::is_empty)
+                || card.promotion.deferred_reason.is_some()
+                || card.raw_parser_family != RawParserFamily::Ccm
+                || card.source_version_scope.state != SourceVersionState::Scoped
+            {
+                issues.push("ruleValidatedMetadataInvalid".to_owned());
+            }
+        }
+        PromotionState::Deferred => {
+            if card
+                .promotion
+                .deferred_reason
+                .as_deref()
+                .is_none_or(|reason| reason.trim().len() < 30)
+                || card.promotion.production_reducer.is_some()
+                || card.promotion.implementation_issue.is_some()
+            {
+                issues.push("deferredMetadataInvalid".to_owned());
+            }
+        }
+        PromotionState::Unknown(_) => issues.push("unknownPromotionState".to_owned()),
+    }
+
+    let guidance_only = matches!(
+        card.promotion.state,
+        PromotionState::Candidate
+            | PromotionState::Observed
+            | PromotionState::FixtureValidated
+            | PromotionState::Deferred
+    );
+    if guidance_only
+        && (!card.semantic_policy.capture_guidance_only
+            || card.semantic_policy.can_create_transactions
+            || card.semantic_policy.can_create_failure_findings)
+    {
+        issues.push("unvalidatedSourceCannotDiagnose".to_owned());
+    }
+    if matches!(card.promotion.state, PromotionState::RuleValidated)
+        && (card.semantic_policy.capture_guidance_only
+            || !card.semantic_policy.can_create_transactions)
+    {
+        issues.push("ruleValidatedSemanticPolicyInvalid".to_owned());
+    }
+
+    issues.sort();
+    issues.dedup();
+    let admitted_to_semantic_catalog =
+        issues.is_empty() && matches!(card.promotion.state, PromotionState::RuleValidated);
+    Validation {
+        valid: issues.is_empty(),
+        admitted_to_semantic_catalog,
+        issues,
+    }
+}
+
+fn validate_path(path: &Path) -> Validation {
+    match load_card(path) {
+        Ok(card) => validate_card(&card),
+        Err(issue) => Validation {
+            valid: false,
+            admitted_to_semantic_catalog: false,
+            issues: vec![issue],
+        },
+    }
+}
+
+#[test]
+fn advanced_role_source_card_inventory_is_exact_and_sorted() {
+    let root = corpus_root().join("source-cards");
+    let actual = fs::read_dir(&root)
+        .expect("advanced-role source-card root exists")
+        .map(|entry| {
+            entry
+                .expect("source-card entry is readable")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect::<BTreeSet<_>>();
+    let expected = SOURCE_CARDS
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn candidate_catalog_is_typed_private_and_not_semantically_admitted() {
+    let root = corpus_root().join("source-cards");
+    let mut card_ids = Vec::new();
+    for filename in SOURCE_CARDS {
+        let path = root.join(filename);
+        let card = load_card(&path).unwrap_or_else(|error| panic!("{filename}: {error}"));
+        let validation = validate_card(&card);
+        assert!(
+            validation.valid,
+            "{filename}: {}",
+            validation.issues.join(", ")
+        );
+        assert!(
+            !validation.admitted_to_semantic_catalog,
+            "{filename}: prep-only source cards cannot enter semantic analyzers"
+        );
+        assert!(
+            matches!(
+                card.promotion.state,
+                PromotionState::Candidate | PromotionState::Deferred
+            ),
+            "{filename}: no lab-observed or rule-validated evidence exists"
+        );
+        assert!(card.semantic_policy.capture_guidance_only);
+        assert!(!card.semantic_policy.can_create_transactions);
+        assert!(!card.semantic_policy.can_create_failure_findings);
+        card_ids.push(card.card_id);
+    }
+    assert!(
+        is_sorted_unique(&card_ids),
+        "source-card filenames must yield a deterministic card-id order"
+    );
+}
+
+#[test]
+fn catalog_fixture_matrix_has_exact_deterministic_admission_results() {
+    let root = corpus_root().join("catalog-fixtures");
+    let actual = fs::read_dir(&root)
+        .expect("advanced-role catalog-fixture root exists")
+        .map(|entry| {
+            entry
+                .expect("catalog-fixture entry is readable")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect::<BTreeSet<_>>();
+    let expected_names = CATALOG_FIXTURES
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected_names);
+
+    for fixture in CATALOG_FIXTURES {
+        let fixture_root = root.join(fixture);
+        let actual = validate_path(&fixture_root.join("source-card.json"));
+        let expected: ExpectedValidation =
+            serde_json::from_value(read_json(&fixture_root.join("expected.json")))
+                .unwrap_or_else(|error| panic!("{fixture}: expected result is typed: {error}"));
+        assert_eq!(expected.schema_version, CARD_SCHEMA_VERSION);
+        assert_eq!(
+            actual,
+            Validation {
+                valid: expected.valid,
+                admitted_to_semantic_catalog: expected.admitted_to_semantic_catalog,
+                issues: expected.issues,
+            },
+            "{fixture}"
+        );
+    }
+}
+
+#[test]
+fn unknown_parser_and_promotion_values_are_preserved_then_rejected() {
+    let path = corpus_root()
+        .join("catalog-fixtures/valid")
+        .join("source-card.json");
+    let mut value = read_json(&path);
+    value["rawParserFamily"] = Value::String("future-binary-parser".to_owned());
+    value["promotion"]["state"] = Value::String("futurePromotion".to_owned());
+    let card: SourceCard =
+        serde_json::from_value(value).expect("unknown values remain inspectable card data");
+    assert_eq!(
+        card.raw_parser_family,
+        RawParserFamily::Unknown("future-binary-parser".to_owned())
+    );
+    assert_eq!(
+        card.promotion.state,
+        PromotionState::Unknown("futurePromotion".to_owned())
+    );
+    let validation = validate_card(&card);
+    assert_eq!(
+        validation.issues,
+        ["unknownPromotionState", "unknownRawParserFamily"]
+    );
+    assert!(!validation.admitted_to_semantic_catalog);
+}
+
+#[test]
+fn deprecation_requires_an_explicit_successor_and_never_panics() {
+    let path = corpus_root()
+        .join("catalog-fixtures/valid")
+        .join("source-card.json");
+    let mut card = load_card(&path).expect("valid fixture loads");
+    card.supersession.state = SupersessionState::Deprecated;
+    let invalid = validate_card(&card);
+    assert!(invalid
+        .issues
+        .contains(&"deprecatedCardRequiresSuccessor".to_owned()));
+
+    card.supersession.superseded_by = Some("advanced-role-successor".to_owned());
+    let valid = validate_card(&card);
+    assert!(!valid
+        .issues
+        .contains(&"deprecatedCardRequiresSuccessor".to_owned()));
+    assert!(
+        !valid.admitted_to_semantic_catalog,
+        "deprecation metadata cannot promote a candidate source"
+    );
+}
+
+#[test]
+fn only_a_fully_linked_rule_validated_card_is_semantically_admitted() {
+    let path = corpus_root()
+        .join("catalog-fixtures/valid")
+        .join("source-card.json");
+    let mut card = load_card(&path).expect("valid fixture loads");
+    card.source_version_scope.state = SourceVersionState::Scoped;
+    card.source_version_scope.allowed_prefixes = vec!["5.00.".to_owned()];
+    card.correlation_policy.key_state = KeyState::Validated;
+    card.correlation_policy.allowed_key_kinds = vec!["requestId".to_owned()];
+    card.fixture_ids = vec!["advanced-role-rule-success".to_owned()];
+    card.promotion.state = PromotionState::RuleValidated;
+    card.promotion.observed_evidence_ids = vec!["sanitized-lab-role-path-version-001".to_owned()];
+    card.promotion.implementation_issue = Some("#400".to_owned());
+    card.promotion.production_reducer = Some("sccm.server.synthetic.reduce".to_owned());
+    card.semantic_policy.capture_guidance_only = false;
+    card.semantic_policy.can_create_transactions = true;
+    card.semantic_policy.can_create_failure_findings = true;
+
+    let admitted = validate_card(&card);
+    assert_eq!(
+        admitted,
+        Validation {
+            valid: true,
+            admitted_to_semantic_catalog: true,
+            issues: Vec::new(),
+        }
+    );
+
+    card.promotion.implementation_issue = None;
+    let blocked = validate_card(&card);
+    assert_eq!(blocked.issues, ["ruleValidatedMetadataInvalid"]);
+    assert!(!blocked.admitted_to_semantic_catalog);
+}

--- a/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
@@ -584,6 +584,16 @@ fn validate_card_with_inventory(card: &SourceCard, inventory: &BTreeSet<String>)
             .issues
             .push("supersessionSuccessorMissing".to_owned());
     }
+    if card
+        .supersession
+        .supersedes
+        .iter()
+        .any(|predecessor| !is_card_id(predecessor) || !inventory.contains(predecessor))
+    {
+        validation
+            .issues
+            .push("supersededPredecessorMissing".to_owned());
+    }
     validation.issues.sort();
     validation.issues.dedup();
     validation.valid = validation.issues.is_empty();
@@ -778,6 +788,28 @@ fn deprecation_requires_an_explicit_successor_and_never_panics() {
     assert!(
         !valid.admitted_to_semantic_catalog,
         "deprecation metadata cannot admit even a RuleValidated source"
+    );
+
+    card.supersession.supersedes = vec!["advanced-role-predecessor".to_owned()];
+    let dangling_predecessor = validate_card_with_inventory(&card, &inventory);
+    assert_eq!(
+        dangling_predecessor.issues,
+        ["supersededPredecessorMissing"],
+        "a supersedes entry must resolve against the catalog inventory"
+    );
+    assert!(!dangling_predecessor.admitted_to_semantic_catalog);
+
+    let inventory = [
+        card.card_id.clone(),
+        "advanced-role-predecessor".to_owned(),
+        "advanced-role-successor".to_owned(),
+    ]
+    .into_iter()
+    .collect();
+    let resolved = validate_card_with_inventory(&card, &inventory);
+    assert!(
+        resolved.valid,
+        "a supersedes entry present in the catalog keeps the card valid"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
@@ -313,6 +313,12 @@ fn nonempty_sorted(values: &[String]) -> bool {
         && values.iter().all(|value| !value.trim().is_empty())
 }
 
+fn is_admitted(card: &SourceCard, issues: &[String]) -> bool {
+    issues.is_empty()
+        && matches!(card.promotion.state, PromotionState::RuleValidated)
+        && card.supersession.state == SupersessionState::Active
+}
+
 fn validate_card(card: &SourceCard) -> Validation {
     let mut issues = Vec::new();
 
@@ -557,9 +563,7 @@ fn validate_card(card: &SourceCard) -> Validation {
 
     issues.sort();
     issues.dedup();
-    let admitted_to_semantic_catalog = issues.is_empty()
-        && matches!(card.promotion.state, PromotionState::RuleValidated)
-        && card.supersession.state == SupersessionState::Active;
+    let admitted_to_semantic_catalog = is_admitted(card, &issues);
     Validation {
         valid: issues.is_empty(),
         admitted_to_semantic_catalog,
@@ -583,9 +587,7 @@ fn validate_card_with_inventory(card: &SourceCard, inventory: &BTreeSet<String>)
     validation.issues.sort();
     validation.issues.dedup();
     validation.valid = validation.issues.is_empty();
-    validation.admitted_to_semantic_catalog = validation.valid
-        && matches!(card.promotion.state, PromotionState::RuleValidated)
-        && card.supersession.state == SupersessionState::Active;
+    validation.admitted_to_semantic_catalog = is_admitted(card, &validation.issues);
     validation
 }
 

--- a/docs/sccm/source-catalog/advanced-roles.md
+++ b/docs/sccm/source-catalog/advanced-roles.md
@@ -1,0 +1,59 @@
+# SCCM advanced-role source-card catalog
+
+Issue: #334
+
+Card schema: `1.0.0`
+
+Evidence status: synthetic contract only
+
+This catalog is a gate for future source discovery. It does not add a parser, reducer, transaction, finding, native collector, or live Windows acceptance claim. The candidate basenames are capture-discovery hints, not assertions that a role is configured or that a file exists. Missing, denied, capped, skipped, unsupported, malformed, and partial sources remain coverage states.
+
+## Admission contract
+
+Every card records a stable card ID/version, role and family, candidate basenames and configured path classes, raw parser family, source-version scope, bounded capture and rotation policy, privacy classes, healthy and terminal evidence requirements, correlation policy, fixture IDs, issue ownership, semantic limits, next evidence, and supersession state.
+
+Promotion is monotonic and evidence-bound:
+
+| State | Required evidence | Permitted use |
+| --- | --- | --- |
+| `candidate` | Reviewable source mapping only | Bounded capture guidance |
+| `observed` | Sanitized role, configured-path, and source-version provenance | Bounded capture guidance |
+| `fixtureValidated` | Observed provenance plus success, failure, coverage, privacy, and rotation fixtures | Contract testing; no production reducer |
+| `ruleValidated` | Exact key, phase, terminal, version, privacy, and incomplete-bundle tests plus a linked implementation issue | Eligible for a production semantic catalog |
+| `deferred` | A precise unsupported reason and next evidence | Coverage preservation only |
+
+Only a valid `ruleValidated` card with a linked implementation issue and named reducer can enter a semantic analyzer. Candidate, observed, fixture-validated, and deferred cards must set `captureGuidanceOnly`, cannot create transactions, and cannot create failure findings. Time-only correlation is forbidden at every state. Unknown parser or promotion values are preserved as inspectable strings and rejected deterministically rather than panicking or being silently admitted.
+
+Public projection is restricted to nonsensitive card, role, capture, and coverage metadata. A card with privacy classes or medium/high sensitivity must require redaction, and raw sensitive field projection is always rejected.
+
+## Initial cards
+
+No initial card has sanitized lab-observed provenance, so none has a follow-up implementation issue or semantic admission.
+
+| Card ID | Candidate scope | Raw grammar | State | Privacy | Exact next promotion evidence |
+| --- | --- | --- | --- | --- | --- |
+| `certificate-enrollment-pki` | Certificate registration point; candidate `crp.log` | CCM | `candidate` | High: certificate, device, and subject identity | Authorized role/path/version observation; success, terminal, privacy, incomplete, and rotation fixtures |
+| `client-notification-bgb` | Server-side notification and management-point context; candidate `BgbServer.log` | CCM | `candidate` | High: device, user, and notification payload | Sanitized server-role observation and independently validated server-versus-client notification keys |
+| `cloud-service-connection` | Service connection point and CMG connection point; candidates `CloudMgr.log`, `SMS_Cloud_ProxyConnector.log` | CCM | `candidate` | High: tenant, endpoint, certificate, and token-like data | Authorized configured-role observation followed by privacy review and bounded scenario fixtures |
+| `osd-pxe` | PXE-enabled distribution point and site server; candidate `smspxe.log` | CCM | `candidate` | High: device, MAC, network, and resource identity | Sanitized configured-role observation plus topology, privacy, rejection, rotation, malformed, and incomplete fixtures |
+| `reporting` | Reporting services point; candidate `srsrp.log` | CCM | `candidate` | High: report, query, account, and data-source identity | Sanitized configured-role observation and bounded redaction fixtures |
+| `sql-database-export` | Explicit operator-provided database supplement | Unsupported | `deferred` | High: database, query, device, and user identity | Separately approved data-minimized export contract, authorization model, schema, and fixtures |
+
+Candidate names must be confirmed against configured role provenance before promotion. A missing default path never proves that a role is absent or broken. Database access is not a parser fallback and is not authorized by this card.
+
+## Determinism and lifecycle
+
+Catalog filenames and card IDs are sorted and unique. Nested role, basename, path, privacy, version-prefix, fixture, key, and supersession lists are also sorted where ordering affects serialization or comparison. Active cards cannot name a successor. Deprecated cards must name an explicit successor, and supersession metadata cannot promote a card.
+
+The synthetic catalog-fixture matrix proves:
+
+- a valid candidate remains outside the semantic catalog;
+- a missing required owner is rejected;
+- a candidate cannot declare a production reducer or diagnostic capabilities;
+- high-sensitivity data cannot disable redaction or project raw sensitive fields;
+- unknown parser and promotion values are retained for review and rejected;
+- deprecation without an explicit successor is rejected.
+
+## Native validation boundary
+
+The development SCCM Server may later provide sanitized observed provenance, but it is not a blocker for this contract and has not been exercised by this slice. Any future promotion must update the individual card with evidence IDs and fixtures, open a dedicated implementation issue, obtain review, and rerun the parser, wasm32, strict Clippy, formatting, and manifest checks before semantic admission.

--- a/docs/sccm/source-catalog/advanced-roles.md
+++ b/docs/sccm/source-catalog/advanced-roles.md
@@ -45,15 +45,18 @@ Candidate names must be confirmed against configured role provenance before prom
 
 Catalog filenames and card IDs are sorted and unique. Nested role, basename, path, privacy, version-prefix, fixture, key, and supersession lists are also sorted where ordering affects serialization or comparison. Active cards cannot name a successor. Deprecated cards must name a valid successor present in the catalog and can never be semantically admitted. Supersession metadata cannot promote a card.
 
-The synthetic catalog-fixture matrix proves:
+The synthetic catalog-fixture matrix (`missing-required-field`, `redaction-required`, `unvalidated-source`, `valid`) proves:
 
 - a valid candidate remains outside the semantic catalog;
 - a missing required owner is rejected;
 - a candidate cannot declare a production reducer or diagnostic capabilities;
-- high-sensitivity data cannot disable redaction or project raw sensitive fields;
-- unknown parser and promotion values are retained for review and rejected;
-- RuleValidated admission still requires validated, nonempty, deterministic key kinds;
-- deprecation without an existing catalog successor is rejected, and deprecated cards remain outside semantic admission.
+- high-sensitivity data cannot disable redaction or project raw sensitive fields.
+
+Dedicated admission tests prove:
+
+- unknown parser and promotion values are retained for review and rejected (`unknown_parser_and_promotion_values_are_preserved_then_rejected`);
+- RuleValidated admission still requires validated, nonempty, deterministic key kinds (`only_a_fully_linked_rule_validated_card_is_semantically_admitted`);
+- deprecation without an existing catalog successor is rejected, and deprecated cards remain outside semantic admission (`deprecation_requires_an_explicit_successor_and_never_panics`).
 
 ## Native validation boundary
 

--- a/docs/sccm/source-catalog/advanced-roles.md
+++ b/docs/sccm/source-catalog/advanced-roles.md
@@ -43,7 +43,7 @@ Candidate names must be confirmed against configured role provenance before prom
 
 ## Determinism and lifecycle
 
-Catalog filenames and card IDs are sorted and unique. Nested role, basename, path, privacy, version-prefix, fixture, key, and supersession lists are also sorted where ordering affects serialization or comparison. Active cards cannot name a successor. Deprecated cards must name a valid successor present in the catalog and can never be semantically admitted. Supersession metadata cannot promote a card.
+Catalog filenames and card IDs are sorted and unique. Nested role, basename, path, privacy, version-prefix, fixture, key, and supersession lists are also sorted where ordering affects serialization or comparison. Active cards cannot name a successor. Deprecated cards must name a valid successor present in the catalog and can never be semantically admitted. Every `supersedes` entry must be a well-formed card ID naming a card present in the catalog. Supersession metadata cannot promote a card.
 
 The synthetic catalog-fixture matrix (`missing-required-field`, `redaction-required`, `unvalidated-source`, `valid`) proves:
 

--- a/docs/sccm/source-catalog/advanced-roles.md
+++ b/docs/sccm/source-catalog/advanced-roles.md
@@ -43,7 +43,7 @@ Candidate names must be confirmed against configured role provenance before prom
 
 ## Determinism and lifecycle
 
-Catalog filenames and card IDs are sorted and unique. Nested role, basename, path, privacy, version-prefix, fixture, key, and supersession lists are also sorted where ordering affects serialization or comparison. Active cards cannot name a successor. Deprecated cards must name an explicit successor, and supersession metadata cannot promote a card.
+Catalog filenames and card IDs are sorted and unique. Nested role, basename, path, privacy, version-prefix, fixture, key, and supersession lists are also sorted where ordering affects serialization or comparison. Active cards cannot name a successor. Deprecated cards must name a valid successor present in the catalog and can never be semantically admitted. Supersession metadata cannot promote a card.
 
 The synthetic catalog-fixture matrix proves:
 
@@ -52,7 +52,8 @@ The synthetic catalog-fixture matrix proves:
 - a candidate cannot declare a production reducer or diagnostic capabilities;
 - high-sensitivity data cannot disable redaction or project raw sensitive fields;
 - unknown parser and promotion values are retained for review and rejected;
-- deprecation without an explicit successor is rejected.
+- RuleValidated admission still requires validated, nonempty, deterministic key kinds;
+- deprecation without an existing catalog successor is rejected, and deprecated cards remain outside semantic admission.
 
 ## Native validation boundary
 


### PR DESCRIPTION
Tracks #334 and epic #317.

## Scope

- add six versioned advanced-role source cards for PXE/OSD, server-side BGB, cloud/service connection, reporting, certificate enrollment/PKI, and SQL/database export
- add a typed, deterministic source-card admission contract with Candidate, Observed, FixtureValidated, RuleValidated, Deferred, and preserved-unknown states
- add exact valid, missing-field, unvalidated-source, and redaction-required fixture cases
- require privacy-safe public projections, topology-aware/non-time-only correlation policy, linked implementation ownership, version scope, and explicit supersession
- document observed-versus-unknown evidence and exact next promotion evidence for every card

This is a preparation/source-card gate only. It adds no production parser, reducer, transaction, finding, native collector, database access, or live Windows acceptance claim. All initial cards are Candidate except SQL/database export, which is Deferred/unsupported. Missing or inaccessible sources remain coverage states.

## Test-first evidence

RED: `cargo test --locked -p cmtraceopen-parser --test sccm_server_advanced_roles_catalog` failed 5/5 because the source-card and catalog-fixture roots did not exist.

GREEN:

- `cargo test --locked -p cmtraceopen-parser --test sccm_server_advanced_roles_catalog` — 6/6
- `cargo test --locked -p cmtraceopen-parser --test sccm_server_intake_fixture_contract` — 1/1
- `cargo test --locked -p cmtraceopen-parser --test sccm_spine_contract` — 61/61
- `cargo test --locked -p cmtraceopen-parser` — pass
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings` — pass
- `cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown` — pass
- `npx tsc --noEmit` — pass
- Rust 1.88 scoped rustfmt, all added JSON through `jq empty`, and `git diff --check` — pass

`cargo +1.88.0 fmt --check --all` remains red only on pre-existing files outside this PR; this PR's Rust file is formatted and does not appear in the baseline diff.

## Review gates

Keep draft/open. Require an independent exact-head review and a substantive exact-head CodeRabbit response before merge. Native SCCM Server discovery and any card promotion remain pending future evidence; no card may enter a semantic analyzer unless RuleValidated with a linked implementation issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an SCCM advanced-role source catalog covering certificate enrollment, client notification, cloud connectivity, PXE, reporting, and SQL database diagnostics.
  * Defined capture, privacy, evidence, correlation, promotion, and supersession requirements for candidate sources.
  * Added validation scenarios for valid, unvalidated, incomplete, and redaction-required catalog entries.

* **Documentation**
  * Documented catalog admission states, unsupported sources, lifecycle rules, fixture requirements, and public projection restrictions.

* **Tests**
  * Added comprehensive validation coverage for source-card schemas, policies, admission rules, and deterministic outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->