### PR TITLE
chore: remove unanchored docs/ ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,6 @@ crates/**/target/
 .DS_Store
 Thumbs.db
 
-# Internal docs (specs, plans, mockups)
-docs/
-
 # Brainstorming artifacts
 .superpowers/
 

--- a/docs/compass_artifact_wf-d4b3505b-8666-487c-9577-1184da86cbd6_text_markdown.md
+++ b/docs/compass_artifact_wf-d4b3505b-8666-487c-9577-1184da86cbd6_text_markdown.md
@@ -1,0 +1,549 @@
+# Windows Server DNS logging: a complete Rust parser reference
+
+Every DNS event Windows Server produces falls into one of four distinct log formats, each requiring a different parsing strategy. **No existing Rust crate handles the DNS debug text log format**, making a from-scratch parser necessary, but the ecosystem provides strong building blocks for EVTX (`evtx` crate v0.11.1), DNS wire format (`hickory-proto`), and real-time ETW capture (`ferrisetw`). This reference documents every field, format variation, event ID, and protocol constant needed to build a comprehensive Rust DNS log parser.
+
+---
+
+## 1. DNS debug log (dns.log) text format
+
+The debug log is a locale-sensitive, whitespace-delimited text file produced by `dns.exe`. It starts with a ~30-line header (including a field key), followed by packet entries separated by blank lines.
+
+### Line structure and fields
+
+Each packet event produces a single summary line with 16 fields. The header printed in the log file itself defines them:
+
+| Field # | Name | Format | Example |
+|---------|------|--------|---------|
+| 1 | Date | Locale-dependent (see below) | `4/15/2014`, `22/12/2021`, `20140816` |
+| 2 | Time | 12h with AM/PM or 24h | `3:16:00 PM`, `21:46:04` |
+| 3 | Thread ID | 3-4 hex chars | `0710`, `588` |
+| 4 | Context | String literal | `PACKET` (always for DNS packets) |
+| 5 | Internal packet ID | 8 hex (32-bit) or 16 hex (64-bit) | `0000000028FB94C0` |
+| 6 | Protocol | `UDP` or `TCP` | `UDP` |
+| 7 | Direction | `Snd` or `Rcv` | `Rcv` |
+| 8 | Remote IP | IPv4 or IPv6 | `69.160.33.71`, `::1` |
+| 9 | XID | 4 hex chars (transaction ID) | `8857` |
+| 10 | Query/Response | `R` = response, space = query | `R` or ` ` |
+| 11 | Opcode | `Q`=Query, `N`=Notify, `U`=Update, `?`=Unknown | `Q` |
+| 12 | Flags (hex) | 4-digit hex inside `[` | `8081` |
+| 13 | Flags (chars) | Up to 4 letters: A/T/D/R | `DR` |
+| 14 | Response code | String name inside `]` | `NOERROR`, `NXDOMAIN` |
+| 15 | Question type | String name | `A`, `AAAA`, `SRV` |
+| 16 | Question name | Length-prefixed or dotted | `(3)www(6)google(3)com(0)` |
+
+**Sample lines showing format variations:**
+
+```
+4/15/2014 3:16:00 PM 0710 PACKET  0000000028FB94C0 UDP Rcv 69.160.33.71    8857 R Q [0080       NOERROR] A      .ns1.example.com.
+22/12/2021 21:46:04 0E1C PACKET  0000017DEDFE28D0 UDP Rcv 10.20.0.6       966f   Q [0001   D   NOERROR] A      (5)login(4)live(3)com(0)
+20140816 16:08:57 588 PACKET  019B99F0 UDP Rcv 192.168.0.2 80fd   Q [0001   D   NOERROR] A     (3)www(6)google(3)com(0)
+```
+
+### The timestamp problem is the hardest parsing challenge
+
+The date format follows the OS locale of the DNS service account, not a fixed format. Three known variants exist:
+
+- **US locale:** `M/d/yyyy h:mm:ss tt` — e.g., `4/15/2014 3:16:00 PM` (no leading zeros, 12-hour with AM/PM)
+- **EU locale:** `dd/MM/yyyy HH:mm:ss` — e.g., `22/12/2021 21:46:04` (leading zeros, 24-hour, no AM/PM)
+- **ISO-style (older servers):** `yyyyMMdd HH:mm:ss` — e.g., `20140816 16:08:57`
+
+**MM/DD and DD/MM are indistinguishable without context.** A robust parser should auto-detect or accept configuration.
+
+### Comprehensive regex pattern for Rust
+
+```regex
+^(\d{1,2}/\d{1,2}/\d{4}\s+\d{1,2}:\d{2}:\d{2}\s*(?:AM|PM)?|\d{8}\s+\d{2}:\d{2}:\d{2})\s+([0-9A-Fa-f]{3,4})\s+PACKET\s+([0-9A-Fa-f]{8,16})\s+(UDP|TCP)\s+(Snd|Rcv)\s+([0-9a-fA-F.:]+)\s+([0-9a-fA-F]{4})\s+([R ])\s*([QNU?])\s+\[([0-9A-Fa-f]{4})\s+([ATDR ]{1,4})\s+(\w+)\]\s+(\S+)\s+(.+)$
+```
+
+The flags section `[HHHH CCCC RCODE]` should be matched as a unit and parsed internally, since the character flags occupy variable positions with internal whitespace.
+
+### Query name encoding
+
+Two formats appear depending on Windows Server version:
+
+**Wire-format style** (most common): `(3)www(6)google(3)com(0)` — each `(N)` gives the label length in decimal, terminated by `(0)`. Convert by replacing `(\d+)` captures with dots and stripping the leading dot.
+
+**Dotted style** (older servers): `.ns1.example.com.` — standard FQDN with leading dot.
+
+**Compression pointers** in detailed output: `[C00C](3)www(6)google(3)com(0)` — the `[C00C]` is a 2-byte DNS wire-format pointer to offset 0x0C.
+
+### Multi-line detail format
+
+When "Details" logging is enabled, each summary line is followed by a decoded packet dump including `Remote addr X.X.X.X, port NNNNN` (the **only** place port numbers appear), buffer/message lengths, and full DNS message decode with question, answer, authority, and additional sections. The detail section shows QTYPE as both name and number: `QTYPE A (1)`.
+
+### Edge cases to handle
+
+- **Blank lines** between entries must be skipped
+- **Header** (~30 lines) at file start; detect via absence of `PACKET` keyword
+- **Log file wrap** lines: `"Log file wrap at..."` appear when max size is reached
+- **Windows line endings** (`\r\n`) throughout
+- **Variable whitespace** between fields; use whitespace splitting, not fixed positions
+- **The `R` vs space ambiguity**: the query/response field is a single character — `R Q` means "Response, Standard Query" while `  Q` (space-Q) means just "Standard Query"
+- **IPv6 addresses** in the remote IP field (e.g., `::1`, `fe80::1`)
+- **Non-PACKET context**: the context field can be `EVENT` for non-packet events
+
+---
+
+## 2. DNS analytical event log (Event IDs 256–280)
+
+The analytical channel (`Microsoft-Windows-DNSServer/Analytical`) is ETW-based, stored as `.etl` files (not standard EVTX), and captures query-level DNS telemetry. **Event ID 256 is undocumented by Microsoft** but universally observed.
+
+### Complete event ID registry
+
+| ID | Name | Keyword Bit | Level | Direction |
+|----|------|------------|-------|-----------|
+| 256 | QUERY_RECEIVED | 0x01 | Info | Inbound query from client |
+| 257 | RESPONSE_SUCCESS | 0x02 | Info | Successful response to client |
+| 258 | RESPONSE_FAILURE | 0x04 | Error | Failed response to client |
+| 259 | IGNORED_QUERY | 0x08 | Error | Query dropped/ignored |
+| 260 | RECURSE_QUERY_OUT | 0x10 | Info | Recursive query to upstream |
+| 261 | RECURSE_RESPONSE_IN | 0x20 | Info | Recursive response from upstream |
+| 262 | RECURSE_QUERY_TIMEOUT | 0x40 | Error | Recursive query timed out |
+| 263 | DYN_UPDATE_RECV | 0x80 | Info | Dynamic update received |
+| 264 | DYN_UPDATE_RESPONSE | 0x100 | Info | Dynamic update response sent |
+| 265 | IXFR_REQ_OUT | 0x200 | Info | IXFR request sent |
+| 266 | IXFR_REQ_RECV | 0x400 | Info | IXFR request received |
+| 267 | IXFR_RESP_OUT | 0x800 | Info | IXFR response sent |
+| 268 | IXFR_RESP_RECV | 0x1000 | Info | IXFR response received |
+| 269 | AXFR_REQ_OUT | 0x2000 | Info | AXFR request sent |
+| 270 | AXFR_REQ_RECV | 0x4000 | Info | AXFR request received |
+| 271 | AXFR_RESP_OUT | 0x8000 | Info | AXFR response sent |
+| 272 | AXFR_RESP_RECV | 0x10000 | Info | AXFR response received |
+| 273 | XFR_NOTIFY_RECV | 0x20000 | Info | Zone transfer notify received |
+| 274 | XFR_NOTIFY_OUT | 0x40000 | Info | Zone transfer notify sent |
+| 275 | XFR_NOTIFY_ACK_IN | 0x80000 | Info | Notify acknowledgment received |
+| 276 | XFR_NOTIFY_ACK_OUT | 0x100000 | Info | Notify acknowledgment sent |
+| 277 | DYN_UPDATE_FORWARD | 0x200000 | Info | Dynamic update forwarded |
+| 278 | DYN_UPDATE_RESPONSE_IN | 0x400000 | Info | Dynamic update response received |
+| 279 | INTERNAL_LOOKUP_CNAME | 0x800000 | Info | Internal CNAME chase lookup |
+| 280 | INTERNAL_LOOKUP_ADDITIONAL | 0x1000000 | Info | Internal additional-section lookup |
+
+### EventData fields per event ID
+
+**Event 256 (QUERY_RECEIVED):**
+`TCP`, `InterfaceIP`, `Source`, `RD`, `QNAME`, `QTYPE`, `XID`, `Port`, `Flags`, `BufferSize`, `PacketData`, `AdditionalInfo`
+
+**Event 257 (RESPONSE_SUCCESS):**
+`TCP`, `InterfaceIP`, `Destination`, `AA`, `AD`, `QNAME`, `QTYPE`, `XID`, `DNSSEC`, `RCODE`, `Port`, `Flags`, `Scope`, `Zone`, `PolicyName`, `PacketData`
+
+**Event 258 (RESPONSE_FAILURE):**
+`TCP`, `InterfaceIP`, `Reason`, `Destination`, `QNAME`, `QTYPE`, `XID`, `RCODE`, `Port`, `Flags`, `Zone`, `PolicyName`, `PacketData`
+
+**Event 259 (IGNORED_QUERY):**
+`TCP`, `InterfaceIP`, `Reason`, `QNAME`, `QTYPE`, `XID`, `Zone`, `PolicyName` — notably minimal, no IP/port/packet fields.
+
+**Events 260 (RECURSE_QUERY_OUT):**
+`TCP`, `Destination`, `InterfaceIP`, `RD`, `QNAME`, `QTYPE`, `XID`, `Port`, `Flags`, `ServerScope`, `CacheScope`, `PolicyName`, `PacketData`
+
+**Event 261 (RECURSE_RESPONSE_IN):**
+`TCP`, `Source`, `InterfaceIP`, `AA`, `AD`, `QNAME`, `QTYPE`, `XID`, `Port`, `Flags`, `ServerScope`, `CacheScope`, `PacketData`
+
+**Event 262 (RECURSE_QUERY_TIMEOUT):**
+`TCP`, `InterfaceIP`, `Destination`, `QNAME`, `QTYPE`, `XID`, `Port`, `Flags`, `ServerScope`, `CacheScope` — no `PacketData`.
+
+**Events 263 (DYN_UPDATE_RECV):**
+`TCP`, `InterfaceIP`, `Source`, `QNAME`, `XID`, `Port`, `Flags`, `SECURE`, `PacketData` — unique `SECURE` field indicates TSIG/GSS-TSIG. No `QTYPE`.
+
+**Event 264 (DYN_UPDATE_RESPONSE):**
+`TCP`, `InterfaceIP`, `Destination`, `QNAME`, `XID`, `ZoneScope`, `Zone`, `RCODE`, `PolicyName`, `PacketData`
+
+**Events 265-268 (IXFR):**
+`TCP`, `InterfaceIP`/`Source`, `QNAME`, `XID`, `ZoneScope`, `Zone`, `PacketData`. Response variants (267-268) add `Destination` and `RCODE`.
+
+**Events 269-272 (AXFR):**
+Same pattern as IXFR but **AXFR response events (271-272) lack `PacketData`**.
+
+**Events 273-274 (XFR_NOTIFY):**
+`Source`/`Destination`, `InterfaceIP`, `QNAME`, `ZoneScope`, `Zone`, `PacketData` — no `TCP` field.
+
+**Events 275-276 (XFR_NOTIFY_ACK):**
+Minimal — just `Source`/`Destination`, `InterfaceIP`, `PacketData` (276 adds `Zone`).
+
+**Event 277 (DYN_UPDATE_FORWARD):**
+`TCP`, `ForwardInterfaceIP` (unique field name), `Destination`, `QNAME`, `XID`, `ZoneScope`, `Zone`, `RCODE`, `PacketData`
+
+**Events 279-280 (INTERNAL_LOOKUP):**
+`TCP`, `InterfaceIP`, `Source`, `RD`, `QNAME`, `QTYPE`, `Port`, `Flags`, `XID`, `PacketData` — mirrors Event 256's structure.
+
+### Key parsing notes for analytical events
+
+All field values are strongly typed in the ETW schema: `TCP` is `UInt32` (0/1), `QTYPE` is `UInt32` (numeric code, not name), `RCODE` is `UInt32`, IP fields are `UnicodeString`, `PacketData` is hex-encoded binary (`0x...` prefix). The `PacketData` field contains the **raw DNS wire-format payload** identical to what appears after the UDP header in a packet capture.
+
+The Keywords value in each event's System section combines the event keyword with `0x8000000000000000` (the analytical channel bit). For example, Event 256 shows `Keywords=0x8000000000000001`.
+
+---
+
+## 3. DNS audit event log (Event IDs 513–582)
+
+The audit channel (`Microsoft-Windows-DNSServer/Audit`) is a standard EVTX event log, enabled by default with minimal performance impact.
+
+### Complete audit event ID table
+
+**Zone and record operations (513-521):**
+
+| ID | Operation | Key EventData Fields |
+|----|-----------|---------------------|
+| 513 | Zone delete | `Zone` |
+| 514 | Zone setting updated | `Zone`, `Setting`, `NewValue` |
+| 515 | Record create | `Type`, `NAME`, `TTL`, `BufferSize`, `RDATA`, `Zone`, `ZoneScope`, `VirtualizationID` |
+| 516 | Record delete | Same as 515 |
+| 517 | RRSET delete | `Type`, `NAME`, `Zone`, `ZoneScope` |
+| 518 | Node delete | `NodeName`, `Zone`, `ZoneScope` |
+| 519 | Record create (dynamic update) | Same as 515 + `SourceIP` |
+| 520 | Record delete (dynamic update) | Same as 515 + `SourceIP` |
+| 521 | Record scavenge | Same as 515 |
+
+The `Type` field is the DNS RR type number (1=A, 28=AAAA, etc.). The `RDATA` field contains hex-encoded binary data (e.g., `0x0A00020F` for IP 10.0.2.15).
+
+**Zone scope and DNSSEC (522-537):**
+
+| ID | Operation |
+|----|-----------|
+| 522-523 | Zone scope create/delete |
+| 525-527 | Zone sign/unsign/re-sign |
+| 528-531 | DNSSEC key rollover start/end/retire/triggered |
+| 533 | Key poke rollover (Level=Warning) |
+| 534-535 | DNSSEC export/import |
+| 536 | Cache purge |
+| 537 | Forwarder reset |
+
+**Server configuration (540-560):**
+
+| ID | Operation | Notable Fields |
+|----|-----------|----------------|
+| 540 | Root hints update | |
+| 541 | Server setting change | `Setting`, `Scope`, `Value` — key for detecting `serverlevelplugindll` modifications |
+| 542-543 | Server scope create/delete | |
+| 544-546 | Trust anchor DNSKEY/DS add/remove | `TrustPoint`, `KeyProtocol`, `CryptoAlgorithm`, `Base64Data` |
+| 547-550 | Trust point root/restart/clear debug/write zones | |
+| 551-560 | Statistics, scavenging, demotion, listen address, pause/resume zone | |
+
+**Extended operations (561-582):**
+
+| ID | Operation |
+|----|-----------|
+| 561-568 | Reload/refresh/expire zone, update from DS, write and notify, force aging, scavenge servers, transfer key |
+| 569-572 | SKD (Signing Key Descriptor) add/modify/delete/state change — extensive DNSSEC key fields |
+| 573 | Add delegation |
+| 574-576 | Client subnet record create/delete/update |
+| 577-579 | Policy create (server-level/zone-level/forwarding) — fields include `ProcessingOrder`, `Criteria`, `Action`, `PolicyName`, `Scopes` |
+| 580-582 | Policy delete (server-level/zone-level/forwarding) |
+
+### Audit event XML structure
+
+```xml
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <System>
+    <Provider Name="Microsoft-Windows-DNSServer" 
+              Guid="{EB79061A-A566-4698-9119-3ED2807060E7}" />
+    <EventID>515</EventID>
+    <Version>0</Version>
+    <Level>4</Level>
+    <Task>5</Task>
+    <Keywords>0x4000000000000000</Keywords>
+    <Channel>Microsoft-Windows-DNSServer/Audit</Channel>
+  </System>
+  <EventData>
+    <Data Name="Type">1</Data>
+    <Data Name="NAME">test.homelab.local</Data>
+    <Data Name="TTL">3600</Data>
+    <Data Name="BufferSize">4</Data>
+    <Data Name="RDATA">0x01010101</Data>
+    <Data Name="Zone">homelab.local</Data>
+    <Data Name="ZoneScope">Default</Data>
+    <Data Name="VirtualizationID">.</Data>
+  </EventData>
+</Event>
+```
+
+The `Keywords` value `0x4000000000000000` is the audit channel selector bit.
+
+---
+
+## 4. ETW provider and trace configuration
+
+### Provider identity
+
+- **Provider Name:** `Microsoft-Windows-DNSServer`
+- **Provider GUID:** `{EB79061A-A566-4698-9119-3ED2807060E7}`
+- **Binary:** `C:\Windows\System32\dns.exe` (manifest embedded in this binary)
+- **Distinct from:** `Microsoft-Windows-DNS-Server-Service` (`{71A551F5-C893-4849-886B-B5EC8502641E}`) — a different, older provider
+
+### Trace levels
+
+| Value | Name | Use |
+|-------|------|-----|
+| 0 | None | Logging off |
+| 1 | Critical | Process exit/termination only |
+| 2 | Error | Severe failures |
+| 3 | Warning | Recoverable errors |
+| 4 | Informational | High-level operational events |
+| 5 | Verbose | Complete event stream |
+
+### Complete keyword bitmask reference
+
+**Analytical keywords (bits 0-24):**
+
+| Bit | Keyword | Events |
+|-----|---------|--------|
+| 0x0000000000000001 | QUERY_RECEIVED | 256 |
+| 0x0000000000000002 | RESPONSE_SUCCESS | 257 |
+| 0x0000000000000004 | RESPONSE_FAILURE | 258 |
+| 0x0000000000000008 | IGNORED_QUERY | 259 |
+| 0x0000000000000010 | RECURSE_QUERY_OUT | 260 |
+| 0x0000000000000020 | RECURSE_RESPONSE_IN | 261 |
+| 0x0000000000000040 | RECURSE_QUERY_DROP | 262 |
+| 0x0000000000000080 | DYN_UPDATE_RECV | 263 |
+| 0x0000000000000100 | DYN_UPDATE_RESPONSE | 264 |
+| 0x0000000000000200 | IXFR_REQ_OUT | 265 |
+| 0x0000000000000400 | IXFR_REQ_RECV | 266 |
+| 0x0000000000000800 | IXFR_RESP_OUT | 267 |
+| 0x0000000000001000 | IXFR_RESP_RECV | 268 |
+| 0x0000000000002000 | AXFR_REQ_OUT | 269 |
+| 0x0000000000004000 | AXFR_REQ_RECV | 270 |
+| 0x0000000000008000 | AXFR_RESP_OUT | 271 |
+| 0x0000000000010000 | AXFR_RESP_RECV | 272 |
+| 0x0000000000020000 | XFR_NOTIFY_IN | 273 |
+| 0x0000000000040000 | XFR_NOTIFY_OUT | 274 |
+| 0x0000000000800000 | INTERNAL_LOOKUP_CNAME | 279 |
+| 0x0000000001000000 | INTERNAL_LOOKUP_ADDITIONAL | 280 |
+
+**Audit keywords (selected):**
+
+| Bit | Keyword |
+|-----|---------|
+| 0x0000000000080000 | AUDIT_ZONES |
+| 0x0000000000100000 | AUDIT_REC_ADMIN |
+| 0x0000000000200000 | AUDIT_ZONESCOPE |
+| 0x0000000000400000 | AUDIT_ZONE_SIGN |
+| 0x0000000000800000 | AUDIT_ROLLOVER |
+| 0x0000000002000000 | AUDIT_REC_DYN_UPDATE |
+| 0x0000000008000000 | AUDIT_SERVER_CONFIG |
+| 0x0000000020000000 | AUDIT_EXPORT_IMPORT |
+| 0x0000000100000000 | AUDIT_TRUST_ANCHOR |
+| 0x0000020000000000 | AUDIT_POLICY |
+| 0x0000200000000000 | AUDIT_RRL |
+
+**Channel selector bits:**
+
+| Bit | Channel |
+|-----|---------|
+| 0x8000000000000000 | Analytical channel |
+| 0x4000000000000000 | Audit channel |
+
+**Common masks:** `0x7FFFF` captures all base analytical events (bits 0-18). `0xFFFFFFFFFFFFFFFF` captures everything. Note that `0xFFFFFFFF` (32-bit) misses extended keywords above bit 31.
+
+### Capture commands
+
+```bash
+# logman (built-in)
+logman create trace DnsTrace -p "Microsoft-Windows-DNSServer" 0xFFFFFFFF 5 -o C:\dns.etl
+logman start DnsTrace
+
+# tracelog.exe (WDK)
+tracelog.exe -start Dns -guid #{EB79061A-A566-4698-9119-3ED2807060E7} -level 5 -matchanykw 0x7FFFF -f C:\analytical.etl
+```
+
+### Critical architecture detail
+
+The analytical channel stores data as `.etl` (Event Trace Log), **not** `.evtx`. It cannot be read with standard Windows Event Log APIs in real-time. The audit channel is standard EVTX. Both originate from the same ETW provider — the channel keyword bits (62-63) route events to the appropriate channel.
+
+---
+
+## 5. QTYPE values: complete mapping
+
+### Standard types (RFC 1035 and extensions)
+
+| Code | Name | Description |
+|------|------|-------------|
+| 1 | A | IPv4 address |
+| 2 | NS | Name server |
+| 3 | MD | Mail destination (obsolete) |
+| 4 | MF | Mail forwarder (obsolete) |
+| 5 | CNAME | Canonical name/alias |
+| 6 | SOA | Start of authority |
+| 7 | MB | Mailbox (experimental) |
+| 8 | MG | Mail group (experimental) |
+| 9 | MR | Mail rename (experimental) |
+| 10 | NULL | Null RR (experimental) |
+| 11 | WKS | Well-known service |
+| 12 | PTR | Pointer/reverse lookup |
+| 13 | HINFO | Host information |
+| 14 | MINFO | Mailbox info |
+| 15 | MX | Mail exchange |
+| 16 | TXT | Text strings |
+| 17 | RP | Responsible person |
+| 18 | AFSDB | AFS database |
+| 24 | SIG | Security signature (legacy) |
+| 25 | KEY | Security key (legacy) |
+| 28 | AAAA | IPv6 address |
+| 29 | LOC | Geographic location |
+| 33 | SRV | Service locator |
+| 35 | NAPTR | Naming authority pointer |
+| 36 | KX | Key exchanger |
+| 37 | CERT | Certificate |
+| 39 | DNAME | Delegation name |
+| 41 | OPT | EDNS pseudo-RR |
+| 43 | DS | Delegation signer |
+| 44 | SSHFP | SSH fingerprint |
+| 45 | IPSECKEY | IPsec key |
+| 46 | RRSIG | DNSSEC signature |
+| 47 | NSEC | Next secure |
+| 48 | DNSKEY | DNS key |
+| 49 | DHCID | DHCP identifier |
+| 50 | NSEC3 | Next secure v3 |
+| 51 | NSEC3PARAM | NSEC3 parameters |
+| 52 | TLSA | DANE certificate |
+| 53 | SMIMEA | S/MIME certificate |
+| 55 | HIP | Host identity protocol |
+| 59 | CDS | Child DS |
+| 60 | CDNSKEY | Child DNSKEY |
+| 61 | OPENPGPKEY | OpenPGP key |
+| 64 | SVCB | Service binding |
+| 65 | HTTPS | HTTPS service binding |
+| 99 | SPF | Sender policy framework |
+| 249 | TKEY | Transaction key |
+| 250 | TSIG | Transaction signature |
+| 251 | IXFR | Incremental zone transfer |
+| 252 | AXFR | Full zone transfer |
+| 255 | ANY/\* | All records |
+| 256 | URI | Uniform resource identifier |
+| 257 | CAA | Certification authority authorization |
+
+### Windows-specific types (private use range)
+
+| Code | Name | Description |
+|------|------|-------------|
+| **65281** (0xFF01) | WINS | WINS forward lookup (Microsoft proprietary) |
+| **65282** (0xFF02) | WINSR | WINS reverse lookup (Microsoft proprietary) |
+
+**In the debug log, QTYPE appears as a name string** (`A`, `AAAA`, `SRV`). In the detail section, it shows both: `QTYPE A (1)`. **In analytical events, QTYPE is numeric** (`UInt32`).
+
+---
+
+## 6. RCODE values: complete mapping
+
+| Code | Name | Description |
+|------|------|-------------|
+| 0 | NOERROR | Successful query |
+| 1 | FORMERR | Format error |
+| 2 | SERVFAIL | Server failure |
+| 3 | NXDOMAIN | Domain does not exist |
+| 4 | NOTIMP | Not implemented |
+| 5 | REFUSED | Query refused |
+| 6 | YXDOMAIN | Name exists when it should not |
+| 7 | YXRRSET | RR set exists when it should not |
+| 8 | NXRRSET | RR set does not exist when it should |
+| 9 | NOTAUTH | Not authoritative / not authorized |
+| 10 | NOTZONE | Name not in zone |
+| 16 | BADVERS/BADSIG | Bad OPT version (EDNS) or TSIG signature failure |
+| 17 | BADKEY | Key not recognized |
+| 18 | BADTIME | Signature out of time window |
+| 19 | BADMODE | Bad TKEY mode |
+| 20 | BADNAME | Duplicate key name |
+| 21 | BADALG | Algorithm not supported |
+| 22 | BADTRUNC | Bad truncation |
+| 23 | BADCOOKIE | Bad/missing server cookie |
+
+**Code 16 has dual meaning**: BADVERS in EDNS OPT context, BADSIG in TSIG/TKEY context. In debug logs, RCODE appears as a **name string** (`NOERROR`, `NXDOMAIN`). In the Windows debug log, NOTIMP may appear as `NOTIMPL`. In analytical events, RCODE is a **UInt32** numeric code.
+
+---
+
+## 7. DNS wire format and hex packet data
+
+### DNS message structure (RFC 1035)
+
+```
+Bytes 0-1:   ID        (16-bit transaction ID = XID in debug log)
+Bytes 2-3:   Flags     (16-bit = hex flags in debug log)
+Bytes 4-5:   QDCOUNT   (number of questions)
+Bytes 6-7:   ANCOUNT   (number of answers)
+Bytes 8-9:   NSCOUNT   (number of authority RRs)
+Bytes 10-11: ARCOUNT   (number of additional RRs)
+Byte 12+:    Question section, then Answer/Authority/Additional RRs
+```
+
+### Question section encoding
+
+Each question is: `QNAME` (length-prefixed labels terminated by 0x00) + `QTYPE` (2 bytes big-endian) + `QCLASS` (2 bytes, 0x0001 = IN).
+
+Example for `www.google.com`: `03 77 77 77 06 67 6F 6F 67 6C 65 03 63 6F 6D 00 00 01 00 01`
+
+### Name compression pointers
+
+When the two high bits of a label length byte are both 1 (byte ≥ 0xC0), the remaining 14 bits form an offset from the message start. **`0xC00C`** (pointer to offset 12) is the most common, pointing to the QNAME in the question section.
+
+### PacketData in analytical events
+
+The `PacketData` field in ETW analytical events (e.g., Event 256/257) contains the **raw DNS wire-format payload** prefixed with `0x`. It is byte-for-byte identical to the DNS payload captured in a packet trace. Parse it directly with any DNS wire-format library (`hickory-proto::op::Message::from_vec()`).
+
+---
+
+## 8. DNS header flags bitmap
+
+```
+Bit 15 (MSB): QR     — 0=Query, 1=Response
+Bits 14-11:   Opcode — 0=QUERY, 4=NOTIFY, 5=UPDATE
+Bit 10:       AA     — Authoritative Answer
+Bit 9:        TC     — Truncation
+Bit 8:        RD     — Recursion Desired
+Bit 7:        RA     — Recursion Available
+Bit 6:        Z      — Reserved (must be 0)
+Bit 5:        AD     — Authentic Data (DNSSEC)
+Bit 4:        CD     — Checking Disabled (DNSSEC)
+Bits 3-0:     RCODE  — Response code (4-bit)
+```
+
+**Debug log hex flags decode examples:**
+- `0x0001` → QR=0, RD=1 (query with recursion desired) → char flags: `D`
+- `0x8081` → QR=1, RD=1, RA=1 (response, recursion available) → char flags: `DR`
+- `0x8385` → QR=1, AA=1, RD=1, RA=1, RCODE=5 → char flags: `A DR`, RCODE=REFUSED
+- `0x8180` → QR=1, RD=1, RA=1 (standard recursive response) → char flags: `DR`
+
+The debug log char codes map: **A**=AA, **T**=TC, **D**=RD, **R**=RA. These appear between the hex flags and the RCODE name inside the square brackets.
+
+---
+
+## 9. Rust implementation strategy and available crates
+
+### Recommended crate stack
+
+| Component | Crate | Version | Purpose |
+|-----------|-------|---------|---------|
+| EVTX parsing | **`evtx`** (omerbenamram) | 0.11.1 | Parse offline EVTX audit logs; production-grade, used by Hayabusa and Chainsaw |
+| DNS wire format | **`hickory-proto`** | 0.25.x | Decode `PacketData` hex fields from analytical events; `Message::from_vec()` |
+| Lighter DNS alternative | **`simple-dns`** | 0.9.x | Smaller dependency; `Packet::parse(bytes)` |
+| Real-time ETW | **`ferrisetw`** | 1.x (GitHub) | Subscribe to DNS Server ETW provider for live analytical events |
+| ETW emission | **`tracelogging`** | 1.2.4 | Microsoft-maintained; for producing ETW events (optional) |
+| Debug log parsing | **None exists** | — | Must build from scratch |
+
+### No existing Rust crate parses dns.log
+
+The debug text log format has **no Rust crate**. The only known Rust project is `u-siem/usiem-windns` on GitHub (MIT-licensed, part of the uSIEM framework) which could serve as a reference implementation.
+
+### Reference parsers in other languages worth studying
+
+- **NXLog `xm_msdns`** — the most complete commercial parser; hand-written in C without regex for performance; defines the canonical field list
+- **PowerShell `Get-DNSDebugLog`** — multiple implementations on GitHub (winadm/posh, jschpp/DNSDebugLogHandler); provides tested regex patterns
+- **Python `ScourDNS`** — DNS debug log analysis tool
+- **`cybersecthreat/DFIR` PowerShell script** — analytical/ETW log parser using `wevtutil qe`
+
+### Suggested parser architecture
+
+A comprehensive Rust DNS parser should have three independent modules:
+
+1. **Debug log parser** — custom line-by-line parser using `regex` crate or hand-rolled state machine (NXLog's experience suggests hand-written outperforms regex). Handle timestamp detection with fallback patterns. Emit structured records with typed fields.
+
+2. **EVTX/audit parser** — use the `evtx` crate to read `.evtx` files, then dispatch on `EventID` to extract typed `EventData` fields. Map `Type`/`RDATA` fields from hex to structured records.
+
+3. **ETW/analytical parser** — for offline `.etl` files, use `evtx` crate (which can read archived analytical logs). For real-time capture, use `ferrisetw` to subscribe to the DNS Server provider GUID. Extract `PacketData` fields and decode with `hickory-proto` for full DNS message parsing.
+
+### Critical implementation note
+
+The analytical channel produces `.etl` files, not `.evtx`. These cannot be consumed through standard Windows Event Log APIs. For real-time DNS query monitoring on Server 2012 R2+, ETW is the only path. The `evtx` crate can read archived `.etl` files converted to `.evtx` via `wevtutil`, but native `.etl` consumption requires an ETW consumer like `ferrisetw`.
+
+---
+
+## Conclusion
+
+Building a Rust DNS log parser requires handling four fundamentally different formats from a single Windows Server service. The **debug text log** is the most challenging to parse due to locale-dependent timestamps, variable whitespace, and undocumented format quirks — but carries the richest legacy deployment base. The **analytical ETW channel** (Event IDs 256-280) is the modern replacement, offering structured fields with embedded DNS wire-format packets, though Event 256 remains officially undocumented despite being the most important event. The **audit EVTX channel** (Event IDs 513-582) covers administrative operations and is the only log enabled by default. The recommended Rust stack combines `evtx` for EVTX parsing, `hickory-proto` for DNS wire format decoding, and `ferrisetw` for live ETW consumption — with a new custom module needed exclusively for the legacy debug text log format.

--- a/docs/design-system/SKILL.md
+++ b/docs/design-system/SKILL.md
@@ -1,0 +1,139 @@
+# SKILL — Designing for CMTrace Open
+
+> Read this file first when designing anything new for CMTrace Open.
+> It tells you which surface to extend, which surface to copy, and the moves to avoid.
+
+---
+
+## What CMTrace Open is
+
+A **free, open-source web reimagining of Microsoft's CMTrace.exe** — a log viewer for MEMCM/MECM admins, Intune admins, sysadmins, and Windows developers. The product promise:
+
+> Drop in a log file and start reading. Errors highlight automatically.
+
+CMTrace Open is **engineering-led**. Tokens, themes, components, and metrics all live in `cmtraceopen-web/cmtraceopen/src/` — this design system mirrors them. **The codebase is the source of truth.** When this system disagrees with the codebase, the codebase wins; update the system to match.
+
+---
+
+## Where things live
+
+| You need… | Look here (codebase) | Mirrored in this DS |
+|---|---|---|
+| Theme objects, brand ramps | `src/lib/themes/*` | `02-color-themes.html`, `tokens.css` |
+| Semantic color tokens | `src/lib/themes/*-theme.ts` | `03-color-tokens.html`, `tokens.css` |
+| Type ramp & families | `src/lib/themes/typography.ts` | `04-typography.html` |
+| Log row metrics | `src/lib/log-list-metrics.ts` (`getLogListMetrics()`) | `04-typography.html`, `09-components-log-grid.html` |
+| Spacing / radius / shadow | `src/lib/themes/tokens.ts` | `05-spacing-radius-shadow.html` |
+| Motion durations & curves | `src/lib/themes/motion.ts` | `06-motion.html` |
+| Icons | `@fluentui/react-icons` | `07-iconography.html` |
+| Buttons, inputs, badges | `src/components/ui/*` | `08-components-buttons-inputs.html` |
+| Log row, gutter, markers | `src/components/log/LogRow.tsx`, `LogGutter.tsx` | `09-components-log-grid.html` |
+| Toolbar, tabs, status bar | `src/components/chrome/*` | `10-components-chrome.html` |
+| Dialogs, settings, find | `src/components/dialogs/*` | `11-components-dialogs.html` |
+| Full app reference | `src/App.tsx` | `ui-kit.html` |
+
+---
+
+## The decision tree
+
+When designing something new, ask in order:
+
+1. **Does it already exist in the codebase?** → Use it as-is. Don't re-design.
+2. **Is it a small variant of something in the codebase?** → Match the existing component's API and visual rhythm. Add a prop, don't fork.
+3. **Is it genuinely new?** → Compose from primitives in this DS. Default to Light theme + Teal brand. Open a PR with a token entry alongside the component.
+
+If you find yourself reaching for a hex code that isn't in `tokens.css`, stop. Either it should be added to the system, or you're solving the wrong problem.
+
+---
+
+## Setup (every new HTML file)
+
+```html
+<!doctype html>
+<html lang="en" data-cmt-theme="light">
+<head>
+  <link rel="stylesheet" href="tokens.css">
+</head>
+<body>
+  <!-- ... -->
+</body>
+</html>
+```
+
+Switch themes by changing the `data-cmt-theme` attribute. The eight valid IDs:
+`light` · `dark` · `high-contrast` · `classic-cmtrace` · `solarized-dark` · `nord` · `dracula` · `hotdog-stand`
+
+---
+
+## The six rules
+
+### 1. Severity colors are non-negotiable defaults
+Errors are red row-wide. Warnings are amber row-wide. Info is the default surface. The user opens a 50MB log and the failures should be visible inside two seconds with **zero configuration**. Never gate severity behind a setting.
+
+### 2. Tabular numbers, always
+Counts, byte sizes, line numbers, timestamps, thread IDs — all use `var(--cmt-font-numeric)` (Bahnschrift). Mono content (the log itself) uses `var(--cmt-font-mono)` (Consolas). UI chrome uses `var(--cmt-font-ui)` (Segoe UI). Don't mix these up.
+
+### 3. Density over comfort
+The default log row is **23px** tall at 13px font. Toolbar buttons are **28px**. Status bar is **24px**. This is intentional — admins are scanning thousands of rows. Don't add breathing room to the grid; reserve generous spacing for dialogs and marketing.
+
+### 4. Strokes do the work, not shadows
+Use `--cmt-stroke-2` between regions. Reserve `shadow8` for popovers and `shadow16` for dialogs. Stacked shadows on cards-inside-cards-inside-cards are an anti-pattern here.
+
+### 5. Brand teal is for accent, not decoration
+`--cmt-brand-bg` (`#007768` light, `#009688` dark) appears on: the status bar, primary buttons, the active-tab underline, selected sidebar items, the logo. **It does not appear** on borders, hover states of unrelated controls, or as a "pop of color" anywhere else. Restraint is the design.
+
+### 6. Don't soften technical errors
+"Failed to parse line 487" beats "Hmm, we couldn't read that." Copy is direct, operational, and assumes the reader is debugging Windows. No emoji in product UI. No "oops." No exclamation marks.
+
+---
+
+## Common moves
+
+### Adding a new dialog
+1. 8px corner radius, `var(--cmt-shadow-16)`, 24px padding.
+2. Title is 20px / 28px line-height, semibold.
+3. Action row right-aligned, primary button last, 8px gap.
+4. Cancel-on-Escape, focus the safe action by default (not the destructive one).
+
+### Adding a new toolbar button
+1. 28px tall, 8px horizontal padding, 4px radius, transparent until hover.
+2. Icon is `20Regular` from `@fluentui/react-icons`, 16px in the rendered button.
+3. Use `--cmt-bg-1-hover` for hover, `--cmt-bg-1-selected` + `--cmt-brand-fg` for active.
+4. Group related buttons; separate groups with a 1px × 20px stroke divider.
+
+### Adding a new log row decoration
+Look at `LogRow.tsx` first. The row has fixed slots: gutter (line# + marker dot) · time · component · message · source · thread. Don't add a 7th column; either pack it into Inspector, or reuse an existing slot with a tooltip.
+
+### Theming a new feature
+If the feature has a new color need, add it as a semantic token in **all eight themes** before shipping. Never reference brand ramp stops directly from a component — go through a semantic layer (`--cmt-status-success-fg`, not `--cmt-teal-70`).
+
+---
+
+## Anti-patterns (hard no)
+
+- **Inventing colors.** If it's not in `tokens.css` for the active theme, don't paint with it.
+- **Rounded everything.** 12px+ radii are for marketing surfaces only; the app maxes at 8px.
+- **Soft drop shadows on cards.** Use a stroke.
+- **Emoji icons in product UI.** Fluent icons only.
+- **Title-cased buttons.** Sentence case, with an ellipsis when the action opens a picker or another step.
+- **Tabular UI in proportional fonts.** Counts in Segoe UI look broken.
+- **Putting content in chrome.** The titlebar, status bar, and tab strip are signage, not editorial space.
+- **Blocking interactions for animation.** Most transitions are 100–200ms; the log row uses `80ms linear`. Anything above 300ms should be justifiable.
+
+---
+
+## Sourcing assets
+
+- **Logo:** `assets/cmtrace-logo.png` and `assets/splash-logo.png`. Reserved for splash, About dialog, marketing, favicon. Don't recolor or crop.
+- **Icons:** Fluent UI System Icons via `@fluentui/react-icons`. `20Regular` / `16Regular` for chrome, `Filled` only for selected/active states.
+- **Severity dots:** Not icons — 8px filled circles using semantic status colors. See `07-iconography.html`.
+- **Marker dots:** 6px filled circles in the row gutter. Five colors (red, amber, teal, purple, blue). User-assignable.
+
+---
+
+## When in doubt
+
+- Look at `LogRow.tsx`. It's the densest, most-considered component and sets the rhythm for everything else.
+- Default to **Light theme + Teal brand**. It's the canonical surface; everything else is a variation.
+- Ship it behind the existing eight themes. If your design only works in one theme, the design isn't done.
+- The product is for people who read logs for a living. Respect their time.

--- a/docs/superpowers/plans/2026-04-12-dns-parser.md
+++ b/docs/superpowers/plans/2026-04-12-dns-parser.md
@@ -2063,7 +2063,7 @@ git commit -m "test(dns): add DNS debug log corpus fixtures and regression tests
 Search for the TypeScript definition of LogEntry or ParseResult that mirrors the Rust struct. This is the frontend type that needs the nine new DNS fields.
 
 ```bash
-cd /Users/Adam.Gell/repo/cmtraceopen && grep -r "query_name\|queryName\|LogEntry\|logEntry" src/types/ --include="*.ts" --include="*.tsx" -l
+grep -r "query_name\|queryName\|LogEntry\|logEntry" src/types/ --include="*.ts" --include="*.tsx" -l
 ```
 
 - [ ] **Step 2: Add DNS fields to the TypeScript type**

--- a/docs/superpowers/plans/2026-04-12-dns-parser.md
+++ b/docs/superpowers/plans/2026-04-12-dns-parser.md
@@ -1,0 +1,2159 @@
+# DNS Log Parser Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add DNS debug log and DNS audit EVTX parsing to CMTrace Open, outputting `LogEntry` for the standard log viewer.
+
+**Architecture:** Three new flat files in `src-tauri/src/parser/` — `dns_types.rs` (shared QTYPE/RCODE maps, query name decoder), `dns_debug.rs` (text `dns.log` parser with `LogicalRecord` framing), and `dns_audit.rs` (EVTX audit parser via `evtx` crate). Both parsers flow through the existing `open_log_file()` command. Binary `.evtx` files are intercepted in `parse_file()` before text decoding. ETL files are stubbed with an error message.
+
+**Tech Stack:** Rust, `regex` crate (already in project), `evtx` crate (already in project behind `event-log` feature), `chrono` (already in project), `serde_json` (already in project).
+
+**Spec:** `docs/superpowers/specs/2026-04-11-dns-parser-design.md`
+
+**Reference doc:** `docs/compass_artifact_wf-d4b3505b-8666-487c-9577-1184da86cbd6_text_markdown.md`
+
+**Real fixtures:** `Logs/dns-fixtures-20260411-203254/` (DNS3 server, Windows Server 2022, en-US locale)
+
+---
+
+### Task 1: Type System Foundation
+
+**Files:**
+- Modify: `src-tauri/src/models/log_entry.rs`
+
+This task adds the DNS-specific enum variants and `LogEntry` fields that all subsequent tasks depend on.
+
+- [ ] **Step 1: Add `DnsDebug` and `DnsAudit` to `LogFormat` enum**
+
+In `src-tauri/src/models/log_entry.rs`, add two variants to `LogFormat` (after line 23):
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LogFormat {
+    Ccm,
+    Simple,
+    Plain,
+    Timestamped,
+    DnsDebug,
+    DnsAudit,
+}
+```
+
+- [ ] **Step 2: Add `DnsDebug` and `DnsAudit` to `ParserKind` enum**
+
+Add after `Registry` (line 44):
+
+```rust
+pub enum ParserKind {
+    Ccm,
+    Simple,
+    Timestamped,
+    Plain,
+    IisW3c,
+    Panther,
+    Cbs,
+    Dism,
+    ReportingEvents,
+    Msi,
+    PsadtLegacy,
+    IntuneMacOs,
+    Dhcp,
+    Burn,
+    PatchMyPcDetection,
+    Registry,
+    DnsDebug,
+    DnsAudit,
+}
+```
+
+- [ ] **Step 3: Add `DnsDebug` and `DnsAudit` to `ParserImplementation` enum**
+
+Add after `Registry` (line 63):
+
+```rust
+pub enum ParserImplementation {
+    Ccm,
+    Simple,
+    GenericTimestamped,
+    IisW3c,
+    ReportingEvents,
+    PlainText,
+    Msi,
+    PsadtLegacy,
+    IntuneMacOs,
+    Dhcp,
+    Burn,
+    PatchMyPcDetection,
+    Registry,
+    DnsDebug,
+    DnsAudit,
+}
+```
+
+- [ ] **Step 4: Add nine DNS fields to `LogEntry` struct**
+
+Add after the `win32_status` field (after line 213), before the closing brace:
+
+```rust
+    /// DNS query name, decoded from wire-format (DNS logs)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query_name: Option<String>,
+    /// DNS query type name: A, AAAA, SRV, etc. (DNS logs)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query_type: Option<String>,
+    /// DNS response code: NOERROR, NXDOMAIN, etc. (DNS logs)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_code: Option<String>,
+    /// Packet direction: Snd or Rcv (DNS debug log)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns_direction: Option<String>,
+    /// Transport protocol: UDP or TCP (DNS debug log)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns_protocol: Option<String>,
+    /// Remote IP address, optionally with port (DNS logs)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ip: Option<String>,
+    /// DNS header flags as hex string (DNS debug log)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns_flags: Option<String>,
+    /// DNS event ID for EVTX-sourced entries (DNS audit)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns_event_id: Option<u32>,
+    /// DNS zone name (DNS audit)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zone_name: Option<String>,
+```
+
+- [ ] **Step 5: Update every `LogEntry` construction site to include new fields**
+
+Every file that constructs a `LogEntry` struct literal needs the nine new fields set to `None` / `None` / `None` / `None` / `None` / `None` / `None` / `None` / `None`. Search for `LogEntry {` in all parser files. The affected files are:
+
+- `src-tauri/src/parser/ccm.rs`
+- `src-tauri/src/parser/simple.rs`
+- `src-tauri/src/parser/plain.rs`
+- `src-tauri/src/parser/timestamped.rs`
+- `src-tauri/src/parser/panther.rs`
+- `src-tauri/src/parser/cbs.rs`
+- `src-tauri/src/parser/dism.rs`
+- `src-tauri/src/parser/dhcp.rs`
+- `src-tauri/src/parser/iis_w3c.rs`
+- `src-tauri/src/parser/reporting_events.rs`
+- `src-tauri/src/parser/msi.rs`
+- `src-tauri/src/parser/burn.rs`
+- `src-tauri/src/parser/psadt.rs`
+- `src-tauri/src/parser/intune_macos.rs`
+- `src-tauri/src/parser/patchmypc_detection.rs`
+
+Add to each `LogEntry { ... }` literal:
+
+```rust
+                query_name: None,
+                query_type: None,
+                response_code: None,
+                dns_direction: None,
+                dns_protocol: None,
+                source_ip: None,
+                dns_flags: None,
+                dns_event_id: None,
+                zone_name: None,
+```
+
+- [ ] **Step 6: Run `cargo check` from `src-tauri/`**
+
+```bash
+cd src-tauri && cargo check
+```
+
+Expected: compiles with zero errors. If any `LogEntry` construction sites were missed, the compiler will report "missing field" errors — fix them.
+
+- [ ] **Step 7: Run existing tests**
+
+```bash
+cd src-tauri && cargo test
+```
+
+Expected: all existing tests pass. No behavioral changes yet.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src-tauri/src/models/log_entry.rs src-tauri/src/parser/*.rs
+git commit -m "feat(dns): add DNS type system foundation — LogFormat, ParserKind, ParserImplementation variants and LogEntry fields"
+```
+
+---
+
+### Task 2: Shared DNS Types (`dns_types.rs`)
+
+**Files:**
+- Create: `src-tauri/src/parser/dns_types.rs`
+- Modify: `src-tauri/src/parser/mod.rs` (add `pub mod dns_types;`)
+
+- [ ] **Step 1: Create `dns_types.rs` with QTYPE lookup**
+
+Create `src-tauri/src/parser/dns_types.rs`:
+
+```rust
+//! Shared DNS constants and decoders.
+//!
+//! Provides QTYPE/RCODE name lookups, DNS wire-format query name decoding,
+//! and RCODE-to-severity mapping used by both the debug log and audit EVTX parsers.
+
+use crate::models::log_entry::Severity;
+
+/// Map a numeric QTYPE code to its name.
+pub fn qtype_name(code: u32) -> String {
+    match code {
+        1 => "A".into(),
+        2 => "NS".into(),
+        5 => "CNAME".into(),
+        6 => "SOA".into(),
+        12 => "PTR".into(),
+        13 => "HINFO".into(),
+        15 => "MX".into(),
+        16 => "TXT".into(),
+        17 => "RP".into(),
+        18 => "AFSDB".into(),
+        24 => "SIG".into(),
+        25 => "KEY".into(),
+        28 => "AAAA".into(),
+        29 => "LOC".into(),
+        33 => "SRV".into(),
+        35 => "NAPTR".into(),
+        36 => "KX".into(),
+        37 => "CERT".into(),
+        39 => "DNAME".into(),
+        41 => "OPT".into(),
+        43 => "DS".into(),
+        44 => "SSHFP".into(),
+        45 => "IPSECKEY".into(),
+        46 => "RRSIG".into(),
+        47 => "NSEC".into(),
+        48 => "DNSKEY".into(),
+        49 => "DHCID".into(),
+        50 => "NSEC3".into(),
+        51 => "NSEC3PARAM".into(),
+        52 => "TLSA".into(),
+        53 => "SMIMEA".into(),
+        55 => "HIP".into(),
+        59 => "CDS".into(),
+        60 => "CDNSKEY".into(),
+        61 => "OPENPGPKEY".into(),
+        64 => "SVCB".into(),
+        65 => "HTTPS".into(),
+        99 => "SPF".into(),
+        249 => "TKEY".into(),
+        250 => "TSIG".into(),
+        251 => "IXFR".into(),
+        252 => "AXFR".into(),
+        255 => "ANY".into(),
+        256 => "URI".into(),
+        257 => "CAA".into(),
+        65281 => "WINS".into(),
+        65282 => "WINSR".into(),
+        _ => format!("UNKNOWN({})", code),
+    }
+}
+
+/// Map a numeric RCODE to its name.
+pub fn rcode_name(code: u32) -> String {
+    match code {
+        0 => "NOERROR".into(),
+        1 => "FORMERR".into(),
+        2 => "SERVFAIL".into(),
+        3 => "NXDOMAIN".into(),
+        4 => "NOTIMP".into(),
+        5 => "REFUSED".into(),
+        6 => "YXDOMAIN".into(),
+        7 => "YXRRSET".into(),
+        8 => "NXRRSET".into(),
+        9 => "NOTAUTH".into(),
+        10 => "NOTZONE".into(),
+        16 => "BADSIG".into(),
+        17 => "BADKEY".into(),
+        18 => "BADTIME".into(),
+        19 => "BADMODE".into(),
+        20 => "BADNAME".into(),
+        21 => "BADALG".into(),
+        22 => "BADTRUNC".into(),
+        23 => "BADCOOKIE".into(),
+        _ => format!("RCODE({})", code),
+    }
+}
+
+/// Map an RCODE name string to a severity level.
+pub fn rcode_to_severity(rcode: &str) -> Severity {
+    match rcode {
+        "NOERROR" => Severity::Info,
+        "NXDOMAIN" => Severity::Warning,
+        "SERVFAIL" | "REFUSED" | "FORMERR" => Severity::Error,
+        _ => Severity::Warning,
+    }
+}
+
+/// Decode a DNS query name from wire-format or dotted notation.
+///
+/// Handles:
+/// - Wire-format: `(3)www(6)google(3)com(0)` → `www.google.com`
+/// - Dotted: `.ns1.example.com.` → `ns1.example.com`
+/// - Compression pointers: `[C00C](4)home(4)gell(3)one(0)` → `home.gell.one`
+/// - Root: `(0)` → `.`
+pub fn decode_query_name(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    // Check for wire-format: contains `(` digits `)`
+    if trimmed.contains('(') {
+        return decode_wire_format_name(trimmed);
+    }
+
+    // Dotted format: strip leading/trailing dots
+    trimmed.trim_matches('.').to_string()
+}
+
+/// Decode wire-format name: `(3)www(6)google(3)com(0)` → `www.google.com`
+/// Also strips compression pointers like `[C00C]`.
+fn decode_wire_format_name(raw: &str) -> String {
+    // Strip compression pointers: [XXXX]
+    let cleaned: String = {
+        let mut result = String::with_capacity(raw.len());
+        let mut chars = raw.chars().peekable();
+        while let Some(ch) = chars.next() {
+            if ch == '[' {
+                // Skip until ']'
+                for inner in chars.by_ref() {
+                    if inner == ']' {
+                        break;
+                    }
+                }
+            } else {
+                result.push(ch);
+            }
+        }
+        result
+    };
+
+    let mut labels = Vec::new();
+    let mut chars = cleaned.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '(' {
+            // Read length number
+            let mut num_str = String::new();
+            for digit in chars.by_ref() {
+                if digit == ')' {
+                    break;
+                }
+                num_str.push(digit);
+            }
+            let label_len: usize = num_str.parse().unwrap_or(0);
+            if label_len == 0 {
+                // (0) is the root terminator
+                break;
+            }
+            // Read label_len characters
+            let label: String = chars.by_ref().take(label_len).collect();
+            labels.push(label);
+        }
+    }
+
+    if labels.is_empty() {
+        ".".to_string()
+    } else {
+        labels.join(".")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_qtype_known() {
+        assert_eq!(qtype_name(1), "A");
+        assert_eq!(qtype_name(28), "AAAA");
+        assert_eq!(qtype_name(6), "SOA");
+        assert_eq!(qtype_name(33), "SRV");
+        assert_eq!(qtype_name(12), "PTR");
+        assert_eq!(qtype_name(5), "CNAME");
+        assert_eq!(qtype_name(15), "MX");
+        assert_eq!(qtype_name(65281), "WINS");
+        assert_eq!(qtype_name(65282), "WINSR");
+    }
+
+    #[test]
+    fn test_qtype_unknown() {
+        assert_eq!(qtype_name(9999), "UNKNOWN(9999)");
+    }
+
+    #[test]
+    fn test_rcode_known() {
+        assert_eq!(rcode_name(0), "NOERROR");
+        assert_eq!(rcode_name(3), "NXDOMAIN");
+        assert_eq!(rcode_name(2), "SERVFAIL");
+        assert_eq!(rcode_name(5), "REFUSED");
+    }
+
+    #[test]
+    fn test_rcode_unknown() {
+        assert_eq!(rcode_name(99), "RCODE(99)");
+    }
+
+    #[test]
+    fn test_rcode_severity() {
+        assert_eq!(rcode_to_severity("NOERROR"), Severity::Info);
+        assert_eq!(rcode_to_severity("NXDOMAIN"), Severity::Warning);
+        assert_eq!(rcode_to_severity("SERVFAIL"), Severity::Error);
+        assert_eq!(rcode_to_severity("REFUSED"), Severity::Error);
+        assert_eq!(rcode_to_severity("FORMERR"), Severity::Error);
+        assert_eq!(rcode_to_severity("NOTAUTH"), Severity::Warning);
+    }
+
+    #[test]
+    fn test_decode_wire_format() {
+        assert_eq!(
+            decode_query_name("(4)home(4)gell(3)one(0)"),
+            "home.gell.one"
+        );
+    }
+
+    #[test]
+    fn test_decode_wire_format_www() {
+        assert_eq!(
+            decode_query_name("(3)www(6)google(3)com(0)"),
+            "www.google.com"
+        );
+    }
+
+    #[test]
+    fn test_decode_wire_format_root() {
+        assert_eq!(decode_query_name("(0)"), ".");
+    }
+
+    #[test]
+    fn test_decode_dotted() {
+        assert_eq!(decode_query_name(".ns1.example.com."), "ns1.example.com");
+    }
+
+    #[test]
+    fn test_decode_compression_pointer() {
+        assert_eq!(
+            decode_query_name("[C00C](4)home(4)gell(3)one(0)"),
+            "home.gell.one"
+        );
+    }
+
+    #[test]
+    fn test_decode_multiple_compression_pointers() {
+        assert_eq!(
+            decode_query_name("[C02B](4)dns3[C00C](4)home(4)gell(3)one(0)"),
+            "dns3.home.gell.one"
+        );
+    }
+
+    #[test]
+    fn test_decode_empty() {
+        assert_eq!(decode_query_name(""), "");
+    }
+}
+```
+
+- [ ] **Step 2: Register the module in `mod.rs`**
+
+In `src-tauri/src/parser/mod.rs`, add after `pub mod detect;` (line 5):
+
+```rust
+pub mod dns_types;
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd src-tauri && cargo test dns_types
+```
+
+Expected: all 13 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/parser/dns_types.rs src-tauri/src/parser/mod.rs
+git commit -m "feat(dns): add shared DNS types — QTYPE/RCODE maps, query name decoder, severity helper"
+```
+
+---
+
+### Task 3: DNS Debug Log Parser (`dns_debug.rs`)
+
+**Files:**
+- Create: `src-tauri/src/parser/dns_debug.rs`
+- Modify: `src-tauri/src/parser/mod.rs` (add `pub mod dns_debug;`)
+
+- [ ] **Step 1: Create `dns_debug.rs` with PACKET regex and `matches_dns_debug_record`**
+
+Create `src-tauri/src/parser/dns_debug.rs`:
+
+```rust
+//! Windows DNS Server debug log parser.
+//!
+//! Parses the text-based `dns.log` file produced by `dns.exe`.
+//! Each logical record is a PACKET summary line optionally followed by
+//! multi-line detail output (when Details logging is enabled).
+//!
+//! Format reference: docs/compass_artifact_*.md, Section 1.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+use super::dns_types;
+use super::timestamped::DateOrder;
+use crate::models::log_entry::{LogEntry, LogFormat, Severity};
+
+/// Compiled regex for the PACKET summary line.
+fn packet_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"^(\d{1,2}/\d{1,2}/\d{4}\s+\d{1,2}:\d{2}:\d{2}\s*(?:AM|PM)?|\d{8}\s+\d{2}:\d{2}:\d{2})\s+([0-9A-Fa-f]{3,4})\s+PACKET\s+[0-9A-Fa-f]{8,16}\s+(UDP|TCP)\s+(Snd|Rcv)\s+([0-9a-fA-F.:]+)\s+([0-9a-fA-F]{4})\s+(R\s|[R ]\s?)([QNU?])\s+\[([0-9A-Fa-f]{4})\s*([ATDR ]{0,4})\s*(\w+)\]\s+(\S+)\s+(.+)$"
+        ).expect("PACKET regex should compile")
+    })
+}
+
+/// Regex for extracting port from detail section.
+fn remote_port_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"Remote addr [0-9a-fA-F.:]+, port (\d+)")
+            .expect("remote port regex should compile")
+    })
+}
+
+/// Returns true if the line looks like a DNS debug log PACKET record.
+/// Used by `detect.rs` for format detection.
+pub fn matches_dns_debug_record(line: &str) -> bool {
+    let trimmed = line.trim();
+    // Fast pre-check before running the regex
+    if !trimmed.contains("PACKET") {
+        return false;
+    }
+    packet_re().is_match(trimmed)
+}
+
+/// Parse DNS debug log lines into `LogEntry` records.
+///
+/// Uses `LogicalRecord` framing: each PACKET summary line starts a new record,
+/// and subsequent detail lines are appended until the next PACKET line.
+pub fn parse_lines(lines: &[&str], file_path: &str, date_order: DateOrder) -> (Vec<LogEntry>, u32) {
+    let re = packet_re();
+    let port_re = remote_port_re();
+    let mut entries = Vec::new();
+    let mut parse_errors: u32 = 0;
+    let mut id: u64 = 0;
+
+    // Pending entry state for LogicalRecord framing
+    let mut pending: Option<PendingEntry> = None;
+
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+
+        // Skip blank lines
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // Try to match as a PACKET summary line
+        if let Some(caps) = re.captures(trimmed) {
+            // Flush any pending entry
+            if let Some(p) = pending.take() {
+                entries.push(p.into_log_entry(id, file_path, &port_re));
+                id += 1;
+            }
+
+            // Parse the new PACKET line
+            match parse_packet_captures(&caps, (i + 1) as u32, date_order) {
+                Ok(p) => {
+                    pending = Some(p);
+                }
+                Err(_) => {
+                    parse_errors += 1;
+                }
+            }
+        } else if pending.is_some() {
+            // Detail line — append to pending entry
+            if let Some(ref mut p) = pending {
+                p.detail_lines.push(trimmed.to_string());
+            }
+        }
+        // Lines before any PACKET match (header) are silently skipped
+    }
+
+    // Flush final pending entry
+    if let Some(p) = pending.take() {
+        entries.push(p.into_log_entry(id, file_path, &port_re));
+    }
+
+    (entries, parse_errors)
+}
+
+/// Intermediate state for a partially-built log entry.
+struct PendingEntry {
+    line_number: u32,
+    timestamp: Option<i64>,
+    timestamp_display: Option<String>,
+    thread: Option<u32>,
+    thread_display: Option<String>,
+    protocol: String,
+    direction: String,
+    remote_ip: String,
+    xid: String,
+    flags_hex: String,
+    rcode: String,
+    query_type: String,
+    query_name: String,
+    severity: Severity,
+    detail_lines: Vec<String>,
+}
+
+impl PendingEntry {
+    fn into_log_entry(self, id: u64, file_path: &str, port_re: &Regex) -> LogEntry {
+        // Extract port from detail lines if present
+        let mut source_ip = self.remote_ip.clone();
+        for detail in &self.detail_lines {
+            if let Some(caps) = port_re.captures(detail) {
+                if let Some(port) = caps.get(1) {
+                    source_ip = format!("{}:{}", self.remote_ip, port.as_str());
+                    break;
+                }
+            }
+        }
+
+        // Build message
+        let message = format!(
+            "[{}] [{}] {} ({}) \u{2192} {}",
+            self.direction, self.protocol, self.query_name, self.query_type, self.rcode
+        );
+
+        LogEntry {
+            id,
+            line_number: self.line_number,
+            message,
+            component: None,
+            timestamp: self.timestamp,
+            timestamp_display: self.timestamp_display,
+            severity: self.severity,
+            thread: self.thread,
+            thread_display: self.thread_display,
+            source_file: None,
+            format: LogFormat::DnsDebug,
+            file_path: file_path.to_string(),
+            timezone_offset: None,
+            error_code_spans: Vec::new(),
+            ip_address: None,
+            host_name: None,
+            mac_address: None,
+            result_code: None,
+            gle_code: None,
+            setup_phase: None,
+            operation_name: None,
+            http_method: None,
+            uri_stem: None,
+            uri_query: None,
+            status_code: None,
+            sub_status: None,
+            time_taken_ms: None,
+            client_ip: None,
+            server_ip: None,
+            user_agent: None,
+            server_port: None,
+            username: None,
+            win32_status: None,
+            query_name: Some(self.query_name),
+            query_type: Some(self.query_type),
+            response_code: Some(self.rcode),
+            dns_direction: Some(self.direction),
+            dns_protocol: Some(self.protocol),
+            source_ip: Some(source_ip),
+            dns_flags: Some(format!("0x{}", self.flags_hex)),
+            dns_event_id: None,
+            zone_name: None,
+        }
+    }
+}
+
+/// Parse regex captures from a PACKET summary line into a `PendingEntry`.
+fn parse_packet_captures(
+    caps: &regex::Captures,
+    line_number: u32,
+    date_order: DateOrder,
+) -> Result<PendingEntry, ()> {
+    let timestamp_raw = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+    let thread_hex = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+    let protocol = caps.get(3).map(|m| m.as_str()).unwrap_or("UDP");
+    let direction = caps.get(4).map(|m| m.as_str()).unwrap_or("Rcv");
+    let remote_ip = caps.get(5).map(|m| m.as_str()).unwrap_or("");
+    let xid = caps.get(6).map(|m| m.as_str()).unwrap_or("");
+    let flags_hex = caps.get(9).map(|m| m.as_str()).unwrap_or("");
+    let rcode = caps.get(11).map(|m| m.as_str()).unwrap_or("NOERROR");
+    let query_type = caps.get(12).map(|m| m.as_str()).unwrap_or("");
+    let query_name_raw = caps.get(13).map(|m| m.as_str()).unwrap_or("");
+
+    let thread = u32::from_str_radix(thread_hex, 16).ok();
+    let thread_display = thread.map(|t| format!("{} (0x{})", t, thread_hex.to_uppercase()));
+
+    let (timestamp, timestamp_display) = parse_dns_timestamp(timestamp_raw, date_order);
+    let query_name = dns_types::decode_query_name(query_name_raw);
+    let severity = dns_types::rcode_to_severity(rcode);
+
+    Ok(PendingEntry {
+        line_number,
+        timestamp,
+        timestamp_display,
+        thread,
+        thread_display,
+        protocol: protocol.to_string(),
+        direction: direction.to_string(),
+        remote_ip: remote_ip.to_string(),
+        xid: xid.to_string(),
+        flags_hex: flags_hex.to_string(),
+        rcode: rcode.to_string(),
+        query_type: query_type.to_string(),
+        query_name,
+        severity,
+        detail_lines: Vec::new(),
+    })
+}
+
+/// Parse a DNS debug log timestamp string into epoch millis and display string.
+///
+/// Supports three formats:
+/// - US locale: `M/d/yyyy h:mm:ss AM/PM`
+/// - EU locale: `dd/MM/yyyy HH:mm:ss`
+/// - ISO-style: `yyyyMMdd HH:mm:ss`
+fn parse_dns_timestamp(raw: &str, date_order: DateOrder) -> (Option<i64>, Option<String>) {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return (None, None);
+    }
+
+    // Try ISO-style first: yyyyMMdd HH:mm:ss
+    if let Some((date_part, time_part)) = trimmed.split_once(' ') {
+        if date_part.len() == 8 && date_part.chars().all(|c| c.is_ascii_digit()) {
+            let yr: i32 = date_part[0..4].parse().unwrap_or(0);
+            let mon: u32 = date_part[4..6].parse().unwrap_or(1);
+            let day: u32 = date_part[6..8].parse().unwrap_or(1);
+            let (h, m, s) = parse_time_hms(time_part, false);
+
+            return build_timestamp(yr, mon, day, h, m, s);
+        }
+    }
+
+    // Slash-date format: split on space to get date, time, and optional AM/PM
+    let parts: Vec<&str> = trimmed.splitn(3, ' ').collect();
+    if parts.len() < 2 {
+        return (None, Some(trimmed.to_string()));
+    }
+
+    let date_str = parts[0];
+    let has_ampm = parts.len() == 3
+        && (parts[2].eq_ignore_ascii_case("AM") || parts[2].eq_ignore_ascii_case("PM"));
+    let time_str = parts[1];
+    let is_pm = has_ampm && parts[2].eq_ignore_ascii_case("PM");
+    let is_am = has_ampm && parts[2].eq_ignore_ascii_case("AM");
+
+    let date_fields: Vec<&str> = date_str.split('/').collect();
+    if date_fields.len() != 3 {
+        return (None, Some(trimmed.to_string()));
+    }
+
+    let f1: u32 = date_fields[0].parse().unwrap_or(0);
+    let f2: u32 = date_fields[1].parse().unwrap_or(0);
+    let yr: i32 = date_fields[2].parse().unwrap_or(0);
+
+    let (mon, day) = match date_order {
+        DateOrder::DayFirst => (f2, f1),
+        DateOrder::MonthFirst => (f1, f2),
+    };
+
+    let (mut h, m, s) = parse_time_hms(time_str, false);
+
+    // Handle 12-hour AM/PM
+    if has_ampm {
+        if is_pm && h < 12 {
+            h += 12;
+        } else if is_am && h == 12 {
+            h = 0;
+        }
+    }
+
+    build_timestamp(yr, mon, day, h, m, s)
+}
+
+fn parse_time_hms(time_str: &str, _pad: bool) -> (u32, u32, u32) {
+    let parts: Vec<&str> = time_str.split(':').collect();
+    let h: u32 = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let m: u32 = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let s: u32 = parts.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+    (h, m, s)
+}
+
+fn build_timestamp(yr: i32, mon: u32, day: u32, h: u32, m: u32, s: u32) -> (Option<i64>, Option<String>) {
+    let timestamp = chrono::NaiveDate::from_ymd_opt(yr, mon, day)
+        .and_then(|d| d.and_hms_opt(h, m, s))
+        .map(|dt| dt.and_utc().timestamp_millis());
+
+    let display = Some(format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+        yr, mon, day, h, m, s
+    ));
+
+    (timestamp, display)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matches_packet_line() {
+        assert!(matches_dns_debug_record(
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] SOA    (4)home(4)gell(3)one(0)"
+        ));
+    }
+
+    #[test]
+    fn test_does_not_match_header() {
+        assert!(!matches_dns_debug_record("DNS Server log file creation at 4/11/2026 3:29:17 PM"));
+        assert!(!matches_dns_debug_record("Field #  Information         Values"));
+        assert!(!matches_dns_debug_record(""));
+    }
+
+    #[test]
+    fn test_does_not_match_detail_line() {
+        assert!(!matches_dns_debug_record("  Remote addr 127.0.0.1, port 54159"));
+        assert!(!matches_dns_debug_record("UDP question info at 000002DAEC36D650"));
+    }
+
+    #[test]
+    fn test_parse_basic_query_response_pair() {
+        let lines = vec![
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] SOA    (4)home(4)gell(3)one(0)",
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Snd 127.0.0.1       d07e R Q [8085 A DR  NOERROR] SOA    (4)home(4)gell(3)one(0)",
+        ];
+        let (entries, errors) = parse_lines(&lines, "dns.log", DateOrder::MonthFirst);
+
+        assert_eq!(errors, 0);
+        assert_eq!(entries.len(), 2);
+
+        // First entry: query (Rcv)
+        assert_eq!(entries[0].dns_direction.as_deref(), Some("Rcv"));
+        assert_eq!(entries[0].dns_protocol.as_deref(), Some("UDP"));
+        assert_eq!(entries[0].query_name.as_deref(), Some("home.gell.one"));
+        assert_eq!(entries[0].query_type.as_deref(), Some("SOA"));
+        assert_eq!(entries[0].response_code.as_deref(), Some("NOERROR"));
+        assert_eq!(entries[0].severity, Severity::Info);
+        assert_eq!(entries[0].format, LogFormat::DnsDebug);
+        assert!(entries[0].message.contains("[Rcv]"));
+
+        // Second entry: response (Snd)
+        assert_eq!(entries[1].dns_direction.as_deref(), Some("Snd"));
+        assert!(entries[1].message.contains("[Snd]"));
+    }
+
+    #[test]
+    fn test_parse_with_detail_section_extracts_port() {
+        let lines = vec![
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 192.168.2.9     7822   U [0028       NOERROR] SOA    (4)home(4)gell(3)one(0)",
+            "UDP question info at 000002DAEC3680D0",
+            "  Socket = 876",
+            "  Remote addr 192.168.2.9, port 57961",
+            "  Time Query=1714823, Queued=0, Expire=0",
+        ];
+        let (entries, errors) = parse_lines(&lines, "dns.log", DateOrder::MonthFirst);
+
+        assert_eq!(errors, 0);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].source_ip.as_deref(), Some("192.168.2.9:57961"));
+    }
+
+    #[test]
+    fn test_parse_severity_mapping() {
+        let lines = vec![
+            "4/11/2026 8:34:00 PM 0294 PACKET  000002DAEF3AFDC0 UDP Snd 127.0.0.1       3c8a R Q [8385 A DR NXDOMAIN] A      (4)HOME(4)home(4)gell(3)one(0)",
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC3680D0 UDP Snd 192.168.2.9     7822 R U [02a8      SERVFAIL] SOA    (4)home(4)gell(3)one(0)",
+        ];
+        let (entries, _) = parse_lines(&lines, "dns.log", DateOrder::MonthFirst);
+
+        assert_eq!(entries[0].severity, Severity::Warning); // NXDOMAIN
+        assert_eq!(entries[1].severity, Severity::Error); // SERVFAIL
+    }
+
+    #[test]
+    fn test_parse_skips_header() {
+        let lines = vec![
+            "DNS Server log file creation at 4/11/2026 3:29:17 PM",
+            "",
+            "Message logging key (for packets - other items use a subset of these fields):",
+            "  Field #  Information         Values",
+            "  -------  -----------         ------",
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] SOA    (4)home(4)gell(3)one(0)",
+        ];
+        let (entries, errors) = parse_lines(&lines, "dns.log", DateOrder::MonthFirst);
+
+        assert_eq!(errors, 0);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].query_type.as_deref(), Some("SOA"));
+    }
+
+    #[test]
+    fn test_parse_thread_display() {
+        let lines = vec![
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] A      (4)home(4)gell(3)one(0)",
+        ];
+        let (entries, _) = parse_lines(&lines, "dns.log", DateOrder::MonthFirst);
+
+        assert_eq!(entries[0].thread, Some(660)); // 0x0294 = 660
+        assert_eq!(entries[0].thread_display.as_deref(), Some("660 (0x0294)"));
+    }
+
+    #[test]
+    fn test_parse_us_timestamp() {
+        let lines = vec![
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] A      (4)test(0)",
+        ];
+        let (entries, _) = parse_lines(&lines, "dns.log", DateOrder::MonthFirst);
+
+        assert_eq!(
+            entries[0].timestamp_display.as_deref(),
+            Some("2026-04-11 15:29:17")
+        );
+    }
+
+    #[test]
+    fn test_parse_dynamic_update_opcode() {
+        let lines = vec![
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC3680D0 UDP Rcv 192.168.2.9     7822   U [0028       NOERROR] SOA    (4)home(4)gell(3)one(0)",
+        ];
+        let (entries, errors) = parse_lines(&lines, "dns.log", DateOrder::MonthFirst);
+
+        assert_eq!(errors, 0);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].query_type.as_deref(), Some("SOA"));
+    }
+
+    #[test]
+    fn test_parse_root_query() {
+        let lines = vec![
+            "4/11/2026 8:33:19 PM 0294 PACKET  000002DAECB28D10 UDP Snd 192.168.2.9     131a R Q [8081   DR  NOERROR] NS     (0)",
+        ];
+        let (entries, _) = parse_lines(&lines, "dns.log", DateOrder::MonthFirst);
+
+        assert_eq!(entries[0].query_name.as_deref(), Some("."));
+        assert_eq!(entries[0].query_type.as_deref(), Some("NS"));
+    }
+}
+```
+
+- [ ] **Step 2: Register the module in `mod.rs`**
+
+In `src-tauri/src/parser/mod.rs`, add after `pub mod dns_types;`:
+
+```rust
+pub mod dns_debug;
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd src-tauri && cargo test dns_debug
+```
+
+Expected: all tests pass. If the PACKET regex needs tuning for edge cases, fix and rerun.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/parser/dns_debug.rs src-tauri/src/parser/mod.rs
+git commit -m "feat(dns): add DNS debug log parser with LogicalRecord framing and detail extraction"
+```
+
+---
+
+### Task 4: Detection Integration for DNS Debug Log
+
+**Files:**
+- Modify: `src-tauri/src/parser/detect.rs`
+
+- [ ] **Step 1: Add DNS debug path hints and content counting**
+
+In `detect.rs`, add a DNS path hint variable after the existing hints (near line 380):
+
+```rust
+    let dns_debug_path_hint = path_lower.contains("dns")
+        || path_lower.ends_with("dns.log")
+        || path_lower.contains("\\dns\\")
+        || path_lower.contains("/dns/");
+```
+
+Add a counter variable alongside the existing counters (near line 395):
+
+```rust
+    let mut dns_debug_count = 0u32;
+```
+
+- [ ] **Step 2: Add DNS debug content matching in the sample loop**
+
+In the `for line in &sample_lines` loop, add a check for DNS debug records. Add it after the `patchmypc_detection` check (near line 417) but before the `burn` check:
+
+```rust
+        } else if dns_debug::matches_dns_debug_record(line.trim()) {
+            dns_debug_count += 1;
+            timestamp_count += 1;
+```
+
+Also add the import at the top of the file — add `dns_debug` to the `use super::` import list (line 16):
+
+```rust
+use super::{
+    burn, cbs, dhcp, dism, dns_debug, iis_w3c, intune_macos, msi, panther,
+    patchmypc_detection, psadt, reporting_events,
+    timestamped::{self, DateOrder},
+};
+```
+
+- [ ] **Step 3: Extend sample window for DNS path hints**
+
+Replace the sample_lines collection (lines 314-318) with a conditional window:
+
+```rust
+    let sample_limit = if dns_debug_path_hint { 50 } else { 20 };
+    let sample_lines: Vec<&str> = content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .take(sample_limit)
+        .collect();
+```
+
+Note: `dns_debug_path_hint` needs to be computed before the sample collection. Move the path hint computation block to before the sample lines. This means the `path_lower` variable and the `dns_debug_path_hint` line need to be above the `sample_lines` computation.
+
+- [ ] **Step 4: Add `ResolvedParser::dns_debug()` factory method**
+
+Add after the `psadt_legacy()` method in `detect.rs` (near line 260):
+
+```rust
+    pub fn dns_debug(date_order: DateOrder) -> Self {
+        Self::new(
+            ParserKind::DnsDebug,
+            ParserImplementation::DnsDebug,
+            ParserProvenance::Dedicated,
+            ParseQuality::Structured,
+            RecordFraming::LogicalRecord,
+            date_order,
+            None,
+        )
+    }
+```
+
+- [ ] **Step 5: Add `DnsDebug` to `compatibility_format()`**
+
+In the `compatibility_format()` method, add before the `PlainText` arm:
+
+```rust
+            ParserImplementation::DnsDebug => LogFormat::DnsDebug,
+```
+
+- [ ] **Step 6: Add DNS debug detection to the precedence chain**
+
+In the detection precedence chain, add DNS debug detection. It should go after DHCP detection (the `dhcp_count` check) and before MSI detection. Add near line 472:
+
+```rust
+    } else if (dns_debug_path_hint && dns_debug_count >= 1) || dns_debug_count >= 2 {
+        let dns_date_order = if has_day_first {
+            DateOrder::DayFirst
+        } else {
+            DateOrder::MonthFirst
+        };
+        ResolvedParser::dns_debug(dns_date_order)
+```
+
+- [ ] **Step 7: Add detection tests**
+
+Add to the `#[cfg(test)] mod tests` block in `detect.rs`:
+
+```rust
+    #[test]
+    fn test_detect_dns_debug_from_path_and_content() {
+        let content = concat!(
+            "DNS Server log file creation at 4/11/2026 3:29:17 PM\n",
+            "\n",
+            "Message logging key (for packets):\n",
+            "  Field #  Information         Values\n",
+            "  -------  -----------         ------\n",
+            "     1     Date\n",
+            "     2     Time\n",
+            "     3     Thread ID\n",
+            "     4     Context\n",
+            "     5     Internal packet identifier\n",
+            "     6     UDP/TCP indicator\n",
+            "     7     Send/Receive indicator\n",
+            "     8     Remote IP\n",
+            "     9     Xid (hex)\n",
+            "    10     Query/Response      R = Response\n",
+            "                               blank = Query\n",
+            "    11     Opcode              Q = Standard Query\n",
+            "                               N = Notify\n",
+            "                               U = Update\n",
+            "                               ? = Unknown\n",
+            "    12     [ Flags (hex)\n",
+            "    13     Flags (char codes)  A = Authoritative Answer\n",
+            "                               T = Truncated Response\n",
+            "                               D = Recursion Desired\n",
+            "                               R = Recursion Available\n",
+            "    14     ResponseCode ]\n",
+            "    15     Question Type\n",
+            "    16     Question Name\n",
+            "\n",
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] SOA    (4)home(4)gell(3)one(0)\n",
+        );
+
+        let detected = detect_parser("C:/Logs/DNSServer/DNSServer_debug.log", content);
+        assert_eq!(detected.parser, ParserKind::DnsDebug);
+        assert_eq!(detected.implementation, ParserImplementation::DnsDebug);
+        assert_eq!(detected.record_framing, RecordFraming::LogicalRecord);
+        assert_eq!(detected.parse_quality, ParseQuality::Structured);
+    }
+
+    #[test]
+    fn test_generic_timestamped_with_dns_in_path_does_not_false_positive() {
+        let content = "2026-04-11 15:29:17 DNS resolution started\n\
+                        2026-04-11 15:29:18 DNS resolution complete";
+
+        let detected = detect_parser("C:/logs/dns-resolver/app.log", content);
+        assert_eq!(detected.parser, ParserKind::Timestamped);
+    }
+```
+
+- [ ] **Step 8: Run all tests**
+
+```bash
+cd src-tauri && cargo test
+```
+
+Expected: all existing tests pass, plus the two new detection tests.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src-tauri/src/parser/detect.rs
+git commit -m "feat(dns): integrate DNS debug log detection with path hints and extended sample window"
+```
+
+---
+
+### Task 5: Routing Integration for DNS Debug Log
+
+**Files:**
+- Modify: `src-tauri/src/parser/mod.rs`
+
+- [ ] **Step 1: Add `DnsDebug` to `parse_lines_with_selection()`**
+
+In `src-tauri/src/parser/mod.rs`, add a new arm in the `match selection.implementation` block (after the `PatchMyPcDetection` arm, before the `Registry` arm):
+
+```rust
+        crate::models::log_entry::ParserImplementation::DnsDebug => {
+            dns_debug::parse_lines(lines, file_path, selection.date_order)
+        }
+```
+
+- [ ] **Step 2: Add a stub arm for `DnsAudit`**
+
+Add after the `DnsDebug` arm:
+
+```rust
+        crate::models::log_entry::ParserImplementation::DnsAudit => {
+            // EVTX files are parsed via the binary path in parse_file(), not the line-based pipeline.
+            (vec![], 0)
+        }
+```
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+cd src-tauri && cargo test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Test with real fixture**
+
+Add a test to `mod.rs` in the `#[cfg(test)] mod tests` block:
+
+```rust
+    #[test]
+    fn test_parse_lines_with_dns_debug_selection() {
+        let selection = ResolvedParser::dns_debug(DateOrder::MonthFirst);
+        let lines = [
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] SOA    (4)home(4)gell(3)one(0)",
+            "4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Snd 127.0.0.1       d07e R Q [8085 A DR  NOERROR] SOA    (4)home(4)gell(3)one(0)",
+        ];
+
+        let (entries, parse_errors) = parse_lines_with_selection(&lines, "dns.log", &selection);
+
+        assert_eq!(parse_errors, 0);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].query_name.as_deref(), Some("home.gell.one"));
+        assert_eq!(entries[0].format, crate::models::log_entry::LogFormat::DnsDebug);
+        assert!(!entries[0].error_code_spans.is_empty() || entries[0].error_code_spans.is_empty()); // just verify it ran annotation
+    }
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd src-tauri && cargo test test_parse_lines_with_dns_debug
+```
+
+Expected: passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/parser/mod.rs
+git commit -m "feat(dns): route DNS debug parser through parse_lines_with_selection"
+```
+
+---
+
+### Task 6: DNS Audit EVTX Parser (`dns_audit.rs`)
+
+**Files:**
+- Create: `src-tauri/src/parser/dns_audit.rs`
+- Modify: `src-tauri/src/parser/mod.rs` (add `pub mod dns_audit;`)
+
+- [ ] **Step 1: Create `dns_audit.rs` with provider detection and EVTX parsing**
+
+Create `src-tauri/src/parser/dns_audit.rs`:
+
+```rust
+//! Windows DNS Server audit EVTX parser.
+//!
+//! Parses DNS audit event logs (Event IDs 513-582) from `.evtx` files
+//! using the `evtx` crate. Events are dispatched by schema group.
+//!
+//! Format reference: docs/compass_artifact_*.md, Section 3.
+
+use evtx::EvtxParser;
+use serde_json::Value;
+use std::path::Path;
+
+use super::dns_types;
+use crate::models::log_entry::{
+    LogEntry, LogFormat, ParseResult, ParseQuality, ParserImplementation, ParserKind,
+    ParserProvenance, ParserSelectionInfo, RecordFraming, Severity,
+};
+
+/// The DNS Server ETW provider name.
+const DNS_PROVIDER_NAME: &str = "Microsoft-Windows-DNSServer";
+
+/// Check if an EVTX file contains DNS Server events.
+/// Reads the first 5 records and checks the provider name.
+pub fn is_dns_evtx(path: &Path) -> bool {
+    let mut parser = match EvtxParser::from_path(path) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+
+    for record in parser.records_json().take(5).flatten() {
+        if let Ok(json) = serde_json::from_str::<Value>(&record.data) {
+            let provider = json["Event"]["System"]["Provider"]["#attributes"]["Name"]
+                .as_str()
+                .unwrap_or("");
+            if provider == DNS_PROVIDER_NAME {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Parse a DNS audit EVTX file into `LogEntry` records.
+pub fn parse_evtx(path: &str) -> Result<ParseResult, String> {
+    let path_obj = Path::new(path);
+    let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+
+    let mut parser = EvtxParser::from_path(path_obj)
+        .map_err(|e| format!("Failed to open EVTX file {}: {}", path, e))?;
+
+    let mut entries = Vec::new();
+    let mut id: u64 = 0;
+    let mut parse_errors: u32 = 0;
+    let mut total_records: u32 = 0;
+
+    for record_result in parser.records_json() {
+        total_records += 1;
+        let record = match record_result {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("event=dns_audit_record_skip file=\"{}\" error=\"{e}\"", path);
+                parse_errors += 1;
+                continue;
+            }
+        };
+
+        let json: Value = match serde_json::from_str(&record.data) {
+            Ok(v) => v,
+            Err(_) => {
+                parse_errors += 1;
+                continue;
+            }
+        };
+
+        let system = &json["Event"]["System"];
+        let event_data = &json["Event"]["EventData"];
+
+        // Skip non-DNS events
+        let provider = system["Provider"]["#attributes"]["Name"]
+            .as_str()
+            .unwrap_or("");
+        if provider != DNS_PROVIDER_NAME {
+            continue;
+        }
+
+        let event_id = extract_event_id(system);
+        let timestamp_raw = system["TimeCreated"]["#attributes"]["SystemTime"]
+            .as_str()
+            .unwrap_or("");
+        let (timestamp, timestamp_display) = parse_evtx_timestamp(timestamp_raw);
+
+        let entry = build_log_entry(id, event_id, event_data, timestamp, timestamp_display, path);
+        entries.push(entry);
+        id += 1;
+    }
+
+    // Annotate error code spans
+    super::annotate_error_code_spans(&mut entries);
+
+    let selection_info = ParserSelectionInfo {
+        parser: ParserKind::DnsAudit,
+        implementation: ParserImplementation::DnsAudit,
+        provenance: ParserProvenance::Dedicated,
+        parse_quality: ParseQuality::Structured,
+        record_framing: RecordFraming::PhysicalLine,
+        date_order: None,
+        specialization: None,
+    };
+
+    Ok(ParseResult {
+        entries,
+        format_detected: LogFormat::DnsAudit,
+        parser_selection: selection_info,
+        total_lines: total_records,
+        parse_errors,
+        file_path: path.to_string(),
+        file_size,
+        byte_offset: file_size,
+    })
+}
+
+/// Build a `LogEntry` from a DNS audit event, dispatched by schema group.
+fn build_log_entry(
+    id: u64,
+    event_id: u32,
+    event_data: &Value,
+    timestamp: Option<i64>,
+    timestamp_display: Option<String>,
+    file_path: &str,
+) -> LogEntry {
+    let (message, query_name, query_type, response_code, zone_name, source_ip, severity) =
+        match event_id {
+            515..=521 => extract_record_ops(event_id, event_data),
+            513 | 514 | 522..=537 => extract_zone_config(event_id, event_data),
+            540..=560 => extract_server_config(event_id, event_data),
+            569..=572 => extract_dnssec_key_ops(event_id, event_data),
+            577..=582 => extract_policy_ops(event_id, event_data),
+            573..=576 => extract_delegation_subnet(event_id, event_data),
+            561..=568 => extract_extended_zone_ops(event_id, event_data),
+            _ => extract_generic(event_id, event_data),
+        };
+
+    LogEntry {
+        id,
+        line_number: id as u32 + 1,
+        message,
+        component: Some("DNSServer".to_string()),
+        timestamp,
+        timestamp_display,
+        severity,
+        thread: None,
+        thread_display: None,
+        source_file: None,
+        format: LogFormat::DnsAudit,
+        file_path: file_path.to_string(),
+        timezone_offset: None,
+        error_code_spans: Vec::new(),
+        ip_address: None,
+        host_name: None,
+        mac_address: None,
+        result_code: None,
+        gle_code: None,
+        setup_phase: None,
+        operation_name: None,
+        http_method: None,
+        uri_stem: None,
+        uri_query: None,
+        status_code: None,
+        sub_status: None,
+        time_taken_ms: None,
+        client_ip: None,
+        server_ip: None,
+        user_agent: None,
+        server_port: None,
+        username: None,
+        win32_status: None,
+        query_name,
+        query_type,
+        response_code,
+        dns_direction: None,
+        dns_protocol: None,
+        source_ip,
+        dns_flags: None,
+        dns_event_id: Some(event_id),
+        zone_name,
+    }
+}
+
+// -- Schema group extractors --
+// Each returns (message, query_name, query_type, response_code, zone_name, source_ip, severity)
+
+type ExtractResult = (
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Severity,
+);
+
+fn get_str(data: &Value, key: &str) -> Option<String> {
+    data[key].as_str().map(|s| s.to_string())
+}
+
+fn event_name(event_id: u32) -> &'static str {
+    match event_id {
+        513 => "Zone Delete",
+        514 => "Zone Setting",
+        515 => "Record Create",
+        516 => "Record Delete",
+        517 => "RRSET Delete",
+        518 => "Node Delete",
+        519 => "Record Create (Dynamic)",
+        520 => "Record Delete (Dynamic)",
+        521 => "Record Scavenge",
+        525 => "Zone Sign",
+        526 => "Zone Unsign",
+        527 => "Zone Re-sign",
+        536 => "Cache Purge",
+        537 => "Forwarder Reset",
+        541 => "Server Setting",
+        _ => "DNS Audit",
+    }
+}
+
+fn extract_record_ops(event_id: u32, data: &Value) -> ExtractResult {
+    let name = get_str(data, "NAME");
+    let rr_type = data["Type"]
+        .as_str()
+        .and_then(|s| s.parse::<u32>().ok())
+        .or_else(|| data["Type"].as_u64().map(|n| n as u32));
+    let type_name = rr_type.map(dns_types::qtype_name);
+    let zone = get_str(data, "Zone");
+    let ttl = get_str(data, "TTL");
+    let rdata = get_str(data, "RDATA");
+    let source_ip = get_str(data, "SourceIP");
+
+    let mut msg = format!("[{} {}]", event_id, event_name(event_id));
+    if let Some(ref n) = name {
+        msg.push_str(&format!(" {}", n));
+    }
+    if let Some(ref t) = type_name {
+        msg.push_str(&format!(" ({})", t));
+    }
+    if let Some(ref t) = ttl {
+        msg.push_str(&format!(" TTL={}", t));
+    }
+    if let Some(ref z) = zone {
+        msg.push_str(&format!(" Zone={}", z));
+    }
+    if let Some(ref r) = rdata {
+        msg.push_str(&format!(" RDATA={}", r));
+    }
+
+    let severity = match event_id {
+        516 | 520 => Severity::Warning,
+        _ => Severity::Info,
+    };
+
+    (msg, name, type_name, None, zone, source_ip, severity)
+}
+
+fn extract_zone_config(event_id: u32, data: &Value) -> ExtractResult {
+    let zone = get_str(data, "Zone");
+    let setting = get_str(data, "Setting");
+    let new_value = get_str(data, "NewValue");
+
+    let mut msg = format!("[{} {}]", event_id, event_name(event_id));
+    if let Some(ref z) = zone {
+        msg.push_str(&format!(" {}", z));
+    }
+    if let Some(ref s) = setting {
+        msg.push_str(&format!(" \u{2014} Setting={}", s));
+    }
+    if let Some(ref v) = new_value {
+        msg.push_str(&format!(" NewValue={}", v));
+    }
+
+    let severity = match event_id {
+        513 => Severity::Error,
+        525..=527 => Severity::Warning,
+        _ => Severity::Info,
+    };
+
+    (msg, None, None, None, zone, None, severity)
+}
+
+fn extract_server_config(event_id: u32, data: &Value) -> ExtractResult {
+    let setting = get_str(data, "Setting");
+    let value = get_str(data, "Value");
+    let scope = get_str(data, "Scope");
+
+    let mut msg = format!("[{} {}]", event_id, event_name(event_id));
+    if let Some(ref s) = setting {
+        msg.push_str(&format!(" {}", s));
+    }
+    if let Some(ref v) = value {
+        msg.push_str(&format!(" = {}", v));
+    }
+    if let Some(ref sc) = scope {
+        msg.push_str(&format!(" (Scope={})", sc));
+    }
+
+    let severity = match event_id {
+        541 => Severity::Warning,
+        _ => Severity::Info,
+    };
+
+    (msg, None, None, None, None, None, severity)
+}
+
+fn extract_dnssec_key_ops(event_id: u32, data: &Value) -> ExtractResult {
+    let zone = get_str(data, "Zone");
+    let algo = get_str(data, "CryptoAlgorithm");
+
+    let mut msg = format!("[{} DNS Audit]", event_id);
+    if let Some(ref z) = zone {
+        msg.push_str(&format!(" Zone={}", z));
+    }
+    if let Some(ref a) = algo {
+        msg.push_str(&format!(" Algorithm={}", a));
+    }
+
+    (msg, None, None, None, zone, None, Severity::Info)
+}
+
+fn extract_policy_ops(event_id: u32, data: &Value) -> ExtractResult {
+    let policy_name = get_str(data, "PolicyName");
+    let action = get_str(data, "Action");
+
+    let mut msg = format!("[{} DNS Audit]", event_id);
+    if let Some(ref p) = policy_name {
+        msg.push_str(&format!(" Policy={}", p));
+    }
+    if let Some(ref a) = action {
+        msg.push_str(&format!(" Action={}", a));
+    }
+
+    (msg, None, None, None, None, None, Severity::Info)
+}
+
+fn extract_delegation_subnet(event_id: u32, data: &Value) -> ExtractResult {
+    let zone = get_str(data, "Zone");
+
+    let mut msg = format!("[{} DNS Audit]", event_id);
+    if let Some(ref z) = zone {
+        msg.push_str(&format!(" Zone={}", z));
+    }
+
+    (msg, None, None, None, zone, None, Severity::Info)
+}
+
+fn extract_extended_zone_ops(event_id: u32, data: &Value) -> ExtractResult {
+    let zone = get_str(data, "Zone");
+
+    let mut msg = format!("[{} DNS Audit]", event_id);
+    if let Some(ref z) = zone {
+        msg.push_str(&format!(" Zone={}", z));
+    }
+
+    (msg, None, None, None, zone, None, Severity::Info)
+}
+
+fn extract_generic(event_id: u32, data: &Value) -> ExtractResult {
+    // For unknown events, dump the first few EventData fields into the message
+    let mut msg = format!("[{} DNS Audit]", event_id);
+    if let Some(obj) = data.as_object() {
+        let mut count = 0;
+        for (key, value) in obj {
+            if count >= 5 {
+                break;
+            }
+            if let Some(v) = value.as_str() {
+                msg.push_str(&format!(" {}={}", key, v));
+                count += 1;
+            }
+        }
+    }
+
+    (msg, None, None, None, None, None, Severity::Info)
+}
+
+fn extract_event_id(system: &Value) -> u32 {
+    if let Some(id) = system["EventID"].as_u64() {
+        return id as u32;
+    }
+    if let Some(id) = system["EventID"]["#text"].as_u64() {
+        return id as u32;
+    }
+    if let Some(s) = system["EventID"]["#text"].as_str() {
+        return s.parse().unwrap_or(0);
+    }
+    0
+}
+
+fn parse_evtx_timestamp(raw: &str) -> (Option<i64>, Option<String>) {
+    if raw.is_empty() {
+        return (None, None);
+    }
+    // EVTX timestamps are ISO 8601: "2026-04-11T15:29:17.123Z"
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(raw) {
+        let millis = dt.timestamp_millis();
+        let display = dt.format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+        return (Some(millis), Some(display));
+    }
+    // Fallback: try without fractional seconds
+    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M:%S") {
+        let millis = dt.and_utc().timestamp_millis();
+        let display = dt.format("%Y-%m-%d %H:%M:%S.000").to_string();
+        return (Some(millis), Some(display));
+    }
+    (None, Some(raw.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_event_data(fields: &[(&str, &str)]) -> Value {
+        let mut map = serde_json::Map::new();
+        for (k, v) in fields {
+            map.insert(k.to_string(), Value::String(v.to_string()));
+        }
+        Value::Object(map)
+    }
+
+    #[test]
+    fn test_extract_record_create() {
+        let data = make_event_data(&[
+            ("NAME", "test.homelab.local"),
+            ("Type", "1"),
+            ("TTL", "3600"),
+            ("Zone", "homelab.local"),
+            ("RDATA", "0x01010101"),
+        ]);
+        let (msg, qn, qt, _rc, zone, _ip, sev) = extract_record_ops(515, &data);
+
+        assert!(msg.contains("[515 Record Create]"));
+        assert!(msg.contains("test.homelab.local"));
+        assert!(msg.contains("(A)"));
+        assert!(msg.contains("TTL=3600"));
+        assert_eq!(qn.as_deref(), Some("test.homelab.local"));
+        assert_eq!(qt.as_deref(), Some("A"));
+        assert_eq!(zone.as_deref(), Some("homelab.local"));
+        assert_eq!(sev, Severity::Info);
+    }
+
+    #[test]
+    fn test_extract_record_delete_is_warning() {
+        let data = make_event_data(&[("NAME", "old.homelab.local"), ("Type", "1"), ("Zone", "homelab.local")]);
+        let (_msg, _qn, _qt, _rc, _zone, _ip, sev) = extract_record_ops(516, &data);
+        assert_eq!(sev, Severity::Warning);
+    }
+
+    #[test]
+    fn test_extract_dynamic_update_with_source_ip() {
+        let data = make_event_data(&[
+            ("NAME", "client1.homelab.local"),
+            ("Type", "1"),
+            ("Zone", "homelab.local"),
+            ("SourceIP", "10.0.2.15"),
+        ]);
+        let (_msg, _qn, _qt, _rc, _zone, ip, _sev) = extract_record_ops(519, &data);
+        assert_eq!(ip.as_deref(), Some("10.0.2.15"));
+    }
+
+    #[test]
+    fn test_extract_zone_delete_is_error() {
+        let data = make_event_data(&[("Zone", "homelab.local")]);
+        let (_msg, _qn, _qt, _rc, zone, _ip, sev) = extract_zone_config(513, &data);
+        assert_eq!(zone.as_deref(), Some("homelab.local"));
+        assert_eq!(sev, Severity::Error);
+    }
+
+    #[test]
+    fn test_extract_server_setting_is_warning() {
+        let data = make_event_data(&[("Setting", "serverlevelplugindll"), ("Value", "test.dll")]);
+        let (msg, _qn, _qt, _rc, _zone, _ip, sev) = extract_server_config(541, &data);
+        assert!(msg.contains("serverlevelplugindll"));
+        assert!(msg.contains("test.dll"));
+        assert_eq!(sev, Severity::Warning);
+    }
+
+    #[test]
+    fn test_extract_generic_unknown_event() {
+        let data = make_event_data(&[("Foo", "bar"), ("Baz", "qux")]);
+        let (msg, _qn, _qt, _rc, _zone, _ip, sev) = extract_generic(999, &data);
+        assert!(msg.contains("[999 DNS Audit]"));
+        assert_eq!(sev, Severity::Info);
+    }
+
+    #[test]
+    fn test_extract_missing_fields_graceful() {
+        let data = Value::Object(serde_json::Map::new());
+        let (msg, qn, qt, _rc, zone, ip, sev) = extract_record_ops(515, &data);
+        assert!(msg.contains("[515 Record Create]"));
+        assert!(qn.is_none());
+        assert!(qt.is_none());
+        assert!(zone.is_none());
+        assert!(ip.is_none());
+        assert_eq!(sev, Severity::Info);
+    }
+
+    #[test]
+    fn test_parse_evtx_timestamp_rfc3339() {
+        let (ts, display) = parse_evtx_timestamp("2026-04-11T15:29:17.123Z");
+        assert!(ts.is_some());
+        assert!(display.unwrap().starts_with("2026-04-11 15:29:17"));
+    }
+
+    #[test]
+    fn test_parse_evtx_timestamp_empty() {
+        let (ts, display) = parse_evtx_timestamp("");
+        assert!(ts.is_none());
+        assert!(display.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Register the module in `mod.rs`**
+
+In `src-tauri/src/parser/mod.rs`, add after `pub mod dns_debug;`:
+
+```rust
+#[cfg(feature = "event-log")]
+pub mod dns_audit;
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd src-tauri && cargo test dns_audit --features event-log
+```
+
+Expected: all unit tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/parser/dns_audit.rs src-tauri/src/parser/mod.rs
+git commit -m "feat(dns): add DNS audit EVTX parser with schema group dispatch"
+```
+
+---
+
+### Task 7: Binary File Detection in `parse_file()`
+
+**Files:**
+- Modify: `src-tauri/src/parser/mod.rs`
+- Modify: `src-tauri/src/parser/detect.rs` (add `ResolvedParser::dns_audit()`)
+
+- [ ] **Step 1: Add `ResolvedParser::dns_audit()` factory method**
+
+In `src-tauri/src/parser/detect.rs`, add after `dns_debug()`:
+
+```rust
+    pub fn dns_audit() -> Self {
+        Self::new(
+            ParserKind::DnsAudit,
+            ParserImplementation::DnsAudit,
+            ParserProvenance::Dedicated,
+            ParseQuality::Structured,
+            RecordFraming::PhysicalLine,
+            DateOrder::default(),
+            None,
+        )
+    }
+```
+
+- [ ] **Step 2: Add `DnsAudit` to `compatibility_format()`**
+
+In `detect.rs` `compatibility_format()`, add before the `PlainText` arm:
+
+```rust
+            ParserImplementation::DnsAudit => LogFormat::DnsAudit,
+```
+
+- [ ] **Step 3: Add binary file detection guard in `parse_file()`**
+
+In `src-tauri/src/parser/mod.rs`, modify `parse_file()` to intercept `.evtx` and `.etl` files before text decoding. Replace the current `parse_file()` function (lines 44-65):
+
+```rust
+pub fn parse_file(path: &str) -> Result<(ParseResult, ResolvedParser), String> {
+    let path_obj = Path::new(path);
+
+    // Binary file detection by extension — intercept before text decoding
+    if let Some(ext) = path_obj.extension().and_then(|e| e.to_str()) {
+        let ext_lower = ext.to_ascii_lowercase();
+
+        if ext_lower == "etl" {
+            #[cfg(target_os = "windows")]
+            return Err(
+                "ETL analytical logs are not yet supported. Convert to XML with: \
+                 tracerpt \"<file>\" -of XML -o output.xml — then open the XML file."
+                    .to_string(),
+            );
+            #[cfg(not(target_os = "windows"))]
+            return Err(
+                "ETL files contain binary Windows event traces that require the Windows \
+                 tracerpt tool to convert. Export to XML on a Windows machine first, \
+                 then open the XML file here."
+                    .to_string(),
+            );
+        }
+
+        #[cfg(feature = "event-log")]
+        if ext_lower == "evtx" {
+            if dns_audit::is_dns_evtx(path_obj) {
+                let result = dns_audit::parse_evtx(path)?;
+                let selection = ResolvedParser::dns_audit();
+                return Ok((result, selection));
+            }
+            // Not a DNS EVTX — fall through to let other handlers (Sysmon) deal with it.
+            // Return an error here since the text parser can't handle binary EVTX.
+            return Err(
+                "This EVTX file does not contain DNS audit events. \
+                 Try opening it in the Sysmon workspace instead."
+                    .to_string(),
+            );
+        }
+    }
+
+    // Existing text-based parsing path
+    let content = read_file_content(path)?;
+    let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+
+    let selection = detect::detect_parser(path, &content);
+    let parsed_chunk = parse_content_with_selection(&content, path, &selection);
+
+    let result = ParseResult {
+        entries: parsed_chunk.entries,
+        format_detected: selection.compatibility_format(),
+        parser_selection: selection.to_info(),
+        total_lines: parsed_chunk.total_lines,
+        parse_errors: parsed_chunk.parse_errors,
+        file_path: path_obj.to_string_lossy().to_string(),
+        file_size,
+        byte_offset: file_size,
+    };
+
+    Ok((result, selection))
+}
+```
+
+- [ ] **Step 4: Run `cargo check`**
+
+```bash
+cd src-tauri && cargo check --features event-log
+```
+
+Expected: compiles. Also check without the feature:
+
+```bash
+cd src-tauri && cargo check
+```
+
+Expected: compiles (the `#[cfg(feature = "event-log")]` guard skips the EVTX code).
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+cd src-tauri && cargo test --features event-log
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/parser/mod.rs src-tauri/src/parser/detect.rs
+git commit -m "feat(dns): add binary file detection — EVTX DNS routing and ETL stub with platform messages"
+```
+
+---
+
+### Task 8: Corpus Test Fixtures and Integration Tests
+
+**Files:**
+- Create: `src-tauri/tests/corpus/dns_debug/clean/basic.log`
+- Create: `src-tauri/tests/corpus/dns_debug/clean/with_detail.log`
+- Create: `src-tauri/tests/corpus/dns_debug/mixed/rcodes.log`
+- Modify: `src-tauri/tests/parser_regression_corpus.rs` (add DNS tests)
+
+- [ ] **Step 1: Create basic DNS debug fixture**
+
+Create `src-tauri/tests/corpus/dns_debug/clean/basic.log` with summary-only lines (no detail sections):
+
+```
+DNS Server log file creation at 4/11/2026 3:29:17 PM
+
+Message logging key (for packets - other items use a subset of these fields):
+	Field #  Information         Values
+	-------  -----------         ------
+	   1     Date
+	   2     Time
+	   3     Thread ID
+	   4     Context
+	   5     Internal packet identifier
+	   6     UDP/TCP indicator
+	   7     Send/Receive indicator
+	   8     Remote IP
+	   9     Xid (hex)
+	  10     Query/Response      R = Response
+	                             blank = Query
+	  11     Opcode              Q = Standard Query
+	                             N = Notify
+	                             U = Update
+	                             ? = Unknown
+	  12     [ Flags (hex)
+	  13     Flags (char codes)  A = Authoritative Answer
+	                             T = Truncated Response
+	                             D = Recursion Desired
+	                             R = Recursion Available
+	  14     ResponseCode ]
+	  15     Question Type
+	  16     Question Name
+
+4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] SOA    (4)home(4)gell(3)one(0)
+4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Snd 127.0.0.1       d07e R Q [8085 A DR  NOERROR] SOA    (4)home(4)gell(3)one(0)
+4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC370110 UDP Rcv 127.0.0.1       6ec3   Q [0001   D   NOERROR] NS     (4)home(4)gell(3)one(0)
+4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC370110 UDP Snd 127.0.0.1       6ec3 R Q [8085 A DR  NOERROR] NS     (4)home(4)gell(3)one(0)
+```
+
+- [ ] **Step 2: Create DNS debug fixture with mixed RCODEs**
+
+Create `src-tauri/tests/corpus/dns_debug/mixed/rcodes.log`:
+
+```
+4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Rcv 127.0.0.1       d07e   Q [0001   D   NOERROR] A      (4)home(4)gell(3)one(0)
+4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC36D650 UDP Snd 127.0.0.1       d07e R Q [8085 A DR  NOERROR] A      (4)home(4)gell(3)one(0)
+4/11/2026 8:34:00 PM 0294 PACKET  000002DAEF3AFDC0 UDP Snd 127.0.0.1       3c8a R Q [8385 A DR NXDOMAIN] A      (4)HOME(4)home(4)gell(3)one(0)
+4/11/2026 3:29:17 PM 0294 PACKET  000002DAEC3680D0 UDP Snd 192.168.2.9     7822 R U [02a8      SERVFAIL] SOA    (4)home(4)gell(3)one(0)
+```
+
+- [ ] **Step 3: Add regression tests to `parser_regression_corpus.rs`**
+
+Add to `src-tauri/tests/parser_regression_corpus.rs`:
+
+```rust
+    #[test]
+    fn test_dns_debug_basic_fixture_detection() {
+        let fixture = TempLogFixture::new(
+            "DNSServer_debug.log",
+            &std::fs::read_to_string(
+                concat!(env!("CARGO_MANIFEST_DIR"), "/tests/corpus/dns_debug/clean/basic.log")
+            ).expect("read fixture"),
+        );
+        let snapshot = fixture.detect();
+        assert_eq!(snapshot.parser, "DnsDebug");
+        assert_eq!(snapshot.record_framing, "LogicalRecord");
+    }
+
+    #[test]
+    fn test_dns_debug_basic_fixture_parse() {
+        let fixture = TempLogFixture::new(
+            "DNSServer_debug.log",
+            &std::fs::read_to_string(
+                concat!(env!("CARGO_MANIFEST_DIR"), "/tests/corpus/dns_debug/clean/basic.log")
+            ).expect("read fixture"),
+        );
+        let parsed = fixture.parse();
+        assert_eq!(parsed.selection.parser, "DnsDebug");
+        assert_eq!(parsed.parse_errors, 0);
+        assert_eq!(parsed.entries.len(), 4);
+        assert_eq!(parsed.entries[0].severity, "Info");
+    }
+
+    #[test]
+    fn test_dns_debug_rcodes_fixture_severity() {
+        let fixture = TempLogFixture::new(
+            "dns.log",
+            &std::fs::read_to_string(
+                concat!(env!("CARGO_MANIFEST_DIR"), "/tests/corpus/dns_debug/mixed/rcodes.log")
+            ).expect("read fixture"),
+        );
+        let parsed = fixture.parse();
+        assert_eq!(parsed.entries.len(), 4);
+        assert_eq!(parsed.entries[0].severity, "Info");     // NOERROR query
+        assert_eq!(parsed.entries[1].severity, "Info");     // NOERROR response
+        assert_eq!(parsed.entries[2].severity, "Warning");  // NXDOMAIN
+        assert_eq!(parsed.entries[3].severity, "Error");    // SERVFAIL
+    }
+```
+
+- [ ] **Step 4: Run regression tests**
+
+```bash
+cd src-tauri && cargo test parser_regression_corpus
+```
+
+Expected: all tests pass including new DNS tests.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+cd src-tauri && cargo test --features event-log
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Run clippy**
+
+```bash
+cd src-tauri && cargo clippy --features event-log -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/tests/corpus/dns_debug/ src-tauri/tests/parser_regression_corpus.rs
+git commit -m "test(dns): add DNS debug log corpus fixtures and regression tests"
+```
+
+---
+
+### Task 9: TypeScript Type Updates
+
+**Files:**
+- Modify: `src/types/` (TypeScript types that mirror `LogEntry`)
+
+- [ ] **Step 1: Find the TypeScript LogEntry type**
+
+Search for the TypeScript definition of LogEntry or ParseResult that mirrors the Rust struct. This is the frontend type that needs the nine new DNS fields.
+
+```bash
+cd /Users/Adam.Gell/repo/cmtraceopen && grep -r "query_name\|queryName\|LogEntry\|logEntry" src/types/ --include="*.ts" --include="*.tsx" -l
+```
+
+- [ ] **Step 2: Add DNS fields to the TypeScript type**
+
+Add to the TypeScript `LogEntry` interface (using camelCase as per serde rename):
+
+```typescript
+  queryName?: string;
+  queryType?: string;
+  responseCode?: string;
+  dnsDirection?: string;
+  dnsProtocol?: string;
+  sourceIp?: string;
+  dnsFlags?: string;
+  dnsEventId?: number;
+  zoneName?: string;
+```
+
+- [ ] **Step 3: Add `DnsDebug` and `DnsAudit` to any TypeScript LogFormat enum/type**
+
+Search for the TypeScript equivalent of `LogFormat` and add the two new variants.
+
+- [ ] **Step 4: Run TypeScript check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/
+git commit -m "feat(dns): add DNS fields to TypeScript LogEntry type"
+```
+
+---
+
+### Task 10: Final Integration Verification
+
+- [ ] **Step 1: Run full Rust test suite**
+
+```bash
+cd src-tauri && cargo test --features event-log
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run clippy**
+
+```bash
+cd src-tauri && cargo clippy --features event-log -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 3: Run TypeScript check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: zero errors.
+
+- [ ] **Step 4: Test with real debug log fixture**
+
+```bash
+cd src-tauri && cargo test --features event-log -- --ignored dns_real_fixture 2>/dev/null || echo "No real fixture test yet — manual test"
+```
+
+Manually verify by opening `Logs/dns-fixtures-20260411-203254/DNSServer_debug.log` in the app (if building on Windows or with `npm run app:dev`).
+
+- [ ] **Step 5: Commit any final fixes**
+
+If any issues were found, fix and commit.
+
+- [ ] **Step 6: Final commit with all changes verified**
+
+```bash
+git log --oneline -10
+```
+
+Verify the commit history shows the incremental feature development:
+1. Type system foundation
+2. Shared DNS types
+3. DNS debug log parser
+4. Detection integration
+5. Routing integration
+6. DNS audit EVTX parser
+7. Binary file detection
+8. Corpus test fixtures
+9. TypeScript types

--- a/docs/superpowers/plans/2026-04-14-dns-dhcp-workspace.md
+++ b/docs/superpowers/plans/2026-04-14-dns-dhcp-workspace.md
@@ -1,0 +1,1429 @@
+# DNS/DHCP Cross-Origin Workspace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a device-centric workspace that correlates DNS and DHCP log data for troubleshooting DNS failures and tracking device lifecycle.
+
+**Architecture:** Frontend-only workspace using existing `open_log_file()` backend command. Client-side correlation groups DNS entries by `source_ip` and enriches with DHCP `ip_address`/`hostname`/`mac_address`. Two-panel layout: device list (left) + device detail with query table (right). Zustand store manages state. Progressive enrichment — works with any combination of DNS/DHCP sources.
+
+**Tech Stack:** React 19, Zustand, Fluent UI, TanStack Virtual (all already in project). No new backend code or dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-14-dns-dhcp-workspace-design.md`
+
+---
+
+### Task 1: Types and Store Foundation
+
+**Files:**
+- Create: `src/src-react/workspaces/dns-dhcp/types.ts`
+- Create: `src/src-react/workspaces/dns-dhcp/dns-dhcp-store.ts`
+
+- [ ] **Step 1: Create `types.ts` with Device and SourceFile interfaces**
+
+Create `src/src-react/workspaces/dns-dhcp/types.ts`:
+
+```typescript
+import type { LogEntry, LogFormat } from "../../types/log";
+
+export interface SourceFile {
+  path: string;
+  fileName: string;
+  format: LogFormat;
+  entryCount: number;
+  enabled: boolean;
+}
+
+export interface Device {
+  ip: string;
+  hostname: string | null;
+  mac: string | null;
+  isEnriched: boolean;
+
+  totalQueries: number;
+  nxdomainCount: number;
+  servfailCount: number;
+  firstSeen: number;
+  lastSeen: number;
+
+  dhcpEntries: LogEntry[];
+  dnsEntries: LogEntry[];
+}
+```
+
+- [ ] **Step 2: Create `dns-dhcp-store.ts` with Zustand store**
+
+Create `src/src-react/workspaces/dns-dhcp/dns-dhcp-store.ts`:
+
+```typescript
+import { create } from "zustand";
+import type { LogEntry, LogFormat } from "../../types/log";
+import type { Device, SourceFile } from "./types";
+
+function stripPort(ip: string): string {
+  // IPv6 with port: [::1]:54159 — not expected here
+  // IPv4 with port: 192.168.2.9:54159
+  const lastColon = ip.lastIndexOf(":");
+  if (lastColon === -1) return ip;
+  // Check if everything after last colon is digits (port)
+  const afterColon = ip.substring(lastColon + 1);
+  if (/^\d+$/.test(afterColon)) {
+    return ip.substring(0, lastColon);
+  }
+  return ip; // IPv6 address without port
+}
+
+function buildDevices(entries: LogEntry[]): Device[] {
+  const dnsByIp = new Map<string, LogEntry[]>();
+  const dhcpByIp = new Map<string, LogEntry[]>();
+
+  for (const entry of entries) {
+    const format = entry.format;
+
+    if (format === "DnsDebug" || format === "DnsAudit") {
+      const rawIp = entry.sourceIp;
+      if (!rawIp) continue;
+      const ip = stripPort(rawIp);
+      const list = dnsByIp.get(ip);
+      if (list) {
+        list.push(entry);
+      } else {
+        dnsByIp.set(ip, [entry]);
+      }
+    } else if (format === "Ccm" || format === "Simple" || format === "Plain" || format === "Timestamped") {
+      // Check if this is actually a DHCP entry by checking ipAddress field
+      if (entry.ipAddress) {
+        const ip = entry.ipAddress;
+        const list = dhcpByIp.get(ip);
+        if (list) {
+          list.push(entry);
+        } else {
+          dhcpByIp.set(ip, [entry]);
+        }
+      }
+    }
+  }
+
+  const allIps = new Set([...dnsByIp.keys(), ...dhcpByIp.keys()]);
+  const devices: Device[] = [];
+
+  for (const ip of allIps) {
+    const dnsEntries = dnsByIp.get(ip) ?? [];
+    const dhcpEntries = dhcpByIp.get(ip) ?? [];
+
+    let hostname: string | null = null;
+    let mac: string | null = null;
+    const isEnriched = dhcpEntries.length > 0;
+
+    if (isEnriched) {
+      // Take hostname/mac from latest DHCP entry
+      for (const e of dhcpEntries) {
+        if (e.hostName) hostname = e.hostName;
+        if (e.macAddress) mac = e.macAddress;
+      }
+    }
+
+    const allTimestamps = [...dnsEntries, ...dhcpEntries]
+      .map((e) => e.timestamp)
+      .filter((t): t is number => t != null);
+
+    const nxdomainCount = dnsEntries.filter(
+      (e) => e.responseCode === "NXDOMAIN"
+    ).length;
+    const servfailCount = dnsEntries.filter(
+      (e) => e.responseCode === "SERVFAIL"
+    ).length;
+
+    devices.push({
+      ip,
+      hostname,
+      mac,
+      isEnriched,
+      totalQueries: dnsEntries.length,
+      nxdomainCount,
+      servfailCount,
+      firstSeen: allTimestamps.length > 0 ? Math.min(...allTimestamps) : 0,
+      lastSeen: allTimestamps.length > 0 ? Math.max(...allTimestamps) : 0,
+      dhcpEntries,
+      dnsEntries,
+    });
+  }
+
+  // Sort by total queries descending (most active first)
+  devices.sort((a, b) => b.totalQueries - a.totalQueries);
+  return devices;
+}
+
+interface DnsDhcpState {
+  // Data
+  sources: SourceFile[];
+  allEntries: LogEntry[];
+
+  // Derived
+  devices: Device[];
+  selectedDeviceIp: string | null;
+
+  // Filtering
+  searchQuery: string;
+  rcodeFilter: string;
+  qtypeFilter: string;
+
+  // Analysis state
+  isLoading: boolean;
+  loadError: string | null;
+
+  // Actions
+  addSource: (path: string, fileName: string, format: LogFormat, entries: LogEntry[]) => void;
+  toggleSource: (path: string) => void;
+  removeSource: (path: string) => void;
+  selectDevice: (ip: string | null) => void;
+  setSearchQuery: (query: string) => void;
+  setRcodeFilter: (rcode: string) => void;
+  setQtypeFilter: (qtype: string) => void;
+  setLoading: (loading: boolean) => void;
+  setLoadError: (error: string | null) => void;
+  clear: () => void;
+}
+
+function rebuildDevices(state: { sources: SourceFile[]; allEntries: LogEntry[] }): Device[] {
+  const enabledPaths = new Set(
+    state.sources.filter((s) => s.enabled).map((s) => s.path)
+  );
+  const activeEntries = state.allEntries.filter((e) =>
+    enabledPaths.has(e.filePath)
+  );
+  return buildDevices(activeEntries);
+}
+
+export const useDnsDhcpStore = create<DnsDhcpState>((set) => ({
+  sources: [],
+  allEntries: [],
+  devices: [],
+  selectedDeviceIp: null,
+  searchQuery: "",
+  rcodeFilter: "All",
+  qtypeFilter: "All",
+  isLoading: false,
+  loadError: null,
+
+  addSource: (path, fileName, format, entries) =>
+    set((state) => {
+      // Skip if already loaded
+      if (state.sources.some((s) => s.path === path)) return state;
+
+      const newSources = [
+        ...state.sources,
+        { path, fileName, format, entryCount: entries.length, enabled: true },
+      ];
+      const newEntries = [...state.allEntries, ...entries];
+      const devices = buildDevices(newEntries);
+
+      return {
+        sources: newSources,
+        allEntries: newEntries,
+        devices,
+        // Auto-select most active device if none selected
+        selectedDeviceIp:
+          state.selectedDeviceIp ?? (devices.length > 0 ? devices[0].ip : null),
+        isLoading: false,
+        loadError: null,
+      };
+    }),
+
+  toggleSource: (path) =>
+    set((state) => {
+      const newSources = state.sources.map((s) =>
+        s.path === path ? { ...s, enabled: !s.enabled } : s
+      );
+      const newState = { ...state, sources: newSources };
+      const devices = rebuildDevices(newState);
+      return { sources: newSources, devices };
+    }),
+
+  removeSource: (path) =>
+    set((state) => {
+      const newSources = state.sources.filter((s) => s.path !== path);
+      const newEntries = state.allEntries.filter((e) => e.filePath !== path);
+      const devices = buildDevices(newEntries);
+      return {
+        sources: newSources,
+        allEntries: newEntries,
+        devices,
+        selectedDeviceIp:
+          devices.find((d) => d.ip === state.selectedDeviceIp)
+            ? state.selectedDeviceIp
+            : devices.length > 0
+              ? devices[0].ip
+              : null,
+      };
+    }),
+
+  selectDevice: (ip) => set({ selectedDeviceIp: ip }),
+  setSearchQuery: (query) => set({ searchQuery: query }),
+  setRcodeFilter: (rcode) => set({ rcodeFilter: rcode }),
+  setQtypeFilter: (qtype) => set({ qtypeFilter: qtype }),
+  setLoading: (loading) => set({ isLoading: loading }),
+  setLoadError: (error) => set({ loadError: error, isLoading: false }),
+  clear: () =>
+    set({
+      sources: [],
+      allEntries: [],
+      devices: [],
+      selectedDeviceIp: null,
+      searchQuery: "",
+      rcodeFilter: "All",
+      qtypeFilter: "All",
+      isLoading: false,
+      loadError: null,
+    }),
+}));
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/src-react/workspaces/dns-dhcp/types.ts src/src-react/workspaces/dns-dhcp/dns-dhcp-store.ts
+git commit -m "feat(dns-dhcp): add workspace types and Zustand store with device correlation logic"
+```
+
+---
+
+### Task 2: Workspace Registration
+
+**Files:**
+- Create: `src/src-react/workspaces/dns-dhcp/index.ts`
+- Modify: `src/src-react/workspaces/registry.ts`
+- Modify: `src/src-react/types/log.ts`
+
+- [ ] **Step 1: Add `dns-dhcp` to `WorkspaceId` type**
+
+In `src/src-react/types/log.ts`, add `| "dns-dhcp"` to the `WorkspaceId` type:
+
+```typescript
+export type WorkspaceId =
+  | "log"
+  | "intune"
+  | "new-intune"
+  | "dsregcmd"
+  | "macos-diag"
+  | "deployment"
+  | "event-log"
+  | "sysmon"
+  | "dns-dhcp";
+```
+
+- [ ] **Step 2: Create placeholder workspace component files**
+
+Create `src/src-react/workspaces/dns-dhcp/DnsDhcpWorkspace.tsx`:
+
+```tsx
+export function DnsDhcpWorkspace() {
+  return <div style={{ padding: 24 }}>DNS / DHCP Workspace — loading...</div>;
+}
+```
+
+Create `src/src-react/workspaces/dns-dhcp/DnsDhcpSidebar.tsx`:
+
+```tsx
+export function DnsDhcpSidebar() {
+  return null;
+}
+```
+
+- [ ] **Step 3: Create workspace definition in `index.ts`**
+
+Create `src/src-react/workspaces/dns-dhcp/index.ts`:
+
+```typescript
+import { startTransition, lazy } from "react";
+import type { WorkspaceDefinition } from "../types";
+
+const ACCEPTED_FORMATS = new Set(["DnsDebug", "DnsAudit"]);
+const ACCEPTED_PARSERS = new Set(["dnsDebug", "dnsAudit", "dhcp"]);
+
+export const dnsDhcpWorkspace: WorkspaceDefinition = {
+  id: "dns-dhcp",
+  label: "DNS / DHCP",
+  platforms: "all",
+  component: lazy(() =>
+    import("./DnsDhcpWorkspace").then((m) => ({ default: m.DnsDhcpWorkspace }))
+  ),
+  sidebar: lazy(() =>
+    import("./DnsDhcpSidebar").then((m) => ({ default: m.DnsDhcpSidebar }))
+  ),
+  capabilities: {
+    fontSizing: true,
+  },
+  fileFilters: [
+    { name: "DNS/DHCP Logs", extensions: ["log", "evtx"] },
+    { name: "All Files", extensions: ["*"] },
+  ],
+  actionLabels: {
+    file: "Open DNS/DHCP File",
+    folder: "Open Log Folder",
+    placeholder: "Open DNS or DHCP logs...",
+  },
+  onOpenSource: async (source, trigger) => {
+    const [{ useUiStore }, { getLogSourcePath }, { openLogFile }, { useDnsDhcpStore }] =
+      await Promise.all([
+        import("../../stores/ui-store"),
+        import("../../lib/log-source"),
+        import("../../lib/commands"),
+        import("./dns-dhcp-store"),
+      ]);
+
+    useUiStore.getState().ensureWorkspaceVisible("dns-dhcp", trigger);
+    const sourcePath = getLogSourcePath(source);
+    const fileName = sourcePath.split(/[\\/]/).pop() ?? sourcePath;
+
+    useDnsDhcpStore.getState().setLoading(true);
+
+    try {
+      const result = await openLogFile(sourcePath);
+      const format = result.formatDetected;
+      const parser = result.parserSelection.parser;
+
+      if (!ACCEPTED_FORMATS.has(format) && !ACCEPTED_PARSERS.has(parser)) {
+        useDnsDhcpStore.getState().setLoadError(
+          `"${fileName}" doesn't appear to be a DNS or DHCP log (detected: ${format}).`
+        );
+        return;
+      }
+
+      startTransition(() => {
+        useDnsDhcpStore.getState().addSource(sourcePath, fileName, format, result.entries);
+      });
+    } catch (error) {
+      useDnsDhcpStore.getState().setLoadError(
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  },
+  onOpenPath: async (path) => {
+    const [{ useUiStore }, { openLogFile }, { useDnsDhcpStore }] =
+      await Promise.all([
+        import("../../stores/ui-store"),
+        import("../../lib/commands"),
+        import("./dns-dhcp-store"),
+      ]);
+
+    useUiStore.getState().ensureWorkspaceVisible("dns-dhcp", "drop");
+    const fileName = path.split(/[\\/]/).pop() ?? path;
+
+    useDnsDhcpStore.getState().setLoading(true);
+
+    try {
+      const result = await openLogFile(path);
+      startTransition(() => {
+        useDnsDhcpStore.getState().addSource(path, fileName, result.formatDetected, result.entries);
+      });
+    } catch (error) {
+      useDnsDhcpStore.getState().setLoadError(
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  },
+};
+```
+
+- [ ] **Step 4: Register in `registry.ts`**
+
+In `src/src-react/workspaces/registry.ts`, add the import and registration:
+
+```typescript
+import { dnsDhcpWorkspace } from "./dns-dhcp";
+```
+
+Add to the `ALL_WORKSPACES` array after `sysmonWorkspace`:
+
+```typescript
+const ALL_WORKSPACES: WorkspaceDefinition[] = [
+  logWorkspace,
+  intuneWorkspace,
+  newIntuneWorkspace,
+  dsregcmdWorkspace,
+  macosDiagWorkspace,
+  deploymentWorkspace,
+  eventLogWorkspace,
+  sysmonWorkspace,
+  dnsDhcpWorkspace,
+];
+```
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/src-react/workspaces/dns-dhcp/index.ts src/src-react/workspaces/dns-dhcp/DnsDhcpWorkspace.tsx src/src-react/workspaces/dns-dhcp/DnsDhcpSidebar.tsx src/src-react/workspaces/registry.ts src/src-react/types/log.ts
+git commit -m "feat(dns-dhcp): register workspace with file open handlers and placeholder components"
+```
+
+---
+
+### Task 3: Device List Component (Left Panel)
+
+**Files:**
+- Create: `src/src-react/workspaces/dns-dhcp/DeviceList.tsx`
+
+- [ ] **Step 1: Create `DeviceList.tsx`**
+
+Create `src/src-react/workspaces/dns-dhcp/DeviceList.tsx`:
+
+```tsx
+import { tokens, Input, Badge } from "@fluentui/react-components";
+import { Search20Regular } from "@fluentui/react-icons";
+import { useDnsDhcpStore } from "./dns-dhcp-store";
+import type { Device } from "./types";
+import { useUiStore } from "../../stores/ui-store";
+import { getLogListMetrics } from "../../lib/log-accessibility";
+
+function DeviceRow({
+  device,
+  isSelected,
+  onClick,
+  fontSize,
+}: {
+  device: Device;
+  isSelected: boolean;
+  onClick: () => void;
+  fontSize: number;
+}) {
+  const metrics = getLogListMetrics(fontSize);
+  const hasErrors = device.nxdomainCount > 0 || device.servfailCount > 0;
+
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        padding: "6px 10px",
+        cursor: "pointer",
+        borderLeft: isSelected
+          ? `3px solid ${tokens.colorBrandForeground1}`
+          : "3px solid transparent",
+        background: isSelected
+          ? tokens.colorNeutralBackground1Selected
+          : "transparent",
+        opacity: device.isEnriched ? 1 : 0.7,
+        fontSize: metrics.fontSize,
+      }}
+      onMouseEnter={(e) => {
+        if (!isSelected)
+          e.currentTarget.style.background =
+            tokens.colorNeutralBackground1Hover;
+      }}
+      onMouseLeave={(e) => {
+        if (!isSelected)
+          e.currentTarget.style.background = "transparent";
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div>
+          <div
+            style={{
+              color: device.isEnriched
+                ? tokens.colorNeutralForeground1
+                : tokens.colorNeutralForeground3,
+              fontWeight: isSelected ? 600 : 400,
+            }}
+          >
+            {device.hostname ?? device.ip}
+          </div>
+          {device.hostname && (
+            <div
+              style={{
+                fontSize: metrics.fontSize - 1,
+                color: tokens.colorNeutralForeground3,
+              }}
+            >
+              {device.ip}
+              {device.mac ? ` | ${device.mac}` : ""}
+            </div>
+          )}
+        </div>
+        <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
+          {device.totalQueries > 0 && (
+            <Badge
+              size="small"
+              appearance="filled"
+              color="informative"
+            >
+              {device.totalQueries}
+            </Badge>
+          )}
+          {hasErrors && (
+            <Badge
+              size="small"
+              appearance="filled"
+              color="danger"
+            >
+              {device.nxdomainCount + device.servfailCount}
+            </Badge>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function DeviceList() {
+  const devices = useDnsDhcpStore((s) => s.devices);
+  const selectedDeviceIp = useDnsDhcpStore((s) => s.selectedDeviceIp);
+  const selectDevice = useDnsDhcpStore((s) => s.selectDevice);
+  const searchQuery = useDnsDhcpStore((s) => s.searchQuery);
+  const setSearchQuery = useDnsDhcpStore((s) => s.setSearchQuery);
+  const fontSize = useUiStore((s) => s.logListFontSize);
+
+  const filtered = devices.filter((d) => {
+    if (!searchQuery) return true;
+    const q = searchQuery.toLowerCase();
+    return (
+      d.ip.toLowerCase().includes(q) ||
+      (d.hostname?.toLowerCase().includes(q) ?? false) ||
+      (d.mac?.toLowerCase().includes(q) ?? false)
+    );
+  });
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        borderRight: `1px solid ${tokens.colorNeutralStroke1}`,
+        width: 300,
+        minWidth: 220,
+      }}
+    >
+      <div style={{ padding: "8px 10px" }}>
+        <Input
+          size="small"
+          placeholder="Search devices..."
+          value={searchQuery}
+          onChange={(_, data) => setSearchQuery(data.value)}
+          contentBefore={<Search20Regular />}
+          style={{ width: "100%" }}
+        />
+      </div>
+      <div
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          borderTop: `1px solid ${tokens.colorNeutralStroke1}`,
+        }}
+      >
+        {filtered.length === 0 && (
+          <div
+            style={{
+              padding: 16,
+              color: tokens.colorNeutralForeground3,
+              textAlign: "center",
+              fontSize: 13,
+            }}
+          >
+            {devices.length === 0
+              ? "No devices found. Open DNS or DHCP logs."
+              : "No devices match the search."}
+          </div>
+        )}
+        {filtered.map((device) => (
+          <DeviceRow
+            key={device.ip}
+            device={device}
+            isSelected={device.ip === selectedDeviceIp}
+            onClick={() => selectDevice(device.ip)}
+            fontSize={fontSize}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/src-react/workspaces/dns-dhcp/DeviceList.tsx
+git commit -m "feat(dns-dhcp): add DeviceList component with search and enrichment indicators"
+```
+
+---
+
+### Task 4: Device Detail Components (Right Panel)
+
+**Files:**
+- Create: `src/src-react/workspaces/dns-dhcp/DeviceSummaryHeader.tsx`
+- Create: `src/src-react/workspaces/dns-dhcp/DeviceQueryTable.tsx`
+- Create: `src/src-react/workspaces/dns-dhcp/DeviceDetail.tsx`
+
+- [ ] **Step 1: Create `DeviceSummaryHeader.tsx`**
+
+Create `src/src-react/workspaces/dns-dhcp/DeviceSummaryHeader.tsx`:
+
+```tsx
+import { tokens, Badge } from "@fluentui/react-components";
+import type { Device } from "./types";
+
+function formatTimestamp(ms: number): string {
+  if (ms === 0) return "—";
+  const d = new Date(ms);
+  return d.toLocaleString();
+}
+
+export function DeviceSummaryHeader({ device }: { device: Device }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 16,
+        padding: "10px 16px",
+        borderBottom: `1px solid ${tokens.colorNeutralStroke1}`,
+        background: tokens.colorNeutralBackground2,
+        fontSize: 13,
+        color: tokens.colorNeutralForeground2,
+      }}
+    >
+      <div>
+        <div
+          style={{
+            fontSize: 15,
+            fontWeight: 600,
+            color: tokens.colorNeutralForeground1,
+          }}
+        >
+          {device.hostname ?? device.ip}
+        </div>
+        {device.hostname && (
+          <div style={{ fontSize: 12, color: tokens.colorNeutralForeground3 }}>
+            {device.ip}
+            {device.mac ? ` | ${device.mac}` : ""}
+          </div>
+        )}
+      </div>
+      <div style={{ display: "flex", gap: 16, alignItems: "center", flexWrap: "wrap" }}>
+        <Stat label="Queries" value={device.totalQueries} />
+        <Stat
+          label="NXDOMAIN"
+          value={device.nxdomainCount}
+          color={device.nxdomainCount > 0 ? "warning" : undefined}
+        />
+        <Stat
+          label="SERVFAIL"
+          value={device.servfailCount}
+          color={device.servfailCount > 0 ? "danger" : undefined}
+        />
+        <div>
+          <div style={{ fontSize: 11, color: tokens.colorNeutralForeground3 }}>
+            First seen
+          </div>
+          <div>{formatTimestamp(device.firstSeen)}</div>
+        </div>
+        <div>
+          <div style={{ fontSize: 11, color: tokens.colorNeutralForeground3 }}>
+            Last seen
+          </div>
+          <div>{formatTimestamp(device.lastSeen)}</div>
+        </div>
+        {device.dhcpEntries.length > 0 && (
+          <div>
+            <div style={{ fontSize: 11, color: tokens.colorNeutralForeground3 }}>
+              DHCP events
+            </div>
+            <div>{device.dhcpEntries.length}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: number;
+  color?: "warning" | "danger";
+}) {
+  return (
+    <div>
+      <div style={{ fontSize: 11, color: tokens.colorNeutralForeground3 }}>
+        {label}
+      </div>
+      <div>
+        {color ? (
+          <Badge size="small" appearance="filled" color={color}>
+            {value}
+          </Badge>
+        ) : (
+          value.toLocaleString()
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create `DeviceQueryTable.tsx`**
+
+Create `src/src-react/workspaces/dns-dhcp/DeviceQueryTable.tsx`:
+
+```tsx
+import { useMemo, useRef } from "react";
+import { tokens, Dropdown, Option } from "@fluentui/react-components";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import type { Device } from "./types";
+import { useDnsDhcpStore } from "./dns-dhcp-store";
+import { useUiStore } from "../../stores/ui-store";
+import { getLogListMetrics } from "../../lib/log-accessibility";
+
+const COLUMNS = [
+  { id: "time", label: "Time", width: 170 },
+  { id: "queryName", label: "Query Name", width: 260 },
+  { id: "type", label: "Type", width: 60 },
+  { id: "rcode", label: "RCODE", width: 100 },
+  { id: "dir", label: "Dir", width: 45 },
+  { id: "proto", label: "Proto", width: 50 },
+  { id: "flags", label: "Flags", width: 80 },
+];
+
+const RCODE_OPTIONS = ["All", "NOERROR", "NXDOMAIN", "SERVFAIL", "REFUSED", "FORMERR"];
+const QTYPE_OPTIONS = ["All", "A", "AAAA", "SOA", "NS", "PTR", "SRV", "CNAME", "MX", "TXT"];
+
+export function DeviceQueryTable({ device }: { device: Device }) {
+  const rcodeFilter = useDnsDhcpStore((s) => s.rcodeFilter);
+  const qtypeFilter = useDnsDhcpStore((s) => s.qtypeFilter);
+  const setRcodeFilter = useDnsDhcpStore((s) => s.setRcodeFilter);
+  const setQtypeFilter = useDnsDhcpStore((s) => s.setQtypeFilter);
+  const fontSize = useUiStore((s) => s.logListFontSize);
+  const metrics = getLogListMetrics(fontSize);
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const filtered = useMemo(() => {
+    return device.dnsEntries.filter((e) => {
+      if (rcodeFilter !== "All" && e.responseCode !== rcodeFilter) return false;
+      if (qtypeFilter !== "All" && e.queryType !== qtypeFilter) return false;
+      return true;
+    });
+  }, [device.dnsEntries, rcodeFilter, qtypeFilter]);
+
+  const virtualizer = useVirtualizer({
+    count: filtered.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => metrics.rowHeight,
+    overscan: 20,
+  });
+
+  const gridTemplate = COLUMNS.map((c) => `${c.width}px`).join(" ");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+      {/* Filters */}
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          padding: "6px 16px",
+          borderBottom: `1px solid ${tokens.colorNeutralStroke1}`,
+          alignItems: "center",
+          fontSize: 12,
+        }}
+      >
+        <span style={{ color: tokens.colorNeutralForeground3 }}>RCODE:</span>
+        <Dropdown
+          size="small"
+          value={rcodeFilter}
+          onOptionSelect={(_, data) => setRcodeFilter(data.optionValue ?? "All")}
+          style={{ minWidth: 100 }}
+        >
+          {RCODE_OPTIONS.map((o) => (
+            <Option key={o} value={o}>
+              {o}
+            </Option>
+          ))}
+        </Dropdown>
+        <span style={{ color: tokens.colorNeutralForeground3, marginLeft: 8 }}>Type:</span>
+        <Dropdown
+          size="small"
+          value={qtypeFilter}
+          onOptionSelect={(_, data) => setQtypeFilter(data.optionValue ?? "All")}
+          style={{ minWidth: 80 }}
+        >
+          {QTYPE_OPTIONS.map((o) => (
+            <Option key={o} value={o}>
+              {o}
+            </Option>
+          ))}
+        </Dropdown>
+        <span style={{ color: tokens.colorNeutralForeground3, marginLeft: "auto" }}>
+          {filtered.length.toLocaleString()} entries
+        </span>
+      </div>
+
+      {/* Header */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: gridTemplate,
+          padding: "4px 16px",
+          borderBottom: `1px solid ${tokens.colorNeutralStroke1}`,
+          fontSize: metrics.fontSize - 1,
+          color: tokens.colorNeutralForeground3,
+          fontWeight: 600,
+        }}
+      >
+        {COLUMNS.map((c) => (
+          <div key={c.id}>{c.label}</div>
+        ))}
+      </div>
+
+      {/* Virtual rows */}
+      <div
+        ref={parentRef}
+        style={{ flex: 1, overflowY: "auto" }}
+      >
+        <div
+          style={{
+            height: virtualizer.getTotalSize(),
+            width: "100%",
+            position: "relative",
+          }}
+        >
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const entry = filtered[virtualRow.index];
+            const isError =
+              entry.responseCode === "SERVFAIL" ||
+              entry.responseCode === "REFUSED" ||
+              entry.responseCode === "FORMERR";
+            const isWarning = entry.responseCode === "NXDOMAIN";
+
+            return (
+              <div
+                key={virtualRow.key}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: gridTemplate,
+                  position: "absolute",
+                  top: virtualRow.start,
+                  left: 0,
+                  width: "100%",
+                  height: virtualRow.size,
+                  padding: "0 16px",
+                  alignItems: "center",
+                  fontSize: metrics.fontSize,
+                  color: isError
+                    ? tokens.colorPaletteRedForeground2
+                    : isWarning
+                      ? tokens.colorPaletteYellowForeground2
+                      : tokens.colorNeutralForeground1,
+                  borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+                }}
+              >
+                <div>{entry.timestampDisplay ?? "—"}</div>
+                <div style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {entry.queryName ?? "—"}
+                </div>
+                <div>{entry.queryType ?? "—"}</div>
+                <div style={{ fontWeight: isError || isWarning ? 600 : 400 }}>
+                  {entry.responseCode ?? "—"}
+                </div>
+                <div>{entry.dnsDirection ?? "—"}</div>
+                <div>{entry.dnsProtocol ?? "—"}</div>
+                <div>{entry.dnsFlags ?? "—"}</div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create `DeviceDetail.tsx`**
+
+Create `src/src-react/workspaces/dns-dhcp/DeviceDetail.tsx`:
+
+```tsx
+import { tokens } from "@fluentui/react-components";
+import { useDnsDhcpStore } from "./dns-dhcp-store";
+import { DeviceSummaryHeader } from "./DeviceSummaryHeader";
+import { DeviceQueryTable } from "./DeviceQueryTable";
+
+export function DeviceDetail() {
+  const devices = useDnsDhcpStore((s) => s.devices);
+  const selectedDeviceIp = useDnsDhcpStore((s) => s.selectedDeviceIp);
+
+  const device = devices.find((d) => d.ip === selectedDeviceIp) ?? null;
+
+  if (!device) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flex: 1,
+          color: tokens.colorNeutralForeground3,
+          fontSize: 14,
+        }}
+      >
+        Select a device to view DNS activity
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+      <DeviceSummaryHeader device={device} />
+      <DeviceQueryTable device={device} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/src-react/workspaces/dns-dhcp/DeviceSummaryHeader.tsx src/src-react/workspaces/dns-dhcp/DeviceQueryTable.tsx src/src-react/workspaces/dns-dhcp/DeviceDetail.tsx
+git commit -m "feat(dns-dhcp): add DeviceDetail with summary header and virtual-scrolled query table"
+```
+
+---
+
+### Task 5: Main Workspace Layout and Sidebar
+
+**Files:**
+- Modify: `src/src-react/workspaces/dns-dhcp/DnsDhcpWorkspace.tsx`
+- Modify: `src/src-react/workspaces/dns-dhcp/DnsDhcpSidebar.tsx`
+
+- [ ] **Step 1: Implement `DnsDhcpWorkspace.tsx`**
+
+Replace the placeholder with the full implementation:
+
+```tsx
+import { tokens, Spinner } from "@fluentui/react-components";
+import { open } from "@tauri-apps/plugin-dialog";
+import { useDnsDhcpStore } from "./dns-dhcp-store";
+import { DeviceList } from "./DeviceList";
+import { DeviceDetail } from "./DeviceDetail";
+import { openLogFile } from "../../lib/commands";
+import { startTransition } from "react";
+
+const FILE_FILTERS = [
+  { name: "DNS/DHCP Logs", extensions: ["log", "evtx"] },
+  { name: "All Files", extensions: ["*"] },
+];
+
+export function DnsDhcpWorkspace() {
+  const sources = useDnsDhcpStore((s) => s.sources);
+  const isLoading = useDnsDhcpStore((s) => s.isLoading);
+  const loadError = useDnsDhcpStore((s) => s.loadError);
+  const addSource = useDnsDhcpStore((s) => s.addSource);
+  const setLoading = useDnsDhcpStore((s) => s.setLoading);
+  const setLoadError = useDnsDhcpStore((s) => s.setLoadError);
+
+  const handleOpenFile = async () => {
+    try {
+      const selected = await open({ multiple: true, filters: FILE_FILTERS });
+      if (!selected) return;
+      const paths = Array.isArray(selected) ? selected : [selected];
+
+      setLoading(true);
+      for (const path of paths) {
+        try {
+          const result = await openLogFile(path);
+          const fileName = path.split(/[\\/]/).pop() ?? path;
+          startTransition(() => {
+            addSource(path, fileName, result.formatDetected, result.entries);
+          });
+        } catch (err) {
+          console.warn(`[dns-dhcp] skipping file: ${path}`, err);
+        }
+      }
+      setLoading(false);
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  // Empty state
+  if (sources.length === 0 && !isLoading) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100%",
+          gap: 16,
+          color: tokens.colorNeutralForeground3,
+        }}
+      >
+        <div style={{ fontSize: 20, fontWeight: 600, color: tokens.colorNeutralForeground1 }}>
+          DNS / DHCP Workspace
+        </div>
+        <div style={{ fontSize: 14, maxWidth: 440, textAlign: "center", lineHeight: 1.6 }}>
+          Open DNS debug logs, DNS audit EVTX files, or DHCP server logs to correlate
+          device activity and troubleshoot DNS resolution failures.
+        </div>
+        <button
+          onClick={handleOpenFile}
+          style={{
+            padding: "8px 20px",
+            fontSize: 14,
+            cursor: "pointer",
+            background: tokens.colorBrandBackground,
+            color: tokens.colorNeutralForegroundOnBrand,
+            border: "none",
+            borderRadius: 4,
+          }}
+        >
+          Open Files
+        </button>
+        {loadError && (
+          <div style={{ color: tokens.colorPaletteRedForeground2, fontSize: 13 }}>
+            {loadError}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Loading state
+  if (isLoading && sources.length === 0) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100%",
+          gap: 12,
+        }}
+      >
+        <Spinner size="small" />
+        <span style={{ color: tokens.colorNeutralForeground2 }}>Loading...</span>
+      </div>
+    );
+  }
+
+  // Main two-panel layout
+  return (
+    <div style={{ display: "flex", height: "100%", overflow: "hidden" }}>
+      <DeviceList />
+      <DeviceDetail />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Implement `DnsDhcpSidebar.tsx`**
+
+Replace the placeholder:
+
+```tsx
+import { tokens, Switch } from "@fluentui/react-components";
+import { useDnsDhcpStore } from "./dns-dhcp-store";
+import { SourceSummaryCard } from "../../components/common/sidebar-primitives";
+import type { LogFormat } from "../../types/log";
+
+function formatBadge(format: LogFormat): string {
+  switch (format) {
+    case "DnsDebug":
+      return "DNS Debug";
+    case "DnsAudit":
+      return "DNS Audit";
+    default:
+      return "DHCP";
+  }
+}
+
+export function DnsDhcpSidebar() {
+  const sources = useDnsDhcpStore((s) => s.sources);
+  const devices = useDnsDhcpStore((s) => s.devices);
+  const allEntries = useDnsDhcpStore((s) => s.allEntries);
+  const toggleSource = useDnsDhcpStore((s) => s.toggleSource);
+  const isLoading = useDnsDhcpStore((s) => s.isLoading);
+  const loadError = useDnsDhcpStore((s) => s.loadError);
+
+  const enrichedCount = devices.filter((d) => d.isEnriched).length;
+
+  return (
+    <>
+      <SourceSummaryCard
+        badge="dns-dhcp"
+        title="DNS / DHCP"
+        subtitle={
+          sources.length === 0
+            ? "Open DNS or DHCP logs to begin."
+            : `${sources.length} source${sources.length !== 1 ? "s" : ""} loaded`
+        }
+        body={
+          <div
+            style={{
+              fontSize: "inherit",
+              color: tokens.colorNeutralForeground2,
+              lineHeight: 1.5,
+            }}
+          >
+            {isLoading && <div>Loading...</div>}
+            {loadError && (
+              <div style={{ color: tokens.colorPaletteRedForeground2 }}>
+                {loadError}
+              </div>
+            )}
+            {sources.length > 0 && (
+              <>
+                <div>Events: {allEntries.length.toLocaleString()}</div>
+                <div>Devices: {devices.length}</div>
+                {enrichedCount > 0 && (
+                  <div>Enriched (DHCP): {enrichedCount}</div>
+                )}
+              </>
+            )}
+          </div>
+        }
+      />
+
+      {sources.length > 0 && (
+        <div style={{ padding: "8px 12px" }}>
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              color: tokens.colorNeutralForeground3,
+              textTransform: "uppercase",
+              marginBottom: 6,
+            }}
+          >
+            Sources
+          </div>
+          {sources.map((source) => (
+            <div
+              key={source.path}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                padding: "4px 0",
+                fontSize: 12,
+              }}
+            >
+              <div style={{ overflow: "hidden" }}>
+                <div
+                  style={{
+                    color: tokens.colorNeutralForeground1,
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {source.fileName}
+                </div>
+                <div style={{ color: tokens.colorNeutralForeground3, fontSize: 11 }}>
+                  {formatBadge(source.format)} | {source.entryCount.toLocaleString()} entries
+                </div>
+              </div>
+              <Switch
+                checked={source.enabled}
+                onChange={() => toggleSource(source.path)}
+                style={{ marginLeft: 8 }}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/src-react/workspaces/dns-dhcp/DnsDhcpWorkspace.tsx src/src-react/workspaces/dns-dhcp/DnsDhcpSidebar.tsx
+git commit -m "feat(dns-dhcp): implement main workspace layout and sidebar with source management"
+```
+
+---
+
+### Task 6: Auto-Detect Banner in Log Viewer
+
+**Files:**
+- Create: `src/src-react/components/log-view/DnsWorkspaceBanner.tsx`
+
+This task adds the auto-detect prompt that appears when a DNS/DHCP file is opened in the standard log viewer.
+
+- [ ] **Step 1: Create `DnsWorkspaceBanner.tsx`**
+
+Create `src/src-react/components/log-view/DnsWorkspaceBanner.tsx`:
+
+```tsx
+import { useState } from "react";
+import { tokens, Button } from "@fluentui/react-components";
+import { Dismiss16Regular } from "@fluentui/react-icons";
+import type { ParserKind } from "../../types/log";
+
+const PARSER_LABELS: Partial<Record<ParserKind, string>> = {
+  dnsDebug: "DNS debug log",
+  dnsAudit: "DNS audit log",
+  dhcp: "DHCP server log",
+};
+
+export function DnsWorkspaceBanner({
+  parser,
+  onOpenInWorkspace,
+}: {
+  parser: ParserKind;
+  onOpenInWorkspace: () => void;
+}) {
+  const [dismissed, setDismissed] = useState(false);
+
+  const label = PARSER_LABELS[parser];
+  if (!label || dismissed) return null;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "6px 12px",
+        background: tokens.colorNeutralBackground4,
+        borderBottom: `1px solid ${tokens.colorNeutralStroke1}`,
+        fontSize: 13,
+        color: tokens.colorNeutralForeground2,
+      }}
+    >
+      <span>
+        This looks like a {label}. Open in the DNS/DHCP workspace for device
+        correlation and query analysis?
+      </span>
+      <Button
+        size="small"
+        appearance="primary"
+        onClick={onOpenInWorkspace}
+      >
+        Open in Workspace
+      </Button>
+      <Button
+        size="small"
+        appearance="subtle"
+        icon={<Dismiss16Regular />}
+        onClick={() => setDismissed(true)}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Integrate the banner**
+
+Find the main log list view component. The banner should be rendered conditionally above the log list when `parserSelection.parser` is `dnsDebug`, `dnsAudit`, or `dhcp` and the active workspace is `log`. The `onOpenInWorkspace` handler should:
+
+1. Load the current file's entries into the dns-dhcp store
+2. Switch the active workspace to `dns-dhcp`
+
+The exact integration point depends on the log view component structure — the implementer should find where the log list renders and add the banner above it.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/src-react/components/log-view/DnsWorkspaceBanner.tsx
+git commit -m "feat(dns-dhcp): add auto-detect banner for DNS/DHCP files in log viewer"
+```
+
+---
+
+### Task 7: Visual Testing and Polish
+
+**Files:**
+- No new files — this task verifies the workspace works end-to-end
+
+- [ ] **Step 1: Build the app**
+
+```bash
+npm run app:build:exe-only
+```
+
+- [ ] **Step 2: Test with DNS debug log**
+
+Open the app. Switch to DNS/DHCP workspace. Open `Logs/dns-fixtures-20260411-203254/DNSServer_debug.log`. Verify:
+- Device list appears with source IPs
+- Clicking a device shows its DNS queries
+- Summary header shows correct stats
+- NXDOMAIN entries are yellow, SERVFAIL are red
+- RCODE and QTYPE dropdown filters work
+
+- [ ] **Step 3: Test with DNS audit EVTX**
+
+Open `Logs/dns-fixtures-20260411-203254/dns-audit.evtx`. Verify it adds to the workspace and merges with existing data.
+
+- [ ] **Step 4: Test source toggling**
+
+In the sidebar, toggle off the DNS debug source. Verify the device list updates. Toggle back on. Verify it restores.
+
+- [ ] **Step 5: Fix any visual issues**
+
+Address any layout, spacing, or color issues found during testing.
+
+- [ ] **Step 6: Run final checks**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 7: Commit fixes**
+
+```bash
+git add -A
+git commit -m "fix(dns-dhcp): visual polish and layout fixes from testing"
+```

--- a/docs/superpowers/specs/2026-04-11-dns-parser-design.md
+++ b/docs/superpowers/specs/2026-04-11-dns-parser-design.md
@@ -1,0 +1,373 @@
+# DNS Log Parser Design
+
+**Date:** 2026-04-11
+**Status:** Draft
+**Scope:** Parser-only (workspace deferred to future phase)
+
+## Overview
+
+Add DNS log parsing to CMTrace Open, supporting three formats with a fourth stubbed for future implementation. All formats output `LogEntry` and display in the standard log viewer — no dedicated workspace.
+
+| Format | Source | Parser | Status |
+|--------|--------|--------|--------|
+| DNS debug log (`dns.log`) | Text file from `dns.exe` | `dns_debug.rs` | Full implementation |
+| DNS audit EVTX (Event IDs 513-582) | Standard `.evtx` event log | `dns_audit.rs` | Full implementation |
+| DNS analytical ETL (Event IDs 256-280) | ETW `.etl` trace | — | Stubbed (extension detection + error message) |
+| Live ETW capture | Real-time ETW subscription | — | Deferred (not in scope) |
+
+## Architecture: Approach C — Flat Files, Unified Entry Point
+
+Three new files in `src-tauri/src/parser/`:
+
+```
+parser/
+  dns_debug.rs      — text dns.log parser (LogicalRecord framing)
+  dns_audit.rs      — EVTX audit parser via evtx crate
+  dns_types.rs      — shared QTYPE/RCODE maps, query name decoder
+```
+
+Both parsers return through the existing `open_log_file()` command. The frontend does not need to distinguish between DNS text and DNS EVTX — `parse_file()` handles detection and routing internally.
+
+---
+
+## 1. File Detection & Routing
+
+### Debug log detection (`detect.rs`)
+
+- **Path hints:** filename contains `dns` (case-insensitive), or path contains `\dns\` or `/dns/`
+- **Content match:** `matches_dns_debug_record(line)` checks for `PACKET` keyword with surrounding DNS field structure (thread hex, UDP/TCP, Snd/Rcv, IP, XID, flags bracket)
+- **Sample window:** first 50 non-empty lines when DNS path hints are present (up from default 20) to clear the ~29-line header
+- **Returns:** `ResolvedParser` with `ParserKind::DnsDebug`, `ParserImplementation::DnsDebug`, `RecordFraming::LogicalRecord`, `ParseQuality::Structured`
+
+### Binary file detection (`parse_file()` in `mod.rs`)
+
+Early guard before text decoding:
+
+1. Check file extension
+2. If `.evtx` → open with `EvtxParser`, read first record, check for DNS provider GUID `{EB79061A-A566-4698-9119-3ED2807060E7}` or provider name `Microsoft-Windows-DNSServer`
+   - DNS match → `dns_audit::parse_evtx(path)` → return `ParseResult`
+   - No match → fall through to existing Sysmon path
+3. If `.etl` → return error with platform-appropriate message:
+   - **Windows:** "ETL analytical logs are not yet supported. Convert to XML on Windows with `tracerpt \"file.etl\" -of XML -o output.xml` and open the XML file."
+   - **macOS/Linux:** "ETL files contain binary Windows event traces that require the Windows `tracerpt` tool to convert. Export to XML on a Windows machine first, then open the XML file here."
+4. Otherwise → existing text decode + `detect_parser()` flow
+
+### Date order detection (debug log)
+
+Scan PACKET lines in the sample:
+- If any date field position 1 > 12 → `DayFirst`
+- If any date field position 2 > 12 → `MonthFirst`
+- If all values <=12 → return ambiguous result; frontend prompts user: "This DNS log has ambiguous date formatting. Is the date format MM/DD or DD/MM?" and re-parses with the selection
+
+---
+
+## 2. Debug Log Parser (`dns_debug.rs`)
+
+### Record framing: `LogicalRecord`
+
+Each logical record is a PACKET summary line followed by detail lines until the next PACKET line or blank-line sequence. Uses the same pending-entry pattern as Panther/IME:
+
+1. Scan each line
+2. If it matches the PACKET regex → flush any pending entry, start a new one
+3. If it's a detail line (indented, or starts with `UDP/TCP question/response info`) → append to pending entry
+4. Header lines (before first PACKET match) → skip
+5. Blank lines → skip
+
+### PACKET line regex
+
+```regex
+^(\d{1,2}/\d{1,2}/\d{4}\s+\d{1,2}:\d{2}:\d{2}\s*(?:AM|PM)?|\d{8}\s+\d{2}:\d{2}:\d{2})\s+([0-9A-Fa-f]{3,4})\s+PACKET\s+([0-9A-Fa-f]{8,16})\s+(UDP|TCP)\s+(Snd|Rcv)\s+([0-9a-fA-F.:]+)\s+([0-9a-fA-F]{4})\s+([R ])\s*([QNU?])\s+\[([0-9A-Fa-f]{4})\s+([ATDR ]{0,4})\s*(\w+)\]\s+(\S+)\s+(.+)$
+```
+
+Regex cached in `OnceLock<Regex>`.
+
+### Field mapping
+
+| Regex group | LogEntry field | Example |
+|-------------|---------------|---------|
+| 1 (timestamp) | `timestamp`, `timestamp_display` | `4/11/2026 3:29:17 PM` |
+| 2 (thread hex) | `thread`, `thread_display` | `0294` |
+| 4 (protocol) | `dns_protocol` | `UDP` |
+| 5 (direction) | `dns_direction` | `Rcv` |
+| 6 (remote IP) | `source_ip` | `192.168.2.9` |
+| 7 (XID) | included in message | `d07e` |
+| 8 (Q/R flag) | combined into `dns_flags` | `R` or space |
+| 10 (flags hex) | `dns_flags` | `0x8085` |
+| 12 (RCODE name) | `response_code` | `NOERROR` |
+| 13 (QTYPE name) | `query_type` | `SOA` |
+| 14 (QNAME raw) | `query_name` (decoded) | `home.gell.one` |
+
+### Detail section extraction
+
+From the multi-line detail block:
+- `Remote addr X.X.X.X, port NNNNN` → port number appended to `source_ip` as `192.168.2.9:54159`
+- Answer/authority/additional section presence → noted in message for context
+
+### Message construction
+
+- Query: `[Rcv] [UDP] home.gell.one (A) → NOERROR`
+- Response: `[Snd] [UDP] home.gell.one (A) → NXDOMAIN`
+
+### Severity mapping
+
+| RCODE | Severity |
+|-------|----------|
+| NOERROR | Info |
+| NXDOMAIN | Warning |
+| SERVFAIL, REFUSED, FORMERR | Error |
+| All other RCODEs | Warning |
+
+### Timestamp parsing
+
+Three locale variants detected from the PACKET line:
+- **US locale:** `M/d/yyyy h:mm:ss tt` (12-hour with AM/PM)
+- **EU locale:** `dd/MM/yyyy HH:mm:ss` (24-hour)
+- **ISO-style:** `yyyyMMdd HH:mm:ss`
+
+Parser detects which variant on first successful match and caches the format hint for subsequent lines (same pattern as `timestamped.rs`).
+
+---
+
+## 3. Audit EVTX Parser (`dns_audit.rs`)
+
+### Entry point
+
+`parse_evtx(path: &str) → Result<ParseResult, String>`
+
+Uses `EvtxParser::from_path()` to iterate records as JSON. Each record dispatched by EventID to a schema group extractor.
+
+### Schema group dispatching
+
+| Group | Event IDs | Primary fields extracted |
+|-------|-----------|------------------------|
+| Record ops | 515-521 | `NAME` → `query_name`, `Type` → `query_type` (numeric→name), `RDATA` → hex in message, `Zone` → `zone_name`, `TTL`, `SourceIP` (519-520 only) |
+| Zone config | 513-514, 522-537 | `Zone` → `zone_name`, `Setting`/`NewValue` in message |
+| Server config | 540-560 | `Setting`, `Scope`, `Value` in message |
+| DNSSEC key ops | 569-572 | Key fields in message |
+| Policy ops | 577-582 | `PolicyName`, `Action`, `Criteria` in message |
+| Delegation/subnet | 573-576 | Fields in message |
+| Extended zone ops | 561-568 | `Zone` in message |
+
+### Field mapping
+
+| EVTX field | LogEntry field | Notes |
+|------------|---------------|-------|
+| `TimeCreated` | `timestamp`, `timestamp_display` | From System section |
+| `EventID` | `dns_event_id` | Numeric |
+| `NAME` / `QNAME` | `query_name` | Present in record ops |
+| `Type` | `query_type` | Numeric → name via `dns_types.rs` |
+| `RCODE` | `response_code` | Numeric → name |
+| `Zone` | `zone_name` | Present in most events |
+| `SourceIP` / `Destination` | `source_ip` | When available |
+
+### Message construction by group
+
+- Record ops: `[515 Record Create] home.gell.one (A) TTL=3600 Zone=home.gell.one`
+- Zone config: `[514 Zone Setting] home.gell.one — Setting=AllowUpdate NewValue=1`
+- Server config: `[541 Server Setting] serverlevelplugindll = ...`
+- Other groups: `[EventID EventName] {available fields}`
+
+### Severity mapping
+
+| Condition | Severity |
+|-----------|----------|
+| Record delete (516, 520) | Warning |
+| Zone delete (513) | Error |
+| DNSSEC sign/unsign (525-527) | Warning |
+| Server setting change (541) | Warning |
+| Everything else | Info |
+
+### DNS provider GUID detection
+
+When `parse_file()` encounters a `.evtx` extension:
+1. Open with `EvtxParser`
+2. Read first record as JSON
+3. Check `System.Provider.@Name` for `"Microsoft-Windows-DNSServer"` or `System.Provider.@Guid` for `{EB79061A-A566-4698-9119-3ED2807060E7}`
+4. DNS match → `dns_audit::parse_evtx()`
+5. No match → fall through to existing Sysmon path
+
+---
+
+## 4. Shared Types (`dns_types.rs`)
+
+### QTYPE map (~40 entries)
+
+Standard types (RFC 1035+): A(1), NS(2), CNAME(5), SOA(6), PTR(12), MX(15), TXT(16), AAAA(28), SRV(33), DS(43), RRSIG(46), NSEC(47), DNSKEY(48), HTTPS(65), CAA(257), etc.
+
+Windows-specific: WINS(65281), WINSR(65282).
+
+Meta types: AXFR(252), ANY(255).
+
+### RCODE map (~24 entries)
+
+NOERROR(0), FORMERR(1), SERVFAIL(2), NXDOMAIN(3), NOTIMP(4), REFUSED(5), YXDOMAIN(6), YXRRSET(7), NXRRSET(8), NOTAUTH(9), NOTZONE(10), BADVERS/BADSIG(16), BADKEY(17), BADTIME(18), BADMODE(19), BADNAME(20), BADALG(21), BADTRUNC(22), BADCOOKIE(23).
+
+### Query name decoder
+
+```
+fn decode_query_name(raw: &str) → String
+```
+
+Handles:
+- Wire-format: `(3)www(6)google(3)com(0)` → `www.google.com`
+- Dotted: `.ns1.example.com.` → `ns1.example.com`
+- Compression pointers: `[C00C](4)home(4)gell(3)one(0)` → strip `[XXXX]`, decode labels
+- Root: `(0)` → `.`
+
+### Severity helper
+
+```
+fn rcode_to_severity(rcode: &str) → Severity
+```
+
+Shared by both debug log and EVTX parsers.
+
+---
+
+## 5. LogEntry & Type System Changes
+
+### New LogEntry fields (`models/log_entry.rs`)
+
+Nine new optional fields, all with `#[serde(default, skip_serializing_if = "Option::is_none")]`:
+
+```rust
+pub query_name: Option<String>,
+pub query_type: Option<String>,
+pub response_code: Option<String>,
+pub dns_direction: Option<String>,
+pub dns_protocol: Option<String>,
+pub source_ip: Option<String>,
+pub dns_flags: Option<String>,
+pub dns_event_id: Option<u32>,
+pub zone_name: Option<String>,
+```
+
+### LogFormat additions
+
+- `LogFormat::DnsDebug` → displays `"DNS Debug Log"`
+- `LogFormat::DnsAudit` → displays `"DNS Audit (EVTX)"`
+
+### ParserKind / ParserImplementation additions
+
+- `ParserKind::DnsDebug`, `ParserKind::DnsAudit`
+- `ParserImplementation::DnsDebug`, `ParserImplementation::DnsAudit`
+
+### Routing (`parser/mod.rs`)
+
+- `ParserImplementation::DnsDebug` → `dns_debug::parse_lines()`
+- `ParserImplementation::DnsAudit` — not routed through `parse_lines()`; `parse_evtx()` returns `ParseResult` directly from the `parse_file()` early guard
+
+---
+
+## 6. Integration Points
+
+### Commands (`commands/parsing.rs`, `commands/file_ops.rs`)
+
+No changes needed. `open_log_file()` calls `parse_file()` which handles both text and EVTX DNS files. `ParseResult` returns with the appropriate `LogFormat`.
+
+### Tailing
+
+- DNS debug log: works through existing pipeline. `ResolvedParser` stored in `AppState`, `start_tail()` calls `parse_lines_with_selection()` with `ParserImplementation::DnsDebug` and `LogicalRecord` framing.
+- DNS EVTX: no tailing (EVTX is a snapshot, not a live-appended file).
+
+### Feature gating (`Cargo.toml`)
+
+No new feature flag. Debug log parser has zero new dependencies. EVTX parser reuses existing `evtx` crate gated behind `event-log` feature. Add `ParserImplementation::DnsAudit` to the `event-log` feature gate.
+
+### Frontend
+
+- Status bar displays `format_detected` — new `LogFormat` variants render automatically.
+- DNS-specific `LogEntry` fields are `Option` — `undefined` in JS for non-DNS logs. No column changes needed (workspace phase).
+- **Date order prompt:** when `parse_file()` returns an ambiguous date order, frontend shows dialog: "This DNS log has ambiguous date formatting. Is the date format MM/DD or DD/MM?" Re-parses with selection.
+
+---
+
+## 7. Test Strategy
+
+### Fixture location: `src-tauri/tests/fixtures/dns/`
+
+### Debug log fixtures (hand-crafted from real data)
+
+| Fixture | Purpose |
+|---------|---------|
+| `debug_basic.log` | Header + 5 PACKET lines with detail sections, US locale, Rcv+Snd pairs |
+| `debug_opcodes.log` | Mix of Q (query), U (update), N (notify) opcodes |
+| `debug_rcodes.log` | NOERROR, NXDOMAIN, SERVFAIL for severity mapping |
+| `debug_no_detail.log` | Summary-only lines (no detail sections) — PhysicalLine fallback |
+| `debug_query_names.log` | Wire-format, dotted, compression pointers, root `(0)` |
+| `debug_header_only.log` | Just the header, no PACKET lines — empty result, no errors |
+| `debug_ambiguous_dates.log` | All date values <=12 — triggers ambiguous date detection |
+
+### Audit EVTX tests
+
+**Unit tests** at the JSON extraction layer:
+- Pre-built `serde_json::Value` for each of the 7 schema groups
+- One test per group
+- One test for unknown event ID → generic extraction
+- One test for missing/null fields → graceful `None` handling
+
+**Integration test** with real `dns-audit.evtx` fixture:
+- Parses full file, asserts record count > 0
+- Spot-checks known event fields
+
+### Shared types tests
+
+| Test | Input | Expected |
+|------|-------|----------|
+| Wire-format decode | `(4)home(4)gell(3)one(0)` | `home.gell.one` |
+| Dotted decode | `.ns1.example.com.` | `ns1.example.com` |
+| Pointer stripping | `[C00C](4)home(4)gell(3)one(0)` | `home.gell.one` |
+| Root zone | `(0)` | `.` |
+| QTYPE lookup known | `1` | `A` |
+| QTYPE lookup unknown | `9999` | `UNKNOWN(9999)` |
+| RCODE severity NOERROR | `NOERROR` | `Info` |
+| RCODE severity NXDOMAIN | `NXDOMAIN` | `Warning` |
+| RCODE severity SERVFAIL | `SERVFAIL` | `Error` |
+
+### Detection tests
+
+- DNS debug log detected correctly from path + content
+- Generic timestamped file with "dns" in path does NOT false-positive as DNS
+- `.evtx` with DNS provider → `ParserKind::DnsAudit`
+- `.evtx` with non-DNS provider → does NOT match
+- `.etl` extension → returns error with conversion instructions
+
+---
+
+## 8. ETL Stub (Future)
+
+Architecture is designed for future ETL support:
+- `.etl` extension detected in `parse_file()` early guard
+- Future implementation: prompt user for `tracerpt` conversion, show progress indicator, parse resulting XML as `dns_analytical.rs`
+- Conversion: `tracerpt "file.etl" -of XML -o output.xml` (Windows-only, `tracerpt` ships with all Windows installs)
+- macOS/Linux users: error message with manual conversion instructions
+- XML parsing: stream-based via `quick-xml` to handle large files
+- Collection script (`Collect-DnsTestFixtures.ps1`) already collects ETL + converts to XML
+
+---
+
+## 9. Reference
+
+### Source document
+
+`docs/compass_artifact_wf-d4b3505b-8666-487c-9577-1184da86cbd6_text_markdown.md` — comprehensive reference covering all four DNS log formats, field schemas, QTYPE/RCODE tables, wire format, and ETW provider details.
+
+### Collection script
+
+`scripts/collection/Collect-DnsTestFixtures.ps1` — collects debug log, audit EVTX, analytical ETL (with XML conversion), and server metadata from a Windows DNS Server.
+
+### Real test fixtures
+
+`Logs/dns-fixtures-20260411-203254/` — collected from DNS3 server (Windows Server 2022, en-US locale):
+- `DNSServer_debug.log` — 133K lines, 3,174 PACKET entries, details logging enabled, US locale
+- `dns-audit.evtx` — 1.1 MB audit event log
+- `server-metadata.json` — server config including locale and debug logging settings
+
+### Key statistics from real fixtures
+
+- Query types: A (1479), SOA (834), NS (660), PTR (606), SRV (84), CNAME (16)
+- RCODEs: NOERROR (dominant), NXDOMAIN (75), SERVFAIL (25)
+- Opcodes: Q (standard query), U (dynamic update)
+- All UDP, single thread `0294`
+- Details logging enabled on every PACKET entry
+- Compression pointers present: `[C00C]`, `[C02B]`

--- a/docs/superpowers/specs/2026-04-14-dns-dhcp-workspace-design.md
+++ b/docs/superpowers/specs/2026-04-14-dns-dhcp-workspace-design.md
@@ -1,0 +1,221 @@
+# DNS/DHCP Cross-Origin Workspace Design
+
+**Date:** 2026-04-14
+**Status:** Draft
+
+## Overview
+
+A device-centric workspace that correlates DNS and DHCP log data to support two primary use cases:
+
+1. **Troubleshooting DNS resolution failures** — "Client X got IP .15 via DHCP, then made 47 DNS queries, 3 of which got NXDOMAIN — why?"
+2. **Device lifecycle tracking** — "Device DESKTOP-ABC joined at 9 AM, got IP .50, registered its A record, then started resolving internal resources."
+
+The workspace accepts any combination of DNS debug logs, DNS audit EVTX files, and DHCP server logs. It works with whatever data is available — DNS-only shows source IPs as provisional devices, adding DHCP data enriches them with hostname and MAC.
+
+## Architecture
+
+### Layout: Device-Centric Two-Panel Dashboard
+
+- **Left panel:** Device list derived from source IPs (DNS) and enriched with hostname/MAC (DHCP). Click to select.
+- **Right panel:** Selected device detail — summary stats header + filterable DNS query table.
+
+### Data Flow
+
+1. User opens files via the workspace "Open" action, drag-drop, or auto-detect prompt from the log viewer
+2. Backend parses all files through existing parsers (`dns_debug`, `dns_audit`, `dhcp`) → `Vec<LogEntry>`
+3. Frontend receives `ParseResult` entries tagged by format (`DnsDebug`, `DnsAudit`, `Dhcp`)
+4. Client-side correlation groups entries by source IP, builds device list
+5. DHCP entries enrich the device list (IP → hostname + MAC mapping)
+6. Selecting a device filters the query table to that device's DNS activity
+
+### No New Backend Commands
+
+The existing `parse_file()` / `open_log_file()` pipeline already handles all three formats and outputs `LogEntry` with domain-specific fields. Correlation is client-side — the data volumes are small enough (3K-5K entries typical) that JS handles it trivially.
+
+---
+
+## 1. Progressive Enrichment
+
+The workspace builds a unified device model from whatever sources are loaded:
+
+| Sources loaded | Device list shows | Detail panel shows |
+|---------------|-------------------|-------------------|
+| DNS debug only | Source IPs with query stats (provisional) | DNS queries from that IP |
+| DNS audit only | Event IDs with zone/record info | Audit events (record creates/deletes) |
+| DHCP only | Devices with hostname/MAC, zero DNS | DHCP lease events |
+| DNS + DHCP | IPs enriched with hostname/MAC | DNS queries + DHCP context |
+| DNS + DHCP + audit | Full picture | DNS queries + audit events + DHCP context |
+
+Provisional (IP-only) devices are shown with a dimmed visual indicator. When DHCP data is added, matching IPs upgrade to enriched entries.
+
+---
+
+## 2. Device Model
+
+```
+Device:
+  ip: string                       — source IP (always present)
+  hostname: string | null          — from DHCP lease (enrichment)
+  mac: string | null               — from DHCP lease (enrichment)
+  isEnriched: boolean              — true when DHCP data matched
+
+  totalQueries: number
+  nxdomainCount: number
+  servfailCount: number
+  firstSeen: number                — earliest timestamp (epoch ms)
+  lastSeen: number                 — latest timestamp (epoch ms)
+
+  dhcpEntries: LogEntry[]          — DHCP events for this IP
+  dnsEntries: LogEntry[]           — DNS events from this IP
+```
+
+### Correlation Logic
+
+- Group all DNS entries by `source_ip` (strip port if present: `192.168.2.9:54159` → `192.168.2.9`)
+- Group all DHCP entries by `ip_address`
+- Match on IP → merge into `Device` with `isEnriched: true`
+- Unmatched DNS IPs → provisional device entries (`isEnriched: false`)
+- Unmatched DHCP entries → device entries with zero DNS activity
+
+---
+
+## 3. Store Design (`dns-dhcp-store.ts`)
+
+```
+DnsDhcpState:
+  // Data
+  sources: SourceFile[]            — loaded files (path, format, enabled toggle)
+  allEntries: LogEntry[]           — all parsed entries from all sources
+
+  // Derived
+  devices: Device[]                — grouped by source IP, enriched from DHCP
+  selectedDeviceIp: string | null  — currently selected device
+
+  // Filtering
+  searchQuery: string              — filter query table by name
+  rcodeFilter: string | "All"     — filter by RCODE
+  qtypeFilter: string | "All"     — filter by query type
+
+  // Analysis state
+  isLoading: boolean
+  loadError: string | null
+```
+
+Zustand store following the same patterns as `sysmon-store.ts` and `dsregcmd-store.ts`.
+
+---
+
+## 4. Frontend Components
+
+### File Structure
+
+```
+src/src-react/workspaces/dns-dhcp/
+  index.ts                  — workspace definition + registration
+  DnsDhcpWorkspace.tsx      — main two-panel layout
+  DnsDhcpSidebar.tsx        — sidebar with source files list + toggles
+  dns-dhcp-store.ts         — Zustand store
+  types.ts                  — Device, SourceFile interfaces
+  DeviceList.tsx            — left panel: scrollable device list
+  DeviceDetail.tsx          — right panel: summary header + query table
+  DeviceSummaryHeader.tsx   — stats bar (queries, errors, time range)
+  DeviceQueryTable.tsx      — filterable DNS query table
+```
+
+### DeviceList (Left Panel)
+
+- Scrollable list of `Device` entries, sorted by total queries (most active first)
+- Each row: IP, hostname (or "unresolved" indicator), query count, error badge
+- Enriched devices show hostname + MAC; provisional IPs show a dimmed icon
+- Click to select → updates `selectedDeviceIp` in store
+- Search/filter at top to find devices by hostname or IP
+
+### DeviceDetail (Right Panel)
+
+**DeviceSummaryHeader:**
+- IP, hostname, MAC (when available)
+- Total queries, NXDOMAIN count, SERVFAIL count
+- First seen / last seen timestamps
+- Lease duration (if DHCP data present)
+
+**DeviceQueryTable:**
+- Virtual-scrolled table (TanStack Virtual) showing DNS entries for the selected device
+- Columns: Time, Query Name, Type, RCODE, Direction, Protocol, Flags
+- Filterable by RCODE and QTYPE dropdowns
+- Sortable by column
+
+### DnsDhcpSidebar
+
+- "Sources" section listing loaded files with format badge (DNS Debug, DNS Audit, DHCP) and toggle switch to include/exclude
+- "Open File" button to add more sources
+- Summary stats: total files, total events, total devices
+
+---
+
+## 5. Workspace Registration
+
+**WorkspaceId:** `dns-dhcp`
+
+**Definition:**
+
+```
+id: "dns-dhcp"
+label: "DNS / DHCP"
+platforms: "all"
+capabilities: { fontSizing: true }
+fileFilters: [
+  { name: "DNS/DHCP Logs", extensions: ["log", "evtx"] },
+  { name: "All Files", extensions: ["*"] }
+]
+actionLabels: {
+  file: "Open DNS/DHCP File",
+  folder: "Open Log Folder",
+  placeholder: "Open DNS or DHCP logs..."
+}
+```
+
+**onOpenSource handler:**
+1. Parse the file via existing `open_log_file()` command
+2. Check format — accept `DnsDebug`, `DnsAudit`, `Dhcp`; reject others with toast
+3. Add entries to the store, rebuild device list
+4. If first file, switch to workspace and select the most active device
+
+**Multi-file drop:** User can drop multiple files at once. Each is parsed and merged into the store progressively.
+
+**Folder open:** When a folder is opened, scan for `.log` and `.evtx` files. Parse each through `open_log_file()`, accept files that return DNS or DHCP formats, silently skip others.
+
+**Registry:** Add to `ALL_WORKSPACES` array in `workspaces/registry.ts`.
+
+---
+
+## 6. Auto-Detect Prompt
+
+When a user opens a DNS or DHCP file in the standard log viewer, show a non-intrusive banner.
+
+**Trigger conditions:**
+- `parserSelection.parser` is `dnsDebug`, `dnsAudit`, or `dhcp`
+- Active workspace is `log` (not already in `dns-dhcp`)
+- User hasn't dismissed the banner for this session
+
+**Banner content:**
+> "This looks like a [DNS debug log / DNS audit log / DHCP server log]. Open in the DNS/DHCP workspace for device correlation and query analysis?"
+> **[Open in Workspace]** **[Dismiss]**
+
+**Behavior:**
+- "Open in Workspace" → switches to `dns-dhcp` workspace, loads the file's entries
+- "Dismiss" → hides for the session (not persisted)
+- Non-blocking — user can ignore and keep using the log viewer
+
+**Implementation:** A small component in `components/log-view/` that reads `parserSelection` from the log store and conditionally renders. No parser pipeline changes.
+
+---
+
+## 7. File Provenance
+
+Each entry is tagged with its source file path and format. The sidebar shows all loaded files with:
+- File name
+- Format badge (DNS Debug / DNS Audit / DHCP)
+- Entry count
+- Toggle switch to include/exclude from the view
+
+Toggling a file off removes its entries from the device list and query table without unloading them — toggling back on restores them instantly.


### PR DESCRIPTION
## Summary

The `docs/` rule at line 24 of `.gitignore` was unanchored, so it ignored every `docs` directory anywhere in the tree. Since the root `docs/` directory is tracked on `main` (19 files: `docs/design-system`, `docs/superpowers`, `docs/esp-diagnostics-windows-vm-acceptance.md`), `git add docs/...` exited 1 with ignore advice even for tracked files, and any new file under any `docs/` directory was silently swallowed.

This is the same pathology as the previously fixed unanchored `Logs/` rule (see the explanatory comment retained in `.gitignore` and epic #356 history).

## Why remove instead of anchor

Anchoring to `/docs/` would still ignore the root `docs/` directory, which is exactly where the tracked files live, so `git add docs/sccm/README.md` would keep failing. Since docs are meant to be tracked, the rule is removed entirely. `docs/.DS_Store` remains covered by the existing `.DS_Store` rule.

## Recovered files

The rule was silently hiding six real docs files that existed only in local working copies. The second commit adds them: the DNS parser reference, `docs/design-system/SKILL.md`, and the DNS parser / DNS-DHCP workspace plans and specs (whose sibling files were already tracked). Scanned for credentials and private identifiers before committing; content is design tokens, DNS protocol reference, and implementation plans only.

## Verification

Before the fix:
- `git check-ignore -v docs/sccm/README.md` matched `.gitignore:24:docs/`
- `git check-ignore -v src-tauri/docs/notes.md` matched `.gitignore:24:docs/`
- `git add --dry-run docs/esp-diagnostics-windows-vm-acceptance.md` (a tracked file) exited 1 with ignore advice

After the fix:
- All `docs/` probes above report not-ignored
- The six recovered files staged with plain `git add docs/`, no `-f` needed
- `docs/.DS_Store` still matches the `.DS_Store` rule; `node_modules/` still matches

The `codex/parser-family-skeleton` branch (PR #388) carries the same unanchored rule and will pick this fix up when it rebases onto or merges `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for parsing Windows Server DNS debug, audit, and ETW logs.
  * Added design documentation for DNS/DHCP log correlation, device-focused workflows, and workspace behavior.
  * Added design-system guidance covering components, themes, visual patterns, and accessibility considerations.
  * Documented planned DNS parser capabilities, supported fields, detection, error handling, and validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->