### PR TITLE
feat(intune): land the parser-family skeleton for epic #356

### DIFF
--- a/.github/workflows/cmtrace-ci.yml
+++ b/.github/workflows/cmtrace-ci.yml
@@ -70,6 +70,18 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy --all-targets -- -D warnings
 
+      # Every step above runs with working-directory: src-tauri, which selects
+      # only the cmtrace-open package. The parser crate's own test targets were
+      # therefore never built or run here, and its source was never linted: the
+      # sole parser test in CI was the Windows-only `--test esp_diagnostics` job.
+      # These two steps close that gap once, so each workload leaf added under
+      # epic #356 is gated without touching this workflow.
+      - name: Parser crate tests
+        run: cargo test --locked -p cmtraceopen-parser
+
+      - name: Parser crate clippy
+        run: cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings
+
       - name: Install cargo-deny and cargo-audit
         uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -26,17 +26,19 @@ docs/
 # Brainstorming artifacts
 .superpowers/
 
-# Test logs
-Logs/
-
-# ...but not source. `Logs/` is matched case-insensitively on macOS and Windows,
-# so it silently swallowed the `logs` leaf modules of the Intune Company Portal
-# tree (epic #356). Those built locally, where the untracked files still exist,
-# and would have failed on a fresh checkout the moment a parent `mod.rs`
-# declared `pub mod logs;`. Re-include the directories first: git cannot
-# re-include a file whose parent directory is still excluded.
-!crates/cmtraceopen-parser/src/**/logs/
-!crates/cmtraceopen-parser/src/**/logs/**
+# Test logs, at the repository root only.
+#
+# Anchored deliberately. Unanchored, `Logs/` matches at every depth, and macOS
+# and Windows match it case-insensitively, so it also swallowed the `logs` leaf
+# modules of the Intune Company Portal tree (epic #356) and would have swallowed
+# their fixture corpora under tests/fixtures/ too. Those build locally, where the
+# untracked files still exist, and break on a fresh checkout the moment a parent
+# `mod.rs` declares `pub mod logs;`.
+#
+# Anchoring fixes the whole class. Per-path negations do not: they only cover the
+# directories someone remembered, and git cannot re-include a file whose parent
+# directory is still excluded.
+/Logs/
 
 # Playwright artifacts (HTML reports, run results, MCP browser session output)
 playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,15 @@ docs/
 # Test logs
 Logs/
 
+# ...but not source. `Logs/` is matched case-insensitively on macOS and Windows,
+# so it silently swallowed the `logs` leaf modules of the Intune Company Portal
+# tree (epic #356). Those built locally, where the untracked files still exist,
+# and would have failed on a fresh checkout the moment a parent `mod.rs`
+# declared `pub mod logs;`. Re-include the directories first: git cannot
+# re-include a file whose parent directory is still excluded.
+!crates/cmtraceopen-parser/src/**/logs/
+!crates/cmtraceopen-parser/src/**/logs/**
+
 # Playwright artifacts (HTML reports, run results, MCP browser session output)
 playwright-report/
 test-results/

--- a/crates/cmtraceopen-parser/src/intune/apps/macos/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/apps/macos/mod.rs
@@ -1,0 +1,4 @@
+//! Intune macOS application workloads.
+
+pub mod pkg;
+pub mod shell_scripts;

--- a/crates/cmtraceopen-parser/src/intune/apps/macos/pkg/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/apps/macos/pkg/mod.rs
@@ -1,0 +1,10 @@
+//! Intune macOS package deployment evidence.
+//!
+//! Owner: issue #361 of epic #356. Implementation pending.
+//!
+//! Shares a raw record parser with shell scripts, but reduces separately because package phases and terminal semantics differ.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #361 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/apps/macos/shell_scripts/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/apps/macos/shell_scripts/mod.rs
@@ -1,0 +1,10 @@
+//! Intune macOS shell-script execution evidence.
+//!
+//! Owner: issue #361 of epic #356. Implementation pending.
+//!
+//! Shares a raw record parser with package deployment, but reduces separately because script phases and terminal semantics differ.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #361 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/apps/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/apps/mod.rs
@@ -4,4 +4,5 @@
 //! single "app" state machine, because a platform script, a remediation pair,
 //! and a Win32 installer reach terminal states for different reasons.
 
+pub mod macos;
 pub mod windows;

--- a/crates/cmtraceopen-parser/src/intune/apps/windows/microsoft_store/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/apps/windows/microsoft_store/mod.rs
@@ -1,0 +1,10 @@
+//! Intune-managed Microsoft Store app evidence.
+//!
+//! Owner: issue #358 of epic #356. Implementation pending.
+//!
+//! Separates UWP/MSIX, provisioned AppX, and Store-delivered Win32 packages rather than assuming one installer grammar.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #358 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/apps/windows/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/apps/windows/mod.rs
@@ -3,4 +3,7 @@
 //! These modules are pure: they consume artifacts the caller already read and
 //! decoded, and they never touch the filesystem, registry, or network.
 
+pub mod microsoft_store;
+pub mod remediations;
 pub mod scripts;
+pub mod win32;

--- a/crates/cmtraceopen-parser/src/intune/apps/windows/remediations/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/apps/windows/remediations/mod.rs
@@ -1,0 +1,10 @@
+//! Intune Windows detection and remediation script evidence.
+//!
+//! Owner: issue #360 of epic #356. Implementation pending.
+//!
+//! Models the paired detection/remediation lifecycle and post-remediation state.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #360 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/apps/windows/win32/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/apps/windows/win32/mod.rs
@@ -1,0 +1,10 @@
+//! Intune Win32 app deployment transactions.
+//!
+//! Owner: issue #357 of epic #356. Implementation pending.
+//!
+//! Explains where a deployment stopped across assignment, applicability, requirements, dependencies, content, detection, enforcement, post-install detection, and reporting.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #357 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/device/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/mod.rs
@@ -1,0 +1,3 @@
+//! Intune device-management workloads.
+
+pub mod windows;

--- a/crates/cmtraceopen-parser/src/intune/device/windows/compliance/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/compliance/mod.rs
@@ -1,0 +1,10 @@
+//! Intune device compliance evaluation and reporting evidence.
+//!
+//! Owner: issue #364 of epic #356. Implementation pending.
+//!
+//! Does not equate Conditional Access denial, stale cloud state, or missing user evaluation with a failed local setting.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #364 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/mod.rs
@@ -1,0 +1,10 @@
+//! Intune/MDM configuration policy evidence.
+//!
+//! Owner: issue #363 of epic #356. Implementation pending.
+//!
+//! Explains whether a setting was delivered, processed by its CSP, applied, rejected, conflicted, superseded, or left unresolved.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #363 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs
@@ -1,0 +1,10 @@
+//! Intune Device Inventory agent log family.
+//!
+//! Owner: issue #354 of epic #356. Implementation pending.
+//!
+//! Reserved by the skeleton; issue #354 has in-flight work on branch `codex/intune-device-inventory` and is not part of the current batch.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #354 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/device/windows/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/mod.rs
@@ -1,0 +1,6 @@
+//! Intune Windows device workloads.
+
+pub mod compliance;
+pub mod configuration;
+pub mod inventory;
+pub mod updates;

--- a/crates/cmtraceopen-parser/src/intune/device/windows/updates/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/updates/mod.rs
@@ -1,0 +1,10 @@
+//! Windows Update for Business evidence under Intune management.
+//!
+//! Owner: issue #365 of epic #356. Implementation pending.
+//!
+//! Separates 'Intune delivered update settings' from 'Windows scanned, downloaded, or installed an update'.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #365 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/enrollment/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/mod.rs
@@ -1,0 +1,3 @@
+//! Intune enrollment workloads.
+
+pub mod windows;

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/mod.rs
@@ -1,0 +1,10 @@
+//! Windows Autopilot identity, profile, and OOBE evidence outside ESP.
+//!
+//! Owner: issue #362 of epic #356. Implementation pending.
+//!
+//! ESP remains a sibling reducer in `crate::esp` and may be correlated through explicit enrollment/session keys; it is not renamed into Autopilot.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #362 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/mod.rs
@@ -1,0 +1,3 @@
+//! Intune Windows enrollment workloads.
+
+pub mod autopilot;

--- a/crates/cmtraceopen-parser/src/intune/evidence.rs
+++ b/crates/cmtraceopen-parser/src/intune/evidence.rs
@@ -1,0 +1,383 @@
+//! Shared evidence, provenance, coverage, and finding contracts for the Intune
+//! parser family (epic #356).
+//!
+//! Every workload leaf under `intune::{apps, enrollment, device, portal}` emits
+//! observations that carry an [`IntuneObservationContext`]. That envelope is what
+//! lets a result distinguish *absent*, *inaccessible*, *capped*, *skipped*,
+//! *unsupported*, and *malformed* evidence from a successful workload, instead of
+//! silently collapsing all six into "no data".
+//!
+//! The shape deliberately mirrors `crate::esp` so that the two trees stay legible
+//! side by side, but the types are separate: ESP's schema is stable and versioned
+//! on its own cadence, and coupling the families would make either one hard to
+//! evolve.
+//!
+//! This module is owned by the parser-family skeleton. Workload leaves consume it
+//! and must not need to modify it; see the note on additive extension at the
+//! bottom of this file.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Schema version for every type in this module.
+///
+/// Bump only on a breaking change. Adding an optional field, or a variant to a
+/// [`intune_raw_preserving_string_enum`] enum, is additive and does not bump it.
+pub const INTUNE_EVIDENCE_SCHEMA_VERSION: u32 = 1;
+
+/// Define an enum whose wire form round-trips values it does not recognize.
+///
+/// Microsoft's vocabularies grow without warning. An unrecognized status must
+/// survive a decode/encode cycle verbatim rather than becoming `Unknown` and
+/// losing the original token, because the raw token is often the only evidence a
+/// human has to work from.
+macro_rules! intune_raw_preserving_string_enum {
+    (
+        $(#[$meta:meta])*
+        pub enum $name:ident {
+            $($variant:ident => $wire_value:literal),+ $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        pub enum $name {
+            $($variant,)+
+            /// A wire value this build does not recognize, preserved verbatim.
+            Unknown(String),
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                let value = match self {
+                    $(Self::$variant => $wire_value,)+
+                    Self::Unknown(raw) => raw.as_str(),
+                };
+
+                serializer.serialize_str(value)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let raw = String::deserialize(deserializer)?;
+                Ok(match raw.as_str() {
+                    $($wire_value => Self::$variant,)+
+                    _ => Self::Unknown(raw),
+                })
+            }
+        }
+    };
+}
+
+// Re-exported for the workload leaves of epic #356, which parse Microsoft
+// vocabularies that grow over time and need the same round-tripping behavior.
+// It has no in-crate consumer besides `IntuneSourceKind` below until the first
+// leaf lands, and an unused re-export is a hard error under `-D warnings`.
+#[allow(unused_imports)]
+pub(crate) use intune_raw_preserving_string_enum;
+
+intune_raw_preserving_string_enum! {
+    /// The kind of artifact an observation was read from.
+    ///
+    /// Unrecognized kinds round-trip so a leaf can introduce a source without
+    /// editing this shared enum.
+    pub enum IntuneSourceKind {
+        ImeLog => "imeLog",
+        CcmLog => "ccmLog",
+        AgentLog => "agentLog",
+        PlainTextLog => "plainTextLog",
+        Registry => "registry",
+        EventLog => "eventLog",
+        Json => "json",
+        UnifiedLog => "unifiedLog",
+        DiagnosticReport => "diagnosticReport",
+        SuppliedFact => "suppliedFact",
+        Graph => "graph",
+        Coverage => "coverage",
+    }
+}
+
+/// How a source timestamp was expressed before normalization.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum IntuneTimestampKind {
+    Utc,
+    Offset,
+    Local,
+    Unspecified,
+    Invalid,
+}
+
+/// A timestamp that keeps its original text alongside the normalized value.
+///
+/// The raw text is retained because Intune logs mix local time, explicit offsets,
+/// and bare wall-clock strings; discarding the original makes a wrong timezone
+/// inference impossible to audit after the fact.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IntuneTimestamp {
+    pub raw_text: String,
+    pub original_offset: Option<String>,
+    pub normalized_utc: Option<String>,
+    pub kind: IntuneTimestampKind,
+}
+
+/// A stable pointer to one observation, used by findings and coverage entries.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub struct IntuneEvidenceRef {
+    pub evidence_id: String,
+    pub source_artifact_id: String,
+}
+
+/// Registry location an observation came from, when the source is a registry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IntuneRegistryProvenance {
+    pub hive: String,
+    pub key: String,
+    pub value_name: Option<String>,
+}
+
+/// Event-log coordinates an observation came from, when the source is an event log.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IntuneEventProvenance {
+    pub channel: String,
+    pub provider: String,
+    pub event_id: u32,
+    pub record_id: Option<u64>,
+}
+
+/// Where an observation physically came from.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IntuneProvenance {
+    pub source_kind: IntuneSourceKind,
+    pub source_artifact_id: String,
+    pub file_path: Option<String>,
+    pub line_number: Option<u64>,
+    pub record_number: Option<u64>,
+    pub registry: Option<IntuneRegistryProvenance>,
+    pub event: Option<IntuneEventProvenance>,
+}
+
+/// Privacy classification governing whether a value may appear in an export.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum IntuneSensitivity {
+    Public,
+    Sensitive,
+    Restricted,
+}
+
+/// Whether the record was understood, and if not, how it failed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum IntuneParseState {
+    Parsed,
+    Raw,
+    Malformed,
+    Unsupported,
+}
+
+/// Whether the underlying artifact could be read at all.
+///
+/// `Capped` and `Skipped` are distinct from `Missing` on purpose: a truncated or
+/// deliberately skipped source means the absence of a signal proves nothing,
+/// whereas a genuinely missing artifact is itself a diagnostic fact.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum IntuneAccessState {
+    Available,
+    Missing,
+    PermissionDenied,
+    Capped,
+    Skipped,
+    Failed,
+    Unsupported,
+}
+
+/// The uniform envelope every workload observation carries.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IntuneObservationContext {
+    pub evidence_ref: IntuneEvidenceRef,
+    pub provenance: IntuneProvenance,
+    pub source_timestamp: Option<IntuneTimestamp>,
+    pub observed_at_utc: String,
+    pub sensitivity: IntuneSensitivity,
+    pub parse_state: IntuneParseState,
+    pub access_state: IntuneAccessState,
+}
+
+/// A name/value pair carried without interpretation.
+///
+/// Leaves use this to retain fields they do not model yet, so that adding a typed
+/// field later is a widening change rather than a re-parse.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IntuneNamedValue {
+    pub name: String,
+    pub value: String,
+}
+
+/// A return/exit/error token, kept in every form it was observed in.
+///
+/// Intune surfaces the same failure as a signed decimal, an unsigned decimal, and
+/// a hex HRESULT depending on the artifact. Storing the raw token plus both
+/// derived forms avoids assigning a meaning the evidence does not carry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IntuneErrorCode {
+    pub raw: String,
+    pub decimal: Option<i64>,
+    pub hex: Option<String>,
+}
+
+/// Whether an expected artifact was usable.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum IntuneArtifactStatus {
+    Available,
+    Missing,
+    PermissionDenied,
+    Capped,
+    Skipped,
+    ParseFailed,
+    Unsupported,
+}
+
+/// One expected artifact and what became of it.
+///
+/// Coverage is emitted for artifacts that were *not* read as well as those that
+/// were; a finding may then cite a coverage gap instead of overclaiming.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IntuneArtifactCoverage {
+    pub artifact_id: String,
+    pub family: String,
+    pub status: IntuneArtifactStatus,
+    pub detail: Option<String>,
+    pub observed_at_utc: String,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+/// How serious a finding is.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum IntuneFindingSeverity {
+    Info,
+    Warning,
+    Error,
+    Blocker,
+}
+
+/// How strongly the evidence supports a finding.
+///
+/// Kept separate from severity because a catastrophic outcome inferred from thin
+/// evidence and a minor one confirmed outright are different claims.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum IntuneFindingConfidence {
+    Low,
+    Medium,
+    High,
+}
+
+/// A conservative, evidence-backed conclusion.
+///
+/// Invariant every leaf must uphold: a finding carries at least one entry in
+/// `evidence` or at least one entry in `coverage_gap_ids`. A finding backed by
+/// neither is an assertion, not a diagnosis.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IntuneFinding {
+    pub finding_id: String,
+    pub severity: IntuneFindingSeverity,
+    pub confidence: IntuneFindingConfidence,
+    pub title: String,
+    pub summary: String,
+    pub recommended_checks: Vec<String>,
+    pub evidence: Vec<IntuneEvidenceRef>,
+    pub coverage_gap_ids: Vec<String>,
+}
+
+impl IntuneFinding {
+    /// Whether this finding cites anything at all.
+    ///
+    /// Leaves should assert this in their own contract tests rather than relying
+    /// on review to catch an uncited finding.
+    pub fn is_evidence_backed(&self) -> bool {
+        !self.evidence.is_empty() || !self.coverage_gap_ids.is_empty()
+    }
+}
+
+// Extending this module from a workload leaf:
+//
+// Prefer `IntuneSourceKind::Unknown("...")` and `IntuneNamedValue` over new
+// shared types; both round-trip and neither requires touching this file. If a
+// genuinely shared concept is missing, append a variant at the end of the
+// relevant enum or an `Option<T>` field at the end of the relevant struct. Both
+// are additive, keep the schema version at 1, and produce a two-line merge rather
+// than a conflict if two branches do it at once.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_kind_round_trips_known_values() {
+        let encoded = serde_json::to_string(&IntuneSourceKind::ImeLog).unwrap();
+        assert_eq!(encoded, "\"imeLog\"");
+        let decoded: IntuneSourceKind = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, IntuneSourceKind::ImeLog);
+    }
+
+    #[test]
+    fn source_kind_preserves_unknown_values_verbatim() {
+        let decoded: IntuneSourceKind = serde_json::from_str("\"someFutureSource\"").unwrap();
+        assert_eq!(
+            decoded,
+            IntuneSourceKind::Unknown("someFutureSource".to_owned())
+        );
+        assert_eq!(
+            serde_json::to_string(&decoded).unwrap(),
+            "\"someFutureSource\""
+        );
+    }
+
+    #[test]
+    fn access_state_distinguishes_capped_and_skipped_from_missing() {
+        for (state, wire) in [
+            (IntuneAccessState::Missing, "\"missing\""),
+            (IntuneAccessState::Capped, "\"capped\""),
+            (IntuneAccessState::Skipped, "\"skipped\""),
+        ] {
+            assert_eq!(serde_json::to_string(&state).unwrap(), wire);
+        }
+    }
+
+    #[test]
+    fn finding_without_evidence_or_coverage_gap_is_not_evidence_backed() {
+        let mut finding = IntuneFinding {
+            finding_id: "f1".to_owned(),
+            severity: IntuneFindingSeverity::Error,
+            confidence: IntuneFindingConfidence::Low,
+            title: "t".to_owned(),
+            summary: "s".to_owned(),
+            recommended_checks: Vec::new(),
+            evidence: Vec::new(),
+            coverage_gap_ids: Vec::new(),
+        };
+        assert!(!finding.is_evidence_backed());
+
+        finding.coverage_gap_ids.push("gap".to_owned());
+        assert!(finding.is_evidence_backed());
+    }
+}

--- a/crates/cmtraceopen-parser/src/intune/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/mod.rs
@@ -1,9 +1,34 @@
+//! Intune log parsing and workload diagnostics.
+//!
+//! Two generations of module live here side by side.
+//!
+//! The flat modules (`event_tracker`, `download_stats`, `policy_parser`,
+//! `guid_registry`, `timeline`, `ime_parser`, `models`) are the original
+//! IME-centered surface. They remain public and behavior-compatible.
+//!
+//! The workload namespaces (`apps`, `enrollment`, `device`, `portal`) are the
+//! family described by epic #356, organized by what an administrator is actually
+//! troubleshooting rather than by which log file happens to hold the evidence.
+//! Leaves that are not yet implemented are reserved slots, each owned by exactly
+//! one child issue and filled in by that issue's own pull request.
+//!
+//! `evidence` and `normalized` hold the contracts shared across those leaves.
+//! They live here, not inside any one leaf, so that the child issues can be
+//! implemented and merged in any order.
+//!
+//! `ccm` stays the shared raw CMTrace-compatible grammar used by both IME and
+//! SCCM. Nothing in this tree adds a second raw CCM parser.
+
 pub mod apps;
+pub mod device;
 pub mod download_stats;
+pub mod enrollment;
 pub mod event_tracker;
+pub mod evidence;
 pub mod guid_registry;
 pub mod ime_parser;
 pub mod models;
+pub mod normalized;
 pub mod policy_parser;
 pub mod portal;
 pub mod timeline;

--- a/crates/cmtraceopen-parser/src/intune/normalized.rs
+++ b/crates/cmtraceopen-parser/src/intune/normalized.rs
@@ -1,0 +1,198 @@
+//! Platform-neutral normalized inputs shared by the Windows workload leaves.
+//!
+//! Issues #358, #363, #364, and #365 all need to reason over Windows event-log
+//! records and CSP/setting report rows. The native side of the product reads
+//! those from EVTX files, the live Windows event log, and MDM diagnostic reports,
+//! none of which can be represented in this crate: `evtx`, `windows`, and
+//! `winreg` are all excluded by the wasm32 invariant documented in `lib.rs`.
+//!
+//! So the boundary is drawn here. Native adapters decode their platform sources
+//! and hand the pure crate the normalized shapes below. The leaves then contain
+//! only pure reduction logic, which is what makes them testable from fixtures
+//! with no device present.
+//!
+//! This module is owned by the parser-family skeleton because four separate
+//! issues depend on it. If it lived in one of them, the other three could not
+//! merge until that one landed.
+
+use serde::{Deserialize, Serialize};
+
+use crate::intune::evidence::{IntuneErrorCode, IntuneNamedValue, IntuneObservationContext};
+
+/// Schema version for the normalized input contracts in this module.
+pub const INTUNE_NORMALIZED_SCHEMA_VERSION: u32 = 1;
+
+/// Severity level of a Windows event, as the platform reported it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum NormalizedEventLevel {
+    Critical,
+    Error,
+    Warning,
+    Information,
+    Verbose,
+    Unknown,
+}
+
+/// A Windows event-log record projected into a form this crate can consume.
+///
+/// Field choice follows what the four consuming issues actually key on:
+/// `provider` + `event_id` identify the signal, `record_id` orders records within
+/// a channel, `activity_id` correlates a multi-event operation, and `named_data`
+/// carries the event's payload without interpretation so a leaf can extract what
+/// it needs without this type growing a field per workload.
+///
+/// `message` is the already-rendered description. It is `Option` because
+/// rendering requires the provider's message resources, which are frequently
+/// unavailable when an EVTX file is read off-box.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NormalizedWindowsEvent {
+    pub context: IntuneObservationContext,
+    pub channel: String,
+    pub provider: String,
+    pub event_id: u32,
+    pub level: NormalizedEventLevel,
+    pub task: Option<String>,
+    pub keywords: Option<String>,
+    pub record_id: Option<u64>,
+    pub activity_id: Option<String>,
+    pub named_data: Vec<IntuneNamedValue>,
+    pub message: Option<String>,
+}
+
+/// Outcome the device reported for a single setting or policy row.
+///
+/// `NotApplicable` and `Unknown` are separate because "this device was never in
+/// scope" and "we could not tell" lead to different next steps.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum NormalizedSettingOutcome {
+    Applied,
+    Pending,
+    Failed,
+    Conflict,
+    Superseded,
+    NotApplicable,
+    Unknown,
+}
+
+/// One row of a CSP, configuration, or compliance report.
+///
+/// `setting_uri` is the OMA-DM node path when the source provides one; leaves
+/// that key on a policy or setting GUID instead use `setting_id`. Both are
+/// optional because different report sources supply different identifiers, and
+/// fabricating the missing one would invent a correlation key.
+///
+/// `value` is deliberately `Option<String>` and classified by the enclosing
+/// context's sensitivity: configuration values routinely contain tenant-specific
+/// data that must not reach a redacted export.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NormalizedSettingReport {
+    pub context: IntuneObservationContext,
+    pub setting_uri: Option<String>,
+    pub setting_id: Option<String>,
+    pub policy_id: Option<String>,
+    pub display_name: Option<String>,
+    pub outcome: NormalizedSettingOutcome,
+    pub value: Option<String>,
+    pub error: Option<IntuneErrorCode>,
+    pub named_data: Vec<IntuneNamedValue>,
+}
+
+// Extending this module from a workload leaf:
+//
+// Read anything not modeled here out of `named_data`, which is carried verbatim.
+// If a field is genuinely shared across leaves, append an `Option<T>` at the end
+// of the struct; that is additive, keeps the schema version at 1, and does not
+// disturb sibling branches.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intune::evidence::{
+        IntuneAccessState, IntuneEvidenceRef, IntuneParseState, IntuneProvenance, IntuneSensitivity,
+        IntuneSourceKind,
+    };
+
+    fn context() -> IntuneObservationContext {
+        IntuneObservationContext {
+            evidence_ref: IntuneEvidenceRef {
+                evidence_id: "e1".to_owned(),
+                source_artifact_id: "a1".to_owned(),
+            },
+            provenance: IntuneProvenance {
+                source_kind: IntuneSourceKind::EventLog,
+                source_artifact_id: "a1".to_owned(),
+                file_path: None,
+                line_number: None,
+                record_number: Some(7),
+                registry: None,
+                event: None,
+            },
+            source_timestamp: None,
+            observed_at_utc: "2026-07-31T00:00:00Z".to_owned(),
+            sensitivity: IntuneSensitivity::Public,
+            parse_state: IntuneParseState::Parsed,
+            access_state: IntuneAccessState::Available,
+        }
+    }
+
+    #[test]
+    fn windows_event_round_trips_through_json() {
+        let event = NormalizedWindowsEvent {
+            context: context(),
+            channel: "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin"
+                .to_owned(),
+            provider: "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider"
+                .to_owned(),
+            event_id: 404,
+            level: NormalizedEventLevel::Error,
+            task: None,
+            keywords: None,
+            record_id: Some(7),
+            activity_id: None,
+            named_data: vec![IntuneNamedValue {
+                name: "NodeUri".to_owned(),
+                value: "./Device/Vendor/MSFT/Policy".to_owned(),
+            }],
+            message: None,
+        };
+
+        let encoded = serde_json::to_string(&event).unwrap();
+        let decoded: NormalizedWindowsEvent = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, event);
+    }
+
+    #[test]
+    fn setting_report_keeps_unmodeled_fields_in_named_data() {
+        let report = NormalizedSettingReport {
+            context: context(),
+            setting_uri: Some("./Device/Vendor/MSFT/Policy/Config/Update".to_owned()),
+            setting_id: None,
+            policy_id: None,
+            display_name: None,
+            outcome: NormalizedSettingOutcome::Conflict,
+            value: None,
+            error: None,
+            named_data: vec![IntuneNamedValue {
+                name: "WinningPolicyId".to_owned(),
+                value: "00000000-0000-0000-0000-000000000001".to_owned(),
+            }],
+        };
+
+        let decoded: NormalizedSettingReport =
+            serde_json::from_str(&serde_json::to_string(&report).unwrap()).unwrap();
+        assert_eq!(decoded.named_data.len(), 1);
+        assert_eq!(decoded.outcome, NormalizedSettingOutcome::Conflict);
+    }
+
+    #[test]
+    fn setting_outcome_wire_values_are_camel_case() {
+        assert_eq!(
+            serde_json::to_string(&NormalizedSettingOutcome::NotApplicable).unwrap(),
+            "\"notApplicable\""
+        );
+    }
+}

--- a/crates/cmtraceopen-parser/src/intune/portal/android/company_portal/diagnostics/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/android/company_portal/diagnostics/mod.rs
@@ -1,0 +1,10 @@
+//! Android Company Portal imported diagnostic artifacts.
+//!
+//! Owner: issue #371 of epic #356. Implementation pending.
+//!
+//! No stable parser is exposed until a sanitized artifact contract is documented. Archive extraction safety lives outside the parser.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #371 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/portal/android/company_portal/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/android/company_portal/mod.rs
@@ -1,0 +1,3 @@
+//! Android Company Portal application evidence.
+
+pub mod diagnostics;

--- a/crates/cmtraceopen-parser/src/intune/portal/android/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/android/mod.rs
@@ -1,0 +1,3 @@
+//! Android Company Portal evidence.
+
+pub mod company_portal;

--- a/crates/cmtraceopen-parser/src/intune/portal/ios_ipados/company_portal/diagnostics/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/ios_ipados/company_portal/diagnostics/mod.rs
@@ -1,0 +1,10 @@
+//! iOS/iPadOS Company Portal Console diagnostic captures.
+//!
+//! Owner: issue #372 of epic #356. Implementation pending.
+//!
+//! Plain-text troubleshooting captures exported from the macOS Console app while a device reproduces the problem.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #372 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/portal/ios_ipados/company_portal/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/ios_ipados/company_portal/mod.rs
@@ -1,0 +1,3 @@
+//! iOS and iPadOS Company Portal application evidence.
+
+pub mod diagnostics;

--- a/crates/cmtraceopen-parser/src/intune/portal/ios_ipados/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/ios_ipados/mod.rs
@@ -1,0 +1,3 @@
+//! iOS and iPadOS Company Portal evidence.
+
+pub mod company_portal;

--- a/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/diagnostics/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/diagnostics/mod.rs
@@ -1,0 +1,10 @@
+//! macOS Company Portal saved diagnostic reports.
+//!
+//! Owner: issue #369 of epic #356. Implementation pending.
+//!
+//! Separate from direct app logs because the saved report may be an archive or multi-artifact package with its own schema. Archive I/O stays outside the pure parser.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #369 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/logs/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/logs/mod.rs
@@ -1,0 +1,10 @@
+//! macOS Company Portal direct app log parser.
+//!
+//! Owner: issue #368 of epic #356. Implementation pending.
+//!
+//! Covers files discovered under `~/Library/Logs/CompanyPortal/`.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #368 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/mod.rs
@@ -1,0 +1,5 @@
+//! macOS Company Portal application evidence.
+
+pub mod diagnostics;
+pub mod logs;
+pub mod unified_log;

--- a/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/unified_log/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/unified_log/mod.rs
@@ -1,0 +1,10 @@
+//! Apple unified-log records relevant to Company Portal.
+//!
+//! Owner: issue #370 of epic #356. Implementation pending.
+//!
+//! Consumes normalized records; it does not run `log show` or decode the binary `.tracev3` store in the pure crate.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #370 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/portal/macos/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/macos/mod.rs
@@ -1,0 +1,3 @@
+//! macOS Company Portal evidence.
+
+pub mod company_portal;

--- a/crates/cmtraceopen-parser/src/intune/portal/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/mod.rs
@@ -5,4 +5,7 @@
 //! sub-case of IME or ESP. Platform-specific contracts live under the matching
 //! platform module.
 
+pub mod android;
+pub mod ios_ipados;
+pub mod macos;
 pub mod windows;

--- a/crates/cmtraceopen-parser/src/intune/portal/windows/company_portal/logs/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/windows/company_portal/logs/mod.rs
@@ -1,0 +1,10 @@
+//! Windows Company Portal LocalState `Log_<n>.log` parser.
+//!
+//! Owner: issue #366 of epic #356. Implementation pending.
+//!
+//! Reserved by the skeleton; issue #366 has in-flight work on branch `claude/366-company-portal-windows-logs` and is not part of the current batch.
+//!
+//! This is a reserved slot created by the parser-family skeleton so that issue
+//! #366 can be implemented without editing any file shared with a sibling issue.
+//! Add source classification, reduction, and findings submodules here, and
+//! consume the shared contracts in [`crate::intune::evidence`].

--- a/crates/cmtraceopen-parser/src/intune/portal/windows/company_portal/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/windows/company_portal/mod.rs
@@ -1,3 +1,4 @@
 //! Windows Company Portal evidence contracts.
 
+pub mod logs;
 pub mod package_state;

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/_skeleton/reference-scenario/evidence/skeleton-ime/current/IntuneManagementExtension.log
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/_skeleton/reference-scenario/evidence/skeleton-ime/current/IntuneManagementExtension.log
@@ -1,0 +1,1 @@
+<![LOG[# SYNTHETIC FIXTURE: reference corpus for epic #356; synthetic data only]LOG]!><time="00:00:00.000+000" date="07-31-2026" component="IntuneManagementExtension" context="" type="1" thread="1" file="skeleton.cs:1">

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/_skeleton/reference-scenario/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/_skeleton/reference-scenario/expected.json
@@ -1,0 +1,24 @@
+{
+  "scenario": "reference-scenario",
+  "workload": "_skeleton",
+  "coverage": [
+    { "artifactId": "skeleton-ime-current", "status": "available" },
+    { "artifactId": "skeleton-appworkload-absent", "status": "missing" }
+  ],
+  "findings": [
+    {
+      "findingId": "skeleton-coverage-gap",
+      "severity": "info",
+      "confidence": "high",
+      "title": "Expected app workload evidence was not collected",
+      "summary": "AppWorkload.log was absent, so app-level enforcement cannot be evaluated from this bundle.",
+      "recommendedChecks": ["Collect AppWorkload.log and re-run the analysis"],
+      "evidence": [],
+      "coverageGapIds": ["skeleton-appworkload-absent"]
+    }
+  ],
+  "assertions": [
+    "a finding may cite a coverage gap instead of evidence, but never neither",
+    "an absent artifact still produces a coverage entry"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/_skeleton/reference-scenario/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/_skeleton/reference-scenario/manifest.json
@@ -1,0 +1,35 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "reference-scenario",
+  "workload": "_skeleton",
+  "description": "Reference layout for epic #356 corpora. Shows one captured artifact and one absent artifact, so a leaf can see how a coverage gap is expressed rather than omitted.",
+  "artifacts": [
+    {
+      "artifactId": "skeleton-ime-current",
+      "family": "ime",
+      "sourceKind": "imeLog",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "IntuneManagementExtension.log",
+      "sanitizedSourcePath": "SYNTHETIC://ime/IntuneManagementExtension.log",
+      "relativePath": "evidence/skeleton-ime/current/IntuneManagementExtension.log",
+      "bytesCopied": 220,
+      "capturedUtc": "2026-07-31T00:00:00Z",
+      "rotation": { "kind": "current", "fragmentComplete": true }
+    },
+    {
+      "artifactId": "skeleton-appworkload-absent",
+      "family": "ime",
+      "sourceKind": "imeLog",
+      "captureState": "absent",
+      "encoding": null,
+      "originalBasename": "AppWorkload.log",
+      "sanitizedSourcePath": null,
+      "relativePath": null,
+      "bytesCopied": 0,
+      "capturedUtc": "2026-07-31T00:00:01Z",
+      "rotation": { "kind": "current", "fragmentComplete": true }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/intune_skeleton_contract.rs
+++ b/crates/cmtraceopen-parser/tests/intune_skeleton_contract.rs
@@ -244,6 +244,25 @@ fn privacy_scanner_flags_forbidden_material() {
 }
 
 #[test]
+fn privacy_scanner_flags_emails_joined_by_delimiters() {
+    // A semicolon-joined recipient list is the shape a pasted mail header has.
+    // Splitting only on whitespace made the whole run one token, whose domain
+    // then contained `;` and a second `@`, so both real addresses slipped through.
+    for sample in [
+        "user1@corp.com;user2@corp.com",
+        "to:person@corp.com",
+        "<person@corp.com>",
+        "owner=person@corp.com|next",
+        "[person@corp.com]",
+    ] {
+        assert!(
+            !privacy_problems("sample", sample).is_empty(),
+            "privacy scanner missed an email in {sample:?}"
+        );
+    }
+}
+
+#[test]
 fn privacy_scanner_allows_reserved_synthetic_domains() {
     assert!(
         privacy_problems("sample", "user synthetic.user@example.invalid signed in").is_empty(),

--- a/crates/cmtraceopen-parser/tests/intune_skeleton_contract.rs
+++ b/crates/cmtraceopen-parser/tests/intune_skeleton_contract.rs
@@ -1,0 +1,267 @@
+//! Contract tests for the Intune parser-family skeleton (epic #356).
+//!
+//! Two jobs:
+//!
+//! 1. Prove the shared harness in `tests/support/` actually rejects what it
+//!    claims to reject. Fifteen workload leaves will depend on it, so a validator
+//!    that silently passes everything would be worse than no validator.
+//! 2. Pin the reference corpus layout that those leaves copy.
+
+mod support;
+
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use support::{
+    load_json, mutated, privacy_problems, scenario_names, validate_scenario, Failures,
+    SYNTHETIC_MARKER,
+};
+
+fn reference_root() -> PathBuf {
+    support::corpus_root("_skeleton").join("reference-scenario")
+}
+
+fn reference_pair() -> (Value, Value) {
+    let root = reference_root();
+    (
+        load_json(&root.join("manifest.json")),
+        load_json(&root.join("expected.json")),
+    )
+}
+
+fn validate(root: &Path, manifest: &Value, expected: &Value) -> Failures {
+    validate_scenario("reference-scenario", root, manifest, expected)
+}
+
+#[test]
+fn reference_scenario_satisfies_the_shared_contract() {
+    let (manifest, expected) = reference_pair();
+    validate(&reference_root(), &manifest, &expected).assert_empty("reference scenario");
+}
+
+#[test]
+fn skeleton_corpus_exposes_exactly_the_reference_scenario() {
+    assert_eq!(
+        scenario_names(&support::corpus_root("_skeleton")),
+        vec!["reference-scenario".to_owned()],
+    );
+}
+
+// ── Adversarial mutations: each must be rejected ────────────────────────────
+
+fn assert_rejected(mutation: &str, manifest: &Value, expected: &Value, needle: &str) {
+    let failures = validate(&reference_root(), manifest, expected);
+    assert!(
+        !failures.is_empty(),
+        "{mutation}: validator accepted a corpus it should have rejected"
+    );
+    assert!(
+        failures.entries().iter().any(|entry| entry.contains(needle)),
+        "{mutation}: expected a failure mentioning {needle:?}, got {:?}",
+        failures.entries()
+    );
+}
+
+#[test]
+fn wrong_manifest_version_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "manifest version",
+        &mutated(&manifest, "/intuneManifestVersion", json!(2)),
+        &expected,
+        "intuneManifestVersion",
+    );
+}
+
+#[test]
+fn dropping_the_synthetic_fixture_flag_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "synthetic flag",
+        &mutated(&manifest, "/syntheticFixture", json!(false)),
+        &expected,
+        "syntheticFixture",
+    );
+}
+
+#[test]
+fn scenario_name_drift_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "scenario name",
+        &mutated(&manifest, "/scenario", json!("something-else")),
+        &expected,
+        "manifest scenario",
+    );
+}
+
+#[test]
+fn a_byte_count_that_disagrees_with_the_file_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "byte count",
+        &mutated(&manifest, "/artifacts/0/bytesCopied", json!(999)),
+        &expected,
+        "bytesCopied",
+    );
+}
+
+#[test]
+fn an_absent_artifact_claiming_a_file_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "absent artifact with a path",
+        &mutated(
+            &manifest,
+            "/artifacts/1/relativePath",
+            json!("evidence/skeleton-ime/current/IntuneManagementExtension.log"),
+        ),
+        &expected,
+        "relativePath null",
+    );
+}
+
+#[test]
+fn a_captured_artifact_pointing_outside_evidence_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "path escape",
+        &mutated(
+            &manifest,
+            "/artifacts/0/relativePath",
+            json!("../../../../etc/passwd"),
+        ),
+        &expected,
+        "normal components",
+    );
+}
+
+#[test]
+fn a_captured_artifact_outside_the_evidence_directory_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "non-evidence root",
+        &mutated(&manifest, "/artifacts/0/relativePath", json!("manifest.json")),
+        &expected,
+        "evidence directory",
+    );
+}
+
+#[test]
+fn a_missing_evidence_file_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "missing file",
+        &mutated(
+            &manifest,
+            "/artifacts/0/relativePath",
+            json!("evidence/skeleton-ime/current/NotThere.log"),
+        ),
+        &expected,
+        "does not exist",
+    );
+}
+
+#[test]
+fn an_unknown_capture_state_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "capture state",
+        &mutated(&manifest, "/artifacts/0/captureState", json!("probably")),
+        &expected,
+        "captureState",
+    );
+}
+
+#[test]
+fn a_duplicate_artifact_id_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "duplicate id",
+        &mutated(
+            &manifest,
+            "/artifacts/1/artifactId",
+            json!("skeleton-ime-current"),
+        ),
+        &expected,
+        "duplicate artifactId",
+    );
+}
+
+#[test]
+fn coverage_that_omits_a_manifest_artifact_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "coverage omission",
+        &manifest,
+        &mutated(&expected, "/coverage", json!([])),
+        "no coverage entry",
+    );
+}
+
+#[test]
+fn coverage_naming_an_undeclared_artifact_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "coverage overreach",
+        &manifest,
+        &mutated(
+            &expected,
+            "/coverage/0/artifactId",
+            json!("never-declared"),
+        ),
+        "which no manifest artifact declares",
+    );
+}
+
+#[test]
+fn a_finding_citing_neither_evidence_nor_a_coverage_gap_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "uncited finding",
+        &manifest,
+        &mutated(&expected, "/findings/0/coverageGapIds", json!([])),
+        "cites neither evidence nor a coverage gap",
+    );
+}
+
+// ── Privacy scanner ─────────────────────────────────────────────────────────
+
+#[test]
+fn privacy_scanner_flags_forbidden_material() {
+    for (label, sample) in [
+        ("user path", "opened C:\\Users\\adam\\file.log"),
+        ("bearer token", "Authorization: Bearer abc.def.ghi"),
+        ("client secret", "client_secret=hunter2"),
+        ("sid", "owner S-1-5-21-1004336348-1177238915-682003330-512"),
+        ("email", "signed in as real.person@contoso.com"),
+        ("private key", "-----BEGIN PRIVATE KEY-----"),
+    ] {
+        assert!(
+            !privacy_problems("sample", sample).is_empty(),
+            "privacy scanner missed {label}"
+        );
+    }
+}
+
+#[test]
+fn privacy_scanner_allows_reserved_synthetic_domains() {
+    assert!(
+        privacy_problems("sample", "user synthetic.user@example.invalid signed in").is_empty(),
+        "reserved .invalid domains are the documented way to write a synthetic identity"
+    );
+}
+
+#[test]
+fn reference_evidence_carries_the_synthetic_marker() {
+    let evidence =
+        reference_root().join("evidence/skeleton-ime/current/IntuneManagementExtension.log");
+    let contents = std::fs::read_to_string(&evidence).expect("reference evidence is readable");
+    assert!(
+        contents
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .contains(SYNTHETIC_MARKER),
+        "the first line of every evidence file must contain {SYNTHETIC_MARKER:?}"
+    );
+}

--- a/crates/cmtraceopen-parser/tests/intune_skeleton_contract.rs
+++ b/crates/cmtraceopen-parser/tests/intune_skeleton_contract.rs
@@ -224,12 +224,69 @@ fn a_finding_citing_neither_evidence_nor_a_coverage_gap_is_rejected() {
     );
 }
 
+#[test]
+fn coverage_status_contradicting_the_capture_state_is_rejected() {
+    // The manifest declares skeleton-appworkload-absent as absent. Claiming it
+    // was available is self-declared contract drift: the corpus would assert
+    // coverage it never had, and any finding citing that entry inherits the lie.
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "coverage status drift",
+        &manifest,
+        &mutated(&expected, "/coverage/1/status", json!("available")),
+        "requires coverage status",
+    );
+}
+
+#[test]
+fn a_missing_coverage_status_is_rejected() {
+    let (manifest, expected) = reference_pair();
+    assert_rejected(
+        "absent coverage status",
+        &manifest,
+        &mutated(&expected, "/coverage/0/status", json!(null)),
+        "requires coverage status",
+    );
+}
+
+#[test]
+fn parse_failed_artifacts_may_carry_evidence() {
+    // parseFailed means the artifact was collected and could not be interpreted,
+    // so the malformed bytes are the point. Epic #356 requires a malformed
+    // scenario from every child issue; forcing parseFailed to have no file made
+    // that shape inexpressible.
+    let (manifest, expected) = reference_pair();
+    let manifest = mutated(&manifest, "/artifacts/0/captureState", json!("parseFailed"));
+    let expected = mutated(&expected, "/coverage/0/status", json!("parseFailed"));
+    validate(&reference_root(), &manifest, &expected)
+        .assert_empty("parseFailed artifact with real evidence");
+}
+
+#[test]
+fn parse_failed_without_evidence_is_still_rejected() {
+    let (manifest, expected) = reference_pair();
+    let manifest = mutated(&manifest, "/artifacts/1/captureState", json!("parseFailed"));
+    let expected = mutated(&expected, "/coverage/1/status", json!("parseFailed"));
+    assert_rejected(
+        "parseFailed with no file",
+        &manifest,
+        &expected,
+        "requires a relativePath",
+    );
+}
+
 // ── Privacy scanner ─────────────────────────────────────────────────────────
 
 #[test]
 fn privacy_scanner_flags_forbidden_material() {
     for (label, sample) in [
         ("user path", "opened C:\\Users\\adam\\file.log"),
+        // JSON-escaped form: this is how a Windows path is necessarily written
+        // inside manifest.json, and the literal-only check never matched it.
+        (
+            "json-escaped user path",
+            r#"{"path":"C:\\Users\\adam\\file.log"}"#,
+        ),
         ("bearer token", "Authorization: Bearer abc.def.ghi"),
         ("client secret", "client_secret=hunter2"),
         ("sid", "owner S-1-5-21-1004336348-1177238915-682003330-512"),
@@ -268,6 +325,103 @@ fn privacy_scanner_allows_reserved_synthetic_domains() {
         privacy_problems("sample", "user synthetic.user@example.invalid signed in").is_empty(),
         "reserved .invalid domains are the documented way to write a synthetic identity"
     );
+}
+
+#[test]
+#[cfg(unix)]
+fn a_symlink_escaping_the_scenario_is_rejected() {
+    // The component check is lexical, so without target resolution a symlink
+    // under evidence/ reads host files and the privacy scan runs against content
+    // that is not in the corpus at all.
+    use std::os::unix::fs::symlink;
+
+    let temp = std::env::temp_dir().join(format!(
+        "cmtrace-symlink-escape-{}",
+        std::process::id()
+    ));
+    let scenario = temp.join("escape");
+    let evidence = scenario.join("evidence/skeleton-ime/current");
+    std::fs::create_dir_all(&evidence).expect("scratch scenario is creatable");
+
+    let outside = temp.join("outside.log");
+    std::fs::write(&outside, "SYNTHETIC FIXTURE outside the corpus\n")
+        .expect("outside file is writable");
+    let link = evidence.join("IntuneManagementExtension.log");
+    let _ = std::fs::remove_file(&link);
+    symlink(&outside, &link).expect("symlink is creatable");
+
+    let bytes = std::fs::metadata(&link).expect("link target metadata").len();
+    let manifest = json!({
+        "intuneManifestVersion": 1,
+        "syntheticFixture": true,
+        "scenario": "escape",
+        "artifacts": [{
+            "artifactId": "escaping",
+            "captureState": "captured",
+            "relativePath": "evidence/skeleton-ime/current/IntuneManagementExtension.log",
+            "bytesCopied": bytes,
+        }],
+    });
+    let expected = json!({
+        "scenario": "escape",
+        "coverage": [{ "artifactId": "escaping", "status": "available" }],
+        "findings": [],
+    });
+
+    let failures = validate_scenario("escape", &scenario, &manifest, &expected);
+    let outside_rejected = failures
+        .entries()
+        .iter()
+        .any(|entry| entry.contains("outside the scenario directory"));
+
+    std::fs::remove_dir_all(&temp).ok();
+    assert!(
+        outside_rejected,
+        "a symlink resolving outside the scenario must be rejected, got {:?}",
+        failures.entries()
+    );
+}
+
+#[test]
+fn descriptor_files_are_privacy_scanned() {
+    // manifest.json and expected.json are hand written and carry the free-text
+    // fields where a real path or identity gets typed by mistake. Scanning only
+    // the evidence left the likeliest leak unchecked.
+    let scenario = std::env::temp_dir().join(format!(
+        "cmtrace-descriptor-privacy-{}/leaky",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&scenario).expect("scratch scenario is creatable");
+    std::fs::write(
+        scenario.join("manifest.json"),
+        r#"{"sanitizedSourcePath":"C:\\Users\\jsmith\\AppData\\Local\\app.log"}"#,
+    )
+    .expect("manifest is writable");
+    std::fs::write(scenario.join("expected.json"), r#"{"displayName":"ok"}"#)
+        .expect("expected is writable");
+
+    let mut failures = Failures::new();
+    support::validate_descriptor_privacy("leaky", &scenario, &mut failures);
+    let leaked = failures
+        .entries()
+        .iter()
+        .any(|entry| entry.contains("manifest.json") && entry.contains("forbidden fixture material"));
+
+    std::fs::remove_dir_all(scenario.parent().expect("temp parent")).ok();
+    assert!(
+        leaked,
+        "a user path in manifest.json must be caught, got {:?}",
+        failures.entries()
+    );
+}
+
+#[test]
+#[should_panic(expected = "is readable")]
+fn a_missing_corpus_directory_panics_rather_than_passing_vacuously() {
+    // Returning an empty vec made a misspelled corpus path indistinguishable
+    // from an empty corpus, so a loop over scenarios validated nothing and
+    // still reported success.
+    scenario_names(&support::corpus_root("_skeleton/definitely-not-a-corpus"));
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/support/mod.rs
+++ b/crates/cmtraceopen-parser/tests/support/mod.rs
@@ -505,8 +505,22 @@ fn find_windows_sid(contents: &str) -> Option<String> {
 
 /// Find an email address, ignoring the reserved `.invalid` and `.example` TLDs
 /// that fixtures are expected to use for synthetic identities.
+///
+/// The delimiter set has to be generous. Splitting only on whitespace and quotes
+/// lets `a@corp.com;b@corp.com` arrive as one token, whose domain then contains
+/// `;` and a second `@`; that fails the final character check and the token is
+/// skipped, so *both* real addresses slip through. Semicolon-joined recipient
+/// lists are exactly the shape a pasted mail header has, so this is the case the
+/// scanner most needs to catch.
 fn find_email(contents: &str) -> Option<String> {
-    for token in contents.split(|c: char| c.is_whitespace() || c == '"' || c == '\'' || c == ',') {
+    for token in contents.split(|c: char| {
+        c.is_whitespace()
+            || matches!(
+                c,
+                '"' | '\'' | ',' | ';' | ':' | '<' | '>' | '(' | ')' | '[' | ']' | '{' | '}' | '='
+                    | '|'
+            )
+    }) {
         let Some((local, domain)) = token.split_once('@') else {
             continue;
         };

--- a/crates/cmtraceopen-parser/tests/support/mod.rs
+++ b/crates/cmtraceopen-parser/tests/support/mod.rs
@@ -24,7 +24,7 @@
 #![allow(dead_code)]
 
 use serde_json::Value;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Component, Path, PathBuf};
 
 /// Envelope version every Intune fixture manifest declares.
@@ -50,7 +50,34 @@ pub const CAPTURE_STATES: [&str; 7] = [
 ];
 
 /// Capture states that must be backed by a real file on disk.
-pub const CAPTURE_STATES_WITH_FILE: [&str; 2] = ["captured", "capped"];
+///
+/// `parseFailed` belongs here: it means the artifact *was* collected and could
+/// not be interpreted, so the malformed bytes are the entire point of the
+/// scenario. Requiring it to have no file would make the malformed-evidence
+/// fixture that epic #356 mandates of every child issue inexpressible.
+pub const CAPTURE_STATES_WITH_FILE: [&str; 3] = ["captured", "capped", "parseFailed"];
+
+/// Capture states that may or may not have a file.
+///
+/// `unsupported` covers both "we recognized the format and refuse to parse it",
+/// which has bytes, and "this source does not exist on this platform", which does
+/// not. Both are legitimate, so neither is enforced.
+pub const CAPTURE_STATES_OPTIONAL_FILE: [&str; 1] = ["unsupported"];
+
+/// The coverage status `expected.json` must report for each capture state.
+///
+/// Without this binding a corpus can declare an artifact absent in its manifest
+/// and available in its expected output, which is the self-declared-contract
+/// drift the whole fixture format exists to prevent.
+pub const CAPTURE_STATE_COVERAGE: [(&str, &str); 7] = [
+    ("captured", "available"),
+    ("capped", "capped"),
+    ("absent", "missing"),
+    ("accessDenied", "permissionDenied"),
+    ("skipped", "skipped"),
+    ("unsupported", "unsupported"),
+    ("parseFailed", "parseFailed"),
+];
 
 // ── Paths ───────────────────────────────────────────────────────────────────
 
@@ -69,10 +96,20 @@ pub fn corpus_root(corpus_relative: &str) -> PathBuf {
 }
 
 /// Sorted scenario directory names inside a corpus.
+///
+/// Panics when the corpus directory is missing. Returning an empty vec made a
+/// misspelled corpus path indistinguishable from an empty corpus, so a test that
+/// loops over scenarios reported success having validated nothing. A loud
+/// failure is the only useful behavior here.
 pub fn scenario_names(corpus: &Path) -> Vec<String> {
-    let Ok(entries) = std::fs::read_dir(corpus) else {
-        return Vec::new();
-    };
+    let entries = std::fs::read_dir(corpus).unwrap_or_else(|error| {
+        panic!(
+            "corpus directory {} is readable: {error}\n\
+             (a missing directory here usually means the corpus path is misspelled \
+             or the fixtures were never created)",
+            corpus.display()
+        )
+    });
     let mut names = entries
         .map(|entry| entry.expect("corpus directory entry is readable").path())
         .filter(|path| path.is_dir())
@@ -208,8 +245,27 @@ pub fn validate_scenario(
     validate_evidence_closure(scenario, scenario_root, &referenced, &mut failures);
     validate_expected_coverage(scenario, manifest, expected, &mut failures);
     validate_findings_are_evidence_backed(scenario, expected, &mut failures);
+    validate_descriptor_privacy(scenario, scenario_root, &mut failures);
 
     failures
+}
+
+/// Scan `manifest.json` and `expected.json` themselves for private data.
+///
+/// The evidence files are scanned as they are read, but the descriptors are hand
+/// written and carry exactly the free-text fields where a real path or identity
+/// gets typed by mistake: `sanitizedSourcePath`, `displayName`, and finding
+/// summaries. Scanning only the evidence left the likeliest leak unchecked.
+pub fn validate_descriptor_privacy(scenario: &str, scenario_root: &Path, failures: &mut Failures) {
+    for descriptor in ["manifest.json", "expected.json"] {
+        let path = scenario_root.join(descriptor);
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => {
+                failures.absorb(privacy_problems(&format!("{scenario}/{descriptor}"), &contents))
+            }
+            Err(error) => failures.push(format!("{scenario}: {descriptor} is not readable: {error}")),
+        }
+    }
 }
 
 fn validate_envelope(scenario: &str, manifest: &Value, expected: &Value, failures: &mut Failures) {
@@ -274,8 +330,9 @@ fn validate_artifacts(
 
         let relative_path = artifact["relativePath"].as_str();
         let needs_file = CAPTURE_STATES_WITH_FILE.contains(&capture_state);
+        let may_have_file = CAPTURE_STATES_OPTIONAL_FILE.contains(&capture_state);
 
-        if !needs_file {
+        if !needs_file && !may_have_file {
             failures.require(relative_path.is_none(), || {
                 format!("{scenario}/{id}: captureState {capture_state} must have relativePath null")
             });
@@ -286,9 +343,19 @@ fn validate_artifacts(
         }
 
         let Some(relative_path) = relative_path else {
-            failures.push(format!(
-                "{scenario}/{id}: captureState {capture_state} requires a relativePath"
-            ));
+            if needs_file {
+                failures.push(format!(
+                    "{scenario}/{id}: captureState {capture_state} requires a relativePath"
+                ));
+            } else {
+                // Optional-file state with no file: still must not claim bytes.
+                failures.require(artifact["bytesCopied"].as_u64() == Some(0), || {
+                    format!(
+                        "{scenario}/{id}: captureState {capture_state} has no file but reports bytesCopied {}",
+                        artifact["bytesCopied"]
+                    )
+                });
+            }
             continue;
         };
 
@@ -334,10 +401,28 @@ fn validate_artifacts(
             )),
         }
 
-        if let Ok(canonical) = file_path.canonicalize() {
-            failures.require(referenced.insert(canonical), || {
-                format!("{scenario}/{id}: {relative_path} is referenced by more than one artifact")
-            });
+        // Resolve symlinks and confirm the target is still inside the scenario.
+        // The component check above is lexical only, so without this a symlink
+        // under evidence/ reads host files and the privacy scan runs against
+        // content that is not in the corpus at all.
+        match (file_path.canonicalize(), scenario_root.canonicalize()) {
+            (Ok(canonical), Ok(root)) => {
+                if canonical.starts_with(&root) {
+                    failures.require(referenced.insert(canonical), || {
+                        format!(
+                            "{scenario}/{id}: {relative_path} is referenced by more than one artifact"
+                        )
+                    });
+                } else {
+                    failures.push(format!(
+                        "{scenario}/{id}: {relative_path} resolves to {}, outside the scenario directory",
+                        canonical.display()
+                    ));
+                }
+            }
+            _ => failures.push(format!(
+                "{scenario}/{id}: {relative_path} could not be resolved to a real path"
+            )),
         }
     }
 
@@ -418,6 +503,45 @@ fn validate_expected_coverage(
         .map(str::to_owned)
         .collect::<BTreeSet<_>>();
 
+    // Bind each coverage status to the capture state that produced it. Comparing
+    // only the id sets let a corpus declare an artifact absent in the manifest
+    // and available in the expected output.
+    let capture_states = manifest["artifacts"]
+        .as_array()
+        .map(|artifacts| {
+            artifacts
+                .iter()
+                .filter_map(|artifact| {
+                    Some((
+                        artifact["artifactId"].as_str()?.to_owned(),
+                        artifact["captureState"].as_str()?.to_owned(),
+                    ))
+                })
+                .collect::<BTreeMap<_, _>>()
+        })
+        .unwrap_or_default();
+
+    for entry in coverage {
+        let Some(id) = entry["artifactId"].as_str() else {
+            continue;
+        };
+        let Some(capture_state) = capture_states.get(id) else {
+            continue;
+        };
+        let Some((_, required)) = CAPTURE_STATE_COVERAGE
+            .iter()
+            .find(|(state, _)| state == capture_state)
+        else {
+            continue;
+        };
+        let declared = entry["status"].as_str().unwrap_or_default();
+        failures.require(declared == *required, || {
+            format!(
+                "{scenario}/{id}: manifest captureState {capture_state} requires coverage status {required:?}, expected.json declares {declared:?}"
+            )
+        });
+    }
+
     for missing in manifest_ids.difference(&coverage_ids) {
         failures.push(format!(
             "{scenario}: manifest artifact {missing} has no coverage entry in expected.json"
@@ -474,9 +598,15 @@ pub fn privacy_problems(context: &str, contents: &str) -> Failures {
         "BEGIN PRIVATE KEY",
         "BEGIN RSA PRIVATE KEY",
     ] {
-        failures.require(!contents.contains(forbidden), || {
-            format!("{context}: contains forbidden fixture material {forbidden:?}")
-        });
+        // Check the JSON-escaped form too. Inside manifest.json and
+        // expected.json a Windows path is necessarily written `C:\\Users\\`,
+        // so searching only for the literal `C:\Users\` never matches and the
+        // descriptors leak exactly the paths this list exists to block.
+        let escaped = forbidden.replace('\\', "\\\\");
+        failures.require(
+            !contents.contains(forbidden) && !contents.contains(escaped.as_str()),
+            || format!("{context}: contains forbidden fixture material {forbidden:?}"),
+        );
     }
 
     if let Some(sid) = find_windows_sid(contents) {

--- a/crates/cmtraceopen-parser/tests/support/mod.rs
+++ b/crates/cmtraceopen-parser/tests/support/mod.rs
@@ -1,0 +1,528 @@
+//! Shared fixture-contract harness for the Intune corpora of epic #356.
+//!
+//! Each workload leaf ships a scenario corpus laid out as:
+//!
+//! ```text
+//! tests/fixtures/intune/<workload path>/<scenario>/
+//!     manifest.json                       inputs and provenance
+//!     expected.json                       asserted outputs and coverage
+//!     evidence/<artifact>/<rotation>/<file>
+//! ```
+//!
+//! Everything every corpus shares is validated here: the manifest envelope, path
+//! safety, byte-count truth, file/manifest closure, the synthetic-fixture marker,
+//! and a privacy scan. Workload-specific semantics — state chains, key binding,
+//! terminal outcomes — stay in each leaf's own test file, where exactly one issue
+//! owns them.
+//!
+//! # Why `allow(dead_code)`
+//!
+//! Cargo compiles a separate binary per `tests/*.rs` file, and each one compiles
+//! its own copy of this module. Any helper a given binary does not call is
+//! genuinely dead in that binary and would fail `clippy -D warnings`.
+//! `src-tauri/tests/common/mod.rs` sets the same precedent.
+#![allow(dead_code)]
+
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+
+/// Envelope version every Intune fixture manifest declares.
+pub const INTUNE_MANIFEST_VERSION: u64 = 1;
+
+/// Literal the first line of every evidence file must contain.
+///
+/// This is the tripwire against a real customer log being pasted into the corpus.
+pub const SYNTHETIC_MARKER: &str = "SYNTHETIC FIXTURE";
+
+/// Capture states a manifest artifact may declare.
+///
+/// These mirror `IntuneAccessState` so a fixture can express "this source was
+/// capped" or "this source was skipped" rather than collapsing both to absent.
+pub const CAPTURE_STATES: [&str; 7] = [
+    "captured",
+    "capped",
+    "absent",
+    "accessDenied",
+    "skipped",
+    "unsupported",
+    "parseFailed",
+];
+
+/// Capture states that must be backed by a real file on disk.
+pub const CAPTURE_STATES_WITH_FILE: [&str; 2] = ["captured", "capped"];
+
+// ── Paths ───────────────────────────────────────────────────────────────────
+
+/// Root of the Intune fixture tree.
+pub fn fixtures_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/intune")
+}
+
+/// One corpus, e.g. `corpus_root("device/windows/configuration")`.
+pub fn corpus_root(corpus_relative: &str) -> PathBuf {
+    let mut root = fixtures_root();
+    for segment in corpus_relative.split('/').filter(|s| !s.is_empty()) {
+        root.push(segment);
+    }
+    root
+}
+
+/// Sorted scenario directory names inside a corpus.
+pub fn scenario_names(corpus: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(corpus) else {
+        return Vec::new();
+    };
+    let mut names = entries
+        .map(|entry| entry.expect("corpus directory entry is readable").path())
+        .filter(|path| path.is_dir())
+        .map(|path| {
+            path.file_name()
+                .expect("scenario directory has a name")
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect::<Vec<_>>();
+    names.sort();
+    names
+}
+
+/// Depth-first, deterministically ordered file list.
+///
+/// Returns empty when `root` is absent, because a scenario in which nothing was
+/// captured legitimately has no `evidence/` directory.
+pub fn walk_files(root: &Path) -> Vec<PathBuf> {
+    if !root.exists() {
+        return Vec::new();
+    }
+    let mut pending = vec![root.to_path_buf()];
+    let mut files = Vec::new();
+    while let Some(path) = pending.pop() {
+        if path.is_dir() {
+            let mut children = std::fs::read_dir(&path)
+                .expect("fixture directory is readable")
+                .map(|entry| entry.expect("fixture entry is readable").path())
+                .collect::<Vec<_>>();
+            children.sort();
+            pending.extend(children.into_iter().rev());
+        } else {
+            files.push(path);
+        }
+    }
+    files
+}
+
+/// Read and parse a JSON fixture, panicking with the path on failure.
+pub fn load_json(path: &Path) -> Value {
+    let contents = std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("{} is readable: {error}", path.display()));
+    serde_json::from_str(&contents)
+        .unwrap_or_else(|error| panic!("{} contains valid JSON: {error}", path.display()))
+}
+
+/// Return a copy of `value` with one JSON pointer replaced.
+///
+/// This is what makes an adversarial mutation test a one-liner: corrupt a field,
+/// then assert the validator rejects the corrupted copy.
+pub fn mutated(value: &Value, pointer: &str, replacement: Value) -> Value {
+    let mut clone = value.clone();
+    let slot = clone
+        .pointer_mut(pointer)
+        .unwrap_or_else(|| panic!("json pointer {pointer} exists"));
+    *slot = replacement;
+    clone
+}
+
+// ── Failure accumulator ─────────────────────────────────────────────────────
+
+/// Collects every contract failure so one run reports all of them.
+///
+/// A per-assertion `assert!` stops at the first problem, which turns fixing a
+/// corpus into a serial guessing game. This reports the whole set at once.
+#[derive(Debug, Default)]
+pub struct Failures {
+    entries: Vec<String>,
+}
+
+impl Failures {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, message: impl Into<String>) {
+        self.entries.push(message.into());
+    }
+
+    /// Record `message()` when `condition` is false.
+    ///
+    /// The closure means the message is only formatted on failure.
+    pub fn require(&mut self, condition: bool, message: impl FnOnce() -> String) {
+        if !condition {
+            self.entries.push(message());
+        }
+    }
+
+    pub fn absorb(&mut self, other: Failures) {
+        self.entries.extend(other.entries);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn entries(&self) -> &[String] {
+        &self.entries
+    }
+
+    /// Panic with every accumulated failure, or return quietly.
+    #[track_caller]
+    pub fn assert_empty(self, context: &str) {
+        if self.entries.is_empty() {
+            return;
+        }
+        panic!(
+            "{context}: {} contract failure(s)\n  - {}",
+            self.entries.len(),
+            self.entries.join("\n  - ")
+        );
+    }
+}
+
+// ── Contract validation ─────────────────────────────────────────────────────
+
+/// Validate the manifest envelope, artifacts, evidence files, and expected
+/// coverage for one scenario directory.
+///
+/// Returns accumulated failures rather than asserting, so callers can reuse it
+/// for adversarial mutation tests that expect rejection.
+pub fn validate_scenario(
+    scenario: &str,
+    scenario_root: &Path,
+    manifest: &Value,
+    expected: &Value,
+) -> Failures {
+    let mut failures = Failures::new();
+
+    validate_envelope(scenario, manifest, expected, &mut failures);
+    let referenced = validate_artifacts(scenario, scenario_root, manifest, &mut failures);
+    validate_evidence_closure(scenario, scenario_root, &referenced, &mut failures);
+    validate_expected_coverage(scenario, manifest, expected, &mut failures);
+    validate_findings_are_evidence_backed(scenario, expected, &mut failures);
+
+    failures
+}
+
+fn validate_envelope(scenario: &str, manifest: &Value, expected: &Value, failures: &mut Failures) {
+    failures.require(
+        manifest["intuneManifestVersion"].as_u64() == Some(INTUNE_MANIFEST_VERSION),
+        || {
+            format!(
+                "{scenario}: intuneManifestVersion must be {INTUNE_MANIFEST_VERSION}, got {}",
+                manifest["intuneManifestVersion"]
+            )
+        },
+    );
+    failures.require(manifest["syntheticFixture"].as_bool() == Some(true), || {
+        format!("{scenario}: manifest must declare syntheticFixture: true")
+    });
+    failures.require(manifest["scenario"].as_str() == Some(scenario), || {
+        format!(
+            "{scenario}: manifest scenario is {}, expected the directory name",
+            manifest["scenario"]
+        )
+    });
+    failures.require(expected["scenario"].as_str() == Some(scenario), || {
+        format!(
+            "{scenario}: expected scenario is {}, expected the directory name",
+            expected["scenario"]
+        )
+    });
+    failures.require(manifest["artifacts"].is_array(), || {
+        format!("{scenario}: manifest artifacts must be an array")
+    });
+}
+
+/// Validate each artifact and return the set of evidence files it referenced.
+fn validate_artifacts(
+    scenario: &str,
+    scenario_root: &Path,
+    manifest: &Value,
+    failures: &mut Failures,
+) -> BTreeSet<PathBuf> {
+    let mut referenced = BTreeSet::new();
+    let mut seen_ids = BTreeSet::new();
+
+    let Some(artifacts) = manifest["artifacts"].as_array() else {
+        return referenced;
+    };
+
+    for artifact in artifacts {
+        let id = artifact["artifactId"].as_str().unwrap_or_default();
+        failures.require(!id.is_empty(), || {
+            format!("{scenario}: every artifact needs a non-empty artifactId")
+        });
+        failures.require(seen_ids.insert(id.to_owned()), || {
+            format!("{scenario}: duplicate artifactId {id}")
+        });
+
+        let capture_state = artifact["captureState"].as_str().unwrap_or_default();
+        failures.require(CAPTURE_STATES.contains(&capture_state), || {
+            format!(
+                "{scenario}/{id}: captureState {capture_state:?} is not one of {CAPTURE_STATES:?}"
+            )
+        });
+
+        let relative_path = artifact["relativePath"].as_str();
+        let needs_file = CAPTURE_STATES_WITH_FILE.contains(&capture_state);
+
+        if !needs_file {
+            failures.require(relative_path.is_none(), || {
+                format!("{scenario}/{id}: captureState {capture_state} must have relativePath null")
+            });
+            failures.require(artifact["bytesCopied"].as_u64() == Some(0), || {
+                format!("{scenario}/{id}: captureState {capture_state} must report bytesCopied 0")
+            });
+            continue;
+        }
+
+        let Some(relative_path) = relative_path else {
+            failures.push(format!(
+                "{scenario}/{id}: captureState {capture_state} requires a relativePath"
+            ));
+            continue;
+        };
+
+        if let Some(problem) = path_safety_problem(relative_path) {
+            failures.push(format!("{scenario}/{id}: {problem}"));
+            continue;
+        }
+
+        let file_path = scenario_root.join(relative_path);
+        let Ok(metadata) = std::fs::metadata(&file_path) else {
+            failures.push(format!(
+                "{scenario}/{id}: referenced evidence file {relative_path} does not exist"
+            ));
+            continue;
+        };
+
+        failures.require(
+            artifact["bytesCopied"].as_u64() == Some(metadata.len()),
+            || {
+                format!(
+                    "{scenario}/{id}: bytesCopied is {} but {relative_path} is {} bytes",
+                    artifact["bytesCopied"],
+                    metadata.len()
+                )
+            },
+        );
+
+        match std::fs::read_to_string(&file_path) {
+            Ok(contents) => {
+                let first_line = contents.lines().next().unwrap_or_default();
+                failures.require(first_line.contains(SYNTHETIC_MARKER), || {
+                    format!(
+                        "{scenario}/{id}: first line of {relative_path} must contain {SYNTHETIC_MARKER:?}"
+                    )
+                });
+                failures.absorb(privacy_problems(
+                    &format!("{scenario}/{id}:{relative_path}"),
+                    &contents,
+                ));
+            }
+            Err(error) => failures.push(format!(
+                "{scenario}/{id}: {relative_path} is not readable as UTF-8: {error}"
+            )),
+        }
+
+        if let Ok(canonical) = file_path.canonicalize() {
+            failures.require(referenced.insert(canonical), || {
+                format!("{scenario}/{id}: {relative_path} is referenced by more than one artifact")
+            });
+        }
+    }
+
+    referenced
+}
+
+/// Reject absolute paths, parent traversal, and any path not rooted at `evidence`.
+fn path_safety_problem(relative_path: &str) -> Option<String> {
+    let path = Path::new(relative_path);
+    if path.is_absolute() {
+        return Some(format!("relativePath {relative_path} must be relative"));
+    }
+    if !path
+        .components()
+        .all(|component| matches!(component, Component::Normal(_)))
+    {
+        return Some(format!(
+            "relativePath {relative_path} must contain only normal components"
+        ));
+    }
+    match path.components().next() {
+        Some(Component::Normal(first)) if first == "evidence" => None,
+        _ => Some(format!(
+            "relativePath {relative_path} must start with the evidence directory"
+        )),
+    }
+}
+
+/// Every file under `evidence/` must be referenced by exactly one artifact.
+///
+/// Without this, an orphaned file silently contributes nothing while looking like
+/// coverage, and a corpus can drift out of sync with its manifest unnoticed.
+fn validate_evidence_closure(
+    scenario: &str,
+    scenario_root: &Path,
+    referenced: &BTreeSet<PathBuf>,
+    failures: &mut Failures,
+) {
+    let on_disk = walk_files(&scenario_root.join("evidence"))
+        .into_iter()
+        .filter_map(|path| path.canonicalize().ok())
+        .collect::<BTreeSet<_>>();
+
+    for orphan in on_disk.difference(referenced) {
+        failures.push(format!(
+            "{scenario}: evidence file {} is not referenced by any manifest artifact",
+            orphan.display()
+        ));
+    }
+}
+
+/// `expected.json` coverage must name exactly the manifest's artifacts.
+fn validate_expected_coverage(
+    scenario: &str,
+    manifest: &Value,
+    expected: &Value,
+    failures: &mut Failures,
+) {
+    let manifest_ids = manifest["artifacts"]
+        .as_array()
+        .map(|artifacts| {
+            artifacts
+                .iter()
+                .filter_map(|artifact| artifact["artifactId"].as_str())
+                .map(str::to_owned)
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+
+    let Some(coverage) = expected["coverage"].as_array() else {
+        failures.push(format!("{scenario}: expected.json must have a coverage array"));
+        return;
+    };
+
+    let coverage_ids = coverage
+        .iter()
+        .filter_map(|entry| entry["artifactId"].as_str())
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+
+    for missing in manifest_ids.difference(&coverage_ids) {
+        failures.push(format!(
+            "{scenario}: manifest artifact {missing} has no coverage entry in expected.json"
+        ));
+    }
+    for extra in coverage_ids.difference(&manifest_ids) {
+        failures.push(format!(
+            "{scenario}: expected.json covers {extra}, which no manifest artifact declares"
+        ));
+    }
+}
+
+/// A finding must cite evidence or a coverage gap.
+///
+/// This is the corpus-level enforcement of the conservative-findings rule that
+/// epic #356 requires of every child issue.
+fn validate_findings_are_evidence_backed(
+    scenario: &str,
+    expected: &Value,
+    failures: &mut Failures,
+) {
+    let Some(findings) = expected["findings"].as_array() else {
+        return;
+    };
+    for finding in findings {
+        let id = finding["findingId"].as_str().unwrap_or("<unnamed>");
+        let has_evidence = finding["evidence"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty());
+        let has_gap = finding["coverageGapIds"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty());
+        failures.require(has_evidence || has_gap, || {
+            format!("{scenario}: finding {id} cites neither evidence nor a coverage gap")
+        });
+    }
+}
+
+// ── Privacy ─────────────────────────────────────────────────────────────────
+
+/// Shapes that must never appear in a committed fixture.
+///
+/// Checked as plain substrings and simple scans rather than regexes so this stays
+/// cheap enough to run over every file of every corpus.
+pub fn privacy_problems(context: &str, contents: &str) -> Failures {
+    let mut failures = Failures::new();
+
+    for forbidden in [
+        "C:\\Users\\",
+        "/Users/",
+        "Authorization:",
+        "Bearer ",
+        "client_secret",
+        "BEGIN PRIVATE KEY",
+        "BEGIN RSA PRIVATE KEY",
+    ] {
+        failures.require(!contents.contains(forbidden), || {
+            format!("{context}: contains forbidden fixture material {forbidden:?}")
+        });
+    }
+
+    if let Some(sid) = find_windows_sid(contents) {
+        failures.push(format!("{context}: contains a Windows SID {sid:?}"));
+    }
+    if let Some(email) = find_email(contents) {
+        failures.push(format!("{context}: contains an email address {email:?}"));
+    }
+
+    failures
+}
+
+/// Find a `S-1-…` SID with at least three sub-authorities.
+fn find_windows_sid(contents: &str) -> Option<String> {
+    for (index, _) in contents.match_indices("S-1-") {
+        let candidate = contents[index..]
+            .split(|c: char| !(c.is_ascii_digit() || c == '-' || c == 'S'))
+            .next()
+            .unwrap_or_default();
+        if candidate.matches('-').count() >= 4 && candidate.ends_with(|c: char| c.is_ascii_digit()) {
+            return Some(candidate.to_owned());
+        }
+    }
+    None
+}
+
+/// Find an email address, ignoring the reserved `.invalid` and `.example` TLDs
+/// that fixtures are expected to use for synthetic identities.
+fn find_email(contents: &str) -> Option<String> {
+    for token in contents.split(|c: char| c.is_whitespace() || c == '"' || c == '\'' || c == ',') {
+        let Some((local, domain)) = token.split_once('@') else {
+            continue;
+        };
+        if local.is_empty() || !domain.contains('.') {
+            continue;
+        }
+        let domain = domain.trim_end_matches(|c: char| !c.is_ascii_alphanumeric());
+        if domain.ends_with(".invalid") || domain.ends_with(".example") {
+            continue;
+        }
+        if domain
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+        {
+            return Some(token.to_owned());
+        }
+    }
+    None
+}

--- a/src-tauri/src/intune/mod.rs
+++ b/src-tauri/src/intune/mod.rs
@@ -5,9 +5,16 @@
 // Native-only readers (evtx_parser, eventlog_win32) stay in src-tauri because
 // they depend on the `evtx` crate and Windows event-log APIs — neither of
 // which belong in a wasm-compatible library.
+//
+// The epic #356 workload namespaces are re-exported as roots, not leaf by leaf.
+// Rust resolves paths transitively through a re-exported module, so
+// `app_lib::intune::device::windows::configuration` resolves as soon as `device`
+// is listed here. That is what keeps the child issues of #356 from ever needing
+// to edit this file.
 
 pub use cmtraceopen_parser::intune::{
-    download_stats, event_tracker, guid_registry, ime_parser, models, policy_parser, timeline,
+    apps, device, download_stats, enrollment, event_tracker, evidence, guid_registry, ime_parser,
+    models, normalized, policy_parser, portal, timeline,
 };
 
 #[cfg(feature = "intune-diagnostics")]


### PR DESCRIPTION
## Why

Epic #356 reorganizes `cmtraceopen_parser::intune` from a flat, IME-centered list of seven modules into workload namespaces (`apps`, `enrollment`, `device`, `portal`) across seventeen child issues.

Implemented naively, **every one of those issues would edit the same handful of `mod.rs` files**, so no two child PRs could merge independently. Epic #356's own dependency order names this as step 1: "land the parser-family skeleton and canonical compatibility façades."

This PR is that step. It creates the entire tree up front, with every leaf reserved as a documented placeholder owned by exactly one issue. A child PR then touches only its own leaf directory, its own `tests/*.rs`, and its own fixture subtree.

## What is shared, and why it lives here

- **`intune::evidence`** carries the provenance envelope every observation rides on. It distinguishes *absent*, *inaccessible*, *capped*, *skipped*, *unsupported*, and *malformed* evidence instead of collapsing all six into "no data", and `IntuneFinding` records the invariant that a conclusion must cite either evidence or a coverage gap.
- **`intune::normalized`** holds the platform-neutral Windows event and setting-report inputs. Issues #358, #363, #364, and #365 all need these, and #364/#365 are explicitly told to reuse #363's. Leaving them in #363 would block the other three behind it.
- **`tests/support/`** is the shared fixture harness, so fifteen leaves do not each copy ~300 lines of manifest/expected/evidence validation.
- **`tests/fixtures/intune/_skeleton/`** pins the reference corpus layout the leaves copy.

## The CI change matters most

Every Rust step in the `check` job runs with `working-directory: src-tauri`, which selects only the `cmtrace-open` package. The sole parser-crate test in CI was the Windows-only `--test esp_diagnostics`.

**New parser test targets would not have run at all, and the parser crate had no clippy gate.** Both are now wired into the `check` job once, so each leaf added under #356 lands gated without editing a workflow.

## Behavior

Unchanged. No existing module, type, or public path is modified. `intune::models` keeps its hand-written 13-field `Serialize` impl untouched. `src/lib.rs`, `Cargo.toml`, and `Cargo.lock` are untouched.

## Verification

```
cargo test --locked -p cmtraceopen-parser
  -> 362 + 222 + 19 passed, 0 failed
cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings
  -> clean
cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets
  -> Finished
npx tsc --noEmit -> exit 0
```

The 19 tests in `intune_skeleton_contract.rs` include 14 adversarial mutations proving the fixture validator actually rejects version drift, byte-count lies, path escapes, duplicate artifact ids, coverage omissions, and uncited findings. A validator that silently passes everything would be worse than none.

The second commit fixes a false negative found in review: the privacy scanner tokenized only on whitespace, quotes, and commas, so `a@corp.com;b@corp.com` arrived as one token and **both** real addresses slipped through. A pasted mail header is exactly the shape most likely to carry real customer data into a fixture.

Refs #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foundational Intune evidence and normalized-data contracts for timestamps, provenance, parsing states, coverage, findings, events, and setting reports.
  * Exposed parser areas covering Intune apps, devices, enrollment, and Company Portal diagnostics across Windows, macOS, Android, and iOS/iPadOS.
  * Added forward-compatible schema versions and JSON serialization support.

* **Documentation**
  * Documented planned Intune parser workloads and their evidence boundaries.

* **Tests**
  * Added comprehensive fixture-contract validation, privacy checks, path-safety checks, and serialization tests.
  * CI now runs parser tests and Clippy with warnings treated as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->