### PR TITLE
test: fix temp-fixture directory collisions in parser test suites

### DIFF
--- a/src-tauri/tests/cmtlog_parser.rs
+++ b/src-tauri/tests/cmtlog_parser.rs
@@ -2,37 +2,29 @@ mod common;
 
 use std::fs;
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+
+use tempfile::TempDir;
 
 struct TempLogFixture {
-    dir: PathBuf,
+    /// Held so the directory outlives the fixture; `TempDir` removes it on drop.
+    _dir: TempDir,
     path: PathBuf,
 }
 
 impl TempLogFixture {
     fn new(file_name: &str, content: &str) -> Self {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time before unix epoch")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("cmtrace-open-cmtlog-test-{unique}"));
-        fs::create_dir_all(&dir).expect("create temp fixture dir");
+        let dir =
+            TempDir::with_prefix("cmtrace-open-cmtlog-test-").expect("create temp fixture dir");
 
-        let path = dir.join(file_name);
+        let path = dir.path().join(file_name);
         fs::write(&path, content).expect("write temp fixture");
 
-        Self { dir, path }
+        Self { _dir: dir, path }
     }
 
     fn detect(&self) -> app_lib::parser::ResolvedParser {
         let content = fs::read_to_string(&self.path).expect("fixture should be readable as UTF-8");
         app_lib::parser::detect::detect_parser(&self.path.to_string_lossy(), &content)
-    }
-}
-
-impl Drop for TempLogFixture {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.dir);
     }
 }
 

--- a/src-tauri/tests/common/mod.rs
+++ b/src-tauri/tests/common/mod.rs
@@ -3,26 +3,23 @@
 use std::fmt::Write;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+
+use tempfile::TempDir;
 
 pub struct TempBenchFile {
-    dir: PathBuf,
+    /// Held so the directory outlives the fixture; `TempDir` removes it on drop.
+    _dir: TempDir,
     path: PathBuf,
 }
 
 impl TempBenchFile {
     pub fn new(file_name: &str, content: String) -> Self {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time before unix epoch")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("cmtrace-open-bench-{unique}"));
-        fs::create_dir_all(&dir).expect("create temp benchmark dir");
+        let dir = TempDir::with_prefix("cmtrace-open-bench-").expect("create temp benchmark dir");
 
-        let path = dir.join(file_name);
+        let path = dir.path().join(file_name);
         fs::write(&path, content).expect("write benchmark fixture");
 
-        Self { dir, path }
+        Self { _dir: dir, path }
     }
 
     pub fn path(&self) -> &Path {
@@ -31,12 +28,6 @@ impl TempBenchFile {
 
     pub fn path_string(&self) -> String {
         self.path.to_string_lossy().to_string()
-    }
-}
-
-impl Drop for TempBenchFile {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.dir);
     }
 }
 

--- a/src-tauri/tests/parser_expanded_corpus.rs
+++ b/src-tauri/tests/parser_expanded_corpus.rs
@@ -3,28 +3,25 @@ mod common;
 use common::{detect_fixture, parse_fixture};
 use std::fs;
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+
+use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
 // Helper: create a temp file for detection/parsing tests
 // ---------------------------------------------------------------------------
 
 struct TempLogFixture {
-    dir: PathBuf,
+    /// Held so the directory outlives the fixture; `TempDir` removes it on drop.
+    _dir: TempDir,
     path: PathBuf,
 }
 
 impl TempLogFixture {
     fn new(file_name: &str, content: &str) -> Self {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("cmtrace-open-expanded-{unique}"));
-        fs::create_dir_all(&dir).expect("create temp dir");
-        let path = dir.join(file_name);
+        let dir = TempDir::with_prefix("cmtrace-open-expanded-").expect("create temp dir");
+        let path = dir.path().join(file_name);
         fs::write(&path, content).expect("write fixture");
-        Self { dir, path }
+        Self { _dir: dir, path }
     }
 
     fn detect(&self) -> common::SelectionSnapshot {
@@ -60,12 +57,6 @@ impl TempLogFixture {
                 })
                 .collect(),
         }
-    }
-}
-
-impl Drop for TempLogFixture {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.dir);
     }
 }
 

--- a/src-tauri/tests/parser_regression_corpus.rs
+++ b/src-tauri/tests/parser_regression_corpus.rs
@@ -2,28 +2,26 @@ mod common;
 
 use std::fs;
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+
+use tempfile::TempDir;
 
 use common::{detect_fixture, parse_fixture, ParsedFixture, SelectionSnapshot};
 
 struct TempLogFixture {
-    dir: PathBuf,
+    /// Held so the directory outlives the fixture; `TempDir` removes it on drop.
+    _dir: TempDir,
     path: PathBuf,
 }
 
 impl TempLogFixture {
     fn new(file_name: &str, content: &str) -> Self {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time before unix epoch")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("cmtrace-open-parser-regression-{unique}"));
-        fs::create_dir_all(&dir).expect("create temp fixture dir");
+        let dir = TempDir::with_prefix("cmtrace-open-parser-regression-")
+            .expect("create temp fixture dir");
 
-        let path = dir.join(file_name);
+        let path = dir.path().join(file_name);
         fs::write(&path, content).expect("write temp fixture");
 
-        Self { dir, path }
+        Self { _dir: dir, path }
     }
 
     fn detect(&self) -> SelectionSnapshot {
@@ -62,12 +60,6 @@ impl TempLogFixture {
                 })
                 .collect(),
         }
-    }
-}
-
-impl Drop for TempLogFixture {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.dir);
     }
 }
 


### PR DESCRIPTION
## Problem

`src-tauri/tests/cmtlog_parser.rs` had a race that made the whole test binary intermittently fail:

```
---- header_entry_parsed_correctly stdout ----
thread 'header_entry_parsed_correctly' panicked at src-tauri/tests/cmtlog_parser.rs:135:30:
index out of bounds: the len is 0 but the index is 0
test result: FAILED. 8 passed; 1 failed
```

`TempLogFixture::new` derived its temp directory name from `SystemTime::now().duration_since(UNIX_EPOCH).as_nanos()`. `as_nanos()` does not guarantee distinct values between calls; macOS clock granularity is coarser than a nanosecond, so two fixtures constructed within the same observed tick got the **same** directory path.

Each fixture also implemented `Drop` as `fs::remove_dir_all(&self.dir)`. The test harness runs a binary's tests on parallel threads, so whichever test finished first deleted the other test's fixture file. The victim then read an empty/missing file, parsed zero entries, and panicked on `result.entries[0]`.

This reproduced roughly 1 run in 5 of the full `cargo test --locked` suite on an M-series Mac. Running the single binary alone rarely reproduced it, since there is far less scheduling pressure.

## Scope

The same time-derived pattern had been copied into four places, all with the same `remove_dir_all` destructor:

| File | Prefix |
|---|---|
| `src-tauri/tests/cmtlog_parser.rs` | `cmtrace-open-cmtlog-test-` |
| `src-tauri/tests/parser_regression_corpus.rs` | `cmtrace-open-parser-regression-` |
| `src-tauri/tests/parser_expanded_corpus.rs` | `cmtrace-open-expanded-` |
| `src-tauri/tests/common/mod.rs` (`TempBenchFile`) | `cmtrace-open-bench-` |

`tests/common/mod.rs` is also pulled into `benches/intune_pipeline.rs` via `#[path = "../tests/common/mod.rs"]`, so the benchmark fixture carried the defect too.

## Fix

`tempfile = "3"` was already in `[dev-dependencies]`, so each fixture now holds a `TempDir` built with `TempDir::with_prefix(...)`. That takes uniqueness from the OS (random suffix plus `O_EXCL` retry) rather than from the clock, and `TempDir`'s own `Drop` handles cleanup, so all four hand-rolled `Drop` impls are removed. Net 34 lines deleted.

The fixture structs keep the directory alive via a `_dir: TempDir` field; dropping it early would delete the directory out from under the still-live `path`.

## Verification

- 12 consecutive `cargo test --locked` runs, 785 tests each, zero failures
- One `cargo test --locked --all-features` run, adding the feature-gated binaries including `esp_diagnostics_sources`, zero failures
- `cargo clippy --all-targets -- -D warnings` clean
- 5 further full suites after a collateral revert (below): still zero failures

## Note

`cargo fmt` reformatted 13 unrelated files on this branch that were already non-conformant (12 under `src-tauri/src/`, plus `tests/esp_diagnostics_sources.rs`). That collateral was reverted to keep this diff minimal. There is no `cargo fmt --check` gate in `.github/workflows/`, so the drift is pre-existing and unenforced; worth cleaning up separately if desired.

Found while working #395, but entirely unrelated to it, so it lands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by using dedicated temporary directories.
  * Automated cleanup of temporary test data to reduce leftover files and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->