### PR TITLE
feat(elevation): application-wide restart as administrator

### DIFF
--- a/src-tauri/src/commands/elevation.rs
+++ b/src-tauri/src/commands/elevation.rs
@@ -1,0 +1,279 @@
+//! Tauri IPC for application-wide restart as administrator.
+//!
+//! This is the only place the application decides to relaunch itself elevated.
+//! Every workspace, the global menu, and the Access Denied recovery prompt go
+//! through `restart_as_administrator`; none of them owns a relaunch of its own.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use serde::Serialize;
+use tauri::{AppHandle, Manager, State};
+use thiserror::Error;
+
+use crate::elevation::relaunch::{
+    restart_with_provider, NativeRelaunchProvider, RelaunchError, RelaunchReason, RelaunchResult,
+};
+use crate::elevation::restore_ticket::{
+    consume_ticket, discard_ticket, prune_expired, ticket_directory, ticket_for, RestoreTicket,
+    TicketError,
+};
+use crate::elevation::{AppElevationState, ElevationRequest, ElevationValidationError};
+use crate::state::app_state::AppState;
+
+/// Guards against a double-click or two workspaces racing the same prompt.
+///
+/// Only one request may be in flight: a second concurrent call is refused
+/// rather than queued, so the user cannot stack UAC prompts.
+static REQUEST_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+/// Releases the in-flight guard however the request ends, including on an early
+/// return or a panic unwinding through the command.
+struct InFlightGuard;
+
+impl InFlightGuard {
+    fn acquire() -> Option<Self> {
+        REQUEST_IN_FLIGHT
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .ok()
+            .map(|_| Self)
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        REQUEST_IN_FLIGHT.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Why a restart request could not be carried out.
+///
+/// Nested causes stay nested rather than flattened: both this enum and its
+/// sources are internally tagged on `kind`, so flattening would collide.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Error)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ElevationCommandError {
+    #[error("another administrator restart is already in progress")]
+    AlreadyInProgress,
+    #[error("the elevation request was rejected: {reason}")]
+    InvalidRequest { reason: ElevationValidationError },
+    #[error("the elevation restore ticket could not be prepared")]
+    TicketUnavailable,
+    #[error("{source}")]
+    Relaunch { source: RelaunchError },
+    #[error("the application state directory is unavailable")]
+    StateDirectoryUnavailable,
+}
+
+impl From<ElevationValidationError> for ElevationCommandError {
+    fn from(reason: ElevationValidationError) -> Self {
+        Self::InvalidRequest { reason }
+    }
+}
+
+impl From<RelaunchError> for ElevationCommandError {
+    fn from(source: RelaunchError) -> Self {
+        Self::Relaunch { source }
+    }
+}
+
+/// Report whether elevation can be offered and whether it is already held.
+#[tauri::command]
+pub fn get_app_elevation_state() -> AppElevationState {
+    crate::elevation::current_elevation_state()
+}
+
+/// Relaunch elevated, restoring only the requested workspace and source.
+///
+/// The current process exits only after Windows confirms the elevated child
+/// started. Cancelling UAC, running on an unsupported platform, and already
+/// being elevated all return normally with `launched: false` so the caller
+/// keeps its state.
+#[tauri::command]
+pub async fn restart_as_administrator(
+    app: AppHandle,
+    request: ElevationRequest,
+) -> Result<RelaunchResult, ElevationCommandError> {
+    let Some(_in_flight) = InFlightGuard::acquire() else {
+        return Err(ElevationCommandError::AlreadyInProgress);
+    };
+
+    let request = request.validated()?;
+
+    // Answer the cheap, no-side-effect outcomes before writing anything: an
+    // unsupported platform or an already-elevated process must not leave a
+    // ticket behind.
+    let state = crate::elevation::current_elevation_state();
+    if !state.platform_supported {
+        return Ok(RelaunchResult {
+            launched: false,
+            reason: RelaunchReason::UnsupportedPlatform,
+        });
+    }
+    if state.is_elevated {
+        return Ok(RelaunchResult {
+            launched: false,
+            reason: RelaunchReason::AlreadyElevated,
+        });
+    }
+
+    let directory = ticket_directory(
+        &app.path()
+            .app_local_data_dir()
+            .map_err(|_| ElevationCommandError::StateDirectoryUnavailable)?,
+    );
+    let ticket = ticket_for(request.workspace, request.target, request.reason, now_ms());
+    let ticket_id = crate::elevation::restore_ticket::write_ticket(&directory, &ticket)
+        .map_err(|_| ElevationCommandError::TicketUnavailable)?;
+
+    let launch_id = ticket_id.clone();
+    let outcome = tauri::async_runtime::spawn_blocking(move || {
+        restart_with_provider(&NativeRelaunchProvider, Some(&launch_id))
+    })
+    .await
+    .map_err(|_| {
+        ElevationCommandError::from(RelaunchError::LaunchFailed {
+            message: "administrator restart task failed".to_string(),
+        })
+    })?;
+
+    match outcome {
+        Ok(result) if result.launched => {
+            app.exit(0);
+            Ok(result)
+        }
+        // Cancelled, unsupported, or already elevated: the ticket was never
+        // read, so remove it rather than leaving it to expire.
+        Ok(result) => {
+            discard_ticket(&directory, &ticket_id);
+            Ok(result)
+        }
+        Err(error) => {
+            discard_ticket(&directory, &ticket_id);
+            Err(error.into())
+        }
+    }
+}
+
+/// Claim the restore ticket this elevated process was started with, if any.
+///
+/// Returns `Ok(None)` for every unusable case — no ticket, expired, malformed,
+/// or already consumed. A failed restore is never fatal: the application starts
+/// normally, which is why this reports absence rather than an error.
+#[tauri::command]
+pub fn get_initial_elevation_restore(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<Option<RestoreTicket>, crate::error::AppError> {
+    let ticket_id = {
+        let mut guard = state
+            .initial_elevation_restore
+            .lock()
+            .map_err(|error| crate::error::AppError::State(error.to_string()))?;
+        guard.take()
+    };
+
+    let Ok(app_data) = app.path().app_local_data_dir() else {
+        return Ok(None);
+    };
+    let directory = ticket_directory(&app_data);
+
+    // Clear abandoned tickets from cancelled prompts on the way past.
+    prune_expired(&directory);
+
+    let Some(ticket_id) = ticket_id else {
+        return Ok(None);
+    };
+
+    match consume_ticket(&directory, &ticket_id, now_ms()) {
+        Ok(ticket) => Ok(Some(ticket)),
+        Err(error) => {
+            log::warn!(
+                "[elevation] ignoring restore ticket: {}",
+                ticket_summary(&error)
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// A bounded description of why a ticket was ignored, safe for the app log.
+fn ticket_summary(error: &TicketError) -> &'static str {
+    match error {
+        TicketError::MalformedId => "malformed identifier",
+        TicketError::NotFound => "not found",
+        TicketError::NotARegularFile => "not a regular file",
+        TicketError::TooLarge => "too large",
+        TicketError::Unreadable => "unreadable",
+        TicketError::Unwritable => "unwritable",
+        TicketError::Malformed => "malformed contents",
+        TicketError::UnsupportedSchema => "unsupported schema",
+        TicketError::Expired => "expired",
+        TicketError::InvalidContents => "invalid contents",
+    }
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_in_flight_guard_admits_one_request_at_a_time() {
+        let first = InFlightGuard::acquire().expect("first request proceeds");
+        assert!(
+            InFlightGuard::acquire().is_none(),
+            "a concurrent request must be refused"
+        );
+        drop(first);
+        assert!(
+            InFlightGuard::acquire().is_some(),
+            "the guard must release once the request finishes"
+        );
+    }
+
+    #[test]
+    fn elevation_state_matches_platform_support() {
+        let state = get_app_elevation_state();
+        assert_eq!(state.platform_supported, cfg!(target_os = "windows"));
+        if !cfg!(target_os = "windows") {
+            assert!(
+                !state.is_elevated,
+                "a platform without UAC never reports an elevated token"
+            );
+        }
+    }
+
+    #[test]
+    fn every_ticket_rejection_has_a_bounded_summary() {
+        for error in [
+            TicketError::MalformedId,
+            TicketError::NotFound,
+            TicketError::NotARegularFile,
+            TicketError::TooLarge,
+            TicketError::Unreadable,
+            TicketError::Unwritable,
+            TicketError::Malformed,
+            TicketError::UnsupportedSchema,
+            TicketError::Expired,
+            TicketError::InvalidContents,
+        ] {
+            let summary = ticket_summary(&error);
+            assert!(!summary.is_empty());
+            assert!(summary.len() < 64, "summaries stay short for the app log");
+        }
+    }
+
+    #[test]
+    fn command_errors_serialize_with_a_stable_kind() {
+        let error = ElevationCommandError::AlreadyInProgress;
+        let json = serde_json::to_value(&error).expect("serialize");
+        assert_eq!(json["kind"], "alreadyInProgress");
+
+        let error = ElevationCommandError::from(ElevationValidationError::RelativePath);
+        let json = serde_json::to_value(&error).expect("serialize");
+        assert_eq!(json["kind"], "invalidRequest");
+    }
+}

--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -83,6 +83,13 @@ pub fn open_log_file(
     path: String,
     state: State<'_, AppState>,
 ) -> Result<ParseResult, crate::error::AppError> {
+    // Classify a permission failure here: `parse_file` returns a String, which
+    // discards the OS error kind the elevation prompt has to key off. Anything
+    // other than a permission failure falls through to the normal error.
+    if let Some(denied) = crate::source_access::probe_file_access(&path) {
+        return Err(crate::error::AppError::SourceAccess(denied));
+    }
+
     let (result, parser_selection) = parser::parse_file(&path)?;
 
     // Store in AppState so tail parsing reuses the same backend parser selection.
@@ -420,7 +427,18 @@ pub fn list_log_folder(path: String) -> Result<FolderListingResult, crate::error
         )));
     }
 
-    let read_dir = fs::read_dir(&requested_path).map_err(crate::error::AppError::Io)?;
+    let read_dir = fs::read_dir(&requested_path).map_err(|error| {
+        // The io::Error is still intact here, so classify it directly rather
+        // than probing.
+        match crate::source_access::classify_io_error(
+            &error,
+            crate::source_access::SourceOperation::ListFolder,
+            Some(crate::source_access::SourceContext::path(&requested_path)),
+        ) {
+            Some(denied) => crate::error::AppError::SourceAccess(denied),
+            None => crate::error::AppError::Io(error),
+        }
+    })?;
 
     let mut entries: Vec<FolderEntry> = Vec::new();
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod deployment;
 pub mod dns_dhcp;
 #[cfg(feature = "dsregcmd")]
 pub mod dsregcmd;
+pub mod elevation;
 pub mod error_lookup;
 #[cfg(feature = "esp-diagnostics")]
 pub mod esp_diagnostics;

--- a/src-tauri/src/elevation/mod.rs
+++ b/src-tauri/src/elevation/mod.rs
@@ -1,0 +1,381 @@
+//! Application-wide, user-initiated Windows elevation.
+//!
+//! One owner for restart-as-administrator across every workspace. The elevated
+//! child receives only an opaque one-time restore ticket identifier — never a
+//! source path, token, filter, or serialized session. See `relaunch` for the
+//! platform mechanics and `restore_ticket` for the handoff.
+
+pub mod relaunch;
+pub mod restore_ticket;
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Longest accepted known-source identifier.
+pub const MAX_SOURCE_ID_LEN: usize = 128;
+
+/// Longest accepted restore path, in bytes of its lossy UTF-8 form.
+///
+/// Windows extended-length paths stop at 32767 wide chars; this is well above
+/// any real log path while still bounding the ticket.
+pub const MAX_RESTORE_PATH_LEN: usize = 4096;
+
+/// Workspaces the elevated process may be asked to restore.
+///
+/// Mirrors `WorkspaceId` in `src/types/log.ts`. Restoration is an allowlist: a
+/// ticket naming an unknown workspace is rejected, never forwarded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AppWorkspace {
+    Log,
+    Intune,
+    NewIntune,
+    Dsregcmd,
+    MacosDiag,
+    Deployment,
+    EventLog,
+    EspDiagnostics,
+    Secureboot,
+    Sysmon,
+    Timeline,
+    DnsDhcp,
+}
+
+impl AppWorkspace {
+    /// The frontend workspace identifier, matching `WorkspaceId`.
+    pub fn as_id(self) -> &'static str {
+        match self {
+            Self::Log => "log",
+            Self::Intune => "intune",
+            Self::NewIntune => "new-intune",
+            Self::Dsregcmd => "dsregcmd",
+            Self::MacosDiag => "macos-diag",
+            Self::Deployment => "deployment",
+            Self::EventLog => "event-log",
+            Self::EspDiagnostics => "esp-diagnostics",
+            Self::Secureboot => "secureboot",
+            Self::Sysmon => "sysmon",
+            Self::Timeline => "timeline",
+            Self::DnsDhcp => "dns-dhcp",
+        }
+    }
+}
+
+/// Why elevation was requested. Drives the confirmation copy and the retry
+/// marker; it never widens what the elevated process is allowed to do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ElevationReason {
+    /// The global File menu action.
+    ExplicitMenu,
+    /// A source operation returned a confirmed access-denied classification.
+    AccessDenied,
+    /// The ESP banner's coverage recommendation.
+    CoverageRecommended,
+}
+
+/// The source intent to reopen after elevation, alongside the workspace.
+///
+/// `Workspace` restores navigation only. The remaining variants each carry one
+/// validated source reference and nothing else.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum RestoreTarget {
+    /// Restore the workspace with no source.
+    Workspace,
+    /// Reopen one file through the normal log-source path.
+    File { path: PathBuf },
+    /// Reopen one folder through the normal folder-source path.
+    Folder {
+        path: PathBuf,
+        /// Whether the original request aggregated the folder into one view.
+        #[serde(default)]
+        aggregate: bool,
+    },
+    /// Reopen a catalog entry by stable identifier, not by expanded path.
+    KnownSource { source_id: String },
+}
+
+/// A validated frontend elevation request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElevationRequest {
+    pub reason: ElevationReason,
+    pub workspace: AppWorkspace,
+    #[serde(default = "workspace_only")]
+    pub target: RestoreTarget,
+}
+
+fn workspace_only() -> RestoreTarget {
+    RestoreTarget::Workspace
+}
+
+/// Whether this build/process can offer elevation, and whether it already has it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppElevationState {
+    /// Elevation is only offered where the platform provides UAC.
+    pub platform_supported: bool,
+    /// True when the current process already holds an elevated token.
+    pub is_elevated: bool,
+    /// Present when the elevation state could not be determined.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Rejection reasons for an untrusted elevation request or restore ticket.
+///
+/// Every variant is a refusal to act. None of them is recoverable by retrying
+/// with the same input.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Error)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ElevationValidationError {
+    #[error("the restore path is empty")]
+    EmptyPath,
+    #[error("the restore path is not absolute")]
+    RelativePath,
+    #[error("the restore path exceeds the maximum accepted length")]
+    PathTooLong,
+    #[error("the restore path contains an unsupported character")]
+    UnsafePathCharacter,
+    #[error("the known-source identifier is empty")]
+    EmptySourceId,
+    #[error("the known-source identifier exceeds the maximum accepted length")]
+    SourceIdTooLong,
+    #[error("the known-source identifier contains an unsupported character")]
+    UnsafeSourceId,
+}
+
+impl ElevationRequest {
+    /// Validate every untrusted field, returning a request safe to persist.
+    ///
+    /// Validation is total: a request that returns `Ok` has a bounded, absolute,
+    /// control-character-free path or a bounded identifier drawn from a
+    /// conservative character set.
+    pub fn validated(self) -> Result<Self, ElevationValidationError> {
+        let target = match self.target {
+            RestoreTarget::Workspace => RestoreTarget::Workspace,
+            RestoreTarget::File { path } => RestoreTarget::File {
+                path: validate_restore_path(&path)?,
+            },
+            RestoreTarget::Folder { path, aggregate } => RestoreTarget::Folder {
+                path: validate_restore_path(&path)?,
+                aggregate,
+            },
+            RestoreTarget::KnownSource { source_id } => RestoreTarget::KnownSource {
+                source_id: validate_source_id(&source_id)?,
+            },
+        };
+        Ok(Self { target, ..self })
+    }
+}
+
+/// Accept only absolute, bounded, control-character-free paths.
+///
+/// This is a shape check, not an authorization check: the elevated process
+/// still opens the path through the ordinary log-source path, which applies
+/// the same permission and existence rules it always has.
+pub fn validate_restore_path(path: &Path) -> Result<PathBuf, ElevationValidationError> {
+    let text = path.to_string_lossy();
+    if text.is_empty() {
+        return Err(ElevationValidationError::EmptyPath);
+    }
+    if text.len() > MAX_RESTORE_PATH_LEN {
+        return Err(ElevationValidationError::PathTooLong);
+    }
+    if text.chars().any(|character| character.is_control()) {
+        return Err(ElevationValidationError::UnsafePathCharacter);
+    }
+    if !path.is_absolute() {
+        return Err(ElevationValidationError::RelativePath);
+    }
+    Ok(path.to_path_buf())
+}
+
+/// Accept only bounded known-source identifiers drawn from `[A-Za-z0-9._:-]`.
+///
+/// Catalog identifiers are app-authored slugs. Refusing separators keeps a
+/// tampered ticket from steering the catalog lookup toward a path.
+pub fn validate_source_id(source_id: &str) -> Result<String, ElevationValidationError> {
+    if source_id.is_empty() {
+        return Err(ElevationValidationError::EmptySourceId);
+    }
+    if source_id.len() > MAX_SOURCE_ID_LEN {
+        return Err(ElevationValidationError::SourceIdTooLong);
+    }
+    if !source_id
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | ':' | '-'))
+    {
+        return Err(ElevationValidationError::UnsafeSourceId);
+    }
+    Ok(source_id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn absolute(path: &str) -> PathBuf {
+        PathBuf::from(path)
+    }
+
+    #[cfg(target_os = "windows")]
+    const ABSOLUTE_FILE: &str = r"C:\ProgramData\CMTrace\app.log";
+    #[cfg(not(target_os = "windows"))]
+    const ABSOLUTE_FILE: &str = "/var/log/app.log";
+
+    #[test]
+    fn workspace_ids_match_the_frontend_union() {
+        // Guards the Rust <-> TypeScript allowlist. A new workspace must be
+        // added to both or restoration silently falls back to the default.
+        let ids: Vec<&str> = [
+            AppWorkspace::Log,
+            AppWorkspace::Intune,
+            AppWorkspace::NewIntune,
+            AppWorkspace::Dsregcmd,
+            AppWorkspace::MacosDiag,
+            AppWorkspace::Deployment,
+            AppWorkspace::EventLog,
+            AppWorkspace::EspDiagnostics,
+            AppWorkspace::Secureboot,
+            AppWorkspace::Sysmon,
+            AppWorkspace::Timeline,
+            AppWorkspace::DnsDhcp,
+        ]
+        .iter()
+        .map(|workspace| workspace.as_id())
+        .collect();
+
+        assert_eq!(
+            ids,
+            vec![
+                "log",
+                "intune",
+                "new-intune",
+                "dsregcmd",
+                "macos-diag",
+                "deployment",
+                "event-log",
+                "esp-diagnostics",
+                "secureboot",
+                "sysmon",
+                "timeline",
+                "dns-dhcp",
+            ]
+        );
+    }
+
+    #[test]
+    fn workspace_serializes_to_the_frontend_identifier() {
+        let json = serde_json::to_string(&AppWorkspace::EspDiagnostics).expect("serialize");
+        assert_eq!(json, "\"esp-diagnostics\"");
+        let parsed: AppWorkspace = serde_json::from_str("\"dns-dhcp\"").expect("deserialize");
+        assert_eq!(parsed, AppWorkspace::DnsDhcp);
+    }
+
+    #[test]
+    fn unknown_workspace_is_rejected() {
+        let parsed = serde_json::from_str::<AppWorkspace>("\"not-a-workspace\"");
+        assert!(parsed.is_err(), "unknown workspace ids must not deserialize");
+    }
+
+    #[test]
+    fn relative_restore_path_is_rejected() {
+        let error = validate_restore_path(Path::new("relative/app.log")).unwrap_err();
+        assert_eq!(error, ElevationValidationError::RelativePath);
+    }
+
+    #[test]
+    fn empty_restore_path_is_rejected() {
+        let error = validate_restore_path(Path::new("")).unwrap_err();
+        assert_eq!(error, ElevationValidationError::EmptyPath);
+    }
+
+    #[test]
+    fn oversized_restore_path_is_rejected() {
+        let long = format!("{}{}", ABSOLUTE_FILE, "a".repeat(MAX_RESTORE_PATH_LEN));
+        let error = validate_restore_path(Path::new(&long)).unwrap_err();
+        assert_eq!(error, ElevationValidationError::PathTooLong);
+    }
+
+    #[test]
+    fn control_characters_in_restore_path_are_rejected() {
+        // A NUL would truncate the path at the Win32 boundary; reject the whole
+        // control range rather than only the byte that happens to be fatal.
+        let error = validate_restore_path(Path::new("/var/log/app\u{0}.log")).unwrap_err();
+        assert_eq!(error, ElevationValidationError::UnsafePathCharacter);
+    }
+
+    #[test]
+    fn absolute_restore_path_is_accepted() {
+        let path = validate_restore_path(Path::new(ABSOLUTE_FILE)).expect("absolute path");
+        assert_eq!(path, absolute(ABSOLUTE_FILE));
+    }
+
+    #[test]
+    fn source_id_rejects_traversal_and_separators() {
+        for candidate in ["../escape", "a/b", "a\\b", "a b", ""] {
+            assert!(
+                validate_source_id(candidate).is_err(),
+                "source id {candidate:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn source_id_accepts_catalog_slugs() {
+        for candidate in ["company-portal-logs", "esp.bundle_1", "ns:source-2"] {
+            assert!(
+                validate_source_id(candidate).is_ok(),
+                "source id {candidate:?} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn oversized_source_id_is_rejected() {
+        let error = validate_source_id(&"a".repeat(MAX_SOURCE_ID_LEN + 1)).unwrap_err();
+        assert_eq!(error, ElevationValidationError::SourceIdTooLong);
+    }
+
+    #[test]
+    fn request_validation_rewrites_only_the_target() {
+        let request = ElevationRequest {
+            reason: ElevationReason::AccessDenied,
+            workspace: AppWorkspace::Log,
+            target: RestoreTarget::File {
+                path: absolute(ABSOLUTE_FILE),
+            },
+        };
+
+        let validated = request.clone().validated().expect("valid request");
+
+        assert_eq!(validated.reason, request.reason);
+        assert_eq!(validated.workspace, request.workspace);
+        assert_eq!(
+            validated.target,
+            RestoreTarget::File {
+                path: absolute(ABSOLUTE_FILE)
+            }
+        );
+    }
+
+    #[test]
+    fn request_validation_rejects_an_unsafe_target() {
+        let request = ElevationRequest {
+            reason: ElevationReason::ExplicitMenu,
+            workspace: AppWorkspace::Log,
+            target: RestoreTarget::KnownSource {
+                source_id: "../../etc/passwd".to_string(),
+            },
+        };
+
+        assert_eq!(
+            request.validated().unwrap_err(),
+            ElevationValidationError::UnsafeSourceId
+        );
+    }
+}

--- a/src-tauri/src/elevation/mod.rs
+++ b/src-tauri/src/elevation/mod.rs
@@ -125,6 +125,41 @@ pub struct AppElevationState {
     pub detail: Option<String>,
 }
 
+/// Whether this platform offers a user-initiated elevation mechanism.
+///
+/// Elevation is a Windows/UAC concept. Everywhere else the menu item is hidden
+/// and the recovery prompt never appears, rather than failing at the last step.
+pub fn is_elevation_supported() -> bool {
+    cfg!(target_os = "windows")
+}
+
+/// Probe the current process's elevation, for menus and recovery prompts.
+///
+/// A probe failure reports `is_elevated: false` with a `detail`, so the UI can
+/// still offer the action instead of disabling it on an unknown state.
+pub fn current_elevation_state() -> AppElevationState {
+    if !is_elevation_supported() {
+        return AppElevationState {
+            platform_supported: false,
+            is_elevated: false,
+            detail: Some("Restarting as administrator is only supported on Windows".to_string()),
+        };
+    }
+
+    match relaunch::is_process_elevated() {
+        Ok(is_elevated) => AppElevationState {
+            platform_supported: true,
+            is_elevated,
+            detail: None,
+        },
+        Err(detail) => AppElevationState {
+            platform_supported: true,
+            is_elevated: false,
+            detail: Some(detail),
+        },
+    }
+}
+
 /// Rejection reasons for an untrusted elevation request or restore ticket.
 ///
 /// Every variant is a refusal to act. None of them is recoverable by retrying
@@ -205,10 +240,9 @@ pub fn validate_source_id(source_id: &str) -> Result<String, ElevationValidation
     if source_id.len() > MAX_SOURCE_ID_LEN {
         return Err(ElevationValidationError::SourceIdTooLong);
     }
-    if !source_id
-        .chars()
-        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | ':' | '-'))
-    {
+    if !source_id.chars().all(|character| {
+        character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | ':' | '-')
+    }) {
         return Err(ElevationValidationError::UnsafeSourceId);
     }
     Ok(source_id.to_string())
@@ -279,7 +313,10 @@ mod tests {
     #[test]
     fn unknown_workspace_is_rejected() {
         let parsed = serde_json::from_str::<AppWorkspace>("\"not-a-workspace\"");
-        assert!(parsed.is_err(), "unknown workspace ids must not deserialize");
+        assert!(
+            parsed.is_err(),
+            "unknown workspace ids must not deserialize"
+        );
     }
 
     #[test]

--- a/src-tauri/src/elevation/mod.rs
+++ b/src-tauri/src/elevation/mod.rs
@@ -80,8 +80,16 @@ pub enum ElevationReason {
 ///
 /// `Workspace` restores navigation only. The remaining variants each carry one
 /// validated source reference and nothing else.
+// `rename_all` on an enum renames the VARIANTS only. Struct-variant fields need
+// `rename_all_fields`, without which `KnownSource { source_id }` crosses the IPC
+// boundary as `source_id` while the TypeScript contract says `sourceId` — and
+// neither clippy nor tsc can see across that boundary.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum RestoreTarget {
     /// Restore the workspace with no source.
     Workspace,
@@ -308,6 +316,58 @@ mod tests {
         assert_eq!(json, "\"esp-diagnostics\"");
         let parsed: AppWorkspace = serde_json::from_str("\"dns-dhcp\"").expect("deserialize");
         assert_eq!(parsed, AppWorkspace::DnsDhcp);
+    }
+
+    #[test]
+    fn restore_targets_use_the_camel_case_wire_contract() {
+        // The frontend declares these field names in src/types/elevation.ts.
+        // A mismatch here is invisible to both clippy and tsc — it only shows
+        // up as a rejected IPC call at runtime — so assert the exact JSON.
+        let known = serde_json::to_value(RestoreTarget::KnownSource {
+            source_id: "ccm-client-logs".to_string(),
+        })
+        .expect("serialize");
+        assert_eq!(
+            known,
+            serde_json::json!({"kind": "knownSource", "sourceId": "ccm-client-logs"})
+        );
+
+        let folder = serde_json::to_value(RestoreTarget::Folder {
+            path: PathBuf::from(ABSOLUTE_FILE),
+            aggregate: true,
+        })
+        .expect("serialize");
+        assert_eq!(folder["kind"], "folder");
+        assert_eq!(folder["aggregate"], true);
+
+        assert_eq!(
+            serde_json::to_value(RestoreTarget::Workspace).expect("serialize"),
+            serde_json::json!({"kind": "workspace"})
+        );
+    }
+
+    #[test]
+    fn restore_targets_deserialize_from_the_frontend_payload() {
+        // The exact shape src/lib/elevation-context.ts emits.
+        let parsed: RestoreTarget =
+            serde_json::from_str(r#"{"kind":"knownSource","sourceId":"ccm-client-logs"}"#)
+                .expect("the frontend payload must deserialize");
+        assert_eq!(
+            parsed,
+            RestoreTarget::KnownSource {
+                source_id: "ccm-client-logs".to_string()
+            }
+        );
+
+        // The snake_case form must NOT be accepted: allowing both would let the
+        // contract drift without any test noticing.
+        assert!(
+            serde_json::from_str::<RestoreTarget>(
+                r#"{"kind":"knownSource","source_id":"ccm-client-logs"}"#
+            )
+            .is_err(),
+            "only the camelCase wire contract is accepted"
+        );
     }
 
     #[test]

--- a/src-tauri/src/elevation/relaunch.rs
+++ b/src-tauri/src/elevation/relaunch.rs
@@ -341,10 +341,7 @@ fn elevated_working_directory(exe: &std::path::Path) -> Vec<u16> {
     use std::iter::once;
     use std::os::windows::ffi::OsStrExt;
 
-    if let Some(parent) = exe
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-    {
+    if let Some(parent) = exe.parent().filter(|parent| !parent.as_os_str().is_empty()) {
         return parent.as_os_str().encode_wide().chain(once(0)).collect();
     }
 
@@ -447,7 +444,9 @@ mod tests {
             Self {
                 supported: true,
                 elevated: Ok(false),
-                executable: Ok(PathBuf::from(r"C:\Program Files\CMTrace Open\cmtrace-open.exe")),
+                executable: Ok(PathBuf::from(
+                    r"C:\Program Files\CMTrace Open\cmtrace-open.exe",
+                )),
                 outcome: None,
                 seen: RefCell::new(Vec::new()),
             }
@@ -688,7 +687,10 @@ mod tests {
             parse_restore_argument(&["--workspace=esp-diagnostics".to_string()]),
             None
         );
-        assert_eq!(parse_restore_argument(&["--elevation-restore=".to_string()]), None);
+        assert_eq!(
+            parse_restore_argument(&["--elevation-restore=".to_string()]),
+            None
+        );
         assert_eq!(
             parse_restore_argument(&["--elevation-restore=../../etc/passwd".to_string()]),
             None

--- a/src-tauri/src/elevation/relaunch.rs
+++ b/src-tauri/src/elevation/relaunch.rs
@@ -1,0 +1,755 @@
+//! Platform mechanics for restart-as-administrator.
+//!
+//! This module owns the only `ShellExecute`/`runas` implementation in the
+//! application. It is deliberately free of any workspace's models so it stays
+//! available regardless of which product features are compiled in.
+//!
+//! What reaches the elevated child is rebuilt from nothing: the current
+//! executable, the fixed `runas` verb, and at most one validated opaque restore
+//! ticket identifier. The caller's own startup arguments are never forwarded.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::restore_ticket::validate_ticket_id;
+
+/// The single startup option the elevated child accepts.
+pub const ELEVATION_RESTORE_FLAG: &str = "--elevation-restore=";
+
+/// Substrings that must never appear in anything handed to the elevated child.
+///
+/// Nothing is forwarded today, so this is a standing assertion rather than a
+/// filter: if a future change starts propagating arguments, it fails closed.
+const SECRET_MARKERS: &[&str] = &[
+    "access-token",
+    "accesstoken",
+    "api-key",
+    "apikey",
+    "authorization",
+    "bearer",
+    "client-secret",
+    "clientsecret",
+    "password",
+    "refresh-token",
+    "refreshtoken",
+    "secret",
+    "token",
+];
+
+/// Longest failure detail shown to the user.
+const MAX_FAILURE_DETAIL: usize = 256;
+
+/// The outcome of a restart request. Cancellation is an outcome, not an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RelaunchReason {
+    Launched,
+    AlreadyElevated,
+    ElevationCancelled,
+    UnsupportedPlatform,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelaunchResult {
+    pub launched: bool,
+    pub reason: RelaunchReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Error)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum RelaunchError {
+    #[error("an unsafe startup argument prevented administrator restart")]
+    UnsafeArgument,
+    #[error("administrator restart failed: {message}")]
+    LaunchFailed { message: String },
+}
+
+/// Separates "the user said no" from "the launch broke".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ElevationLaunchError {
+    Cancelled,
+    Failed(String),
+}
+
+/// Exactly what will be handed to `ShellExecuteExW`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelaunchRequest {
+    pub verb: String,
+    pub executable: PathBuf,
+    pub arguments: Vec<String>,
+    pub parameters: String,
+    pub close_process_handle: bool,
+}
+
+/// The platform surface the restart flow needs, so the policy above it is
+/// testable without a Windows token or a UAC prompt.
+pub trait RelaunchProvider {
+    fn platform_supported(&self) -> bool;
+    fn is_elevated(&self) -> Result<bool, String>;
+    fn current_executable(&self) -> Result<PathBuf, String>;
+    fn launch_elevated(&self, request: &RelaunchRequest) -> Result<(), ElevationLaunchError>;
+}
+
+/// Request an elevated restart, optionally carrying a restore ticket.
+///
+/// Returns `Ok` with `launched: false` for the three non-failure outcomes
+/// (unsupported platform, already elevated, user cancelled UAC). Only the
+/// caller decides whether to exit the current process, and only when
+/// `launched` is true.
+pub fn restart_with_provider(
+    provider: &impl RelaunchProvider,
+    restore_ticket_id: Option<&str>,
+) -> Result<RelaunchResult, RelaunchError> {
+    if !provider.platform_supported() {
+        return Ok(result(false, RelaunchReason::UnsupportedPlatform));
+    }
+    if provider
+        .is_elevated()
+        .map_err(|_| launch_failed("unable to determine the current elevation state"))?
+    {
+        return Ok(result(false, RelaunchReason::AlreadyElevated));
+    }
+
+    let arguments = elevated_arguments(restore_ticket_id)?;
+    let executable = provider
+        .current_executable()
+        .map_err(|_| launch_failed("unable to resolve the CMTrace Open executable"))?;
+    if executable.to_string_lossy().contains('\0') {
+        return Err(RelaunchError::UnsafeArgument);
+    }
+
+    let request = RelaunchRequest {
+        verb: "runas".to_string(),
+        executable,
+        parameters: build_windows_parameter_line(&arguments),
+        arguments,
+        close_process_handle: true,
+    };
+
+    match provider.launch_elevated(&request) {
+        Ok(()) => Ok(result(true, RelaunchReason::Launched)),
+        Err(ElevationLaunchError::Cancelled) => {
+            Ok(result(false, RelaunchReason::ElevationCancelled))
+        }
+        Err(ElevationLaunchError::Failed(message)) => {
+            Err(launch_failed(&sanitize_failure_detail(&message)))
+        }
+    }
+}
+
+fn result(launched: bool, reason: RelaunchReason) -> RelaunchResult {
+    RelaunchResult { launched, reason }
+}
+
+fn launch_failed(message: &str) -> RelaunchError {
+    RelaunchError::LaunchFailed {
+        message: message.to_string(),
+    }
+}
+
+/// Build the child's argument list from scratch.
+///
+/// The result is either empty or exactly one `--elevation-restore=<id>` whose
+/// identifier has already passed the ticket character-set check.
+fn elevated_arguments(restore_ticket_id: Option<&str>) -> Result<Vec<String>, RelaunchError> {
+    let Some(id) = restore_ticket_id else {
+        return Ok(Vec::new());
+    };
+    validate_ticket_id(id).map_err(|_| RelaunchError::UnsafeArgument)?;
+
+    let argument = format!("{ELEVATION_RESTORE_FLAG}{id}");
+    if argument.contains('\0') || contains_secret_marker(&argument) {
+        return Err(RelaunchError::UnsafeArgument);
+    }
+    Ok(vec![argument])
+}
+
+fn contains_secret_marker(value: &str) -> bool {
+    let normalized = value.to_ascii_lowercase();
+    SECRET_MARKERS
+        .iter()
+        .any(|marker| normalized.contains(marker))
+}
+
+/// Read the restore ticket identifier out of a startup argument list.
+///
+/// Only the exact `--elevation-restore=<id>` form is accepted, and the
+/// identifier must pass the same validation used when it was minted. A
+/// malformed option yields `None`: it is never treated as a file path, and it
+/// never suppresses a legitimate positional open.
+pub fn parse_restore_argument<S: AsRef<str>>(arguments: &[S]) -> Option<String> {
+    arguments.iter().find_map(|argument| {
+        let id = argument.as_ref().strip_prefix(ELEVATION_RESTORE_FLAG)?;
+        validate_ticket_id(id).ok()?;
+        Some(id.to_string())
+    })
+}
+
+/// Join arguments using the Win32 `CommandLineToArgvW` quoting rules.
+pub fn build_windows_parameter_line(arguments: &[String]) -> String {
+    arguments
+        .iter()
+        .map(|argument| quote_windows_argument(argument))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn quote_windows_argument(argument: &str) -> String {
+    if !argument.is_empty()
+        && !argument
+            .chars()
+            .any(|character| character.is_whitespace() || character == '"')
+    {
+        return argument.to_string();
+    }
+
+    let mut quoted = String::from("\"");
+    let mut backslashes = 0usize;
+    for character in argument.chars() {
+        if character == '\\' {
+            backslashes += 1;
+            continue;
+        }
+        if character == '"' {
+            quoted.extend(std::iter::repeat_n('\\', backslashes * 2 + 1));
+            quoted.push('"');
+        } else {
+            quoted.extend(std::iter::repeat_n('\\', backslashes));
+            quoted.push(character);
+        }
+        backslashes = 0;
+    }
+    quoted.extend(std::iter::repeat_n('\\', backslashes * 2));
+    quoted.push('"');
+    quoted
+}
+
+/// Strip secret-shaped text and control characters, then bound the length.
+fn sanitize_failure_detail(message: &str) -> String {
+    let redacted = if contains_secret_marker(message) {
+        "[REDACTED]".to_string()
+    } else {
+        message.to_string()
+    };
+    redacted
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(MAX_FAILURE_DETAIL)
+        .collect()
+}
+
+/// Whether the current process holds an elevated token.
+///
+/// A probe failure is reported rather than swallowed: silently answering
+/// "not elevated" would make the app offer a pointless UAC prompt to a user who
+/// is already an administrator.
+pub fn is_process_elevated() -> Result<bool, String> {
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::Foundation::{CloseHandle, HANDLE};
+        use windows::Win32::Security::{
+            GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+        };
+        use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+        struct HandleGuard(HANDLE);
+        impl Drop for HandleGuard {
+            fn drop(&mut self) {
+                if !self.0.is_invalid() {
+                    // SAFETY: the handle came from OpenProcessToken and is closed once.
+                    let _ = unsafe { CloseHandle(self.0) };
+                }
+            }
+        }
+
+        let mut token = HANDLE::default();
+        // SAFETY: token points to valid writable storage and is closed by HandleGuard.
+        if let Err(error) =
+            unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) }
+        {
+            log::warn!("elevation probe: OpenProcessToken failed: {error:?}");
+            return Err("process token query failed".to_string());
+        }
+        let _token = HandleGuard(token);
+
+        let mut elevation = TOKEN_ELEVATION::default();
+        let mut returned = 0_u32;
+        // SAFETY: elevation is valid writable TOKEN_ELEVATION storage of the declared size.
+        if let Err(error) = unsafe {
+            GetTokenInformation(
+                token,
+                TokenElevation,
+                Some((&mut elevation as *mut TOKEN_ELEVATION).cast()),
+                std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+                &mut returned,
+            )
+        } {
+            log::warn!("elevation probe: GetTokenInformation(TokenElevation) failed: {error:?}");
+            return Err("token elevation query failed".to_string());
+        }
+        Ok(elevation.TokenIsElevated != 0)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        Err("unsupported platform".to_string())
+    }
+}
+
+/// The provider used in production.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NativeRelaunchProvider;
+
+impl RelaunchProvider for NativeRelaunchProvider {
+    fn platform_supported(&self) -> bool {
+        cfg!(target_os = "windows")
+    }
+
+    fn is_elevated(&self) -> Result<bool, String> {
+        is_process_elevated()
+    }
+
+    fn current_executable(&self) -> Result<PathBuf, String> {
+        std::env::current_exe().map_err(|error| error.to_string())
+    }
+
+    fn launch_elevated(&self, request: &RelaunchRequest) -> Result<(), ElevationLaunchError> {
+        launch_elevated_native(request)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn launch_elevated_native(_request: &RelaunchRequest) -> Result<(), ElevationLaunchError> {
+    Err(ElevationLaunchError::Failed(
+        "unsupported platform".to_string(),
+    ))
+}
+
+/// Resolve the working directory the elevated child should start in.
+///
+/// Returns the executable's parent (the verified app install directory)
+/// wide-encoded and NUL-terminated. If the executable has no parent, falls
+/// back to the Windows system directory. Both are trusted, non-attacker-
+/// writable locations, so the elevated process never inherits the caller's
+/// (untrusted) working directory — closing a DLL-planting elevation-of-
+/// privilege lever where a name-resolved DLL in an attacker-writable cwd would
+/// otherwise load elevated.
+#[cfg(target_os = "windows")]
+fn elevated_working_directory(exe: &std::path::Path) -> Vec<u16> {
+    use std::iter::once;
+    use std::os::windows::ffi::OsStrExt;
+
+    if let Some(parent) = exe
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        return parent.as_os_str().encode_wide().chain(once(0)).collect();
+    }
+
+    windows_system_directory()
+}
+
+/// The Windows system directory (e.g. `C:\Windows\System32`) wide-encoded and
+/// NUL-terminated, used as a trusted fallback working directory.
+#[cfg(target_os = "windows")]
+fn windows_system_directory() -> Vec<u16> {
+    use windows::Win32::System::SystemInformation::GetSystemDirectoryW;
+
+    // MAX_PATH-sized buffer; GetSystemDirectoryW returns the length written
+    // (excluding the terminator) on success, or 0 on failure.
+    let mut buffer = [0u16; 260];
+    let length = unsafe { GetSystemDirectoryW(Some(&mut buffer)) } as usize;
+    if length == 0 || length >= buffer.len() {
+        // Last-resort fixed path; still a trusted, non-attacker-writable dir.
+        return "C:\\Windows\\System32\0".encode_utf16().collect();
+    }
+
+    buffer[..length]
+        .iter()
+        .copied()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+#[cfg(target_os = "windows")]
+fn launch_elevated_native(request: &RelaunchRequest) -> Result<(), ElevationLaunchError> {
+    use std::ffi::OsStr;
+    use std::iter::once;
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows::core::{HRESULT, PCWSTR};
+    use windows::Win32::Foundation::{CloseHandle, ERROR_CANCELLED};
+    use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW};
+    use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+    let verb = OsStr::new(&request.verb)
+        .encode_wide()
+        .chain(once(0))
+        .collect::<Vec<_>>();
+    let executable = request
+        .executable
+        .as_os_str()
+        .encode_wide()
+        .chain(once(0))
+        .collect::<Vec<_>>();
+    let parameters = OsStr::new(&request.parameters)
+        .encode_wide()
+        .chain(once(0))
+        .collect::<Vec<_>>();
+    // Pin the elevated child's working directory to the trusted install dir.
+    // This buffer must outlive the ShellExecuteExW call, like the others.
+    let directory = elevated_working_directory(&request.executable);
+    let mut execute = SHELLEXECUTEINFOW {
+        cbSize: std::mem::size_of::<SHELLEXECUTEINFOW>() as u32,
+        fMask: SEE_MASK_NOCLOSEPROCESS,
+        lpVerb: PCWSTR(verb.as_ptr()),
+        lpFile: PCWSTR(executable.as_ptr()),
+        lpParameters: PCWSTR(parameters.as_ptr()),
+        lpDirectory: PCWSTR(directory.as_ptr()),
+        nShow: SW_SHOWNORMAL.0,
+        ..Default::default()
+    };
+
+    if let Err(error) = unsafe { ShellExecuteExW(&mut execute) } {
+        if error.code() == HRESULT::from_win32(ERROR_CANCELLED.0) {
+            return Err(ElevationLaunchError::Cancelled);
+        }
+        return Err(ElevationLaunchError::Failed(error.to_string()));
+    }
+
+    if request.close_process_handle && !execute.hProcess.is_invalid() {
+        if let Err(error) = unsafe { CloseHandle(execute.hProcess) } {
+            log::warn!("unable to close elevated process handle: {error}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    use crate::elevation::restore_ticket::new_ticket_id;
+
+    struct FakeProvider {
+        supported: bool,
+        elevated: Result<bool, String>,
+        executable: Result<PathBuf, String>,
+        outcome: Option<ElevationLaunchError>,
+        seen: RefCell<Vec<RelaunchRequest>>,
+    }
+
+    impl FakeProvider {
+        fn windows() -> Self {
+            Self {
+                supported: true,
+                elevated: Ok(false),
+                executable: Ok(PathBuf::from(r"C:\Program Files\CMTrace Open\cmtrace-open.exe")),
+                outcome: None,
+                seen: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl RelaunchProvider for FakeProvider {
+        fn platform_supported(&self) -> bool {
+            self.supported
+        }
+        fn is_elevated(&self) -> Result<bool, String> {
+            self.elevated.clone()
+        }
+        fn current_executable(&self) -> Result<PathBuf, String> {
+            self.executable.clone()
+        }
+        fn launch_elevated(&self, request: &RelaunchRequest) -> Result<(), ElevationLaunchError> {
+            self.seen.borrow_mut().push(request.clone());
+            match &self.outcome {
+                None => Ok(()),
+                Some(error) => Err(error.clone()),
+            }
+        }
+    }
+
+    #[test]
+    fn an_unsupported_platform_does_not_prompt() {
+        let provider = FakeProvider {
+            supported: false,
+            ..FakeProvider::windows()
+        };
+
+        let result = restart_with_provider(&provider, None).expect("no error");
+
+        assert_eq!(
+            result,
+            RelaunchResult {
+                launched: false,
+                reason: RelaunchReason::UnsupportedPlatform
+            }
+        );
+        assert!(
+            provider.seen.borrow().is_empty(),
+            "no launch may be attempted on an unsupported platform"
+        );
+    }
+
+    #[test]
+    fn an_already_elevated_process_does_not_relaunch() {
+        let provider = FakeProvider {
+            elevated: Ok(true),
+            ..FakeProvider::windows()
+        };
+
+        let result = restart_with_provider(&provider, None).expect("no error");
+
+        assert_eq!(result.reason, RelaunchReason::AlreadyElevated);
+        assert!(!result.launched);
+        assert!(provider.seen.borrow().is_empty());
+    }
+
+    #[test]
+    fn an_unreadable_elevation_state_is_a_sanitized_failure() {
+        let provider = FakeProvider {
+            elevated: Err("token query failed".to_string()),
+            ..FakeProvider::windows()
+        };
+
+        let error = restart_with_provider(&provider, None).unwrap_err();
+
+        assert_eq!(
+            error,
+            RelaunchError::LaunchFailed {
+                message: "unable to determine the current elevation state".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn a_successful_launch_builds_the_fixed_runas_request() {
+        let provider = FakeProvider::windows();
+        let id = new_ticket_id();
+
+        let result = restart_with_provider(&provider, Some(&id)).expect("no error");
+
+        assert_eq!(result.reason, RelaunchReason::Launched);
+        assert!(result.launched);
+
+        let seen = provider.seen.borrow();
+        let request = seen.first().expect("one launch");
+        assert_eq!(request.verb, "runas");
+        assert_eq!(
+            request.executable,
+            PathBuf::from(r"C:\Program Files\CMTrace Open\cmtrace-open.exe")
+        );
+        assert_eq!(request.arguments, vec![format!("--elevation-restore={id}")]);
+        assert!(request.close_process_handle);
+    }
+
+    #[test]
+    fn a_workspace_only_restart_passes_no_arguments() {
+        let provider = FakeProvider::windows();
+
+        restart_with_provider(&provider, None).expect("no error");
+
+        let seen = provider.seen.borrow();
+        let request = seen.first().expect("one launch");
+        assert!(
+            request.arguments.is_empty(),
+            "a restart with no ticket must forward nothing"
+        );
+        assert_eq!(request.parameters, "");
+    }
+
+    #[test]
+    fn a_malformed_ticket_identifier_is_refused() {
+        let provider = FakeProvider::windows();
+
+        let error = restart_with_provider(&provider, Some("../../etc/passwd")).unwrap_err();
+
+        assert_eq!(error, RelaunchError::UnsafeArgument);
+        assert!(
+            provider.seen.borrow().is_empty(),
+            "a bad identifier must be caught before any launch"
+        );
+    }
+
+    #[test]
+    fn cancellation_is_reported_as_an_outcome_not_a_failure() {
+        let provider = FakeProvider {
+            outcome: Some(ElevationLaunchError::Cancelled),
+            ..FakeProvider::windows()
+        };
+
+        let result = restart_with_provider(&provider, None).expect("cancellation is not an error");
+
+        assert_eq!(result.reason, RelaunchReason::ElevationCancelled);
+        assert!(!result.launched);
+    }
+
+    #[test]
+    fn a_launch_failure_is_sanitized() {
+        let provider = FakeProvider {
+            outcome: Some(ElevationLaunchError::Failed(
+                "failed with bearer token abc123\u{7}".to_string(),
+            )),
+            ..FakeProvider::windows()
+        };
+
+        let error = restart_with_provider(&provider, None).unwrap_err();
+
+        let RelaunchError::LaunchFailed { message } = error else {
+            panic!("expected a launch failure");
+        };
+        assert_eq!(message, "[REDACTED]");
+    }
+
+    #[test]
+    fn a_launch_failure_drops_control_characters_and_is_bounded() {
+        let provider = FakeProvider {
+            outcome: Some(ElevationLaunchError::Failed(format!(
+                "boom\u{7}{}",
+                "x".repeat(MAX_FAILURE_DETAIL * 2)
+            ))),
+            ..FakeProvider::windows()
+        };
+
+        let error = restart_with_provider(&provider, None).unwrap_err();
+
+        let RelaunchError::LaunchFailed { message } = error else {
+            panic!("expected a launch failure");
+        };
+        assert_eq!(message.len(), MAX_FAILURE_DETAIL);
+        assert!(!message.chars().any(char::is_control));
+    }
+
+    #[test]
+    fn an_executable_containing_nul_is_rejected() {
+        let provider = FakeProvider {
+            executable: Ok(PathBuf::from("C:\\CMTrace\0\\cmtrace-open.exe")),
+            ..FakeProvider::windows()
+        };
+
+        assert_eq!(
+            restart_with_provider(&provider, None).unwrap_err(),
+            RelaunchError::UnsafeArgument
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_executable_is_a_sanitized_failure() {
+        let provider = FakeProvider {
+            executable: Err("no such process".to_string()),
+            ..FakeProvider::windows()
+        };
+
+        assert_eq!(
+            restart_with_provider(&provider, None).unwrap_err(),
+            RelaunchError::LaunchFailed {
+                message: "unable to resolve the CMTrace Open executable".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn windows_quoting_handles_spaces_quotes_and_trailing_slashes() {
+        assert_eq!(build_windows_parameter_line(&[]), "");
+        assert_eq!(
+            build_windows_parameter_line(&["--plain".to_string()]),
+            "--plain"
+        );
+        assert_eq!(
+            build_windows_parameter_line(&["with space".to_string()]),
+            "\"with space\""
+        );
+        assert_eq!(
+            build_windows_parameter_line(&[r#"say "hi""#.to_string()]),
+            r#""say \"hi\"""#
+        );
+        // A trailing backslash before the closing quote must be doubled or it
+        // would escape the quote itself.
+        assert_eq!(
+            build_windows_parameter_line(&[r"C:\dir with space\".to_string()]),
+            r#""C:\dir with space\\""#
+        );
+        assert_eq!(build_windows_parameter_line(&[String::new()]), "\"\"");
+    }
+
+    #[test]
+    fn restore_argument_parsing_accepts_only_the_exact_option() {
+        let id = new_ticket_id();
+
+        assert_eq!(
+            parse_restore_argument(&[format!("--elevation-restore={id}")]),
+            Some(id.clone())
+        );
+        assert_eq!(
+            parse_restore_argument(&["--workspace=esp-diagnostics".to_string()]),
+            None
+        );
+        assert_eq!(parse_restore_argument(&["--elevation-restore=".to_string()]), None);
+        assert_eq!(
+            parse_restore_argument(&["--elevation-restore=../../etc/passwd".to_string()]),
+            None
+        );
+        // A separate value is not the accepted form.
+        assert_eq!(
+            parse_restore_argument(&["--elevation-restore".to_string(), id.clone()]),
+            None
+        );
+    }
+
+    #[test]
+    fn a_positional_path_is_never_read_as_a_ticket() {
+        let id = new_ticket_id();
+        let arguments = vec![
+            r"C:\logs\app.log".to_string(),
+            format!("--elevation-restore={id}"),
+        ];
+
+        // The positional path is untouched and the option still resolves.
+        assert_eq!(parse_restore_argument(&arguments), Some(id));
+        assert_eq!(
+            parse_restore_argument(&[r"C:\logs\--elevation-restore=x.log".to_string()]),
+            None
+        );
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod windows_relaunch_tests {
+    use super::*;
+    use std::iter::once;
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::Path;
+
+    #[test]
+    fn elevated_working_directory_pins_the_executable_parent() {
+        let exe = Path::new(r"C:\Program Files\CMTrace Open\cmtrace-open.exe");
+        let expected: Vec<u16> = Path::new(r"C:\Program Files\CMTrace Open")
+            .as_os_str()
+            .encode_wide()
+            .chain(once(0))
+            .collect();
+
+        let directory = elevated_working_directory(exe);
+
+        assert_eq!(directory, expected);
+        // The pointer handed to SHELLEXECUTEINFOW.lpDirectory must be non-null
+        // (non-empty) and the wide string NUL-terminated.
+        assert_eq!(directory.last(), Some(&0));
+        assert!(directory.len() > 1);
+    }
+
+    #[test]
+    fn elevated_working_directory_falls_back_to_system_dir_without_parent() {
+        // A bare filename has an empty parent, so the trusted system directory
+        // is used instead of leaving the working directory NULL (which would
+        // inherit the caller's untrusted cwd).
+        let directory = elevated_working_directory(Path::new("cmtrace-open.exe"));
+
+        assert_eq!(directory.last(), Some(&0));
+        assert!(directory.len() > 1, "fallback directory must be non-empty");
+    }
+}

--- a/src-tauri/src/elevation/restore_ticket.rs
+++ b/src-tauri/src/elevation/restore_ticket.rs
@@ -189,7 +189,8 @@ pub fn consume_ticket(
     if ticket.ticket_id != id {
         return Err(TicketError::InvalidContents);
     }
-    if now_ms.saturating_sub(ticket.created_at_ms) > TICKET_TTL_MS || now_ms < ticket.created_at_ms {
+    if now_ms.saturating_sub(ticket.created_at_ms) > TICKET_TTL_MS || now_ms < ticket.created_at_ms
+    {
         return Err(TicketError::Expired);
     }
 
@@ -294,7 +295,10 @@ mod tests {
     fn generated_identifiers_validate() {
         for _ in 0..32 {
             let id = new_ticket_id();
-            assert!(validate_ticket_id(&id).is_ok(), "generated id {id} rejected");
+            assert!(
+                validate_ticket_id(&id).is_ok(),
+                "generated id {id} rejected"
+            );
         }
     }
 
@@ -463,7 +467,10 @@ mod tests {
             consume_ticket(directory.path(), &id, NOW).unwrap_err(),
             TicketError::TooLarge
         );
-        assert!(!path.exists(), "an oversized ticket must not be left behind");
+        assert!(
+            !path.exists(),
+            "an oversized ticket must not be left behind"
+        );
     }
 
     #[test]
@@ -500,8 +507,7 @@ mod tests {
     #[test]
     fn a_serialized_ticket_carries_only_approved_fields() {
         let ticket = sample(NOW);
-        let value: serde_json::Value =
-            serde_json::to_value(&ticket).expect("serialize");
+        let value: serde_json::Value = serde_json::to_value(&ticket).expect("serialize");
         let object = value.as_object().expect("object");
 
         let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();

--- a/src-tauri/src/elevation/restore_ticket.rs
+++ b/src-tauri/src/elevation/restore_ticket.rs
@@ -1,0 +1,547 @@
+//! One-time restore tickets for the elevated child process.
+//!
+//! The elevated process is started with a single opaque identifier. Everything
+//! it is allowed to restore lives in a small, typed, short-lived file under an
+//! application-owned per-user directory.
+//!
+//! The ticket is untrusted input even though it sits in per-user storage: it is
+//! bounded, schema-versioned, expiring, and consumed exactly once, and it can
+//! request only navigation and source opening — never command execution or a
+//! privileged write.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::{AppWorkspace, ElevationReason, ElevationValidationError, RestoreTarget};
+
+/// Current ticket schema. A ticket written by another version is rejected, not
+/// migrated: the elevated process starts normally instead.
+pub const TICKET_SCHEMA_VERSION: u32 = 1;
+
+/// Directory beneath the app's local data directory that holds pending tickets.
+pub const TICKET_DIRECTORY: &str = "elevation-restore";
+
+/// How long a ticket stays valid. A UAC prompt the user leaves sitting is the
+/// long case; five minutes covers it without leaving a stale ticket around.
+pub const TICKET_TTL_MS: i64 = 5 * 60 * 1000;
+
+/// Largest accepted ticket file. The serialized form is a few hundred bytes.
+pub const MAX_TICKET_BYTES: u64 = 8 * 1024;
+
+/// Length of the opaque identifier — a hyphenated UUID.
+const TICKET_ID_LEN: usize = 36;
+
+/// What the elevated process is permitted to restore.
+///
+/// Field order is fixed and the struct is `deny_unknown_fields`: a tampered or
+/// future ticket is refused rather than partially honoured.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RestoreTicket {
+    pub schema_version: u32,
+    pub ticket_id: String,
+    pub created_at_ms: i64,
+    pub origin_pid: u32,
+    pub workspace: AppWorkspace,
+    pub target: RestoreTarget,
+    pub reason: ElevationReason,
+    /// Set on the restored request so a second failure cannot offer elevation again.
+    pub retry_attempted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Error)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum TicketError {
+    #[error("the elevation restore identifier is malformed")]
+    MalformedId,
+    #[error("the elevation restore ticket was not found")]
+    NotFound,
+    #[error("the elevation restore ticket is not a regular file")]
+    NotARegularFile,
+    #[error("the elevation restore ticket exceeds the maximum accepted size")]
+    TooLarge,
+    #[error("the elevation restore ticket could not be read")]
+    Unreadable,
+    #[error("the elevation restore ticket could not be written")]
+    Unwritable,
+    #[error("the elevation restore ticket is malformed")]
+    Malformed,
+    #[error("the elevation restore ticket schema is unsupported")]
+    UnsupportedSchema,
+    #[error("the elevation restore ticket has expired")]
+    Expired,
+    #[error("the elevation restore ticket contents are not valid")]
+    InvalidContents,
+}
+
+impl From<ElevationValidationError> for TicketError {
+    fn from(_: ElevationValidationError) -> Self {
+        Self::InvalidContents
+    }
+}
+
+/// Generate an opaque, unguessable ticket identifier.
+pub fn new_ticket_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// Accept only a lowercase hyphenated UUID.
+///
+/// This is what keeps `--elevation-restore=<id>` from ever naming a path: the
+/// character set excludes every separator, dot, and drive letter form.
+pub fn validate_ticket_id(id: &str) -> Result<(), TicketError> {
+    if id.len() != TICKET_ID_LEN {
+        return Err(TicketError::MalformedId);
+    }
+    let valid = id.chars().enumerate().all(|(index, character)| {
+        if matches!(index, 8 | 13 | 18 | 23) {
+            character == '-'
+        } else {
+            character.is_ascii_digit() || (character.is_ascii_lowercase() && character <= 'f')
+        }
+    });
+    if valid {
+        Ok(())
+    } else {
+        Err(TicketError::MalformedId)
+    }
+}
+
+/// The directory pending tickets live in, given the app's local data directory.
+pub fn ticket_directory(app_local_data_dir: &Path) -> PathBuf {
+    app_local_data_dir.join(TICKET_DIRECTORY)
+}
+
+/// Resolve a ticket's path, refusing anything that would escape the directory.
+fn ticket_path(directory: &Path, id: &str) -> Result<PathBuf, TicketError> {
+    validate_ticket_id(id)?;
+    let path = directory.join(format!("{id}.json"));
+    // Defence in depth: the validated identifier cannot contain a separator, so
+    // this can only fail if `directory` itself was unexpected.
+    if path.parent() != Some(directory) {
+        return Err(TicketError::MalformedId);
+    }
+    Ok(path)
+}
+
+/// Persist a ticket, returning its identifier for the child command line.
+pub fn write_ticket(directory: &Path, ticket: &RestoreTicket) -> Result<String, TicketError> {
+    let path = ticket_path(directory, &ticket.ticket_id)?;
+    fs::create_dir_all(directory).map_err(|_| TicketError::Unwritable)?;
+    let encoded = serde_json::to_vec(ticket).map_err(|_| TicketError::Unwritable)?;
+    if encoded.len() as u64 > MAX_TICKET_BYTES {
+        return Err(TicketError::TooLarge);
+    }
+    fs::write(&path, &encoded).map_err(|_| TicketError::Unwritable)?;
+    Ok(ticket.ticket_id.clone())
+}
+
+/// Delete a ticket that was written for a launch that never happened.
+///
+/// Best effort: a ticket left behind still expires and is still single-use.
+pub fn discard_ticket(directory: &Path, id: &str) {
+    if let Ok(path) = ticket_path(directory, id) {
+        let _ = fs::remove_file(path);
+    }
+}
+
+/// Atomically claim and validate a ticket.
+///
+/// The file is renamed before it is read, so two processes racing the same
+/// identifier cannot both restore it — the loser sees `NotFound`. The claim is
+/// removed whether or not its contents turn out to be valid, so a malformed or
+/// expired ticket cannot be retried.
+pub fn consume_ticket(
+    directory: &Path,
+    id: &str,
+    now_ms: i64,
+) -> Result<RestoreTicket, TicketError> {
+    let path = ticket_path(directory, id)?;
+
+    // Reject symlinks and reparse points before touching the contents: follow a
+    // symlink here and an attacker-planted link could redirect the read.
+    let metadata = fs::symlink_metadata(&path).map_err(map_missing)?;
+    if !metadata.file_type().is_file() {
+        return Err(TicketError::NotARegularFile);
+    }
+    if metadata.len() > MAX_TICKET_BYTES {
+        // Remove it: an oversized ticket is never going to become valid.
+        let _ = fs::remove_file(&path);
+        return Err(TicketError::TooLarge);
+    }
+
+    let claim = directory.join(format!("{id}.claim"));
+    fs::rename(&path, &claim).map_err(map_missing)?;
+    let contents = fs::read_to_string(&claim).map_err(|_| TicketError::Unreadable);
+    let _ = fs::remove_file(&claim);
+    let contents = contents?;
+
+    let ticket: RestoreTicket =
+        serde_json::from_str(&contents).map_err(|_| TicketError::Malformed)?;
+
+    if ticket.schema_version != TICKET_SCHEMA_VERSION {
+        return Err(TicketError::UnsupportedSchema);
+    }
+    if ticket.ticket_id != id {
+        return Err(TicketError::InvalidContents);
+    }
+    if now_ms.saturating_sub(ticket.created_at_ms) > TICKET_TTL_MS || now_ms < ticket.created_at_ms {
+        return Err(TicketError::Expired);
+    }
+
+    // Re-validate the source intent. The ticket was validated when written, but
+    // it is read back as untrusted input.
+    match &ticket.target {
+        RestoreTarget::Workspace => {}
+        RestoreTarget::File { path } | RestoreTarget::Folder { path, .. } => {
+            super::validate_restore_path(path)?;
+        }
+        RestoreTarget::KnownSource { source_id } => {
+            super::validate_source_id(source_id)?;
+        }
+    }
+
+    Ok(ticket)
+}
+
+/// Remove tickets and abandoned claims older than the TTL.
+///
+/// Called at startup so a cancelled UAC prompt does not leave files behind.
+pub fn prune_expired(directory: &Path) {
+    let Ok(entries) = fs::read_dir(directory) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_ticket = path
+            .extension()
+            .is_some_and(|extension| extension == "json" || extension == "claim");
+        if !is_ticket {
+            continue;
+        }
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let expired = metadata
+            .modified()
+            .ok()
+            .and_then(|modified| modified.elapsed().ok())
+            .map(|elapsed| elapsed.as_millis() as i64 > TICKET_TTL_MS)
+            // A file whose mtime cannot be read is pruned rather than kept: it
+            // is single-use anyway and a fresh request writes a new one.
+            .unwrap_or(true);
+        if expired {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+fn map_missing(error: io::Error) -> TicketError {
+    if error.kind() == io::ErrorKind::NotFound {
+        TicketError::NotFound
+    } else {
+        TicketError::Unreadable
+    }
+}
+
+/// Build a ticket for a validated request.
+pub fn ticket_for(
+    workspace: AppWorkspace,
+    target: RestoreTarget,
+    reason: ElevationReason,
+    now_ms: i64,
+) -> RestoreTicket {
+    RestoreTicket {
+        schema_version: TICKET_SCHEMA_VERSION,
+        ticket_id: new_ticket_id(),
+        created_at_ms: now_ms,
+        origin_pid: std::process::id(),
+        workspace,
+        target,
+        reason,
+        retry_attempted: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[cfg(target_os = "windows")]
+    const ABSOLUTE_FILE: &str = r"C:\ProgramData\CMTrace\app.log";
+    #[cfg(not(target_os = "windows"))]
+    const ABSOLUTE_FILE: &str = "/var/log/app.log";
+
+    const NOW: i64 = 1_760_000_000_000;
+
+    fn sample(now_ms: i64) -> RestoreTicket {
+        ticket_for(
+            AppWorkspace::Log,
+            RestoreTarget::File {
+                path: PathBuf::from(ABSOLUTE_FILE),
+            },
+            ElevationReason::AccessDenied,
+            now_ms,
+        )
+    }
+
+    #[test]
+    fn generated_identifiers_validate() {
+        for _ in 0..32 {
+            let id = new_ticket_id();
+            assert!(validate_ticket_id(&id).is_ok(), "generated id {id} rejected");
+        }
+    }
+
+    #[test]
+    fn identifier_validation_rejects_traversal_and_separators() {
+        for candidate in [
+            "..",
+            "../../etc/passwd",
+            "a/b",
+            "a\\b",
+            r"C:\Windows\System32",
+            "",
+            "short",
+            // Correct length and shape but uppercase — the canonical form is lowercase.
+            "1487DC30-3BB0-46BF-98EE-76771BD9953E",
+            // Correct length, wrong separator positions.
+            "1487dc303-bb0-46bf-98ee-76771bd9953e",
+            // Correct length and separators, non-hex payload.
+            "1487dc30-3bb0-46bf-98ee-76771bd995zz",
+        ] {
+            assert!(
+                validate_ticket_id(candidate).is_err(),
+                "identifier {candidate:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn a_ticket_round_trips_and_is_consumed_once() {
+        let directory = TempDir::new().expect("temp dir");
+        let ticket = sample(NOW);
+        let id = write_ticket(directory.path(), &ticket).expect("write");
+
+        let restored = consume_ticket(directory.path(), &id, NOW + 1_000).expect("consume");
+        assert_eq!(restored, ticket);
+
+        // Single use: the second attempt finds nothing.
+        assert_eq!(
+            consume_ticket(directory.path(), &id, NOW + 1_000).unwrap_err(),
+            TicketError::NotFound
+        );
+    }
+
+    #[test]
+    fn a_stale_ticket_is_rejected_and_consumed() {
+        let directory = TempDir::new().expect("temp dir");
+        let ticket = sample(NOW);
+        let id = write_ticket(directory.path(), &ticket).expect("write");
+
+        assert_eq!(
+            consume_ticket(directory.path(), &id, NOW + TICKET_TTL_MS + 1).unwrap_err(),
+            TicketError::Expired
+        );
+        // An expired ticket must not survive to be retried.
+        assert_eq!(
+            consume_ticket(directory.path(), &id, NOW).unwrap_err(),
+            TicketError::NotFound
+        );
+    }
+
+    #[test]
+    fn a_ticket_created_in_the_future_is_rejected() {
+        let directory = TempDir::new().expect("temp dir");
+        let id = write_ticket(directory.path(), &sample(NOW)).expect("write");
+
+        assert_eq!(
+            consume_ticket(directory.path(), &id, NOW - 1).unwrap_err(),
+            TicketError::Expired
+        );
+    }
+
+    #[test]
+    fn a_schema_mismatch_is_rejected() {
+        let directory = TempDir::new().expect("temp dir");
+        let mut ticket = sample(NOW);
+        ticket.schema_version = TICKET_SCHEMA_VERSION + 1;
+        let id = write_ticket(directory.path(), &ticket).expect("write");
+
+        assert_eq!(
+            consume_ticket(directory.path(), &id, NOW).unwrap_err(),
+            TicketError::UnsupportedSchema
+        );
+    }
+
+    #[test]
+    fn an_unknown_field_is_rejected() {
+        let directory = TempDir::new().expect("temp dir");
+        let id = new_ticket_id();
+        let path = directory.path().join(format!("{id}.json"));
+        fs::write(
+            &path,
+            format!(
+                r#"{{"schemaVersion":1,"ticketId":"{id}","createdAtMs":{NOW},"originPid":1,"workspace":"log","target":{{"kind":"workspace"}},"reason":"explicitMenu","retryAttempted":true,"command":"calc.exe"}}"#
+            ),
+        )
+        .expect("write");
+
+        assert_eq!(
+            consume_ticket(directory.path(), &id, NOW).unwrap_err(),
+            TicketError::Malformed
+        );
+    }
+
+    #[test]
+    fn an_unknown_workspace_is_rejected() {
+        let directory = TempDir::new().expect("temp dir");
+        let id = new_ticket_id();
+        let path = directory.path().join(format!("{id}.json"));
+        fs::write(
+            &path,
+            format!(
+                r#"{{"schemaVersion":1,"ticketId":"{id}","createdAtMs":{NOW},"originPid":1,"workspace":"root-shell","target":{{"kind":"workspace"}},"reason":"explicitMenu","retryAttempted":true}}"#
+            ),
+        )
+        .expect("write");
+
+        assert_eq!(
+            consume_ticket(directory.path(), &id, NOW).unwrap_err(),
+            TicketError::Malformed
+        );
+    }
+
+    #[test]
+    fn a_tampered_relative_path_is_rejected() {
+        let directory = TempDir::new().expect("temp dir");
+        let id = new_ticket_id();
+        let path = directory.path().join(format!("{id}.json"));
+        fs::write(
+            &path,
+            format!(
+                r#"{{"schemaVersion":1,"ticketId":"{id}","createdAtMs":{NOW},"originPid":1,"workspace":"log","target":{{"kind":"file","path":"relative.log"}},"reason":"explicitMenu","retryAttempted":true}}"#
+            ),
+        )
+        .expect("write");
+
+        assert_eq!(
+            consume_ticket(directory.path(), &id, NOW).unwrap_err(),
+            TicketError::InvalidContents
+        );
+    }
+
+    #[test]
+    fn an_identifier_mismatch_is_rejected() {
+        let directory = TempDir::new().expect("temp dir");
+        let mut ticket = sample(NOW);
+        let real_id = ticket.ticket_id.clone();
+        ticket.ticket_id = new_ticket_id();
+        // Store it under the first identifier while its body claims another.
+        let path = directory.path().join(format!("{real_id}.json"));
+        fs::write(&path, serde_json::to_vec(&ticket).expect("encode")).expect("write");
+
+        assert_eq!(
+            consume_ticket(directory.path(), &real_id, NOW).unwrap_err(),
+            TicketError::InvalidContents
+        );
+    }
+
+    #[test]
+    fn an_oversized_ticket_is_rejected_and_removed() {
+        let directory = TempDir::new().expect("temp dir");
+        let id = new_ticket_id();
+        let path = directory.path().join(format!("{id}.json"));
+        fs::write(&path, vec![b'a'; (MAX_TICKET_BYTES + 1) as usize]).expect("write");
+
+        assert_eq!(
+            consume_ticket(directory.path(), &id, NOW).unwrap_err(),
+            TicketError::TooLarge
+        );
+        assert!(!path.exists(), "an oversized ticket must not be left behind");
+    }
+
+    #[test]
+    fn a_missing_ticket_reports_not_found() {
+        let directory = TempDir::new().expect("temp dir");
+        assert_eq!(
+            consume_ticket(directory.path(), &new_ticket_id(), NOW).unwrap_err(),
+            TicketError::NotFound
+        );
+    }
+
+    #[test]
+    fn a_malformed_identifier_never_reaches_the_filesystem() {
+        let directory = TempDir::new().expect("temp dir");
+        assert_eq!(
+            consume_ticket(directory.path(), "../../etc/passwd", NOW).unwrap_err(),
+            TicketError::MalformedId
+        );
+    }
+
+    #[test]
+    fn discarding_removes_an_unused_ticket() {
+        let directory = TempDir::new().expect("temp dir");
+        let id = write_ticket(directory.path(), &sample(NOW)).expect("write");
+
+        discard_ticket(directory.path(), &id);
+
+        assert_eq!(
+            consume_ticket(directory.path(), &id, NOW).unwrap_err(),
+            TicketError::NotFound
+        );
+    }
+
+    #[test]
+    fn a_serialized_ticket_carries_only_approved_fields() {
+        let ticket = sample(NOW);
+        let value: serde_json::Value =
+            serde_json::to_value(&ticket).expect("serialize");
+        let object = value.as_object().expect("object");
+
+        let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "createdAtMs",
+                "originPid",
+                "reason",
+                "retryAttempted",
+                "schemaVersion",
+                "target",
+                "ticketId",
+                "workspace",
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_ticket_is_refused() {
+        let directory = TempDir::new().expect("temp dir");
+        let secret = directory.path().join("secret.json");
+        fs::write(&secret, "{}").expect("write");
+
+        let id = new_ticket_id();
+        std::os::unix::fs::symlink(&secret, directory.path().join(format!("{id}.json")))
+            .expect("symlink");
+
+        assert_eq!(
+            consume_ticket(directory.path(), &id, NOW).unwrap_err(),
+            TicketError::NotARegularFile
+        );
+        assert!(secret.exists(), "the symlink target must be untouched");
+    }
+
+    #[test]
+    fn ticket_directory_is_namespaced_under_app_data() {
+        let directory = ticket_directory(Path::new("/app/data"));
+        assert_eq!(directory, Path::new("/app/data").join(TICKET_DIRECTORY));
+    }
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -27,11 +27,25 @@ pub enum AppError {
 
     #[error("{0}")]
     Internal(String),
+
+    /// A source failure the frontend is allowed to branch on structurally.
+    ///
+    /// Unlike every other variant this crosses the IPC boundary as an object
+    /// rather than a string, so the elevation recovery prompt can key off a
+    /// stable classification instead of matching localized OS text.
+    #[error("{0}")]
+    SourceAccess(#[from] crate::source_access::SourceAccessError),
 }
 
 impl From<AppError> for tauri::ipc::InvokeError {
     fn from(err: AppError) -> Self {
-        tauri::ipc::InvokeError::from(err.to_string())
+        match err {
+            // Tauri's blanket `impl<T: Serialize> From<T> for InvokeError`
+            // turns this into structured JSON. Everything else keeps the
+            // string form every existing frontend consumer already expects.
+            AppError::SourceAccess(detail) => tauri::ipc::InvokeError::from(detail),
+            other => tauri::ipc::InvokeError::from(other.to_string()),
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod commands;
 mod constants;
 #[cfg(feature = "dsregcmd")]
 pub mod dsregcmd;
+pub mod elevation;
 pub mod error;
 pub use cmtraceopen_parser::error_db;
 #[cfg(feature = "esp-diagnostics")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ pub mod parser;
 pub mod process_util;
 #[cfg(feature = "secureboot")]
 pub mod secureboot;
+pub mod source_access;
 mod state;
 #[cfg(feature = "sysmon")]
 pub mod sysmon;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,13 +42,18 @@ const ESP_STARTUP_WORKSPACE: &str = "esp-diagnostics";
 struct InitialLaunchArguments {
     file_paths: Vec<String>,
     workspace: Option<String>,
+    elevation_restore: Option<String>,
 }
 
 /// Parses app-owned startup options separately from positional file paths.
 ///
-/// The elevation flow emits an exact workspace option so the replacement
-/// process returns to ESP Diagnostics. Split workspace values are consumed
-/// even when unsupported so they can never be mistaken for file paths.
+/// Three kinds of argument are recognised and they never blend into each other:
+/// positional paths from an OS file association, the legacy workspace option
+/// that the ESP relaunch still emits, and the elevation restore ticket.
+///
+/// An option that fails validation is dropped rather than demoted to a file
+/// path, so a malformed `--elevation-restore=` can never be opened as evidence
+/// and never suppresses a legitimate positional open.
 fn parse_initial_launch_arguments(
     arguments: impl IntoIterator<Item = String>,
 ) -> InitialLaunchArguments {
@@ -63,6 +68,16 @@ fn parse_initial_launch_arguments(
                 {
                     launch.workspace = Some(ESP_STARTUP_WORKSPACE.to_string());
                 }
+            }
+            continue;
+        }
+
+        if argument.starts_with(elevation::relaunch::ELEVATION_RESTORE_FLAG) {
+            // Keep only the first valid ticket; a second one is a tampering
+            // signal, not a queue.
+            if launch.elevation_restore.is_none() {
+                launch.elevation_restore =
+                    elevation::relaunch::parse_restore_argument(std::slice::from_ref(&argument));
             }
             continue;
         }
@@ -138,6 +153,7 @@ pub fn run() {
         .manage(AppState::with_initial_launch(
             initial_launch.file_paths,
             initial_launch.workspace,
+            initial_launch.elevation_restore,
         ))
         .setup(|app| {
             #[cfg(desktop)]
@@ -238,6 +254,9 @@ pub fn run() {
             commands::file_ops::write_text_output_file,
             commands::file_ops::get_initial_file_paths,
             commands::file_ops::get_initial_workspace,
+            commands::elevation::get_app_elevation_state,
+            commands::elevation::restart_as_administrator,
+            commands::elevation::get_initial_elevation_restore,
             commands::file_ops::compute_file_hash,
             commands::bundle_ops::inspect_evidence_bundle,
             commands::bundle_ops::inspect_evidence_artifact,
@@ -406,6 +425,79 @@ mod tests {
 
         assert_eq!(launch.workspace, None);
         assert_eq!(launch.file_paths, [r"C:\Logs\real.log"]);
+    }
+
+    #[test]
+    fn a_valid_restore_ticket_is_parsed_and_never_opened_as_a_file() {
+        let id = crate::elevation::restore_ticket::new_ticket_id();
+
+        let launch =
+            parse_initial_launch_arguments(strings(&[&format!("--elevation-restore={id}")]));
+
+        assert_eq!(launch.elevation_restore.as_deref(), Some(id.as_str()));
+        assert!(launch.file_paths.is_empty());
+        assert_eq!(launch.workspace, None);
+    }
+
+    #[test]
+    fn a_malformed_restore_option_is_dropped_without_becoming_a_file_path() {
+        // The whole point of the option form: a tampered value must not be
+        // demoted to evidence to open.
+        let launch = parse_initial_launch_arguments(strings(&[
+            "--elevation-restore=../../etc/passwd",
+            r"C:\Logs\real.log",
+        ]));
+
+        assert_eq!(launch.elevation_restore, None);
+        assert_eq!(launch.file_paths, [r"C:\Logs\real.log"]);
+    }
+
+    #[test]
+    fn an_empty_restore_option_is_dropped() {
+        let launch = parse_initial_launch_arguments(strings(&["--elevation-restore="]));
+
+        assert_eq!(launch.elevation_restore, None);
+        assert!(launch.file_paths.is_empty());
+    }
+
+    #[test]
+    fn a_file_association_path_keeps_precedence_alongside_a_ticket() {
+        let id = crate::elevation::restore_ticket::new_ticket_id();
+
+        let launch = parse_initial_launch_arguments(strings(&[
+            r"C:\Logs\opened-by-association.log",
+            &format!("--elevation-restore={id}"),
+        ]));
+
+        // Both survive parsing; the frontend applies the documented precedence.
+        assert_eq!(launch.file_paths, [r"C:\Logs\opened-by-association.log"]);
+        assert_eq!(launch.elevation_restore.as_deref(), Some(id.as_str()));
+    }
+
+    #[test]
+    fn only_the_first_restore_ticket_is_kept() {
+        let first = crate::elevation::restore_ticket::new_ticket_id();
+        let second = crate::elevation::restore_ticket::new_ticket_id();
+
+        let launch = parse_initial_launch_arguments(strings(&[
+            &format!("--elevation-restore={first}"),
+            &format!("--elevation-restore={second}"),
+        ]));
+
+        assert_eq!(launch.elevation_restore.as_deref(), Some(first.as_str()));
+    }
+
+    #[test]
+    fn a_path_that_merely_contains_the_option_text_stays_a_path() {
+        let launch = parse_initial_launch_arguments(strings(&[
+            r"C:\Logs\--elevation-restore=not-an-option.log",
+        ]));
+
+        assert_eq!(launch.elevation_restore, None);
+        assert_eq!(
+            launch.file_paths,
+            [r"C:\Logs\--elevation-restore=not-an-option.log"]
+        );
     }
 
     #[cfg(all(feature = "esp-diagnostics", not(target_os = "windows")))]

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -34,6 +34,7 @@ pub const MENU_ID_FILE_NEW_TIMELINE_FROM_FOLDER: &str = "file.new_timeline_from_
 pub const MENU_ID_FILE_NEW_EMPTY_TIMELINE: &str = "file.new_empty_timeline";
 pub const MENU_ID_FILE_SAVE_SESSION: &str = "file.save_session";
 pub const MENU_ID_FILE_OPEN_SESSION: &str = "file.open_session";
+pub const MENU_ID_FILE_RESTART_AS_ADMINISTRATOR: &str = "file.restart_as_administrator";
 pub const MENU_ID_FILE_QUIT: &str = "file.quit";
 
 pub const MENU_ID_EDIT_FIND: &str = "edit.find";
@@ -98,6 +99,26 @@ const FILE_ORDER: &[&str] = &[
     MENU_SEPARATOR,
     MENU_ID_FILE_OPEN_SESSION,
     MENU_ID_FILE_SAVE_SESSION,
+    MENU_SEPARATOR,
+    MENU_ID_FILE_QUIT,
+];
+/// Windows gains the elevation action in its own group above Exit.
+///
+/// UAC is a Windows concept, so the item is not rendered at all elsewhere
+/// rather than being shown disabled — muda has no `set_visible`, so an item
+/// that should never apply must not be created.
+const FILE_ORDER_WINDOWS: &[&str] = &[
+    MENU_ID_FILE_OPEN_LOG_FILE,
+    MENU_ID_FILE_OPEN_LOG_FOLDER,
+    MENU_ID_FILE_KNOWN_SOURCES,
+    MENU_ID_FILE_RECENT,
+    MENU_SEPARATOR,
+    MENU_ID_FILE_NEW_TIMELINE,
+    MENU_SEPARATOR,
+    MENU_ID_FILE_OPEN_SESSION,
+    MENU_ID_FILE_SAVE_SESSION,
+    MENU_SEPARATOR,
+    MENU_ID_FILE_RESTART_AS_ADMINISTRATOR,
     MENU_SEPARATOR,
     MENU_ID_FILE_QUIT,
 ];
@@ -376,10 +397,10 @@ fn top_level_menu_order(platform: MenuPlatform) -> &'static [&'static str] {
 }
 
 fn file_item_order(platform: MenuPlatform) -> &'static [&'static str] {
-    if platform == MenuPlatform::Macos {
-        FILE_ORDER_MAC
-    } else {
-        FILE_ORDER
+    match platform {
+        MenuPlatform::Macos => FILE_ORDER_MAC,
+        MenuPlatform::Windows => FILE_ORDER_WINDOWS,
+        _ => FILE_ORDER,
     }
 }
 
@@ -614,6 +635,14 @@ fn build_file_menu<R: Runtime>(
     let open_session = normal_item(app, MENU_ID_FILE_OPEN_SESSION, "Open Session…", platform)?;
     let save_session = normal_item(app, MENU_ID_FILE_SAVE_SESSION, "Save Session…", platform)?;
     let quit = normal_item(app, MENU_ID_FILE_QUIT, "Exit", platform)?;
+    // Built unconditionally but only referenced by FILE_ORDER_WINDOWS, so on
+    // other platforms it is dropped without ever being appended.
+    let restart_as_administrator = normal_item(
+        app,
+        MENU_ID_FILE_RESTART_AS_ADMINISTRATOR,
+        "Restart as Administrator…",
+        platform,
+    )?;
 
     let submenu = Submenu::with_id(app, MENU_ID_FILE, "File", true)?;
     for &item_id in file_item_order(platform) {
@@ -625,6 +654,7 @@ fn build_file_menu<R: Runtime>(
             MENU_ID_FILE_NEW_TIMELINE => submenu.append(&new_timeline)?,
             MENU_ID_FILE_OPEN_SESSION => submenu.append(&open_session)?,
             MENU_ID_FILE_SAVE_SESSION => submenu.append(&save_session)?,
+            MENU_ID_FILE_RESTART_AS_ADMINISTRATOR => submenu.append(&restart_as_administrator)?,
             MENU_ID_FILE_QUIT => submenu.append(&quit)?,
             MENU_SEPARATOR => append_separator(app, &submenu)?,
             _ => unreachable!("unknown File menu item: {item_id}"),
@@ -1815,8 +1845,34 @@ mod tests {
 
     #[test]
     fn submenu_order_matches_the_native_menu_design() {
-        assert_eq!(file_item_order(MenuPlatform::Windows), FILE_ORDER);
+        assert_eq!(file_item_order(MenuPlatform::Windows), FILE_ORDER_WINDOWS);
         assert_eq!(file_item_order(MenuPlatform::Macos), FILE_ORDER_MAC);
+        assert_eq!(file_item_order(MenuPlatform::Linux), FILE_ORDER);
+
+        // UAC is Windows-only, and muda has no `set_visible`, so the item must
+        // be absent from the other platforms' menus rather than shown disabled.
+        assert!(
+            FILE_ORDER_WINDOWS.contains(&MENU_ID_FILE_RESTART_AS_ADMINISTRATOR),
+            "Windows File menu must offer the elevation action"
+        );
+        for order in [FILE_ORDER, FILE_ORDER_MAC] {
+            assert!(
+                !order.contains(&MENU_ID_FILE_RESTART_AS_ADMINISTRATOR),
+                "only Windows may render the elevation action"
+            );
+        }
+
+        // It sits in its own group directly above Exit: a destructive-adjacent
+        // action should not be adjacent to Save Session.
+        let windows_tail = &FILE_ORDER_WINDOWS[FILE_ORDER_WINDOWS.len() - 3..];
+        assert_eq!(
+            windows_tail,
+            [
+                MENU_ID_FILE_RESTART_AS_ADMINISTRATOR,
+                MENU_SEPARATOR,
+                MENU_ID_FILE_QUIT,
+            ]
+        );
         assert_eq!(
             NEW_TIMELINE_ORDER,
             [

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1726,6 +1726,7 @@ fn payload_for_menu_id(menu_id: &str) -> Option<AppMenuActionPayload> {
         MENU_ID_FILE_NEW_EMPTY_TIMELINE => ("timeline_new_empty", "file"),
         MENU_ID_FILE_SAVE_SESSION => ("save_session", "file"),
         MENU_ID_FILE_OPEN_SESSION => ("open_session", "file"),
+        MENU_ID_FILE_RESTART_AS_ADMINISTRATOR => ("restart_as_administrator", "file"),
         MENU_ID_EDIT_FIND => ("show_find", "edit"),
         MENU_ID_EDIT_FIND_NEXT => ("find_next", "edit"),
         MENU_ID_EDIT_FIND_PREVIOUS => ("find_previous", "edit"),
@@ -2198,6 +2199,11 @@ mod tests {
             (MENU_ID_WINDOW_SETTINGS, "show_settings", "window"),
             (MENU_ID_HELP_CHECK_FOR_UPDATES, "check_for_updates", "help"),
             (MENU_ID_HELP_ABOUT, "show_about", "help"),
+            (
+                MENU_ID_FILE_RESTART_AS_ADMINISTRATOR,
+                "restart_as_administrator",
+                "file",
+            ),
         ];
 
         for (menu_id, action, category) in cases {
@@ -2209,6 +2215,53 @@ mod tests {
             assert_eq!(payload.path, None);
             assert_eq!(payload.workspace, None);
             assert_eq!(payload.kind, None);
+        }
+    }
+
+    #[test]
+    fn every_ordered_menu_item_dispatches_an_action() {
+        // The case list above is maintained by hand, so it cannot prove an item
+        // was not forgotten — a new id can be appended to an ORDER constant,
+        // rendered as a real clickable item, and still fall through
+        // `payload_for_menu_id`'s `_ => return None` arm. That compiles, passes
+        // clippy, and ships a menu entry that silently does nothing.
+        //
+        // This walks the orders instead, so any future item is covered the
+        // moment it becomes reachable.
+        // Containers open a submenu rather than dispatching; their children are
+        // covered because the child orders are walked too.
+        const SUBMENU_CONTAINERS: &[&str] = &[
+            MENU_ID_FILE_KNOWN_SOURCES,
+            MENU_ID_FILE_RECENT,
+            MENU_ID_FILE_NEW_TIMELINE,
+            MENU_ID_VIEW_TEXT_SIZE,
+        ];
+
+        let orders: Vec<&[&str]> = vec![
+            FILE_ORDER,
+            FILE_ORDER_WINDOWS,
+            FILE_ORDER_MAC,
+            NEW_TIMELINE_ORDER,
+            EDIT_ORDER,
+            VIEW_ORDER,
+            TEXT_SIZE_ORDER,
+            HELP_ORDER,
+        ];
+
+        for order in orders {
+            for &menu_id in order {
+                if menu_id == MENU_SEPARATOR || SUBMENU_CONTAINERS.contains(&menu_id) {
+                    continue;
+                }
+                // Quit is handled before dispatch, so it has no payload.
+                if menu_id == MENU_ID_FILE_QUIT {
+                    continue;
+                }
+                assert!(
+                    payload_for_menu_id(menu_id).is_some(),
+                    "menu item {menu_id} is rendered but dispatches no action"
+                );
+            }
         }
     }
 

--- a/src-tauri/src/source_access.rs
+++ b/src-tauri/src/source_access.rs
@@ -1,0 +1,309 @@
+//! Stable, structured classification for log-source access failures.
+//!
+//! The frontend must never decide to offer elevation by matching localized
+//! strings like "Access is denied" or "os error 5". Those vary by Windows
+//! display language and by which layer produced the message. This module gives
+//! the decision a typed answer instead.
+//!
+//! Only the operating system's own error kind promotes a failure to
+//! `accessDenied`. A missing file, a malformed log, a parse failure, and a
+//! network timeout all keep their existing classification and reach the
+//! frontend as ordinary string errors, so the recovery prompt cannot appear for
+//! a problem elevation would not fix.
+
+use std::io;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Longest path echoed back to the frontend as context.
+///
+/// The path is shown to the user so they know which source failed, so it is
+/// bounded rather than omitted. Anything longer is truncated from the left,
+/// keeping the file name that actually identifies the source.
+const MAX_CONTEXT_PATH_LEN: usize = 260;
+
+/// Which source operation was refused.
+///
+/// This drives the recovery prompt's wording and lets the frontend rebuild the
+/// exact restore intent, rather than guessing from whatever it last opened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SourceOperation {
+    ReadFile,
+    ListFolder,
+    OpenKnownSource,
+    WorkspaceAction,
+}
+
+/// Bounded identification of the source that was refused.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum SourceContext {
+    Path { path: String },
+    KnownSource { source_id: String },
+}
+
+impl SourceContext {
+    /// Identify a source by path, bounded and with control characters removed.
+    pub fn path(path: impl AsRef<std::path::Path>) -> Self {
+        Self::Path {
+            path: bounded_path(&path.as_ref().to_string_lossy()),
+        }
+    }
+
+    /// Identify a source by its catalog id.
+    pub fn known_source(source_id: impl Into<String>) -> Self {
+        let source_id: String = source_id.into();
+        Self::KnownSource {
+            source_id: source_id.chars().take(128).collect(),
+        }
+    }
+}
+
+/// A source failure the frontend is allowed to act on structurally.
+///
+/// Serialized with a `kind` tag so new classifications can be added without
+/// breaking the frontend's exhaustiveness.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum SourceAccessError {
+    #[error("{message}")]
+    AccessDenied {
+        operation: SourceOperation,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        context: Option<SourceContext>,
+        /// Safe, app-authored text. Never the raw OS message, which can embed
+        /// an unrelated path or a command line.
+        message: String,
+    },
+}
+
+impl SourceAccessError {
+    pub fn operation(&self) -> SourceOperation {
+        match self {
+            Self::AccessDenied { operation, .. } => *operation,
+        }
+    }
+}
+
+/// Promote an I/O error to `accessDenied`, or decline to classify it.
+///
+/// Returns `None` for every error the operating system did not report as a
+/// permission failure. Callers keep their existing error for that case: a
+/// missing file must never offer elevation, because elevation will not find it.
+///
+/// `ErrorKind::PermissionDenied` is the whole test. On Windows the Rust
+/// standard library already maps `ERROR_ACCESS_DENIED` (5) and
+/// `ERROR_PRIVILEGE_NOT_HELD` (1314) onto it, so matching the kind covers the
+/// native codes without hardcoding them. A sharing violation is deliberately
+/// excluded — a file locked by another process is not fixed by elevating.
+pub fn classify_io_error(
+    error: &io::Error,
+    operation: SourceOperation,
+    context: Option<SourceContext>,
+) -> Option<SourceAccessError> {
+    if error.kind() != io::ErrorKind::PermissionDenied {
+        return None;
+    }
+
+    Some(SourceAccessError::AccessDenied {
+        operation,
+        context,
+        message: message_for(operation),
+    })
+}
+
+/// Classify a file that cannot be opened, before a string-typed read path
+/// discards the operating system's error kind.
+///
+/// This is a classification probe, not an authorization check. If it succeeds
+/// and the real read then fails, the caller's existing error still applies —
+/// the only thing lost is the chance to offer elevation, which is the safe
+/// direction to fail.
+pub fn probe_file_access(path: &str) -> Option<SourceAccessError> {
+    match std::fs::File::open(path) {
+        Ok(_) => None,
+        Err(error) => classify_io_error(
+            &error,
+            SourceOperation::ReadFile,
+            Some(SourceContext::path(path)),
+        ),
+    }
+}
+
+fn message_for(operation: SourceOperation) -> String {
+    match operation {
+        SourceOperation::ReadFile => "CMTrace Open does not have permission to read this file.",
+        SourceOperation::ListFolder => "CMTrace Open does not have permission to read this folder.",
+        SourceOperation::OpenKnownSource => {
+            "CMTrace Open does not have permission to open this source."
+        }
+        SourceOperation::WorkspaceAction => {
+            "CMTrace Open does not have permission to complete this action."
+        }
+    }
+    .to_string()
+}
+
+/// Bound a path for display, keeping the identifying tail.
+fn bounded_path(path: &str) -> String {
+    let cleaned: String = path.chars().filter(|c| !c.is_control()).collect();
+    if cleaned.chars().count() <= MAX_CONTEXT_PATH_LEN {
+        return cleaned;
+    }
+    // Keep the end: the file name identifies the source, the root rarely does.
+    let tail: String = cleaned
+        .chars()
+        .skip(cleaned.chars().count() - MAX_CONTEXT_PATH_LEN)
+        .collect();
+    format!("…{tail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn denied() -> io::Error {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Access is denied. (os error 5)",
+        )
+    }
+
+    #[test]
+    fn a_permission_failure_is_classified() {
+        let classified = classify_io_error(
+            &denied(),
+            SourceOperation::ReadFile,
+            Some(SourceContext::path("C:\\Windows\\CCM\\Logs\\ccmexec.log")),
+        )
+        .expect("permission denied must classify");
+
+        assert_eq!(classified.operation(), SourceOperation::ReadFile);
+    }
+
+    #[test]
+    fn non_permission_failures_are_not_classified() {
+        // Elevation cannot conjure a missing file, fix malformed data, or
+        // shorten a network timeout, so none of these may offer it.
+        for kind in [
+            io::ErrorKind::NotFound,
+            io::ErrorKind::InvalidData,
+            io::ErrorKind::TimedOut,
+            io::ErrorKind::UnexpectedEof,
+            io::ErrorKind::AlreadyExists,
+            io::ErrorKind::InvalidInput,
+        ] {
+            let error = io::Error::new(kind, "boom");
+            assert!(
+                classify_io_error(&error, SourceOperation::ReadFile, None).is_none(),
+                "{kind:?} must not be classified as access denied"
+            );
+        }
+    }
+
+    #[test]
+    fn the_message_never_carries_the_raw_os_text() {
+        // The OS string can embed an unrelated path or a command line.
+        let classified =
+            classify_io_error(&denied(), SourceOperation::ReadFile, None).expect("classified");
+        let SourceAccessError::AccessDenied { message, .. } = &classified;
+
+        assert!(!message.contains("os error"));
+        assert!(!message.contains("Access is denied"));
+        assert_eq!(
+            message,
+            "CMTrace Open does not have permission to read this file."
+        );
+    }
+
+    #[test]
+    fn each_operation_has_its_own_wording() {
+        let messages: Vec<String> = [
+            SourceOperation::ReadFile,
+            SourceOperation::ListFolder,
+            SourceOperation::OpenKnownSource,
+            SourceOperation::WorkspaceAction,
+        ]
+        .iter()
+        .map(|operation| message_for(*operation))
+        .collect();
+
+        let mut unique = messages.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            messages.len(),
+            "wording must be distinguishable"
+        );
+    }
+
+    #[test]
+    fn the_wire_contract_is_camel_case_and_tagged() {
+        let classified = classify_io_error(
+            &denied(),
+            SourceOperation::ListFolder,
+            Some(SourceContext::known_source("ccm-client-logs")),
+        )
+        .expect("classified");
+
+        let value = serde_json::to_value(&classified).expect("serialize");
+        assert_eq!(value["kind"], "accessDenied");
+        assert_eq!(value["operation"], "listFolder");
+        assert_eq!(value["context"]["kind"], "knownSource");
+        assert_eq!(value["context"]["sourceId"], "ccm-client-logs");
+        assert!(value["message"].is_string());
+    }
+
+    #[test]
+    fn a_missing_context_is_omitted_rather_than_null() {
+        let classified = classify_io_error(&denied(), SourceOperation::WorkspaceAction, None)
+            .expect("classified");
+        let value = serde_json::to_value(&classified).expect("serialize");
+
+        assert!(value.get("context").is_none());
+    }
+
+    #[test]
+    fn a_path_context_is_bounded_and_keeps_the_file_name() {
+        let long = format!("C:\\{}\\ccmexec.log", "a".repeat(MAX_CONTEXT_PATH_LEN * 2));
+        let SourceContext::Path { path } = SourceContext::path(&long) else {
+            panic!("expected a path context");
+        };
+
+        assert!(path.chars().count() <= MAX_CONTEXT_PATH_LEN + 1);
+        assert!(
+            path.ends_with("ccmexec.log"),
+            "the identifying file name must survive truncation"
+        );
+    }
+
+    #[test]
+    fn control_characters_are_stripped_from_path_context() {
+        let SourceContext::Path { path } = SourceContext::path("C:\\Logs\\a\u{7}b.log") else {
+            panic!("expected a path context");
+        };
+
+        assert_eq!(path, "C:\\Logs\\ab.log");
+    }
+
+    #[test]
+    fn a_source_id_context_is_bounded() {
+        let SourceContext::KnownSource { source_id } = SourceContext::known_source("x".repeat(500))
+        else {
+            panic!("expected a known-source context");
+        };
+
+        assert_eq!(source_id.chars().count(), 128);
+    }
+}

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -32,6 +32,10 @@ pub struct AppState {
     /// App-owned workspace selected by a validated startup argument.
     /// Consumed on first retrieval so the launch intent is applied once.
     pub initial_workspace: Mutex<Option<String>>,
+    /// Opaque elevation restore ticket identifier supplied by the elevated
+    /// relaunch. Consumed on first retrieval; the ticket it names is itself
+    /// single-use, so a replayed identifier restores nothing.
+    pub initial_elevation_restore: Mutex<Option<String>>,
     /// Active unified multi-file timelines keyed by timeline id.
     pub timelines: Mutex<HashMap<String, Timeline>>,
     /// Installed during Tauri setup and taken during application shutdown so
@@ -42,18 +46,20 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(initial_file_paths: Vec<String>) -> Self {
-        Self::with_initial_launch(initial_file_paths, None)
+        Self::with_initial_launch(initial_file_paths, None, None)
     }
 
     pub fn with_initial_launch(
         initial_file_paths: Vec<String>,
         initial_workspace: Option<String>,
+        initial_elevation_restore: Option<String>,
     ) -> Self {
         Self {
             open_files: Mutex::new(HashMap::new()),
             tail_sessions: Mutex::new(HashMap::new()),
             initial_file_paths: Mutex::new(initial_file_paths),
             initial_workspace: Mutex::new(initial_workspace),
+            initial_elevation_restore: Mutex::new(initial_elevation_restore),
             timelines: Mutex::new(HashMap::new()),
             #[cfg(feature = "esp-diagnostics")]
             esp_session_manager: Mutex::new(None),

--- a/src/hooks/use-app-menu.ts
+++ b/src/hooks/use-app-menu.ts
@@ -219,6 +219,34 @@ export function useAppMenu() {
             await invoke("set_always_on_top", { enabled: next });
             return;
           }
+          case "restart_as_administrator": {
+            const [{ confirm }, elevation, context] = await Promise.all([
+              import("@tauri-apps/plugin-dialog"),
+              import("../lib/elevation"),
+              import("../lib/elevation-context"),
+            ]);
+
+            const request = context.activeElevationRequest("explicitMenu");
+            // Ask before touching the backend: UAC must never appear without
+            // an explicit click, and Cancel must cost nothing.
+            const confirmed = await confirm(
+              context.elevationConfirmationMessage(request.target),
+              { title: "Restart as administrator", kind: "warning" },
+            );
+            if (!confirmed) {
+              return;
+            }
+
+            const outcome = await elevation.requestElevatedRestart(request);
+            if (outcome.status !== "launched") {
+              // A launched restart is terminal — the process is exiting, so
+              // there is no one left to inform.
+              console.info("[app-menu] administrator restart not started", {
+                outcome: elevation.describeElevationOutcome(outcome),
+              });
+            }
+            return;
+          }
           case "increase_text_size":
             increaseLogListTextSize();
             return;

--- a/src/hooks/use-file-association.test.tsx
+++ b/src/hooks/use-file-association.test.tsx
@@ -1,24 +1,60 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getInitialFilePaths, getInitialWorkspace } from "../lib/commands";
-import { loadFilesAsLogSource, loadPathAsLogSource } from "../lib/log-source";
+import {
+  getInitialElevationRestore,
+  getInitialFilePaths,
+  getInitialWorkspace,
+} from "../lib/commands";
+import { markElevationRetryAttempted } from "../lib/elevation";
+import {
+  getKnownSourceMetadataById,
+  loadFilesAsLogSource,
+  loadLogSource,
+  loadPathAsLogSource,
+} from "../lib/log-source";
 import { useUiStore } from "../stores/ui-store";
+import type { RestoreTicket } from "../types/elevation";
 import { useFileAssociation } from "./use-file-association";
 
 vi.mock("../lib/commands", () => ({
+  getInitialElevationRestore: vi.fn(),
   getInitialFilePaths: vi.fn(),
   getInitialWorkspace: vi.fn(),
 }));
 
+vi.mock("../lib/elevation", () => ({
+  markElevationRetryAttempted: vi.fn(),
+}));
+
 vi.mock("../lib/log-source", () => ({
+  getKnownSourceMetadataById: vi.fn(),
   loadFilesAsLogSource: vi.fn(),
+  loadLogSource: vi.fn(),
   loadPathAsLogSource: vi.fn(),
 }));
 
+const getInitialElevationRestoreMock = vi.mocked(getInitialElevationRestore);
 const getInitialFilePathsMock = vi.mocked(getInitialFilePaths);
 const getInitialWorkspaceMock = vi.mocked(getInitialWorkspace);
+const markElevationRetryAttemptedMock = vi.mocked(markElevationRetryAttempted);
+const getKnownSourceMetadataByIdMock = vi.mocked(getKnownSourceMetadataById);
 const loadFilesAsLogSourceMock = vi.mocked(loadFilesAsLogSource);
+const loadLogSourceMock = vi.mocked(loadLogSource);
 const loadPathAsLogSourceMock = vi.mocked(loadPathAsLogSource);
+
+function ticket(overrides: Partial<RestoreTicket> = {}): RestoreTicket {
+  return {
+    schemaVersion: 1,
+    ticketId: "1487dc30-3bb0-46bf-98ee-76771bd9953e",
+    createdAtMs: 1_760_000_000_000,
+    originPid: 1234,
+    workspace: "log",
+    target: { kind: "workspace" },
+    reason: "accessDenied",
+    retryAttempted: true,
+    ...overrides,
+  };
+}
 
 describe("useFileAssociation startup routing", () => {
   beforeEach(() => {
@@ -30,6 +66,7 @@ describe("useFileAssociation startup routing", () => {
     });
     getInitialFilePathsMock.mockResolvedValue([]);
     getInitialWorkspaceMock.mockResolvedValue(null);
+    getInitialElevationRestoreMock.mockResolvedValue(null);
     loadPathAsLogSourceMock.mockImplementation(async (path) => ({
       source: { kind: "file", path },
       entries: [],
@@ -64,5 +101,144 @@ describe("useFileAssociation startup routing", () => {
     );
     expect(useUiStore.getState().activeView).toBe("log");
     expect(loadFilesAsLogSourceMock).not.toHaveBeenCalled();
+  });
+
+  it("gives an explicit file-open request precedence over a restore ticket", async () => {
+    getInitialFilePathsMock.mockResolvedValue(["C:\\Logs\\ime.log"]);
+    getInitialElevationRestoreMock.mockResolvedValue(
+      ticket({ target: { kind: "file", path: "C:\\Windows\\protected.log" } }),
+    );
+
+    renderHook(() => useFileAssociation());
+
+    await waitFor(() =>
+      expect(loadPathAsLogSourceMock).toHaveBeenCalledWith(
+        "C:\\Logs\\ime.log",
+        { fallbackToFolder: false },
+      ),
+    );
+    expect(loadPathAsLogSourceMock).toHaveBeenCalledOnce();
+    expect(loadPathAsLogSourceMock).not.toHaveBeenCalledWith(
+      "C:\\Windows\\protected.log",
+      expect.anything(),
+    );
+  });
+
+  it("restores only the workspace a workspace-only ticket names", async () => {
+    getInitialElevationRestoreMock.mockResolvedValue(
+      ticket({ workspace: "esp-diagnostics" }),
+    );
+
+    renderHook(() => useFileAssociation());
+
+    await waitFor(() =>
+      expect(useUiStore.getState().activeView).toBe("esp-diagnostics"),
+    );
+    expect(loadPathAsLogSourceMock).not.toHaveBeenCalled();
+    expect(loadFilesAsLogSourceMock).not.toHaveBeenCalled();
+    expect(loadLogSourceMock).not.toHaveBeenCalled();
+  });
+
+  it("reopens the exact file a ticket names, without folder fallback", async () => {
+    getInitialElevationRestoreMock.mockResolvedValue(
+      ticket({ target: { kind: "file", path: "C:\\Windows\\protected.log" } }),
+    );
+
+    renderHook(() => useFileAssociation());
+
+    await waitFor(() =>
+      expect(loadPathAsLogSourceMock).toHaveBeenCalledWith(
+        "C:\\Windows\\protected.log",
+        { fallbackToFolder: false },
+      ),
+    );
+  });
+
+  it("reopens a folder ticket through the folder source path", async () => {
+    getInitialElevationRestoreMock.mockResolvedValue(
+      ticket({ target: { kind: "folder", path: "C:\\Windows\\Logs" } }),
+    );
+
+    renderHook(() => useFileAssociation());
+
+    await waitFor(() =>
+      expect(loadPathAsLogSourceMock).toHaveBeenCalledWith(
+        "C:\\Windows\\Logs",
+        { fallbackToFolder: true },
+      ),
+    );
+  });
+
+  it("resolves a known source by id rather than a persisted path", async () => {
+    const source = { kind: "folder" as const, path: "C:\\Windows\\CCM\\Logs" };
+    getKnownSourceMetadataByIdMock.mockResolvedValue({
+      id: "ccm-client-logs",
+      label: "ConfigMgr Client Logs",
+      description: "",
+      platform: "windows",
+      sourceKind: "folder",
+      source,
+      filePatterns: [],
+    });
+    getInitialElevationRestoreMock.mockResolvedValue(
+      ticket({ target: { kind: "knownSource", sourceId: "ccm-client-logs" } }),
+    );
+
+    renderHook(() => useFileAssociation());
+
+    await waitFor(() => expect(loadLogSourceMock).toHaveBeenCalledWith(source));
+    expect(getKnownSourceMetadataByIdMock).toHaveBeenCalledWith(
+      "ccm-client-logs",
+    );
+  });
+
+  it("degrades to a warning when a restored known source no longer exists", async () => {
+    getKnownSourceMetadataByIdMock.mockResolvedValue(null);
+    getInitialElevationRestoreMock.mockResolvedValue(
+      ticket({ target: { kind: "knownSource", sourceId: "retired-source" } }),
+    );
+
+    renderHook(() => useFileAssociation());
+
+    await waitFor(() =>
+      expect(getKnownSourceMetadataByIdMock).toHaveBeenCalledOnce(),
+    );
+    expect(loadLogSourceMock).not.toHaveBeenCalled();
+  });
+
+  it("marks the retry so a second denial cannot start an elevation loop", async () => {
+    getInitialElevationRestoreMock.mockResolvedValue(
+      ticket({ target: { kind: "file", path: "C:\\Windows\\protected.log" } }),
+    );
+
+    renderHook(() => useFileAssociation());
+
+    await waitFor(() =>
+      expect(markElevationRetryAttemptedMock).toHaveBeenCalledOnce(),
+    );
+  });
+
+  it("starts normally when the restore ticket cannot be read", async () => {
+    getInitialElevationRestoreMock.mockRejectedValue(new Error("no state dir"));
+    getInitialWorkspaceMock.mockResolvedValue("esp-diagnostics");
+
+    renderHook(() => useFileAssociation());
+
+    // The unreadable ticket is ignored and the workspace flag still applies.
+    await waitFor(() =>
+      expect(useUiStore.getState().activeView).toBe("esp-diagnostics"),
+    );
+    expect(markElevationRetryAttemptedMock).not.toHaveBeenCalled();
+  });
+
+  it("does not restore anything when there is no ticket", async () => {
+    renderHook(() => useFileAssociation());
+
+    await waitFor(() =>
+      expect(getInitialElevationRestoreMock).toHaveBeenCalledOnce(),
+    );
+    expect(markElevationRetryAttemptedMock).not.toHaveBeenCalled();
+    expect(loadPathAsLogSourceMock).not.toHaveBeenCalled();
+    expect(loadLogSourceMock).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/use-file-association.ts
+++ b/src/hooks/use-file-association.ts
@@ -1,47 +1,83 @@
 import { useEffect } from "react";
-import { getInitialFilePaths, getInitialWorkspace } from "../lib/commands";
-import { loadPathAsLogSource, loadFilesAsLogSource } from "../lib/log-source";
+import {
+  getInitialElevationRestore,
+  getInitialFilePaths,
+  getInitialWorkspace,
+} from "../lib/commands";
+import { markElevationRetryAttempted } from "../lib/elevation";
+import {
+  getKnownSourceMetadataById,
+  loadFilesAsLogSource,
+  loadLogSource,
+  loadPathAsLogSource,
+} from "../lib/log-source";
 import { useFilterStore } from "../stores/filter-store";
 import { useUiStore } from "../stores/ui-store";
+import type { RestoreTicket } from "../types/elevation";
 
 /**
  * Hook that handles validated launch intent at app startup.
  *
- * When the user opens `.log` files with CMTrace Open (e.g. by selecting
- * multiple files and choosing "Open with"), the OS launches the application
- * with the file paths as CLI arguments. This hook retrieves those paths on
- * mount and routes them through the appropriate loading flow — explicit file
- * opens take precedence, otherwise an administrator relaunch can return to
- * ESP Diagnostics.
+ * Three launch intents can arrive together and they never blend into each
+ * other. Precedence, highest first:
+ *
+ *   1. positional file paths from an OS file association;
+ *   2. a valid, unconsumed elevation restore ticket;
+ *   3. an approved workspace-only startup argument;
+ *   4. normal default startup.
+ *
+ * A restore ticket reopens exactly one workspace and at most one source. Other
+ * tabs, filters, searches, and selected rows are deliberately not restored.
  */
 export function useFileAssociation() {
   const clearFilter = useFilterStore((s) => s.clearFilter);
 
   useEffect(() => {
-    Promise.all([getInitialFilePaths(), getInitialWorkspace()])
-      .then(async ([paths, workspace]) => {
-        if (paths.length === 0) {
-          if (workspace === "esp-diagnostics") {
-            useUiStore
-              .getState()
-              .ensureWorkspaceVisible("esp-diagnostics", "startup.workspace");
+    Promise.all([
+      getInitialFilePaths(),
+      getInitialWorkspace(),
+      getInitialElevationRestore().catch((error) => {
+        // A restore that cannot even be read must not stop the app starting.
+        console.warn("[elevation] unable to read the restore ticket", {
+          error,
+        });
+        return null;
+      }),
+    ])
+      .then(async ([paths, workspace, ticket]) => {
+        if (ticket) {
+          // Mark before restoring: if the restored source is still denied, the
+          // failure must offer troubleshooting rather than a second prompt.
+          markElevationRetryAttempted();
+        }
+
+        if (paths.length > 0) {
+          useUiStore
+            .getState()
+            .ensureLogViewVisible("file-association.path-open");
+          clearFilter();
+
+          if (paths.length === 1) {
+            await loadPathAsLogSource(paths[0], {
+              fallbackToFolder: false,
+            });
+            return;
           }
+
+          await loadFilesAsLogSource(paths);
           return;
         }
 
-        useUiStore
-          .getState()
-          .ensureLogViewVisible("file-association.path-open");
-        clearFilter();
-
-        if (paths.length === 1) {
-          await loadPathAsLogSource(paths[0], {
-            fallbackToFolder: false,
-          });
+        if (ticket) {
+          await restoreElevatedSource(ticket, clearFilter);
           return;
         }
 
-        await loadFilesAsLogSource(paths);
+        if (workspace === "esp-diagnostics") {
+          useUiStore
+            .getState()
+            .ensureWorkspaceVisible("esp-diagnostics", "startup.workspace");
+        }
       })
       .catch((error) => {
         console.error("[file-association] failed to open initial file paths", {
@@ -49,4 +85,59 @@ export function useFileAssociation() {
         });
       });
   }, [clearFilter]);
+}
+
+/**
+ * Reopen the one workspace and source a validated restore ticket names.
+ *
+ * The workspace is routed through the normal availability check, so a ticket
+ * naming a workspace this platform or build does not offer falls back to the
+ * default rather than forcing an unavailable view.
+ */
+async function restoreElevatedSource(
+  ticket: RestoreTicket,
+  clearFilter: () => void,
+): Promise<void> {
+  const { target, workspace } = ticket;
+
+  if (target.kind === "workspace") {
+    useUiStore
+      .getState()
+      .ensureWorkspaceVisible(workspace, "startup.elevation-restore");
+    return;
+  }
+
+  useUiStore.getState().ensureLogViewVisible("startup.elevation-restore");
+  clearFilter();
+
+  switch (target.kind) {
+    case "file":
+      await loadPathAsLogSource(target.path, { fallbackToFolder: false });
+      return;
+    case "folder":
+      await loadPathAsLogSource(target.path, { fallbackToFolder: true });
+      return;
+    case "knownSource":
+      // Known sources resolve through the catalog by stable id rather than a
+      // persisted expanded path, so the elevated process reads current metadata.
+      await openKnownSourceById(target.sourceId);
+  }
+}
+
+/**
+ * Open a catalog entry by its stable identifier.
+ *
+ * Resolving current catalog metadata rather than replaying a persisted expanded
+ * path means the elevated process opens whatever that source means now, and a
+ * source that has since disappeared degrades to a warning instead of a bad path.
+ */
+async function openKnownSourceById(sourceId: string): Promise<void> {
+  const source = await getKnownSourceMetadataById(sourceId);
+  if (!source) {
+    console.warn("[elevation] restored known source is no longer available", {
+      sourceId,
+    });
+    return;
+  }
+  await loadLogSource(source.source);
 }

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -4,6 +4,7 @@ import {
   getSafeErrorMessage,
   graphGetAuthStatus,
   graphRequestMissingPermissions,
+  getSourceAccessDenial,
   openLogFile,
 } from "./commands";
 
@@ -373,5 +374,69 @@ describe("getSafeErrorMessage", () => {
     expect(getSafeErrorMessage(new BackendFailure(), "safe fallback")).toBe(
       "safe fallback",
     );
+  });
+});
+
+describe("source access classification", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+  });
+
+  it("survives the invoke wrapper's collapse to a plain Error", async () => {
+    // invokeCommand normalizes every rejection into a fresh Error, which would
+    // otherwise discard the one payload the elevation prompt branches on.
+    vi.mocked(invoke).mockRejectedValue({
+      kind: "accessDenied",
+      operation: "readFile",
+      context: { kind: "path", path: "C:\\Windows\\CCM\\Logs\\ccmexec.log" },
+      message: "CMTrace Open does not have permission to read this file.",
+    });
+
+    const error = await captureRejection(openLogFile("C:\\Windows\\x.log"));
+
+    expect(error).toBeInstanceOf(Error);
+    expect(getSourceAccessDenial(error)).toEqual({
+      kind: "accessDenied",
+      operation: "readFile",
+      context: { kind: "path", path: "C:\\Windows\\CCM\\Logs\\ccmexec.log" },
+      message: "CMTrace Open does not have permission to read this file.",
+    });
+    // The user-facing message is the backend's safe text, not a raw OS string.
+    expect((error as Error).message).toBe(
+      "CMTrace Open does not have permission to read this file.",
+    );
+  });
+
+  it("reports no denial for an ordinary string rejection", async () => {
+    vi.mocked(invoke).mockRejectedValue("Failed to read file: not found");
+
+    const error = await captureRejection(openLogFile("C:\\missing.log"));
+
+    expect(getSourceAccessDenial(error)).toBeNull();
+  });
+
+  it("rejects a payload whose operation is not recognized", async () => {
+    // A forged or future operation must not reach the elevation path.
+    vi.mocked(invoke).mockRejectedValue({
+      kind: "accessDenied",
+      operation: "runArbitraryCommand",
+      message: "nope",
+    });
+
+    const error = await captureRejection(openLogFile("C:\\x.log"));
+
+    expect(getSourceAccessDenial(error)).toBeNull();
+  });
+
+  it("ignores a hostile Proxy claiming to be an access denial", async () => {
+    const { rejection, getPrototypeOfReads } =
+      makeHostileErrorProxy("denial");
+    vi.mocked(invoke).mockRejectedValue(rejection);
+
+    const error = await captureRejection(openLogFile("C:\\x.log"));
+
+    expect(getSourceAccessDenial(error)).toBeNull();
+    // Still exactly one prototype probe: classification did not add a second.
+    expect(getPrototypeOfReads()).toBe(1);
   });
 });

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -14,6 +14,12 @@ import type {
   EvidenceArtifactIntakeKind,
 } from "../types/evidence";
 import type { RegistryParseResult } from "../types/registry";
+import type {
+  AppElevationState,
+  ElevationRequest,
+  RelaunchResult,
+  RestoreTicket,
+} from "../types/elevation";
 import type { IntuneAnalysisResult } from "../workspaces/intune/types";
 import type { SysmonAnalysisResult } from "../workspaces/sysmon/types";
 import type {
@@ -418,6 +424,30 @@ export async function getInitialFilePaths(): Promise<string[]> {
 
 export async function getInitialWorkspace(): Promise<WorkspaceId | null> {
   return invokeCommand<WorkspaceId | null>("get_initial_workspace");
+}
+
+// --- Application-wide elevation ---
+
+export async function getAppElevationState(): Promise<AppElevationState> {
+  return invokeCommand<AppElevationState>("get_app_elevation_state");
+}
+
+export async function restartAsAdministrator(
+  request: ElevationRequest,
+): Promise<RelaunchResult> {
+  return invokeCommand<RelaunchResult>("restart_as_administrator", {
+    request,
+  });
+}
+
+/**
+ * Claim the single-use restore ticket this process was started with.
+ *
+ * Returns null for every unusable case — no ticket, expired, malformed, or
+ * already consumed — because a failed restore must never stop the app starting.
+ */
+export async function getInitialElevationRestore(): Promise<RestoreTicket | null> {
+  return invokeCommand<RestoreTicket | null>("get_initial_elevation_restore");
 }
 
 export async function getAvailableWorkspaces(): Promise<WorkspaceId[]> {

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -19,6 +19,9 @@ import type {
   ElevationRequest,
   RelaunchResult,
   RestoreTicket,
+  SourceAccessDenied,
+  SourceContext,
+  SourceOperation,
 } from "../types/elevation";
 import type { IntuneAnalysisResult } from "../workspaces/intune/types";
 import type { SysmonAnalysisResult } from "../workspaces/sysmon/types";
@@ -138,10 +141,9 @@ function humanizeErrorKind(kind: string): string {
  * Returns null for anything that is not a plain data object so the caller keeps
  * the safe fallback.
  */
-function getPlainDataErrorMessage(error: object): string | null {
-  if (!isPlainDataObject(error)) {
-    return null;
-  }
+/// Caller must have already confirmed `error` is a plain data object, so this
+/// adds no further prototype probe.
+function plainDataMessage(error: object): string | null {
   const message = readOwnStringData(error, "message");
   if (message !== null) {
     return message;
@@ -153,12 +155,20 @@ function getPlainDataErrorMessage(error: object): string | null {
   return null;
 }
 
-export function getSafeErrorMessage(
+/**
+ * Classify a rejection once, yielding both its message and any structured
+ * source-access denial.
+ *
+ * Both answers come from a SINGLE plain-data probe. Classifying twice would
+ * hand a hostile Proxy a second `getPrototypeOf` trap invocation, which
+ * `command rejection sanitization` in commands.test.ts pins to exactly one.
+ */
+function classifyCommandError(
   error: unknown,
-  fallback = "The operation failed.",
-): string {
+  fallback: string,
+): { message: string; denial: SourceAccessDenied | null } {
   if (typeof error === "string") {
-    return error.trim() || fallback;
+    return { message: error.trim() || fallback, denial: null };
   }
 
   if (
@@ -169,7 +179,7 @@ export function getSafeErrorMessage(
     // this WeakMap channel cannot invoke Proxy traps.
     const trusted = normalizedCommandErrorMessages.get(error as Error);
     if (trusted !== undefined) {
-      return trusted;
+      return { message: trusted, denial: null };
     }
 
     // Serialized Rust command errors arrive as plain data objects. Surface their
@@ -177,24 +187,114 @@ export function getSafeErrorMessage(
     // plain-prototype objects are inspected, no getter is ever invoked, and a
     // forged descriptor value is rejected. Class instances, functions, Proxies,
     // and accessor-only objects fall through to the safe fallback.
-    if (typeof error === "object") {
-      const plainMessage = getPlainDataErrorMessage(error);
-      if (plainMessage !== null) {
-        return plainMessage;
-      }
+    if (typeof error === "object" && isPlainDataObject(error)) {
+      return {
+        message: plainDataMessage(error) ?? fallback,
+        denial: parseSourceAccessDenied(error),
+      };
     }
 
-    return fallback;
+    return { message: fallback, denial: null };
   }
 
-  return fallback;
+  return { message: fallback, denial: null };
+}
+
+export function getSafeErrorMessage(
+  error: unknown,
+  fallback = "The operation failed.",
+): string {
+  return classifyCommandError(error, fallback).message;
+}
+
+/**
+ * Structured source-access classifications, keyed by the normalized Error.
+ *
+ * `invokeCommand` collapses every rejection into a plain `Error`, which would
+ * otherwise discard the one payload the elevation prompt needs to branch on.
+ * A WeakMap keyed by identity keeps that channel out of reach of a hostile
+ * Proxy, matching how normalized messages are already carried.
+ */
+const sourceAccessDenials = new WeakMap<Error, SourceAccessDenied>();
+
+const SOURCE_OPERATIONS: readonly SourceOperation[] = [
+  "readFile",
+  "listFolder",
+  "openKnownSource",
+  "workspaceAction",
+];
+
+/**
+ * Recognize the backend's `accessDenied` classification.
+ *
+ * Applies the same hostile-Proxy protection as `getPlainDataErrorMessage`: only
+ * plain-prototype objects are inspected and no getter is ever invoked. An
+ * unrecognized operation is rejected rather than passed through, so a forged or
+ * future payload cannot reach the elevation path.
+ */
+function parseSourceAccessDenied(error: object): SourceAccessDenied | null {
+  if (readOwnStringData(error, "kind") !== "accessDenied") return null;
+
+  const operation = readOwnStringData(error, "operation");
+  if (
+    operation === null ||
+    !SOURCE_OPERATIONS.includes(operation as SourceOperation)
+  ) {
+    return null;
+  }
+
+  const message = readOwnStringData(error, "message");
+  if (message === null) return null;
+
+  return {
+    kind: "accessDenied",
+    operation: operation as SourceOperation,
+    message,
+    ...(parseSourceContext(error) ?? {}),
+  };
+}
+
+function parseSourceContext(
+  error: object,
+): { context: SourceContext } | null {
+  const descriptor = Object.getOwnPropertyDescriptor(error, "context");
+  const raw = descriptor && "value" in descriptor ? descriptor.value : null;
+  if (typeof raw !== "object" || raw === null || !isPlainDataObject(raw)) {
+    return null;
+  }
+
+  const kind = readOwnStringData(raw, "kind");
+  if (kind === "path") {
+    const path = readOwnStringData(raw, "path");
+    return path === null ? null : { context: { kind: "path", path } };
+  }
+  if (kind === "knownSource") {
+    const sourceId = readOwnStringData(raw, "sourceId");
+    return sourceId === null
+      ? null
+      : { context: { kind: "knownSource", sourceId } };
+  }
+  return null;
+}
+
+/**
+ * Read the structured access-denied classification behind a command rejection.
+ *
+ * Returns null for every other failure, which is what keeps the elevation
+ * prompt from appearing for a missing file or a parse error.
+ */
+export function getSourceAccessDenial(
+  error: unknown,
+): SourceAccessDenied | null {
+  if (typeof error !== "object" || error === null) return null;
+  return sourceAccessDenials.get(error as Error) ?? null;
 }
 
 function normalizeCommandInvokeError(
   commandName: string,
   error: unknown,
 ): Error {
-  const message = getSafeErrorMessage(
+  const { message, denial } = classifyCommandError(
     error,
     `Command '${commandName}' failed.`,
   );
@@ -210,6 +310,11 @@ function normalizeCommandInvokeError(
 
   const normalizedError = new Error(normalizedMessage);
   normalizedCommandErrorMessages.set(normalizedError, normalizedMessage);
+
+  if (denial) {
+    sourceAccessDenials.set(normalizedError, denial);
+  }
+
   return normalizedError;
 }
 

--- a/src/lib/elevation-context.test.ts
+++ b/src/lib/elevation-context.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  activeElevationRequest,
+  describeRestoreTarget,
+  elevationConfirmationMessage,
+  restoreTargetForSource,
+} from "./elevation-context";
+import { useLogStore } from "../stores/log-store";
+import { useUiStore } from "../stores/ui-store";
+
+describe("elevation context", () => {
+  beforeEach(() => {
+    useUiStore.setState({ activeWorkspace: "log", activeView: "log" });
+    useLogStore.setState({ activeSource: null });
+  });
+
+  it("maps no open source to a workspace-only restore", () => {
+    expect(restoreTargetForSource(null)).toEqual({ kind: "workspace" });
+  });
+
+  it("maps a file source to the exact file", () => {
+    expect(
+      restoreTargetForSource({ kind: "file", path: "C:\\Logs\\ime.log" }),
+    ).toEqual({ kind: "file", path: "C:\\Logs\\ime.log" });
+  });
+
+  it("maps a folder source to an aggregate folder restore", () => {
+    expect(
+      restoreTargetForSource({ kind: "folder", path: "C:\\Logs" }),
+    ).toEqual({ kind: "folder", path: "C:\\Logs", aggregate: true });
+  });
+
+  it("maps a known source by id rather than its expanded path", () => {
+    expect(
+      restoreTargetForSource({
+        kind: "known",
+        sourceId: "ccm-client-logs",
+        defaultPath: "C:\\Windows\\CCM\\Logs",
+        pathKind: "folder",
+      }),
+    ).toEqual({ kind: "knownSource", sourceId: "ccm-client-logs" });
+  });
+
+  it("builds the request from the active workspace and source", () => {
+    useUiStore.setState({
+      activeWorkspace: "esp-diagnostics",
+      activeView: "esp-diagnostics",
+    });
+    useLogStore.setState({
+      activeSource: { kind: "file", path: "/var/log/app.log" },
+    });
+
+    expect(activeElevationRequest()).toEqual({
+      reason: "explicitMenu",
+      workspace: "esp-diagnostics",
+      target: { kind: "file", path: "/var/log/app.log" },
+    });
+  });
+
+  it("carries the caller's reason", () => {
+    expect(activeElevationRequest("accessDenied").reason).toBe("accessDenied");
+  });
+
+  it("labels a target by name rather than full path", () => {
+    // The confirmation should not spell out a sensitive location when the
+    // file name already identifies what will reopen.
+    expect(describeRestoreTarget({ kind: "file", path: "C:\\Logs\\ime.log" })).toBe(
+      "ime.log",
+    );
+    expect(
+      describeRestoreTarget({ kind: "folder", path: "/var/log/ccm/" }),
+    ).toBe("ccm (folder)");
+    expect(describeRestoreTarget({ kind: "workspace" })).toBe(
+      "the current workspace",
+    );
+    expect(
+      describeRestoreTarget({ kind: "knownSource", sourceId: "ccm-logs" }),
+    ).toBe("ccm-logs");
+  });
+
+  it("falls back to the whole string when there is no separator", () => {
+    expect(describeRestoreTarget({ kind: "file", path: "app.log" })).toBe(
+      "app.log",
+    );
+  });
+
+  it("states what will and will not be restored", () => {
+    const message = elevationConfirmationMessage({
+      kind: "file",
+      path: "C:\\Logs\\ime.log",
+    });
+
+    expect(message).toContain("close and reopen as administrator");
+    expect(message).toContain("ime.log");
+    expect(message).toContain(
+      "Other tabs, filters, and searches are not restored.",
+    );
+  });
+});

--- a/src/lib/elevation-context.ts
+++ b/src/lib/elevation-context.ts
@@ -13,6 +13,7 @@ import type {
   ElevationReason,
   ElevationRequest,
   RestoreTarget,
+  SourceAccessDenied,
 } from "../types/elevation";
 
 /**
@@ -73,6 +74,39 @@ function basename(path: string): string {
   const trimmed = path.replace(/[\\/]+$/, "");
   const index = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
   return index >= 0 ? trimmed.slice(index + 1) || trimmed : trimmed;
+}
+
+/**
+ * Rebuild the restore intent from the source that was actually refused.
+ *
+ * The Access Denied prompt must retry the exact failed source, not whatever tab
+ * happens to be selected when the user clicks. That is why the backend echoes a
+ * bounded context back with the classification.
+ */
+export function restoreTargetForDenial(
+  denial: SourceAccessDenied,
+): RestoreTarget {
+  const { context, operation } = denial;
+  if (!context) return { kind: "workspace" };
+
+  if (context.kind === "knownSource") {
+    return { kind: "knownSource", sourceId: context.sourceId };
+  }
+
+  return operation === "listFolder"
+    ? { kind: "folder", path: context.path, aggregate: true }
+    : { kind: "file", path: context.path };
+}
+
+/** The elevation request an Access Denied recovery should carry. */
+export function elevationRequestForDenial(
+  denial: SourceAccessDenied,
+): ElevationRequest {
+  return {
+    reason: "accessDenied",
+    workspace: useUiStore.getState().activeWorkspace,
+    target: restoreTargetForDenial(denial),
+  };
 }
 
 /** The confirmation shown before any UAC prompt is requested. */

--- a/src/lib/elevation-context.ts
+++ b/src/lib/elevation-context.ts
@@ -1,0 +1,87 @@
+/**
+ * Bridges current application state to an elevation request.
+ *
+ * Kept apart from `elevation.ts` so the coordinator stays free of store
+ * imports: the coordinator is called from components, hooks, and the menu, and
+ * none of them should have to agree on where state lives.
+ */
+
+import { useLogStore } from "../stores/log-store";
+import { useUiStore } from "../stores/ui-store";
+import type { LogSource } from "../types/log";
+import type {
+  ElevationReason,
+  ElevationRequest,
+  RestoreTarget,
+} from "../types/elevation";
+
+/**
+ * Map the active log source onto the one source intent worth restoring.
+ *
+ * Returns a workspace-only target when nothing is open, which is the correct
+ * request for a global menu restart with no active source.
+ */
+export function restoreTargetForSource(
+  source: LogSource | null,
+): RestoreTarget {
+  if (!source) return { kind: "workspace" };
+
+  switch (source.kind) {
+    case "file":
+      return { kind: "file", path: source.path };
+    case "folder":
+      return { kind: "folder", path: source.path, aggregate: true };
+    case "known":
+      // Restore by stable id, never by the expanded path: the elevated process
+      // should resolve whatever that catalog entry means now.
+      return { kind: "knownSource", sourceId: source.sourceId };
+  }
+}
+
+/** Build the request a global restart should carry from current state. */
+export function activeElevationRequest(
+  reason: ElevationReason = "explicitMenu",
+): ElevationRequest {
+  return {
+    reason,
+    workspace: useUiStore.getState().activeWorkspace,
+    target: restoreTargetForSource(useLogStore.getState().activeSource),
+  };
+}
+
+/**
+ * A compact label for the confirmation prompt.
+ *
+ * Prefers a file or folder name over the full path so the confirmation does not
+ * expose a sensitive location when a short label conveys the same thing.
+ */
+export function describeRestoreTarget(target: RestoreTarget): string {
+  switch (target.kind) {
+    case "workspace":
+      return "the current workspace";
+    case "file":
+      return basename(target.path);
+    case "folder":
+      return `${basename(target.path)} (folder)`;
+    case "knownSource":
+      return target.sourceId;
+  }
+}
+
+/** Last path segment, tolerating both separators and a trailing one. */
+function basename(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, "");
+  const index = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return index >= 0 ? trimmed.slice(index + 1) || trimmed : trimmed;
+}
+
+/** The confirmation shown before any UAC prompt is requested. */
+export function elevationConfirmationMessage(target: RestoreTarget): string {
+  return [
+    "CMTrace Open will close and reopen as administrator.",
+    "",
+    `Reopens: ${describeRestoreTarget(target)}`,
+    "",
+    "Other tabs, filters, and searches are not restored.",
+  ].join("\n");
+}

--- a/src/lib/elevation-recovery.test.ts
+++ b/src/lib/elevation-recovery.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getSourceAccessDenial } from "./commands";
+import {
+  markElevationRetryAttempted,
+  readElevationState,
+  requestElevatedRestart,
+  resetElevationCoordinatorForTests,
+} from "./elevation";
+import {
+  evaluateRecovery,
+  recoveryPrompt,
+  runRecovery,
+} from "./elevation-recovery";
+import { useUiStore } from "../stores/ui-store";
+import type { SourceAccessDenied } from "../types/elevation";
+
+vi.mock("./commands", () => ({
+  getSourceAccessDenial: vi.fn(),
+}));
+
+vi.mock("./elevation", async () => {
+  const actual =
+    await vi.importActual<typeof import("./elevation")>("./elevation");
+  return {
+    ...actual,
+    readElevationState: vi.fn(),
+    requestElevatedRestart: vi.fn(),
+  };
+});
+
+const getSourceAccessDenialMock = vi.mocked(getSourceAccessDenial);
+const readElevationStateMock = vi.mocked(readElevationState);
+const requestElevatedRestartMock = vi.mocked(requestElevatedRestart);
+
+function denial(
+  overrides: Partial<SourceAccessDenied> = {},
+): SourceAccessDenied {
+  return {
+    kind: "accessDenied",
+    operation: "readFile",
+    context: { kind: "path", path: "C:\\Windows\\CCM\\Logs\\ccmexec.log" },
+    message: "CMTrace Open does not have permission to read this file.",
+    ...overrides,
+  };
+}
+
+describe("access denied recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetElevationCoordinatorForTests();
+    useUiStore.setState({ activeWorkspace: "log", activeView: "log" });
+    readElevationStateMock.mockResolvedValue({
+      platformSupported: true,
+      isElevated: false,
+    });
+  });
+
+  it("offers recovery for a confirmed access-denied classification", async () => {
+    getSourceAccessDenialMock.mockReturnValue(denial());
+
+    const offer = await evaluateRecovery(new Error("boom"));
+
+    expect(offer.kind).toBe("offer");
+  });
+
+  it("does not offer recovery for an unclassified failure", async () => {
+    // A missing file, a parse error, and a timeout all arrive here as plain
+    // errors with no classification. Elevation would not fix any of them.
+    getSourceAccessDenialMock.mockReturnValue(null);
+
+    expect(await evaluateRecovery(new Error("file not found"))).toEqual({
+      kind: "none",
+    });
+    expect(await evaluateRecovery(new Error("unexpected end of file"))).toEqual({
+      kind: "none",
+    });
+    expect(await evaluateRecovery("Access is denied")).toEqual({
+      kind: "none",
+    });
+  });
+
+  it("does not offer recovery when already elevated", async () => {
+    getSourceAccessDenialMock.mockReturnValue(denial());
+    readElevationStateMock.mockResolvedValue({
+      platformSupported: true,
+      isElevated: true,
+    });
+
+    expect(await evaluateRecovery(new Error("boom"))).toEqual({ kind: "none" });
+  });
+
+  it("does not offer recovery on a platform without UAC", async () => {
+    getSourceAccessDenialMock.mockReturnValue(denial());
+    readElevationStateMock.mockResolvedValue({
+      platformSupported: false,
+      isElevated: false,
+    });
+
+    expect(await evaluateRecovery(new Error("boom"))).toEqual({ kind: "none" });
+  });
+
+  it("does not offer recovery once a restored retry already failed", async () => {
+    getSourceAccessDenialMock.mockReturnValue(denial());
+
+    expect((await evaluateRecovery(new Error("boom"))).kind).toBe("offer");
+
+    markElevationRetryAttempted();
+
+    // The loop guard: the restored source is still denied, so the user gets
+    // troubleshooting rather than a second UAC prompt.
+    expect(await evaluateRecovery(new Error("boom"))).toEqual({ kind: "none" });
+  });
+
+  it("names the exact failed source in the prompt", () => {
+    const prompt = recoveryPrompt(denial());
+
+    expect(prompt).toContain("permission to read this file");
+    expect(prompt).toContain("ccmexec.log");
+    expect(prompt).toContain(
+      "Other tabs, filters, and searches are not restored.",
+    );
+  });
+
+  it("retries a folder denial as a folder, not a file", async () => {
+    requestElevatedRestartMock.mockResolvedValue({ status: "launched" });
+
+    await runRecovery(
+      denial({
+        operation: "listFolder",
+        context: { kind: "path", path: "C:\\Windows\\CCM\\Logs" },
+      }),
+      async () => true,
+    );
+
+    expect(requestElevatedRestartMock).toHaveBeenCalledWith({
+      reason: "accessDenied",
+      workspace: "log",
+      target: { kind: "folder", path: "C:\\Windows\\CCM\\Logs", aggregate: true },
+    });
+  });
+
+  it("retries a known source by id rather than a path", async () => {
+    requestElevatedRestartMock.mockResolvedValue({ status: "launched" });
+
+    await runRecovery(
+      denial({
+        operation: "openKnownSource",
+        context: { kind: "knownSource", sourceId: "ccm-client-logs" },
+      }),
+      async () => true,
+    );
+
+    expect(requestElevatedRestartMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: { kind: "knownSource", sourceId: "ccm-client-logs" },
+      }),
+    );
+  });
+
+  it("retries the exact failed source, not the active tab", async () => {
+    requestElevatedRestartMock.mockResolvedValue({ status: "launched" });
+
+    await runRecovery(denial(), async () => true);
+
+    expect(requestElevatedRestartMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: {
+          kind: "file",
+          path: "C:\\Windows\\CCM\\Logs\\ccmexec.log",
+        },
+      }),
+    );
+  });
+
+  it("requests no elevation when the user declines", async () => {
+    const outcome = await runRecovery(denial(), async () => false);
+
+    expect(outcome).toEqual({ status: "declined" });
+    expect(requestElevatedRestartMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a workspace restore when no context was supplied", async () => {
+    requestElevatedRestartMock.mockResolvedValue({ status: "launched" });
+
+    await runRecovery(
+      denial({ operation: "workspaceAction", context: undefined }),
+      async () => true,
+    );
+
+    expect(requestElevatedRestartMock).toHaveBeenCalledWith(
+      expect.objectContaining({ target: { kind: "workspace" } }),
+    );
+  });
+});

--- a/src/lib/elevation-recovery.ts
+++ b/src/lib/elevation-recovery.ts
@@ -1,0 +1,81 @@
+/**
+ * Access Denied recovery.
+ *
+ * The one place that decides whether a failed source operation may offer to
+ * restart elevated. Every guard the issue requires lives here rather than in
+ * each caller's catch block:
+ *
+ * - only a confirmed `accessDenied` classification qualifies, never a string match;
+ * - a missing file, parse failure, or timeout never reaches this path at all;
+ * - the user must click before UAC is requested;
+ * - a restored retry cannot offer elevation a second time.
+ */
+
+import { getSourceAccessDenial } from "./commands";
+import {
+  canOfferElevation,
+  readElevationState,
+  requestElevatedRestart,
+  type ElevationOutcome,
+} from "./elevation";
+import {
+  describeRestoreTarget,
+  elevationRequestForDenial,
+  restoreTargetForDenial,
+} from "./elevation-context";
+import type { SourceAccessDenied } from "../types/elevation";
+
+/** What a caller should do about a failed source operation. */
+export type RecoveryOffer =
+  | { kind: "none" }
+  | { kind: "offer"; denial: SourceAccessDenied; prompt: string };
+
+/**
+ * Decide whether a rejected source operation may offer elevation.
+ *
+ * Returns `none` for everything that elevation would not fix, and for the
+ * second failure after a restored retry — that is the loop guard.
+ */
+export async function evaluateRecovery(
+  error: unknown,
+): Promise<RecoveryOffer> {
+  const denial = getSourceAccessDenial(error);
+  if (!denial) return { kind: "none" };
+
+  const state = await readElevationState();
+  if (!canOfferElevation(state)) return { kind: "none" };
+
+  return {
+    kind: "offer",
+    denial,
+    prompt: recoveryPrompt(denial),
+  };
+}
+
+/** The recovery prompt body, naming the source that will be retried. */
+export function recoveryPrompt(denial: SourceAccessDenied): string {
+  const target = describeRestoreTarget(restoreTargetForDenial(denial));
+  return [
+    denial.message,
+    "",
+    `Restarting as administrator will reopen: ${target}`,
+    "",
+    "Other tabs, filters, and searches are not restored.",
+  ].join("\n");
+}
+
+/**
+ * Run the recovery: confirm, then request the elevated restart.
+ *
+ * `confirm` is injected so this stays testable without the Tauri dialog plugin
+ * and so the caller controls which dialog implementation is used.
+ */
+export async function runRecovery(
+  denial: SourceAccessDenied,
+  confirmAction: (message: string) => Promise<boolean>,
+): Promise<ElevationOutcome | { status: "declined" }> {
+  const confirmed = await confirmAction(recoveryPrompt(denial));
+  if (!confirmed) return { status: "declined" };
+
+  return requestElevatedRestart(elevationRequestForDenial(denial));
+}

--- a/src/lib/elevation.test.ts
+++ b/src/lib/elevation.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAppElevationState, restartAsAdministrator } from "./commands";
+import {
+  canOfferElevation,
+  describeElevationOutcome,
+  markElevationRetryAttempted,
+  readElevationState,
+  requestElevatedRestart,
+  resetElevationCoordinatorForTests,
+} from "./elevation";
+import type { AppElevationState, ElevationRequest } from "../types/elevation";
+
+vi.mock("./commands", () => ({
+  getAppElevationState: vi.fn(),
+  restartAsAdministrator: vi.fn(),
+}));
+
+const getAppElevationStateMock = vi.mocked(getAppElevationState);
+const restartAsAdministratorMock = vi.mocked(restartAsAdministrator);
+
+const menuRequest: ElevationRequest = {
+  reason: "explicitMenu",
+  workspace: "log",
+  target: { kind: "workspace" },
+};
+
+function state(overrides: Partial<AppElevationState> = {}): AppElevationState {
+  return { platformSupported: true, isElevated: false, ...overrides };
+}
+
+describe("elevation coordinator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetElevationCoordinatorForTests();
+  });
+
+  it("reports a launch so the caller can stop rendering", async () => {
+    restartAsAdministratorMock.mockResolvedValue({
+      launched: true,
+      reason: "launched",
+    });
+
+    expect(await requestElevatedRestart(menuRequest)).toEqual({
+      status: "launched",
+    });
+  });
+
+  it("treats a cancelled UAC prompt as an outcome, not a failure", async () => {
+    restartAsAdministratorMock.mockResolvedValue({
+      launched: false,
+      reason: "elevationCancelled",
+    });
+
+    expect(await requestElevatedRestart(menuRequest)).toEqual({
+      status: "cancelled",
+    });
+  });
+
+  it("distinguishes already-elevated and unsupported from failure", async () => {
+    restartAsAdministratorMock.mockResolvedValue({
+      launched: false,
+      reason: "alreadyElevated",
+    });
+    expect(await requestElevatedRestart(menuRequest)).toEqual({
+      status: "alreadyElevated",
+    });
+
+    restartAsAdministratorMock.mockResolvedValue({
+      launched: false,
+      reason: "unsupportedPlatform",
+    });
+    expect(await requestElevatedRestart(menuRequest)).toEqual({
+      status: "unsupported",
+    });
+  });
+
+  it("never throws — a rejected invoke becomes a failure outcome", async () => {
+    restartAsAdministratorMock.mockRejectedValue(
+      new Error("the elevation restore ticket could not be prepared"),
+    );
+
+    expect(await requestElevatedRestart(menuRequest)).toEqual({
+      status: "failed",
+      message: "the elevation restore ticket could not be prepared",
+    });
+  });
+
+  it("collapses duplicate clicks into a single backend request", async () => {
+    let release: (value: { launched: boolean; reason: "launched" }) => void =
+      () => {};
+    restartAsAdministratorMock.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    const first = requestElevatedRestart(menuRequest);
+    const second = await requestElevatedRestart(menuRequest);
+
+    // The second click is refused outright rather than queued behind the first,
+    // so the user cannot stack UAC prompts.
+    expect(second).toEqual({ status: "busy" });
+    expect(restartAsAdministratorMock).toHaveBeenCalledOnce();
+
+    release({ launched: true, reason: "launched" });
+    expect(await first).toEqual({ status: "launched" });
+  });
+
+  it("allows a fresh request once the previous one settles", async () => {
+    restartAsAdministratorMock.mockResolvedValue({
+      launched: false,
+      reason: "elevationCancelled",
+    });
+
+    await requestElevatedRestart(menuRequest);
+    await requestElevatedRestart(menuRequest);
+
+    expect(restartAsAdministratorMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("offers elevation only on a supported, non-elevated platform", () => {
+    expect(canOfferElevation(state())).toBe(true);
+    expect(canOfferElevation(state({ isElevated: true }))).toBe(false);
+    expect(canOfferElevation(state({ platformSupported: false }))).toBe(false);
+    expect(canOfferElevation(null)).toBe(false);
+  });
+
+  it("stops offering elevation once a restored retry was attempted", () => {
+    expect(canOfferElevation(state())).toBe(true);
+
+    markElevationRetryAttempted();
+
+    // This is the loop guard: a restored source that is still denied must not
+    // produce a second elevation prompt.
+    expect(canOfferElevation(state())).toBe(false);
+  });
+
+  it("returns null rather than throwing when the elevation probe fails", async () => {
+    getAppElevationStateMock.mockRejectedValue(new Error("probe failed"));
+
+    expect(await readElevationState()).toBeNull();
+  });
+
+  it("passes through a successful elevation probe", async () => {
+    getAppElevationStateMock.mockResolvedValue(state({ isElevated: true }));
+
+    expect(await readElevationState()).toEqual(state({ isElevated: true }));
+  });
+
+  it("describes every outcome", () => {
+    expect(describeElevationOutcome({ status: "launched" })).toContain(
+      "requested",
+    );
+    expect(describeElevationOutcome({ status: "cancelled" })).toContain(
+      "cancelled",
+    );
+    expect(describeElevationOutcome({ status: "alreadyElevated" })).toContain(
+      "already running as administrator",
+    );
+    expect(describeElevationOutcome({ status: "unsupported" })).toContain(
+      "Windows",
+    );
+    expect(describeElevationOutcome({ status: "busy" })).toContain(
+      "already in progress",
+    );
+    expect(
+      describeElevationOutcome({ status: "failed", message: "disk full" }),
+    ).toBe("disk full");
+  });
+});

--- a/src/lib/elevation.ts
+++ b/src/lib/elevation.ts
@@ -1,0 +1,157 @@
+/**
+ * Application-wide elevation coordinator.
+ *
+ * One owner for "restart as administrator" across the whole app. The global
+ * menu, the Access Denied recovery prompt, and the ESP coverage banner all call
+ * `requestElevatedRestart` rather than each holding their own relaunch state.
+ *
+ * The backend does the security work: it validates the request, mints a
+ * single-use restore ticket, and exits the current process only after Windows
+ * confirms the elevated child started. This module's job is to make sure the
+ * user is asked exactly once, that concurrent requests collapse into one, and
+ * that a restored retry cannot start an elevation loop.
+ */
+
+import type {
+  AppElevationState,
+  ElevationRequest,
+} from "../types/elevation";
+import { getAppElevationState, restartAsAdministrator } from "./commands";
+
+export type {
+  AppElevationState,
+  ElevationReason,
+  ElevationRequest,
+  RelaunchReason,
+  RelaunchResult,
+  RestoreTarget,
+  RestoreTicket,
+} from "../types/elevation";
+
+/**
+ * What the caller should tell the user.
+ *
+ * `launched` is terminal: the process is about to exit, so a caller should stop
+ * rather than render a result the user will never see.
+ */
+export type ElevationOutcome =
+  | { status: "launched" }
+  | { status: "alreadyElevated" }
+  | { status: "cancelled" }
+  | { status: "unsupported" }
+  | { status: "busy" }
+  | { status: "failed"; message: string };
+
+/**
+ * Collapses concurrent requests.
+ *
+ * A double-clicked button, or a menu action racing a recovery prompt, must
+ * produce one UAC prompt. The backend enforces this too; this is the cheap
+ * front line that also keeps the UI honest.
+ */
+let inFlight: Promise<ElevationOutcome> | null = null;
+
+/**
+ * Set once a restored source has been retried, so a second failure offers
+ * troubleshooting rather than another elevation prompt.
+ */
+let retryAttempted = false;
+
+/** Records that this session already came back from an elevated restart. */
+export function markElevationRetryAttempted(): void {
+  retryAttempted = true;
+}
+
+/**
+ * Whether an Access Denied failure may still offer elevation.
+ *
+ * False once a restored retry has been attempted: that is the loop guard.
+ */
+export function canOfferElevation(state: AppElevationState | null): boolean {
+  if (retryAttempted) return false;
+  if (!state) return false;
+  return state.platformSupported && !state.isElevated;
+}
+
+/** Read the current elevation capability, or null when the probe fails. */
+export async function readElevationState(): Promise<AppElevationState | null> {
+  try {
+    return await getAppElevationState();
+  } catch (error) {
+    console.warn("[elevation] unable to read elevation state", { error });
+    return null;
+  }
+}
+
+/**
+ * Ask the backend to relaunch elevated.
+ *
+ * Never throws: every failure is reported as an outcome so callers can render
+ * one consistent message instead of each inventing its own catch block.
+ */
+export async function requestElevatedRestart(
+  request: ElevationRequest,
+): Promise<ElevationOutcome> {
+  if (inFlight) return { status: "busy" };
+
+  const attempt = (async (): Promise<ElevationOutcome> => {
+    try {
+      const result = await restartAsAdministrator(request);
+      if (result.launched) return { status: "launched" };
+      switch (result.reason) {
+        case "elevationCancelled":
+          return { status: "cancelled" };
+        case "alreadyElevated":
+          return { status: "alreadyElevated" };
+        case "unsupportedPlatform":
+          return { status: "unsupported" };
+        default:
+          return {
+            status: "failed",
+            message: "Administrator restart could not be started.",
+          };
+      }
+    } catch (error) {
+      return {
+        status: "failed",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Administrator restart could not be started.",
+      };
+    }
+  })();
+
+  inFlight = attempt;
+  try {
+    return await attempt;
+  } finally {
+    // Keep the guard set after a successful launch: the process is exiting and
+    // a late click must not start a second request during teardown.
+    inFlight = null;
+  }
+}
+
+/** Human-readable status text for the outcomes a caller may still be around to show. */
+export function describeElevationOutcome(outcome: ElevationOutcome): string {
+  switch (outcome.status) {
+    case "launched":
+      return "Administrator restart requested.";
+    case "alreadyElevated":
+      return "CMTrace Open is already running as administrator.";
+    case "cancelled":
+      return "Administrator restart was cancelled.";
+    case "unsupported":
+      return "Restarting as administrator is only supported on Windows.";
+    case "busy":
+      return "An administrator restart is already in progress.";
+    case "failed":
+      return outcome.message;
+  }
+}
+
+/** Test-only reset so module-level guards do not leak between cases. */
+export function resetElevationCoordinatorForTests(): void {
+  inFlight = null;
+  retryAttempted = false;
+}

--- a/src/types/elevation.ts
+++ b/src/types/elevation.ts
@@ -52,6 +52,37 @@ export interface RelaunchResult {
 }
 
 /**
+ * Which source operation was refused.
+ *
+ * Mirrors `SourceOperation` in `src-tauri/src/source_access.rs`.
+ */
+export type SourceOperation =
+  | "readFile"
+  | "listFolder"
+  | "openKnownSource"
+  | "workspaceAction";
+
+/** Bounded identification of the source that was refused. */
+export type SourceContext =
+  | { kind: "path"; path: string }
+  | { kind: "knownSource"; sourceId: string };
+
+/**
+ * A structurally classified source failure.
+ *
+ * This is the whole reason the backend serializes one error variant as an
+ * object: the recovery prompt must never be gated on matching localized OS
+ * text like "Access is denied" or "os error 5".
+ */
+export interface SourceAccessDenied {
+  kind: "accessDenied";
+  operation: SourceOperation;
+  context?: SourceContext;
+  /** Safe, app-authored text — never the raw OS message. */
+  message: string;
+}
+
+/**
  * The claimed restore ticket, as read back by the elevated process.
  *
  * Mirrors `RestoreTicket` in `src-tauri/src/elevation/restore_ticket.rs`. The

--- a/src/types/elevation.ts
+++ b/src/types/elevation.ts
@@ -1,0 +1,71 @@
+/**
+ * Wire types for application-wide elevation.
+ *
+ * These mirror `src-tauri/src/elevation/` exactly. They live apart from the
+ * coordinator in `src/lib/elevation.ts` so the command wrappers can reference
+ * them without importing the coordinator that calls those wrappers.
+ */
+
+import type { WorkspaceId } from "./log";
+
+/** Why elevation was requested. Drives confirmation copy, never permissions. */
+export type ElevationReason =
+  | "explicitMenu"
+  | "accessDenied"
+  | "coverageRecommended";
+
+/**
+ * The source intent to reopen after elevation.
+ *
+ * Exactly one source travels with a request. Other tabs, filters, searches,
+ * and selected rows are deliberately not restored.
+ */
+export type RestoreTarget =
+  | { kind: "workspace" }
+  | { kind: "file"; path: string }
+  | { kind: "folder"; path: string; aggregate?: boolean }
+  | { kind: "knownSource"; sourceId: string };
+
+export interface ElevationRequest {
+  reason: ElevationReason;
+  workspace: WorkspaceId;
+  target: RestoreTarget;
+}
+
+export interface AppElevationState {
+  /** Elevation is only offered where the platform provides UAC. */
+  platformSupported: boolean;
+  isElevated: boolean;
+  /** Present when the elevation state could not be determined. */
+  detail?: string;
+}
+
+export type RelaunchReason =
+  | "launched"
+  | "alreadyElevated"
+  | "elevationCancelled"
+  | "unsupportedPlatform";
+
+export interface RelaunchResult {
+  launched: boolean;
+  reason: RelaunchReason;
+}
+
+/**
+ * The claimed restore ticket, as read back by the elevated process.
+ *
+ * Mirrors `RestoreTicket` in `src-tauri/src/elevation/restore_ticket.rs`. The
+ * backend has already validated every field; the frontend still treats
+ * `workspace` as advisory and routes it through the normal availability check.
+ */
+export interface RestoreTicket {
+  schemaVersion: number;
+  ticketId: string;
+  createdAtMs: number;
+  originPid: number;
+  workspace: WorkspaceId;
+  target: RestoreTarget;
+  reason: ElevationReason;
+  /** Always true on a restored request, so a second failure cannot re-prompt. */
+  retryAttempted: boolean;
+}

--- a/src/workspaces/esp-diagnostics/ElevationBanner.tsx
+++ b/src/workspaces/esp-diagnostics/ElevationBanner.tsx
@@ -4,7 +4,7 @@ import {
   ShieldArrowRightRegular,
   WarningShieldRegular,
 } from "@fluentui/react-icons";
-import { restartEspAsAdministrator } from "../../lib/commands";
+import { requestElevatedRestart } from "../../lib/elevation";
 import {
   LOG_MONOSPACE_FONT_FAMILY,
   LOG_UI_FONT_FAMILY,
@@ -22,19 +22,28 @@ export function ElevationBanner({ elevation }: ElevationBannerProps) {
 
   if (elevation.isElevated) return null;
 
+  // The banner is a coverage recommendation, not a source retry: it restores
+  // the workspace and nothing else. All relaunch behaviour lives in the shared
+  // coordinator, which never throws and collapses concurrent requests.
   const restart = async () => {
     setActionState("requesting");
-    try {
-      const result = await restartEspAsAdministrator();
-      setActionState(
-        result.launched
-          ? "requested"
-          : result.reason === "elevationCancelled"
-            ? "cancelled"
-            : "failed",
-      );
-    } catch {
-      setActionState("failed");
+    const outcome = await requestElevatedRestart({
+      reason: "coverageRecommended",
+      workspace: "esp-diagnostics",
+      target: { kind: "workspace" },
+    });
+    switch (outcome.status) {
+      case "launched":
+        setActionState("requested");
+        break;
+      case "cancelled":
+        setActionState("cancelled");
+        break;
+      case "alreadyElevated":
+        setActionState("idle");
+        break;
+      default:
+        setActionState("failed");
     }
   };
 

--- a/src/workspaces/esp-diagnostics/EspDiagnosticsWorkspace.test.tsx
+++ b/src/workspaces/esp-diagnostics/EspDiagnosticsWorkspace.test.tsx
@@ -1189,7 +1189,7 @@ describe("ESP elevation recommendation", () => {
       if (cmd === "get_esp_elevation_state") {
         return { isElevated: false, restartSupported: true, restrictedSources: [] };
       }
-      if (cmd === "restart_esp_as_administrator") {
+      if (cmd === "restart_as_administrator") {
         return { launched: true, reason: "launched" };
       }
       return undefined;
@@ -1219,11 +1219,17 @@ describe("ESP elevation recommendation", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "Restart as administrator" }),
     );
+    // The banner is a coverage recommendation, so it restores the workspace
+    // and carries no source: it must go through the generic elevation command
+    // rather than owning an ESP-specific relaunch.
     await waitFor(() =>
-      expect(vi.mocked(invoke)).toHaveBeenCalledWith(
-        "restart_esp_as_administrator",
-        undefined,
-      ),
+      expect(vi.mocked(invoke)).toHaveBeenCalledWith("restart_as_administrator", {
+        request: {
+          reason: "coverageRecommended",
+          workspace: "esp-diagnostics",
+          target: { kind: "workspace" },
+        },
+      }),
     );
     expect(
       screen.getByText("Administrator restart requested."),


### PR DESCRIPTION
Implements the backend, frontend, and menu surface of #376.

## What this does

Generalizes the ESP-specific relaunch into one application-owned elevation
mechanism any workspace can use. Before this, `src-tauri/src/esp/relaunch.rs`
owned the only `ShellExecute`/`runas` implementation, always routed to
`esp-diagnostics`, and deliberately discarded every file path — so a user who
hit a protected source anywhere else had to know to close the app and relaunch
it themselves.

### Backend

- `elevation/mod.rs` — the validated request contract. `AppWorkspace` mirrors the
  frontend `WorkspaceId` union as an allowlist; a `RestoreTarget` carries at most
  one bounded, absolute, control-character-free path or one conservative catalog id.
- `elevation/relaunch.rs` — platform mechanics, with no dependency on any product
  module so it survives `esp-diagnostics` being compiled out. Child arguments are
  rebuilt from nothing: fixed `runas` verb, current executable, and at most one
  validated `--elevation-restore=<uuid>`.
- `elevation/restore_ticket.rs` — the handoff. The child gets only an opaque id;
  the typed intent lives in a schema-versioned, expiring, size-bounded file under
  an app-owned per-user directory. Claimed by rename so it is consumed exactly
  once, refuses symlinks and non-regular files, and is re-validated on read
  because per-user storage is still untrusted input.
- The Windows token elevation probe moves out of the ESP system provider so there
  is one owner.

### Frontend

- `src/lib/elevation.ts` is the single coordinator. It never throws — every
  failure, cancellation, and unsupported platform is an outcome — and concurrent
  requests collapse, so UAC prompts cannot stack.
- Startup routing applies the documented precedence: positional file paths, then
  a valid restore ticket, then the legacy workspace argument, then default.
- A ticket restores one workspace and at most one source. Other tabs, filters,
  searches, and selected rows are not restored.
- `markElevationRetryAttempted` fires before restoration, so a restored source
  that is still denied offers troubleshooting rather than a second prompt.

### Menu

`File > Restart as Administrator…` on Windows only, in its own group above Exit.
Absent on macOS and Linux rather than shown disabled: muda has no `set_visible`,
so an action that can never apply must not be appended at all. Confirmation is
requested before the backend is touched, so UAC cannot appear without a click.

## Verification

```
cargo test --locked --manifest-path src-tauri/Cargo.toml --lib   481 passed
cargo clippy --locked --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings   clean
npx tsc --noEmit    clean
npm test -- --run   553 passed
```

## Deliberately not done

- **Structured Access Denied classification and the recovery prompt.** The issue
  requires the frontend not to decide on elevation by matching localized strings,
  which needs a typed classification on the shared log-source loading path.
  `AppError` currently serializes to a plain string via `InvokeError::from`, so
  this needs its own change rather than being bolted on here.
- **Documentation** (issue phase 7).
- **Native Windows acceptance pass.** Cannot be run from this macOS host; the
  Windows-gated code is covered by `#[cfg(target_os = "windows")]` unit tests that
  only execute in CI's Windows job.

## Assumptions

- `cargo fmt --check` is not a CI gate here and the tree has pre-existing drift, so
  only files this PR creates were formatted. Unrelated files are untouched on purpose.
- ESP's `restart_esp_as_administrator` command is left in place for now; the banner
  already routes through the generic coordinator, so there is one backend behavior
  owner even though the old command still exists.

Refs #376
