### PR TITLE
fix(intune): verify auto-labeler permissions on pull requests

### DIFF
--- a/THROWAWAY-labeler-check.md
+++ b/THROWAWAY-labeler-check.md
@@ -1,0 +1,5 @@
+Throwaway file used to verify that the auto-labeler workflow can apply labels
+to pull requests after #398 granted it `pull-requests: write`.
+
+This PR is not intended to merge. Close it and delete the branch once the
+`label` check reports green and the expected labels are present.


### PR DESCRIPTION
Throwaway PR. **Do not merge.**

Verifies the fix from #398, which added `pull-requests: write` to
`.github/workflows/label-new-items.yml`. Before that, every `pull_request_target`
run failed with `Resource not accessible by integration` (403).

This could not be verified before #398 merged: `pull_request_target` loads the
workflow definition from the base branch, so any PR opened against the old `main`
ran the unfixed copy.

The title is chosen to exercise three separate rule paths at once. Expected labels:

| Label | Source |
|---|---|
| `enhancement` | added unconditionally |
| `intune`, `parser` | topic rule `/\bintune\b/i` |
| `bug` | prefix rule `/^fix\(/i` |

No labels were applied by hand, so anything present came from the workflow.
Close and delete the branch once confirmed.