### PR TITLE
ci: give the auto-labeler permission to label pull requests

### DIFF
--- a/.github/workflows/label-new-items.yml
+++ b/.github/workflows/label-new-items.yml
@@ -8,6 +8,11 @@ on:
 
 permissions:
   issues: write
+  # Labelling a pull request needs `pull-requests: write` even though the REST
+  # path is /issues/{n}/labels. Without it the pull_request_target runs 403 with
+  # "Resource not accessible by integration", because this block replaces the
+  # repository default (which is read-only).
+  pull-requests: write
 
 jobs:
   label:


### PR DESCRIPTION
The auto-labeler added in #383 has never successfully labelled a pull request. All three `pull_request_target` runs to date failed:

```
POST /repos/adamgell/cmtraceopen/issues/<n>/labels
403 Resource not accessible by integration
```

The script itself works — the failing run for #397 got as far as
`{"labels":["enhancement","intune","parser","device","feature"]}` and then could not write them.

**Cause.** Labelling a pull request requires `pull-requests: write`, even though the REST path lives under `/issues`. The workflow declared only `issues: write`. An explicit `permissions:` block *replaces* the repository default rather than adding to it, and this repo has `default_workflow_permissions: read`, so the token ended up with no pull-request scope at all. The `issues: opened` trigger was unaffected, which is why the gap was not obvious.

**Fix.** Add `pull-requests: write`. That is the minimum needed; issue labelling keeps working through the existing `issues: write`.

Evidence:

```
$ gh run list --workflow=label-new-items.yml
failure  pull_request_target  feat(intune): discover and parse the Device Inventory Agent
failure  pull_request_target  feat(sccm): assess pure server intake coverage
failure  pull_request_target  feat(intune): deterministic Company Portal Windows package-s

$ gh api repos/:owner/:repo/actions/permissions/workflow
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
```

This PR is itself the test: if it labels correctly on open, the fix is confirmed — though note it will run with the *base* branch workflow, so the real confirmation is the next PR opened after this merges.