### PR TITLE
feat(sccm): analyze site core status evidence

### DIFF
--- a/crates/cmtraceopen-parser/src/sccm/server/windows/mod.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/mod.rs
@@ -1,7 +1,9 @@
 mod catalog;
 mod intake;
 mod management_point;
+mod site_core;
 
 pub use catalog::*;
 pub use intake::*;
 pub use management_point::*;
+pub use site_core::*;

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
@@ -1,0 +1,1614 @@
+//! Server-local site-core and status-system analysis for issue #327.
+//!
+//! The reducer owns evidence produced by the site server itself: the site
+//! component manager family (`server-sitecomp`) and the status/state system
+//! family (`server-status`). It reduces complete logical records into
+//! component-keyed transactions along
+//! `ComponentStart -> ComponentWork -> InboxOrQueue -> StatusOrStateProcessing
+//! -> HealthyOrTerminal`.
+//!
+//! Scope boundaries this module never crosses:
+//!
+//! * Management Point, Distribution Point, Software Update Point, hierarchy
+//!   transport and Provider/Admin Service evidence belongs to other lanes.
+//!   `mpcontrol.log` is site-server produced but carries a Management Point
+//!   workflow subject, so it stays with the `server-mp-policy` source and is
+//!   never admitted here.
+//! * No client impact, downstream-role availability or cross-side causal
+//!   statement is derivable from this analyzer; those claims are declared
+//!   prohibited on every result.
+//!
+//! Only the `sccm-site-core` v1 extraction profile is selected, and only for
+//! the synthetic `5.00.TEST` corpus version. A fact requires a complete logical
+//! record, an exact profile-validated component and work-item key, the
+//! declared producer component for its source family, and a source whose
+//! catalogued basename, family and rotation all agree with its manifest
+//! declaration.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+
+use crate::models::log_entry::Severity;
+use crate::sccm::{
+    classify_artifact_name, SccmArtifact, SccmArtifactFamily, SccmArtifactRequest, SccmConfidence,
+    SccmCoverageState, SccmEvidence, SccmEvidenceRef, SccmFinding, SccmFindingBuilder,
+    SccmFindingClass, SccmFindingCoverageGap, SccmPhase, SccmRole, SccmRotation,
+    SccmTerminalEvidence, SccmTimeOrderingState, SccmTimestamp,
+};
+
+pub const SCCM_SITE_CORE_ANALYSIS_SCHEMA_VERSION: u32 = 1;
+pub const SCCM_SITE_CORE_PROFILE_ID: &str = "sccm-site-core";
+pub const SCCM_SITE_CORE_PROFILE_VERSION: u32 = 1;
+pub const SCCM_SITE_CORE_PROFILE_STABILITY: &str = "experimental";
+pub const SCCM_SITE_CORE_COMPONENT_GROUP: &str = "server-sitecomp";
+pub const SCCM_SITE_CORE_STATUS_GROUP: &str = "server-status";
+
+/// The only ConfigMgr build this profile is validated against.
+const SITE_CORE_PROFILE_VERSION_TOKEN: &str = "5.00.TEST";
+/// Producer component recorded by each admitted source family.
+const COMPONENT_PRODUCER: &str = "SMS_SITE_COMPONENT_MANAGER";
+const STATUS_PRODUCER: &str = "SMS_STATUS_MANAGER";
+/// Floor for a bounded recapture request after a capture limit truncated a
+/// source. Requests never ask for an unbounded file.
+const RECAPTURE_FLOOR_BYTES: u64 = 4096;
+
+const STATE_CHAIN: [SccmSiteCorePhase; 5] = [
+    SccmSiteCorePhase::ComponentStart,
+    SccmSiteCorePhase::ComponentWork,
+    SccmSiteCorePhase::InboxOrQueue,
+    SccmSiteCorePhase::StatusOrStateProcessing,
+    SccmSiteCorePhase::HealthyOrTerminal,
+];
+
+const PROHIBITED_CLAIMS: [SccmSiteCoreProhibitedClaim; 3] = [
+    SccmSiteCoreProhibitedClaim::AbsentDownstreamRole,
+    SccmSiteCoreProhibitedClaim::ClientImpact,
+    SccmSiteCoreProhibitedClaim::CrossSideCausality,
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SccmSiteCoreTopology {
+    pub site_code: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SccmSiteCoreSource {
+    pub artifact: SccmArtifact,
+    pub source_group: String,
+    pub rotation_lineage: String,
+    pub fragment_complete: Option<bool>,
+    pub physical_line_end: Option<u32>,
+    pub capture_limit_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SccmSiteCoreBundle {
+    pub topology: SccmSiteCoreTopology,
+    pub sources: Vec<SccmSiteCoreSource>,
+    pub evidence: Vec<SccmEvidence>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmSiteCoreWorkflow {
+    SiteCore,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmSiteCorePhase {
+    ComponentStart,
+    ComponentWork,
+    InboxOrQueue,
+    StatusOrStateProcessing,
+    HealthyOrTerminal,
+}
+
+impl SccmSiteCorePhase {
+    fn serialized_name(self) -> &'static str {
+        match self {
+            Self::ComponentStart => "componentStart",
+            Self::ComponentWork => "componentWork",
+            Self::InboxOrQueue => "inboxOrQueue",
+            Self::StatusOrStateProcessing => "statusOrStateProcessing",
+            Self::HealthyOrTerminal => "healthyOrTerminal",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmSiteCoreState {
+    Healthy,
+    TerminalFailure,
+    BlockedOrDeferred,
+    Recovered,
+    Incomplete,
+    ParseGap,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmSiteCoreConfidence {
+    None,
+    Low,
+    Moderate,
+    High,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmSiteCoreDiagnosticMeaning {
+    CoverageOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmSiteCoreProhibitedClaim {
+    AbsentDownstreamRole,
+    ClientImpact,
+    CrossSideCausality,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSiteCoreProfile {
+    pub id: String,
+    pub version: u32,
+    pub stability: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSiteCoreTransactionKey {
+    pub profile_id: String,
+    pub profile_version: u32,
+    pub site_code: String,
+    pub component_id: String,
+    pub work_item_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSiteCoreEvidence {
+    pub artifact_id: String,
+    pub entry_id: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub complete_logical_record: Option<bool>,
+}
+
+impl SccmSiteCoreEvidence {
+    fn reference(&self) -> SccmEvidenceRef {
+        SccmEvidenceRef {
+            artifact_id: self.artifact_id.clone(),
+            entry_id: self.entry_id.clone(),
+            line_start: Some(self.line_start),
+            line_end: Some(self.line_end),
+        }
+    }
+
+    fn sort_key(&self) -> (&str, u32, u32, &str) {
+        (
+            self.artifact_id.as_str(),
+            self.line_start,
+            self.line_end,
+            self.entry_id.as_str(),
+        )
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSiteCoreRequestScope {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_item_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rotation_lineage: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSiteCoreArtifactRequest {
+    pub logical_name: String,
+    pub role: SccmRole,
+    pub reason_code: String,
+    pub basenames: Vec<String>,
+    pub rotations: Vec<String>,
+    pub max_artifacts: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_bytes_per_artifact: Option<u64>,
+    pub scope: SccmSiteCoreRequestScope,
+}
+
+impl SccmSiteCoreArtifactRequest {
+    fn sort_key(&self) -> (&str, &str, &str, &SccmSiteCoreRequestScope) {
+        (
+            self.logical_name.as_str(),
+            role_sort_key(&self.role),
+            self.reason_code.as_str(),
+            &self.scope,
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSiteCoreResult {
+    pub result_id: String,
+    pub transaction_key: SccmSiteCoreTransactionKey,
+    pub state: SccmSiteCoreState,
+    pub last_successful_phase: Option<SccmSiteCorePhase>,
+    pub finding_class: Option<SccmFindingClass>,
+    pub confidence: SccmSiteCoreConfidence,
+    pub confidence_ceiling: SccmSiteCoreConfidence,
+    pub evidence: Vec<SccmSiteCoreEvidence>,
+    pub coverage_gap_artifact_ids: Vec<String>,
+    pub next_artifacts: Vec<SccmSiteCoreArtifactRequest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSiteCoreObservation {
+    pub observation_id: String,
+    pub state: SccmSiteCoreState,
+    pub last_successful_phase: Option<SccmSiteCorePhase>,
+    pub finding_class: SccmFindingClass,
+    pub confidence: SccmSiteCoreConfidence,
+    pub confidence_ceiling: SccmSiteCoreConfidence,
+    pub evidence: Vec<SccmSiteCoreEvidence>,
+    pub coverage_gap_artifact_ids: Vec<String>,
+    pub next_artifacts: Vec<SccmSiteCoreArtifactRequest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSiteCoreCoverageGap {
+    pub artifact_id: String,
+    pub state: SccmCoverageState,
+    pub diagnostic_meaning: SccmSiteCoreDiagnosticMeaning,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<SccmSiteCoreEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSiteCoreFinding {
+    #[serde(flatten)]
+    pub finding: SccmFinding,
+    pub subject_id: String,
+    pub last_successful_phase: Option<SccmSiteCorePhase>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSiteCoreAnalysis {
+    pub schema_version: u32,
+    pub workflow: SccmSiteCoreWorkflow,
+    pub profile: SccmSiteCoreProfile,
+    pub state_chain: Vec<SccmSiteCorePhase>,
+    pub results: Vec<SccmSiteCoreResult>,
+    pub unlinked_observations: Vec<SccmSiteCoreObservation>,
+    pub coverage_gaps: Vec<SccmSiteCoreCoverageGap>,
+    pub findings: Vec<SccmSiteCoreFinding>,
+    pub artifact_requests: Vec<SccmSiteCoreArtifactRequest>,
+    pub prohibited_claims: Vec<SccmSiteCoreProhibitedClaim>,
+    pub cross_side_correlation_performed: bool,
+}
+
+/// Reduce a site-core evidence bundle into component-keyed transactions,
+/// source-local observations, coverage gaps and bounded next-artifact requests.
+pub fn analyze_site_core(bundle: &SccmSiteCoreBundle) -> SccmSiteCoreAnalysis {
+    let site_code = normalize_site_code(&bundle.topology.site_code);
+    let admitted_sources = admitted_sources(bundle);
+    let facts = collect_facts(bundle, &admitted_sources, site_code.as_deref());
+    let fragments = collect_fragments(bundle, &admitted_sources);
+    let coverage_gaps = collect_coverage_gaps(bundle, &admitted_sources, &fragments);
+
+    let fragment_artifact_ids = fragments
+        .iter()
+        .map(|fragment| fragment.evidence.artifact_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let transaction_gap_ids = coverage_gaps
+        .iter()
+        .map(|gap| gap.artifact_id.clone())
+        .filter(|artifact_id| !fragment_artifact_ids.contains(artifact_id.as_str()))
+        .collect::<Vec<_>>();
+
+    let mut results = Vec::new();
+    let mut findings = Vec::new();
+    for (key, facts) in group_facts(facts) {
+        let reduced = reduce_transaction(bundle, key, &facts, &transaction_gap_ids);
+        if let Some(finding) = reduced.finding {
+            findings.push(finding);
+        }
+        results.push(reduced.result);
+    }
+
+    let mut unlinked_observations = Vec::new();
+    append_fragment_observations(&fragments, &mut unlinked_observations, &mut findings);
+
+    results.sort_by(|left, right| left.result_id.cmp(&right.result_id));
+    unlinked_observations.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
+    findings.sort_by(|left, right| {
+        left.subject_id
+            .cmp(&right.subject_id)
+            .then_with(|| left.finding.finding_id.cmp(&right.finding.finding_id))
+    });
+
+    let artifact_requests = collect_artifact_requests(&results, &unlinked_observations);
+
+    SccmSiteCoreAnalysis {
+        schema_version: SCCM_SITE_CORE_ANALYSIS_SCHEMA_VERSION,
+        workflow: SccmSiteCoreWorkflow::SiteCore,
+        profile: SccmSiteCoreProfile {
+            id: SCCM_SITE_CORE_PROFILE_ID.to_owned(),
+            version: SCCM_SITE_CORE_PROFILE_VERSION,
+            stability: SCCM_SITE_CORE_PROFILE_STABILITY.to_owned(),
+        },
+        state_chain: STATE_CHAIN.to_vec(),
+        results,
+        unlinked_observations,
+        coverage_gaps,
+        findings,
+        artifact_requests,
+        prohibited_claims: PROHIBITED_CLAIMS.to_vec(),
+        cross_side_correlation_performed: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Source admission
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum SiteCoreGroup {
+    Component,
+    Status,
+}
+
+impl SiteCoreGroup {
+    fn id(self) -> &'static str {
+        match self {
+            Self::Component => SCCM_SITE_CORE_COMPONENT_GROUP,
+            Self::Status => SCCM_SITE_CORE_STATUS_GROUP,
+        }
+    }
+
+    fn slug(self) -> &'static str {
+        match self {
+            Self::Component => "component",
+            Self::Status => "status",
+        }
+    }
+
+    fn producer(self) -> &'static str {
+        match self {
+            Self::Component => COMPONENT_PRODUCER,
+            Self::Status => STATUS_PRODUCER,
+        }
+    }
+
+    fn family(self) -> SccmArtifactFamily {
+        match self {
+            Self::Component => SccmArtifactFamily::SiteComponent,
+            Self::Status => SccmArtifactFamily::SiteStatus,
+        }
+    }
+
+    fn logical_names(self) -> &'static [&'static str] {
+        match self {
+            Self::Component => &["sitecomp", "hman"],
+            Self::Status => &["statmgr", "statesys"],
+        }
+    }
+
+    fn entry_phase(self) -> SccmSiteCorePhase {
+        match self {
+            Self::Component => SccmSiteCorePhase::ComponentStart,
+            Self::Status => SccmSiteCorePhase::StatusOrStateProcessing,
+        }
+    }
+
+    fn from_id(value: &str) -> Option<Self> {
+        match value {
+            SCCM_SITE_CORE_COMPONENT_GROUP => Some(Self::Component),
+            SCCM_SITE_CORE_STATUS_GROUP => Some(Self::Status),
+            _ => None,
+        }
+    }
+}
+
+/// A source that passed shape admission: role, group, catalogued basename,
+/// family, rotation, lineage and profile version all agree.
+struct AdmittedSource<'a> {
+    source: &'a SccmSiteCoreSource,
+    group: SiteCoreGroup,
+    basename: String,
+}
+
+/// Sources are filtered to the site-server role and the two declared site-core
+/// groups *before* being collected by artifact id, so an artifact belonging to
+/// another role can never shadow a site-core source. An artifact id that
+/// appears more than once anywhere in the bundle is ambiguous and is dropped
+/// outright rather than resolved by vector order.
+fn admitted_sources<'a>(bundle: &'a SccmSiteCoreBundle) -> BTreeMap<&'a str, AdmittedSource<'a>> {
+    let mut occurrences: BTreeMap<&str, usize> = BTreeMap::new();
+    for source in &bundle.sources {
+        *occurrences
+            .entry(source.artifact.artifact_id.as_str())
+            .or_default() += 1;
+    }
+
+    bundle
+        .sources
+        .iter()
+        .filter_map(|source| {
+            let group = SiteCoreGroup::from_id(&source.source_group)?;
+            if source.artifact.role != SccmRole::SiteServer {
+                return None;
+            }
+            let admitted = admit_source(source, group)?;
+            let artifact_id = source.artifact.artifact_id.as_str();
+            (safe_opaque_id(artifact_id) && occurrences.get(artifact_id) == Some(&1))
+                .then_some((artifact_id, admitted))
+        })
+        .collect()
+}
+
+fn admit_source<'a>(
+    source: &'a SccmSiteCoreSource,
+    group: SiteCoreGroup,
+) -> Option<AdmittedSource<'a>> {
+    if source.artifact.configmgr_version.as_deref() != Some(SITE_CORE_PROFILE_VERSION_TOKEN) {
+        return None;
+    }
+    let classified = classify_artifact_name(&source.artifact.display_name, SccmRole::SiteServer);
+    let matches_group = classified.supported_for_diagnosis
+        && classified.family == group.family()
+        && group
+            .logical_names()
+            .iter()
+            .any(|logical_name| *logical_name == classified.logical_name)
+        && classified.rotation == source.artifact.rotation
+        && classified.basename == source.rotation_lineage;
+    matches_group.then_some(AdmittedSource {
+        source,
+        group,
+        basename: source.artifact.display_name.clone(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Fact extraction
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FactOutcome {
+    Succeeded,
+    Failed,
+    Deferred,
+}
+
+/// Declared site-core status vocabulary. Each marker fixes the phase it
+/// answers for, its outcome, whether it is a terminal statement, whether it is
+/// a recovery statement, and the source family entitled to record it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct StatusMarker {
+    phase: SccmSiteCorePhase,
+    outcome: FactOutcome,
+    terminal: bool,
+    recovery: bool,
+    group: SiteCoreGroup,
+}
+
+fn status_marker(status_id: &str) -> Option<StatusMarker> {
+    let marker = match status_id {
+        "SC_COMPONENT_START_OK" => StatusMarker {
+            phase: SccmSiteCorePhase::ComponentStart,
+            outcome: FactOutcome::Succeeded,
+            terminal: false,
+            recovery: false,
+            group: SiteCoreGroup::Component,
+        },
+        "SC_COMPONENT_WORK_OK" => StatusMarker {
+            phase: SccmSiteCorePhase::ComponentWork,
+            outcome: FactOutcome::Succeeded,
+            terminal: false,
+            recovery: false,
+            group: SiteCoreGroup::Component,
+        },
+        "SC_INBOX_ACCEPTED" => StatusMarker {
+            phase: SccmSiteCorePhase::InboxOrQueue,
+            outcome: FactOutcome::Succeeded,
+            terminal: false,
+            recovery: false,
+            group: SiteCoreGroup::Component,
+        },
+        "SC_INBOX_BACKLOG" => StatusMarker {
+            phase: SccmSiteCorePhase::InboxOrQueue,
+            outcome: FactOutcome::Deferred,
+            terminal: false,
+            recovery: false,
+            group: SiteCoreGroup::Component,
+        },
+        "SC_COMPONENT_TERMINAL_FAILURE" => StatusMarker {
+            phase: SccmSiteCorePhase::HealthyOrTerminal,
+            outcome: FactOutcome::Failed,
+            terminal: true,
+            recovery: false,
+            group: SiteCoreGroup::Component,
+        },
+        "SC_STATUS_PROCESSING_OK" => StatusMarker {
+            phase: SccmSiteCorePhase::StatusOrStateProcessing,
+            outcome: FactOutcome::Succeeded,
+            terminal: false,
+            recovery: false,
+            group: SiteCoreGroup::Status,
+        },
+        "SC_STATUS_TERMINAL_FAILURE" => StatusMarker {
+            phase: SccmSiteCorePhase::HealthyOrTerminal,
+            outcome: FactOutcome::Failed,
+            terminal: true,
+            recovery: false,
+            group: SiteCoreGroup::Status,
+        },
+        "SC_COMPONENT_HEALTHY" => StatusMarker {
+            phase: SccmSiteCorePhase::HealthyOrTerminal,
+            outcome: FactOutcome::Succeeded,
+            terminal: true,
+            recovery: false,
+            group: SiteCoreGroup::Status,
+        },
+        "SC_COMPONENT_RECOVERED" => StatusMarker {
+            phase: SccmSiteCorePhase::HealthyOrTerminal,
+            outcome: FactOutcome::Succeeded,
+            terminal: true,
+            recovery: true,
+            group: SiteCoreGroup::Status,
+        },
+        _ => return None,
+    };
+    Some(marker)
+}
+
+#[derive(Debug, Clone)]
+struct SiteCoreFact {
+    key: SccmSiteCoreTransactionKey,
+    marker: StatusMarker,
+    reference: SccmEvidenceRef,
+    timestamp: SccmTimestamp,
+}
+
+impl SiteCoreFact {
+    fn ordering_millis(&self) -> Option<i64> {
+        (self.timestamp.ordering_state == SccmTimeOrderingState::NormalizedUtc)
+            .then_some(self.timestamp.utc_millis)
+            .flatten()
+    }
+
+    fn evidence(&self) -> SccmSiteCoreEvidence {
+        let (terminal, recovery) = match (self.marker.outcome, self.marker.recovery) {
+            (_, true) => (Some(true), Some(true)),
+            (FactOutcome::Failed, _) if self.marker.terminal => (Some(true), None),
+            (FactOutcome::Deferred, _) => (Some(false), None),
+            _ => (None, None),
+        };
+        SccmSiteCoreEvidence {
+            artifact_id: self.reference.artifact_id.clone(),
+            entry_id: self.reference.entry_id.clone(),
+            line_start: self.reference.line_start.unwrap_or_default(),
+            line_end: self.reference.line_end.unwrap_or_default(),
+            terminal,
+            recovery,
+            complete_logical_record: None,
+        }
+    }
+}
+
+fn collect_facts(
+    bundle: &SccmSiteCoreBundle,
+    sources: &BTreeMap<&str, AdmittedSource<'_>>,
+    site_code: Option<&str>,
+) -> Vec<SiteCoreFact> {
+    let Some(site_code) = site_code else {
+        return Vec::new();
+    };
+
+    bundle
+        .evidence
+        .iter()
+        .filter_map(|evidence| {
+            let admitted = sources.get(evidence.reference.artifact_id.as_str())?;
+            if !source_carries_facts(admitted)
+                || evidence.role != SccmRole::SiteServer
+                || !evidence_reference_fits_source(evidence, admitted)
+                || !evidence_identity_is_unique(bundle, evidence)
+            {
+                return None;
+            }
+            parse_fact(evidence, admitted, site_code)
+        })
+        .collect()
+}
+
+/// Bytes retained beside a manifest state that is neither `captured` nor
+/// `capped` are coverage-only. A captured source that still carries an
+/// incomplete region is a fragment, not a fact source.
+fn source_carries_facts(admitted: &AdmittedSource<'_>) -> bool {
+    match admitted.source.artifact.coverage {
+        SccmCoverageState::Captured => admitted.source.fragment_complete != Some(false),
+        SccmCoverageState::Capped => true,
+        _ => false,
+    }
+}
+
+fn parse_fact(
+    evidence: &SccmEvidence,
+    admitted: &AdmittedSource<'_>,
+    site_code: &str,
+) -> Option<SiteCoreFact> {
+    if evidence.component.as_deref() != Some(admitted.group.producer()) {
+        return None;
+    }
+    let message = evidence.message.as_str();
+    if token_value(message, "profileId")? != SCCM_SITE_CORE_PROFILE_ID
+        || token_value(message, "profileVersion")? != SCCM_SITE_CORE_PROFILE_VERSION.to_string()
+    {
+        return None;
+    }
+    let record_site_code = normalize_site_code(&token_value(message, "site")?)?;
+    if record_site_code != site_code {
+        return None;
+    }
+
+    let marker = status_marker(&token_value(message, "statusId")?)?;
+    if marker.group != admitted.group {
+        return None;
+    }
+    let declared_outcome = match token_value(message, "outcome")?.as_str() {
+        "success" => FactOutcome::Succeeded,
+        "failure" => FactOutcome::Failed,
+        "deferred" => FactOutcome::Deferred,
+        _ => return None,
+    };
+    let declared_terminal = match token_value(message, "terminal")?.as_str() {
+        "true" => true,
+        "false" => false,
+        _ => return None,
+    };
+    if declared_outcome != marker.outcome || declared_terminal != marker.terminal {
+        return None;
+    }
+
+    let component_id = validated_identifier(&token_value(message, "componentId")?)?;
+    let work_item_id = validated_identifier(&token_value(message, "workItemId")?)?;
+
+    Some(SiteCoreFact {
+        key: SccmSiteCoreTransactionKey {
+            profile_id: SCCM_SITE_CORE_PROFILE_ID.to_owned(),
+            profile_version: SCCM_SITE_CORE_PROFILE_VERSION,
+            site_code: record_site_code,
+            component_id,
+            work_item_id,
+        },
+        marker,
+        reference: evidence.reference.clone(),
+        timestamp: evidence.timestamp.clone(),
+    })
+}
+
+fn group_facts(
+    facts: Vec<SiteCoreFact>,
+) -> BTreeMap<SccmSiteCoreTransactionKey, Vec<SiteCoreFact>> {
+    let mut grouped: BTreeMap<SccmSiteCoreTransactionKey, Vec<SiteCoreFact>> = BTreeMap::new();
+    for fact in facts {
+        grouped.entry(fact.key.clone()).or_default().push(fact);
+    }
+    for facts in grouped.values_mut() {
+        facts.sort_by(compare_facts);
+    }
+    grouped
+}
+
+/// Facts are ordered by usable UTC instant first so that recency decisions are
+/// chronological when — and only when — chronology is comparable. Records
+/// without usable ordering fall back to their stable evidence identity so the
+/// result never depends on input order.
+fn compare_facts(left: &SiteCoreFact, right: &SiteCoreFact) -> Ordering {
+    left.ordering_millis()
+        .cmp(&right.ordering_millis())
+        .then_with(|| compare_references(&left.reference, &right.reference))
+}
+
+// ---------------------------------------------------------------------------
+// Transaction reduction
+// ---------------------------------------------------------------------------
+
+struct ReducedTransaction {
+    result: SccmSiteCoreResult,
+    finding: Option<SccmSiteCoreFinding>,
+}
+
+fn reduce_transaction(
+    bundle: &SccmSiteCoreBundle,
+    key: SccmSiteCoreTransactionKey,
+    facts: &[SiteCoreFact],
+    coverage_gap_artifact_ids: &[String],
+) -> ReducedTransaction {
+    let chronology_usable = facts.iter().all(|fact| fact.ordering_millis().is_some());
+    let conflicting = has_same_instant_conflict(facts);
+
+    let last_success = facts
+        .iter()
+        .rfind(|fact| fact.marker.outcome == FactOutcome::Succeeded);
+    let last_successful_phase = last_success.map(|fact| fact.marker.phase);
+    let terminal_failure = facts
+        .iter()
+        .rfind(|fact| fact.marker.outcome == FactOutcome::Failed && fact.marker.terminal);
+    let terminal_success = facts
+        .iter()
+        .rfind(|fact| fact.marker.outcome == FactOutcome::Succeeded && fact.marker.terminal);
+    let deferred = facts
+        .iter()
+        .rfind(|fact| fact.marker.outcome == FactOutcome::Deferred);
+
+    let recovered = matches!(
+        (terminal_success, terminal_failure),
+        (Some(success), Some(failure))
+            if chronology_usable
+                && success.ordering_millis() > failure.ordering_millis()
+    );
+
+    let (state, finding_class, base_confidence, decisive) = if conflicting {
+        (
+            SccmSiteCoreState::Incomplete,
+            Some(SccmFindingClass::InsufficientEvidence),
+            SccmSiteCoreConfidence::None,
+            None,
+        )
+    } else if recovered {
+        (
+            SccmSiteCoreState::Recovered,
+            Some(SccmFindingClass::Symptom),
+            SccmSiteCoreConfidence::High,
+            terminal_success,
+        )
+    } else if terminal_failure.is_some() {
+        (
+            SccmSiteCoreState::TerminalFailure,
+            Some(SccmFindingClass::ConfirmedFailure),
+            SccmSiteCoreConfidence::High,
+            terminal_failure,
+        )
+    } else if terminal_success.is_some() {
+        (
+            SccmSiteCoreState::Healthy,
+            None,
+            SccmSiteCoreConfidence::High,
+            terminal_success,
+        )
+    } else if deferred.is_some() {
+        (
+            SccmSiteCoreState::BlockedOrDeferred,
+            Some(SccmFindingClass::BlockedOrDeferred),
+            SccmSiteCoreConfidence::Low,
+            deferred,
+        )
+    } else {
+        (
+            SccmSiteCoreState::Incomplete,
+            Some(SccmFindingClass::InsufficientEvidence),
+            SccmSiteCoreConfidence::None,
+            None,
+        )
+    };
+
+    let confidence_ceiling = confidence_ceiling(facts, state, chronology_usable, conflicting);
+    let confidence = base_confidence.min(confidence_ceiling);
+    let next_artifacts = next_artifacts_for_state(bundle, &key, facts, state);
+
+    let mut evidence = facts.iter().map(SiteCoreFact::evidence).collect::<Vec<_>>();
+    evidence.sort_by(|left, right| left.sort_key().cmp(&right.sort_key()));
+    evidence.dedup();
+
+    let result_id = format!(
+        "site-core/{}/{}/{}",
+        key.site_code, key.component_id, key.work_item_id
+    );
+    let finding = finding_class.clone().and_then(|class| {
+        build_finding(
+            &format!("finding:site-core:{result_id}"),
+            &result_id,
+            class,
+            decisive
+                .map(|fact| fact.marker.phase)
+                .or(last_successful_phase)
+                .unwrap_or(SccmSiteCorePhase::ComponentStart),
+            last_successful_phase,
+            confidence,
+            state,
+            &evidence,
+            decisive,
+            coverage_gap_artifact_ids,
+            bundle,
+            &next_artifacts,
+        )
+    });
+
+    ReducedTransaction {
+        result: SccmSiteCoreResult {
+            result_id,
+            transaction_key: key,
+            state,
+            last_successful_phase,
+            finding_class,
+            confidence,
+            confidence_ceiling,
+            evidence,
+            coverage_gap_artifact_ids: coverage_gap_artifact_ids.to_vec(),
+            next_artifacts,
+        },
+        finding,
+    }
+}
+
+/// Two facts at the same instant, in the same phase, disagreeing about the
+/// outcome cannot select a winner without letting vector order decide.
+fn has_same_instant_conflict(facts: &[SiteCoreFact]) -> bool {
+    facts.iter().enumerate().any(|(index, left)| {
+        facts[index + 1..].iter().any(|right| {
+            left.marker.phase == right.marker.phase
+                && left.ordering_millis().is_some()
+                && left.ordering_millis() == right.ordering_millis()
+                && left.marker.outcome != right.marker.outcome
+        })
+    })
+}
+
+fn confidence_ceiling(
+    facts: &[SiteCoreFact],
+    state: SccmSiteCoreState,
+    chronology_usable: bool,
+    conflicting: bool,
+) -> SccmSiteCoreConfidence {
+    if conflicting || facts.is_empty() || state == SccmSiteCoreState::Incomplete {
+        return SccmSiteCoreConfidence::None;
+    }
+    if !chronology_usable || state == SccmSiteCoreState::BlockedOrDeferred {
+        return SccmSiteCoreConfidence::Low;
+    }
+    let has_entry_evidence = facts
+        .iter()
+        .any(|fact| fact.marker.phase == SccmSiteCorePhase::ComponentStart);
+    if has_entry_evidence {
+        SccmSiteCoreConfidence::High
+    } else {
+        SccmSiteCoreConfidence::Moderate
+    }
+}
+
+/// The smallest next artifact bundle when evidence stops. A confirmed terminal
+/// outcome and a healthy or recovered completion need nothing further.
+fn next_artifacts_for_state(
+    bundle: &SccmSiteCoreBundle,
+    key: &SccmSiteCoreTransactionKey,
+    facts: &[SiteCoreFact],
+    state: SccmSiteCoreState,
+) -> Vec<SccmSiteCoreArtifactRequest> {
+    if matches!(
+        state,
+        SccmSiteCoreState::Healthy
+            | SccmSiteCoreState::TerminalFailure
+            | SccmSiteCoreState::Recovered
+            | SccmSiteCoreState::ParseGap
+    ) {
+        return Vec::new();
+    }
+
+    let scope = SccmSiteCoreRequestScope {
+        component_id: Some(key.component_id.clone()),
+        work_item_id: Some(key.work_item_id.clone()),
+        rotation_lineage: None,
+    };
+
+    // A capture limit that truncated the family which carried the last
+    // evidence is the nearest boundary: request that one source again under a
+    // larger bounded limit.
+    if let Some(request) = capped_recapture_request(bundle, facts, &scope) {
+        return vec![request];
+    }
+
+    let statuses = status_group_candidates(bundle);
+    let basenames = if statuses.is_empty() {
+        vec!["statmgr.log".to_owned()]
+    } else {
+        statuses
+    };
+    let rotations = vec!["current".to_owned(), "loUnderscore".to_owned()];
+    vec![SccmSiteCoreArtifactRequest {
+        logical_name: SCCM_SITE_CORE_STATUS_GROUP.to_owned(),
+        role: SccmRole::SiteServer,
+        reason_code: "matching-status-terminal-evidence-missing".to_owned(),
+        max_artifacts: basenames.len() * rotations.len(),
+        basenames,
+        rotations,
+        max_bytes_per_artifact: None,
+        scope,
+    }]
+}
+
+fn capped_recapture_request(
+    bundle: &SccmSiteCoreBundle,
+    facts: &[SiteCoreFact],
+    scope: &SccmSiteCoreRequestScope,
+) -> Option<SccmSiteCoreArtifactRequest> {
+    let cited = facts
+        .iter()
+        .map(|fact| fact.reference.artifact_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let sources = admitted_sources(bundle);
+    let (_, admitted) = sources.iter().find(|(artifact_id, admitted)| {
+        cited.contains(*artifact_id)
+            && admitted.source.artifact.coverage == SccmCoverageState::Capped
+            && truncated_tail(bundle, admitted).is_some()
+    })?;
+
+    let limit = admitted.source.capture_limit_bytes.unwrap_or_default();
+    let requested = RECAPTURE_FLOOR_BYTES.max(limit.saturating_mul(2).next_power_of_two());
+    Some(SccmSiteCoreArtifactRequest {
+        logical_name: admitted.group.id().to_owned(),
+        role: SccmRole::SiteServer,
+        reason_code: "capped-before-next-phase".to_owned(),
+        basenames: vec![admitted.basename.clone()],
+        rotations: vec![rotation_name(&admitted.source.artifact.rotation)?],
+        max_artifacts: 1,
+        max_bytes_per_artifact: Some(requested),
+        scope: scope.clone(),
+    })
+}
+
+fn status_group_candidates(bundle: &SccmSiteCoreBundle) -> Vec<String> {
+    let mut basenames = admitted_sources(bundle)
+        .into_values()
+        .filter(|admitted| admitted.group == SiteCoreGroup::Status)
+        .map(|admitted| admitted.basename)
+        .collect::<Vec<_>>();
+    basenames.sort();
+    basenames.dedup();
+    basenames
+}
+
+// ---------------------------------------------------------------------------
+// Fragments and coverage
+// ---------------------------------------------------------------------------
+
+struct FragmentArtifact {
+    group: SiteCoreGroup,
+    lineage: String,
+    basename: String,
+    rotation: SccmRotation,
+    rotation_rank: u8,
+    evidence: SccmSiteCoreEvidence,
+}
+
+/// A captured source that cannot yield a complete logical record for part of
+/// its physical range. The unparsed tail is cited by its physical line range;
+/// the reference can never collide with a parsed record because it starts
+/// after the last complete record.
+fn collect_fragments(
+    bundle: &SccmSiteCoreBundle,
+    sources: &BTreeMap<&str, AdmittedSource<'_>>,
+) -> Vec<FragmentArtifact> {
+    let mut fragments = sources
+        .values()
+        .filter(|admitted| admitted.source.artifact.coverage == SccmCoverageState::Captured)
+        .filter_map(|admitted| {
+            let tail = truncated_tail(bundle, admitted)?;
+            Some(FragmentArtifact {
+                group: admitted.group,
+                lineage: admitted.source.rotation_lineage.clone(),
+                basename: admitted.basename.clone(),
+                rotation: admitted.source.artifact.rotation.clone(),
+                rotation_rank: rotation_rank(&admitted.source.artifact.rotation),
+                evidence: tail,
+            })
+        })
+        .collect::<Vec<_>>();
+    fragments.sort_by(|left, right| left.evidence.sort_key().cmp(&right.evidence.sort_key()));
+    fragments
+}
+
+fn truncated_tail(
+    bundle: &SccmSiteCoreBundle,
+    admitted: &AdmittedSource<'_>,
+) -> Option<SccmSiteCoreEvidence> {
+    let artifact_id = admitted.source.artifact.artifact_id.as_str();
+    let physical_line_end = admitted.source.physical_line_end?;
+    let parsed_line_end = bundle
+        .evidence
+        .iter()
+        .filter(|evidence| evidence.reference.artifact_id == artifact_id)
+        .filter_map(|evidence| evidence.reference.line_end)
+        .max()
+        .unwrap_or_default();
+    let tail_start = parsed_line_end.checked_add(1)?;
+    if tail_start > physical_line_end {
+        return None;
+    }
+    Some(SccmSiteCoreEvidence {
+        artifact_id: artifact_id.to_owned(),
+        entry_id: format!("{artifact_id}:{tail_start}-{physical_line_end}"),
+        line_start: tail_start,
+        line_end: physical_line_end,
+        terminal: None,
+        recovery: None,
+        complete_logical_record: Some(false),
+    })
+}
+
+fn collect_coverage_gaps(
+    bundle: &SccmSiteCoreBundle,
+    sources: &BTreeMap<&str, AdmittedSource<'_>>,
+    fragments: &[FragmentArtifact],
+) -> Vec<SccmSiteCoreCoverageGap> {
+    let fragment_by_artifact = fragments
+        .iter()
+        .map(|fragment| {
+            (
+                fragment.evidence.artifact_id.as_str(),
+                fragment.evidence.clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    let mut gaps: BTreeMap<String, SccmSiteCoreCoverageGap> = BTreeMap::new();
+    for source in &bundle.sources {
+        if SiteCoreGroup::from_id(&source.source_group).is_none()
+            || source.artifact.role != SccmRole::SiteServer
+        {
+            continue;
+        }
+        let artifact_id = source.artifact.artifact_id.as_str();
+        let admitted = sources.get(artifact_id);
+        let (state, evidence) = match (admitted, &source.artifact.coverage) {
+            // An interpretable source that produced no complete record for
+            // part of its range.
+            (Some(_), SccmCoverageState::Captured) => match fragment_by_artifact.get(artifact_id) {
+                Some(evidence) => (SccmCoverageState::ParseFailed, Some(evidence.clone())),
+                None => continue,
+            },
+            (Some(admitted), SccmCoverageState::Capped) => (
+                SccmCoverageState::Capped,
+                truncated_tail(bundle, admitted).or(None),
+            ),
+            (Some(_), state) => (state.clone(), None),
+            // A source this profile cannot interpret, or whose identity is
+            // ambiguous, is coverage-only and never a diagnosis.
+            (None, _) => (SccmCoverageState::Unsupported, None),
+        };
+        if state == SccmCoverageState::Captured {
+            continue;
+        }
+        gaps.entry(artifact_id.to_owned())
+            .or_insert(SccmSiteCoreCoverageGap {
+                artifact_id: artifact_id.to_owned(),
+                state,
+                diagnostic_meaning: SccmSiteCoreDiagnosticMeaning::CoverageOnly,
+                evidence,
+            });
+    }
+    gaps.into_values().collect()
+}
+
+/// Fragment observations are source-local: they never advance a phase, join a
+/// record across a rotation boundary, or infer a terminal outcome.
+///
+/// A lineage whose fragments span more than one rotation lost its records to a
+/// rollover, which is a pure coverage loss and can only be insufficient
+/// evidence. A single-rotation fragment is an anomaly in the source itself, so
+/// it is reported as a low-confidence symptom and never as a fact.
+fn append_fragment_observations(
+    fragments: &[FragmentArtifact],
+    observations: &mut Vec<SccmSiteCoreObservation>,
+    findings: &mut Vec<SccmSiteCoreFinding>,
+) {
+    let mut by_lineage: BTreeMap<(SiteCoreGroup, &str), Vec<&FragmentArtifact>> = BTreeMap::new();
+    for fragment in fragments {
+        by_lineage
+            .entry((fragment.group, fragment.lineage.as_str()))
+            .or_default()
+            .push(fragment);
+    }
+
+    let mut rotation_boundary: Vec<&FragmentArtifact> = Vec::new();
+    let mut rotation_boundary_requests = Vec::new();
+    let mut malformed: BTreeMap<SiteCoreGroup, (Vec<&FragmentArtifact>, Vec<_>)> = BTreeMap::new();
+
+    for ((group, lineage), lineage_fragments) in by_lineage {
+        let distinct_rotations = lineage_fragments
+            .iter()
+            .map(|fragment| &fragment.rotation)
+            .collect::<Vec<_>>()
+            .windows(2)
+            .any(|pair| pair[0] != pair[1])
+            || lineage_fragments.len() > 1;
+        let request = fragment_request(group, lineage, &lineage_fragments, distinct_rotations);
+        if distinct_rotations {
+            rotation_boundary.extend(lineage_fragments);
+            rotation_boundary_requests.push(request);
+        } else {
+            let entry = malformed.entry(group).or_default();
+            entry.0.extend(lineage_fragments);
+            entry.1.push(request);
+        }
+    }
+
+    if !rotation_boundary.is_empty() {
+        push_observation(
+            "rotation-boundary-fragments",
+            SiteCoreGroup::Component,
+            SccmFindingClass::InsufficientEvidence,
+            SccmSiteCoreConfidence::None,
+            rotation_boundary,
+            rotation_boundary_requests,
+            observations,
+            findings,
+        );
+    }
+    for (group, (group_fragments, requests)) in malformed {
+        push_observation(
+            &format!("malformed-{}-record", group.slug()),
+            group,
+            SccmFindingClass::Symptom,
+            SccmSiteCoreConfidence::Low,
+            group_fragments,
+            requests,
+            observations,
+            findings,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_observation(
+    observation_id: &str,
+    group: SiteCoreGroup,
+    class: SccmFindingClass,
+    confidence: SccmSiteCoreConfidence,
+    fragments: Vec<&FragmentArtifact>,
+    mut next_artifacts: Vec<SccmSiteCoreArtifactRequest>,
+    observations: &mut Vec<SccmSiteCoreObservation>,
+    findings: &mut Vec<SccmSiteCoreFinding>,
+) {
+    let mut evidence = fragments
+        .iter()
+        .map(|fragment| fragment.evidence.clone())
+        .collect::<Vec<_>>();
+    evidence.sort_by(|left, right| left.sort_key().cmp(&right.sort_key()));
+    evidence.dedup();
+    let mut coverage_gap_artifact_ids = evidence
+        .iter()
+        .map(|item| item.artifact_id.clone())
+        .collect::<Vec<_>>();
+    coverage_gap_artifact_ids.sort();
+    coverage_gap_artifact_ids.dedup();
+    next_artifacts.sort_by(|left, right| left.sort_key().cmp(&right.sort_key()));
+    next_artifacts.dedup();
+
+    let gaps = coverage_gap_artifact_ids
+        .iter()
+        .map(|artifact_id| SccmFindingCoverageGap {
+            artifact_id: artifact_id.clone(),
+            role: SccmRole::SiteServer,
+            coverage: SccmCoverageState::ParseFailed,
+        })
+        .collect::<Vec<_>>();
+    if let Some(finding) = build_observation_finding(
+        &format!("finding:site-core:{observation_id}"),
+        observation_id,
+        class.clone(),
+        group.entry_phase(),
+        confidence,
+        &evidence,
+        gaps,
+        &next_artifacts,
+    ) {
+        findings.push(finding);
+    }
+
+    observations.push(SccmSiteCoreObservation {
+        observation_id: observation_id.to_owned(),
+        state: SccmSiteCoreState::ParseGap,
+        last_successful_phase: None,
+        finding_class: class,
+        confidence,
+        confidence_ceiling: confidence,
+        evidence,
+        coverage_gap_artifact_ids,
+        next_artifacts,
+    });
+}
+
+fn fragment_request(
+    group: SiteCoreGroup,
+    lineage: &str,
+    fragments: &[&FragmentArtifact],
+    rotation_boundary: bool,
+) -> SccmSiteCoreArtifactRequest {
+    let mut ordered = fragments.to_vec();
+    ordered.sort_by(|left, right| {
+        left.rotation_rank
+            .cmp(&right.rotation_rank)
+            .then_with(|| left.basename.cmp(&right.basename))
+    });
+    let mut basenames = Vec::new();
+    let mut rotations = Vec::new();
+    let mut pairs = BTreeSet::new();
+    for fragment in &ordered {
+        let Some(rotation) = rotation_name(&fragment.rotation) else {
+            continue;
+        };
+        if !pairs.insert((fragment.basename.clone(), rotation.clone())) {
+            continue;
+        }
+        if !basenames.contains(&fragment.basename) {
+            basenames.push(fragment.basename.clone());
+        }
+        if !rotations.contains(&rotation) {
+            rotations.push(rotation);
+        }
+    }
+
+    SccmSiteCoreArtifactRequest {
+        logical_name: group.id().to_owned(),
+        role: SccmRole::SiteServer,
+        reason_code: if rotation_boundary {
+            "complete-logical-record-required".to_owned()
+        } else {
+            format!("complete-{}-record-required", group.slug())
+        },
+        basenames,
+        rotations,
+        max_artifacts: pairs.len(),
+        max_bytes_per_artifact: None,
+        scope: SccmSiteCoreRequestScope {
+            component_id: None,
+            work_item_id: None,
+            rotation_lineage: Some(lineage.to_owned()),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared findings
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+fn build_finding(
+    finding_id: &str,
+    subject_id: &str,
+    class: SccmFindingClass,
+    phase: SccmSiteCorePhase,
+    last_successful_phase: Option<SccmSiteCorePhase>,
+    confidence: SccmSiteCoreConfidence,
+    state: SccmSiteCoreState,
+    evidence: &[SccmSiteCoreEvidence],
+    decisive: Option<&SiteCoreFact>,
+    coverage_gap_artifact_ids: &[String],
+    bundle: &SccmSiteCoreBundle,
+    next_artifacts: &[SccmSiteCoreArtifactRequest],
+) -> Option<SccmSiteCoreFinding> {
+    let cited = evidence
+        .iter()
+        .map(SccmSiteCoreEvidence::reference)
+        .collect::<Vec<_>>();
+    let terminal_evidence = match (class.clone(), decisive) {
+        (SccmFindingClass::ConfirmedFailure, Some(fact)) => {
+            vec![SccmTerminalEvidence::observed_failure(
+                fact.reference.clone(),
+            )]
+        }
+        _ => Vec::new(),
+    };
+    let gaps = coverage_gap_artifact_ids
+        .iter()
+        .filter_map(|artifact_id| finding_gap(bundle, artifact_id))
+        .collect::<Vec<_>>();
+
+    let mut builder = SccmFindingBuilder::new(finding_id)
+        .class(class)
+        .phase(SccmPhase::Unknown(phase.serialized_name().to_owned()))
+        .role(SccmRole::SiteServer)
+        .severity(match state {
+            SccmSiteCoreState::TerminalFailure => Severity::Error,
+            _ => Severity::Warning,
+        })
+        .confidence(shared_confidence(confidence))
+        .title("Site component and status evidence")
+        .summary("The site component outcome is bounded to the cited site-server evidence.")
+        .evidence(cited)
+        .terminal_evidence(terminal_evidence)
+        .coverage_gaps(gaps)
+        .next_artifacts(shared_requests(next_artifacts));
+    if let Some(phase) = last_successful_phase {
+        builder = builder.summary(format!(
+            "The last confirmed successful phase is {}; later phases are bounded to cited evidence.",
+            phase.serialized_name()
+        ));
+    }
+
+    Some(SccmSiteCoreFinding {
+        finding: builder.build().ok()?,
+        subject_id: subject_id.to_owned(),
+        last_successful_phase,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_observation_finding(
+    finding_id: &str,
+    subject_id: &str,
+    class: SccmFindingClass,
+    phase: SccmSiteCorePhase,
+    confidence: SccmSiteCoreConfidence,
+    evidence: &[SccmSiteCoreEvidence],
+    gaps: Vec<SccmFindingCoverageGap>,
+    next_artifacts: &[SccmSiteCoreArtifactRequest],
+) -> Option<SccmSiteCoreFinding> {
+    let finding = SccmFindingBuilder::new(finding_id)
+        .class(class)
+        .phase(SccmPhase::Unknown(phase.serialized_name().to_owned()))
+        .role(SccmRole::SiteServer)
+        .severity(Severity::Warning)
+        .confidence(shared_confidence(confidence))
+        .title("Site core source-local evidence")
+        .summary("The observation is source-local and cannot establish a component outcome.")
+        .evidence(
+            evidence
+                .iter()
+                .map(SccmSiteCoreEvidence::reference)
+                .collect(),
+        )
+        .coverage_gaps(gaps)
+        .next_artifacts(shared_requests(next_artifacts))
+        .build()
+        .ok()?;
+    Some(SccmSiteCoreFinding {
+        finding,
+        subject_id: subject_id.to_owned(),
+        last_successful_phase: None,
+    })
+}
+
+fn finding_gap(bundle: &SccmSiteCoreBundle, artifact_id: &str) -> Option<SccmFindingCoverageGap> {
+    let source = bundle
+        .sources
+        .iter()
+        .find(|source| source.artifact.artifact_id == artifact_id)?;
+    let coverage = match source.artifact.coverage {
+        SccmCoverageState::Captured => SccmCoverageState::ParseFailed,
+        ref state => state.clone(),
+    };
+    Some(SccmFindingCoverageGap {
+        artifact_id: artifact_id.to_owned(),
+        role: SccmRole::SiteServer,
+        coverage,
+    })
+}
+
+fn shared_confidence(confidence: SccmSiteCoreConfidence) -> SccmConfidence {
+    match confidence {
+        SccmSiteCoreConfidence::None => SccmConfidence::None,
+        SccmSiteCoreConfidence::Low => SccmConfidence::Low,
+        SccmSiteCoreConfidence::Moderate => SccmConfidence::Moderate,
+        SccmSiteCoreConfidence::High => SccmConfidence::High,
+    }
+}
+
+/// Project the bounded site-core request onto the shared catalogued request
+/// contract. Each requested basename becomes one catalogued logical source, so
+/// the shared reason can never widen beyond the artifact it names.
+fn shared_requests(requests: &[SccmSiteCoreArtifactRequest]) -> Vec<SccmArtifactRequest> {
+    let mut shared = requests
+        .iter()
+        .flat_map(|request| request.basenames.iter())
+        .filter_map(|basename| {
+            let classified = classify_artifact_name(basename, SccmRole::SiteServer);
+            classified
+                .supported_for_diagnosis
+                .then(|| SccmArtifactRequest {
+                    logical_id: classified.logical_name.clone(),
+                    role: SccmRole::SiteServer,
+                    reason: format!("Collect the complete {} file.", classified.basename),
+                })
+        })
+        .collect::<Vec<_>>();
+    shared.sort_by(|left, right| left.logical_id.cmp(&right.logical_id));
+    shared.dedup();
+    shared
+}
+
+fn collect_artifact_requests(
+    results: &[SccmSiteCoreResult],
+    observations: &[SccmSiteCoreObservation],
+) -> Vec<SccmSiteCoreArtifactRequest> {
+    let mut requests = results
+        .iter()
+        .flat_map(|result| result.next_artifacts.iter())
+        .chain(
+            observations
+                .iter()
+                .flat_map(|observation| observation.next_artifacts.iter()),
+        )
+        .cloned()
+        .collect::<Vec<_>>();
+    requests.sort_by(|left, right| left.sort_key().cmp(&right.sort_key()));
+    requests.dedup();
+    requests
+}
+
+// ---------------------------------------------------------------------------
+// Exact-token extraction and identity guards
+// ---------------------------------------------------------------------------
+
+/// Exact-token extraction that fails closed. A label preceded by anything other
+/// than a token boundary is an embedded label, and a label that appears twice
+/// is ambiguous; both yield no value rather than a guess.
+fn validated_token_value(message: &str, label: &str) -> Option<Option<String>> {
+    let lowercase = message.to_ascii_lowercase();
+    let needle = format!("{}=", label.to_ascii_lowercase());
+    let mut value = None;
+    for (label_start, _) in lowercase.match_indices(&needle) {
+        let exact_label_boundary = label_start == 0
+            || message[..label_start]
+                .chars()
+                .next_back()
+                .is_some_and(is_token_boundary);
+        if !exact_label_boundary {
+            return None;
+        }
+        let remainder = &message[label_start + needle.len()..];
+        let end = remainder.find(is_token_boundary).unwrap_or(remainder.len());
+        if end == 0 {
+            return None;
+        }
+        if value.replace(remainder[..end].to_owned()).is_some() {
+            return None;
+        }
+    }
+    Some(value)
+}
+
+fn token_value(message: &str, label: &str) -> Option<String> {
+    validated_token_value(message, label)?
+}
+
+fn is_token_boundary(character: char) -> bool {
+    character.is_whitespace() || matches!(character, ',' | ';' | '&')
+}
+
+fn validated_identifier(value: &str) -> Option<String> {
+    (!value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')))
+    .then(|| value.to_owned())
+}
+
+fn normalize_site_code(value: &str) -> Option<String> {
+    (value.len() == 3
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit()))
+    .then(|| value.to_owned())
+}
+
+fn safe_opaque_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b':'))
+}
+
+fn evidence_reference_fits_source(evidence: &SccmEvidence, admitted: &AdmittedSource<'_>) -> bool {
+    let reference = &evidence.reference;
+    safe_opaque_id(&reference.artifact_id)
+        && safe_opaque_id(&reference.entry_id)
+        && evidence.evidence_id == reference.entry_id
+        && matches!(
+            (reference.line_start, reference.line_end),
+            (Some(start), Some(end)) if start > 0 && end >= start
+        )
+        && admitted
+            .source
+            .physical_line_end
+            .zip(reference.line_end)
+            .is_some_and(|(physical_end, line_end)| physical_end > 0 && line_end <= physical_end)
+}
+
+/// Two evidence records that share an identity, or whose physical ranges
+/// overlap within one artifact, cannot both be authoritative. Neither is
+/// admitted.
+fn evidence_identity_is_unique(bundle: &SccmSiteCoreBundle, evidence: &SccmEvidence) -> bool {
+    bundle
+        .evidence
+        .iter()
+        .filter(|candidate| {
+            candidate.evidence_id == evidence.evidence_id
+                || candidate.reference.entry_id == evidence.reference.entry_id
+                || references_overlap(&candidate.reference, &evidence.reference)
+        })
+        .take(2)
+        .count()
+        == 1
+}
+
+fn references_overlap(left: &SccmEvidenceRef, right: &SccmEvidenceRef) -> bool {
+    if left.artifact_id != right.artifact_id {
+        return false;
+    }
+    matches!(
+        (
+            left.line_start,
+            left.line_end,
+            right.line_start,
+            right.line_end,
+        ),
+        (Some(left_start), Some(left_end), Some(right_start), Some(right_end))
+            if left_start <= right_end && right_start <= left_end
+    )
+}
+
+fn compare_references(left: &SccmEvidenceRef, right: &SccmEvidenceRef) -> Ordering {
+    left.artifact_id
+        .cmp(&right.artifact_id)
+        .then_with(|| left.line_start.cmp(&right.line_start))
+        .then_with(|| left.line_end.cmp(&right.line_end))
+        .then_with(|| left.entry_id.cmp(&right.entry_id))
+}
+
+fn rotation_name(rotation: &SccmRotation) -> Option<String> {
+    Some(match rotation {
+        SccmRotation::Current => "current".to_owned(),
+        SccmRotation::LoUnderscore => "loUnderscore".to_owned(),
+        SccmRotation::Numbered(value) => format!("numbered-{value}"),
+        SccmRotation::Timestamped(value) => format!("timestamped-{value}"),
+        SccmRotation::Unknown(_) => return None,
+    })
+}
+
+fn rotation_rank(rotation: &SccmRotation) -> u8 {
+    match rotation {
+        SccmRotation::Current => 0,
+        SccmRotation::LoUnderscore => 1,
+        SccmRotation::Numbered(_) => 2,
+        SccmRotation::Timestamped(_) => 3,
+        SccmRotation::Unknown(_) => 4,
+    }
+}
+
+fn role_sort_key(role: &SccmRole) -> &str {
+    match role {
+        SccmRole::Client => "client",
+        SccmRole::SiteServer => "siteServer",
+        SccmRole::ManagementPoint => "managementPoint",
+        SccmRole::DistributionPoint => "distributionPoint",
+        SccmRole::SoftwareUpdatePoint => "softwareUpdatePoint",
+        SccmRole::WsUs => "wsUs",
+        SccmRole::Provider => "provider",
+        SccmRole::AdminService => "adminService",
+        SccmRole::Unknown(value) => value,
+    }
+}

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
@@ -1016,8 +1016,18 @@ fn capped_recapture_request(
             && context.truncated_tails.contains_key(*artifact_id)
     })?;
 
+    // `capture_limit_bytes` is declared by the caller, and a limit near the top
+    // of the range cannot be doubled and rounded up: `next_power_of_two`
+    // answers that overflow with a panic in debug and a zero in release, so the
+    // reducer would either abort or quietly ask for the floor. The largest
+    // representable power of two keeps the request a real, declared bound that
+    // is still wider than the limit which truncated the source.
     let limit = admitted.source.capture_limit_bytes.unwrap_or_default();
-    let requested = RECAPTURE_FLOOR_BYTES.max(limit.saturating_mul(2).next_power_of_two());
+    let doubled = limit
+        .saturating_mul(2)
+        .checked_next_power_of_two()
+        .unwrap_or(1 << (u64::BITS - 1));
+    let requested = RECAPTURE_FLOOR_BYTES.max(doubled);
     Some(SccmSiteCoreArtifactRequest {
         logical_name: admitted.group.id().to_owned(),
         role: SccmRole::SiteServer,
@@ -1030,11 +1040,17 @@ fn capped_recapture_request(
     })
 }
 
+/// Status basenames worth asking for again. The producer gate applies here too:
+/// a family this profile has no validated producer for cannot answer the
+/// question the request is asking, so naming it would spend the operator's
+/// collection budget on bytes that are already declared unsupported coverage.
+/// With no validated status source in the bundle the caller falls back to the
+/// declared status basename.
 fn status_group_candidates(context: &SiteCoreContext<'_>) -> Vec<String> {
     let mut basenames = context
         .sources
         .values()
-        .filter(|admitted| admitted.group == SiteCoreGroup::Status)
+        .filter(|admitted| admitted.group == SiteCoreGroup::Status && admitted.producer.is_some())
         .map(|admitted| admitted.basename.clone())
         .collect::<Vec<_>>();
     basenames.sort();

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
@@ -309,10 +309,13 @@ pub struct SccmSiteCoreAnalysis {
 /// source-local observations, coverage gaps and bounded next-artifact requests.
 pub fn analyze_site_core(bundle: &SccmSiteCoreBundle) -> SccmSiteCoreAnalysis {
     let site_code = normalize_site_code(&bundle.topology.site_code);
-    let admitted_sources = admitted_sources(bundle);
-    let facts = collect_facts(bundle, &admitted_sources, site_code.as_deref());
-    let fragments = collect_fragments(bundle, &admitted_sources);
-    let coverage_gaps = collect_coverage_gaps(bundle, &admitted_sources, &fragments);
+    let context = SiteCoreContext {
+        bundle,
+        sources: admitted_sources(bundle),
+    };
+    let facts = collect_facts(&context, site_code.as_deref());
+    let fragments = collect_fragments(&context);
+    let coverage_gaps = collect_coverage_gaps(&context, &fragments);
 
     let fragment_artifact_ids = fragments
         .iter()
@@ -327,7 +330,7 @@ pub fn analyze_site_core(bundle: &SccmSiteCoreBundle) -> SccmSiteCoreAnalysis {
     let mut results = Vec::new();
     let mut findings = Vec::new();
     for (key, facts) in group_facts(facts) {
-        let reduced = reduce_transaction(bundle, key, &facts, &transaction_gap_ids);
+        let reduced = reduce_transaction(&context, key, &facts, &transaction_gap_ids);
         if let Some(finding) = reduced.finding {
             findings.push(finding);
         }
@@ -369,6 +372,13 @@ pub fn analyze_site_core(bundle: &SccmSiteCoreBundle) -> SccmSiteCoreAnalysis {
 // ---------------------------------------------------------------------------
 // Source admission
 // ---------------------------------------------------------------------------
+
+/// The admitted view of one bundle. Shape admission runs once so no later
+/// stage can silently re-derive a different source set.
+struct SiteCoreContext<'a> {
+    bundle: &'a SccmSiteCoreBundle,
+    sources: BTreeMap<&'a str, AdmittedSource<'a>>,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum SiteCoreGroup {
@@ -615,24 +625,23 @@ impl SiteCoreFact {
     }
 }
 
-fn collect_facts(
-    bundle: &SccmSiteCoreBundle,
-    sources: &BTreeMap<&str, AdmittedSource<'_>>,
-    site_code: Option<&str>,
-) -> Vec<SiteCoreFact> {
+fn collect_facts(context: &SiteCoreContext<'_>, site_code: Option<&str>) -> Vec<SiteCoreFact> {
     let Some(site_code) = site_code else {
         return Vec::new();
     };
 
-    bundle
+    context
+        .bundle
         .evidence
         .iter()
         .filter_map(|evidence| {
-            let admitted = sources.get(evidence.reference.artifact_id.as_str())?;
+            let admitted = context
+                .sources
+                .get(evidence.reference.artifact_id.as_str())?;
             if !source_carries_facts(admitted)
                 || evidence.role != SccmRole::SiteServer
                 || !evidence_reference_fits_source(evidence, admitted)
-                || !evidence_identity_is_unique(bundle, evidence)
+                || !evidence_identity_is_unique(context.bundle, evidence)
             {
                 return None;
             }
@@ -740,7 +749,7 @@ struct ReducedTransaction {
 }
 
 fn reduce_transaction(
-    bundle: &SccmSiteCoreBundle,
+    context: &SiteCoreContext<'_>,
     key: SccmSiteCoreTransactionKey,
     facts: &[SiteCoreFact],
     coverage_gap_artifact_ids: &[String],
@@ -815,7 +824,7 @@ fn reduce_transaction(
 
     let confidence_ceiling = confidence_ceiling(facts, state, chronology_usable, conflicting);
     let confidence = base_confidence.min(confidence_ceiling);
-    let next_artifacts = next_artifacts_for_state(bundle, &key, facts, state);
+    let next_artifacts = next_artifacts_for_state(context, &key, facts, state);
 
     let mut evidence = facts.iter().map(SiteCoreFact::evidence).collect::<Vec<_>>();
     evidence.sort_by(|left, right| left.sort_key().cmp(&right.sort_key()));
@@ -827,21 +836,22 @@ fn reduce_transaction(
     );
     let finding = finding_class.clone().and_then(|class| {
         build_finding(
-            &format!("finding:site-core:{result_id}"),
-            &result_id,
-            class,
-            decisive
-                .map(|fact| fact.marker.phase)
-                .or(last_successful_phase)
-                .unwrap_or(SccmSiteCorePhase::ComponentStart),
-            last_successful_phase,
-            confidence,
-            state,
-            &evidence,
-            decisive,
-            coverage_gap_artifact_ids,
-            bundle,
-            &next_artifacts,
+            context,
+            TransactionFinding {
+                subject_id: &result_id,
+                class,
+                phase: decisive
+                    .map(|fact| fact.marker.phase)
+                    .or(last_successful_phase)
+                    .unwrap_or(SccmSiteCorePhase::ComponentStart),
+                last_successful_phase,
+                confidence,
+                state,
+                evidence: &evidence,
+                decisive,
+                coverage_gap_artifact_ids,
+                next_artifacts: &next_artifacts,
+            },
         )
     });
 
@@ -900,7 +910,7 @@ fn confidence_ceiling(
 /// The smallest next artifact bundle when evidence stops. A confirmed terminal
 /// outcome and a healthy or recovered completion need nothing further.
 fn next_artifacts_for_state(
-    bundle: &SccmSiteCoreBundle,
+    context: &SiteCoreContext<'_>,
     key: &SccmSiteCoreTransactionKey,
     facts: &[SiteCoreFact],
     state: SccmSiteCoreState,
@@ -924,11 +934,11 @@ fn next_artifacts_for_state(
     // A capture limit that truncated the family which carried the last
     // evidence is the nearest boundary: request that one source again under a
     // larger bounded limit.
-    if let Some(request) = capped_recapture_request(bundle, facts, &scope) {
+    if let Some(request) = capped_recapture_request(context, facts, &scope) {
         return vec![request];
     }
 
-    let statuses = status_group_candidates(bundle);
+    let statuses = status_group_candidates(context);
     let basenames = if statuses.is_empty() {
         vec!["statmgr.log".to_owned()]
     } else {
@@ -948,7 +958,7 @@ fn next_artifacts_for_state(
 }
 
 fn capped_recapture_request(
-    bundle: &SccmSiteCoreBundle,
+    context: &SiteCoreContext<'_>,
     facts: &[SiteCoreFact],
     scope: &SccmSiteCoreRequestScope,
 ) -> Option<SccmSiteCoreArtifactRequest> {
@@ -956,11 +966,10 @@ fn capped_recapture_request(
         .iter()
         .map(|fact| fact.reference.artifact_id.as_str())
         .collect::<BTreeSet<_>>();
-    let sources = admitted_sources(bundle);
-    let (_, admitted) = sources.iter().find(|(artifact_id, admitted)| {
+    let (_, admitted) = context.sources.iter().find(|(artifact_id, admitted)| {
         cited.contains(*artifact_id)
             && admitted.source.artifact.coverage == SccmCoverageState::Capped
-            && truncated_tail(bundle, admitted).is_some()
+            && truncated_tail(context.bundle, admitted).is_some()
     })?;
 
     let limit = admitted.source.capture_limit_bytes.unwrap_or_default();
@@ -977,11 +986,12 @@ fn capped_recapture_request(
     })
 }
 
-fn status_group_candidates(bundle: &SccmSiteCoreBundle) -> Vec<String> {
-    let mut basenames = admitted_sources(bundle)
-        .into_values()
+fn status_group_candidates(context: &SiteCoreContext<'_>) -> Vec<String> {
+    let mut basenames = context
+        .sources
+        .values()
         .filter(|admitted| admitted.group == SiteCoreGroup::Status)
-        .map(|admitted| admitted.basename)
+        .map(|admitted| admitted.basename.clone())
         .collect::<Vec<_>>();
     basenames.sort();
     basenames.dedup();
@@ -1005,15 +1015,13 @@ struct FragmentArtifact {
 /// its physical range. The unparsed tail is cited by its physical line range;
 /// the reference can never collide with a parsed record because it starts
 /// after the last complete record.
-fn collect_fragments(
-    bundle: &SccmSiteCoreBundle,
-    sources: &BTreeMap<&str, AdmittedSource<'_>>,
-) -> Vec<FragmentArtifact> {
-    let mut fragments = sources
+fn collect_fragments(context: &SiteCoreContext<'_>) -> Vec<FragmentArtifact> {
+    let mut fragments = context
+        .sources
         .values()
         .filter(|admitted| admitted.source.artifact.coverage == SccmCoverageState::Captured)
         .filter_map(|admitted| {
-            let tail = truncated_tail(bundle, admitted)?;
+            let tail = truncated_tail(context.bundle, admitted)?;
             Some(FragmentArtifact {
                 group: admitted.group,
                 lineage: admitted.source.rotation_lineage.clone(),
@@ -1057,8 +1065,7 @@ fn truncated_tail(
 }
 
 fn collect_coverage_gaps(
-    bundle: &SccmSiteCoreBundle,
-    sources: &BTreeMap<&str, AdmittedSource<'_>>,
+    context: &SiteCoreContext<'_>,
     fragments: &[FragmentArtifact],
 ) -> Vec<SccmSiteCoreCoverageGap> {
     let fragment_by_artifact = fragments
@@ -1072,14 +1079,14 @@ fn collect_coverage_gaps(
         .collect::<BTreeMap<_, _>>();
 
     let mut gaps: BTreeMap<String, SccmSiteCoreCoverageGap> = BTreeMap::new();
-    for source in &bundle.sources {
+    for source in &context.bundle.sources {
         if SiteCoreGroup::from_id(&source.source_group).is_none()
             || source.artifact.role != SccmRole::SiteServer
         {
             continue;
         }
         let artifact_id = source.artifact.artifact_id.as_str();
-        let admitted = sources.get(artifact_id);
+        let admitted = context.sources.get(artifact_id);
         let (state, evidence) = match (admitted, &source.artifact.coverage) {
             // An interpretable source that produced no complete record for
             // part of its range.
@@ -1089,7 +1096,7 @@ fn collect_coverage_gaps(
             },
             (Some(admitted), SccmCoverageState::Capped) => (
                 SccmCoverageState::Capped,
-                truncated_tail(bundle, admitted).or(None),
+                truncated_tail(context.bundle, admitted),
             ),
             (Some(_), state) => (state.clone(), None),
             // A source this profile cannot interpret, or whose identity is
@@ -1135,15 +1142,14 @@ fn append_fragment_observations(
     let mut malformed: BTreeMap<SiteCoreGroup, (Vec<&FragmentArtifact>, Vec<_>)> = BTreeMap::new();
 
     for ((group, lineage), lineage_fragments) in by_lineage {
-        let distinct_rotations = lineage_fragments
+        let spans_rotations = lineage_fragments
             .iter()
-            .map(|fragment| &fragment.rotation)
-            .collect::<Vec<_>>()
-            .windows(2)
-            .any(|pair| pair[0] != pair[1])
-            || lineage_fragments.len() > 1;
-        let request = fragment_request(group, lineage, &lineage_fragments, distinct_rotations);
-        if distinct_rotations {
+            .map(|fragment| fragment.rotation_rank)
+            .collect::<BTreeSet<_>>()
+            .len()
+            > 1;
+        let request = fragment_request(group, lineage, &lineage_fragments, spans_rotations);
+        if spans_rotations {
             rotation_boundary.extend(lineage_fragments);
             rotation_boundary_requests.push(request);
         } else {
@@ -1154,42 +1160,39 @@ fn append_fragment_observations(
     }
 
     if !rotation_boundary.is_empty() {
-        push_observation(
+        let (observation, finding) = build_observation(
             "rotation-boundary-fragments",
             SiteCoreGroup::Component,
             SccmFindingClass::InsufficientEvidence,
             SccmSiteCoreConfidence::None,
             rotation_boundary,
             rotation_boundary_requests,
-            observations,
-            findings,
         );
+        observations.push(observation);
+        findings.extend(finding);
     }
     for (group, (group_fragments, requests)) in malformed {
-        push_observation(
+        let (observation, finding) = build_observation(
             &format!("malformed-{}-record", group.slug()),
             group,
             SccmFindingClass::Symptom,
             SccmSiteCoreConfidence::Low,
             group_fragments,
             requests,
-            observations,
-            findings,
         );
+        observations.push(observation);
+        findings.extend(finding);
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn push_observation(
+fn build_observation(
     observation_id: &str,
     group: SiteCoreGroup,
     class: SccmFindingClass,
     confidence: SccmSiteCoreConfidence,
     fragments: Vec<&FragmentArtifact>,
     mut next_artifacts: Vec<SccmSiteCoreArtifactRequest>,
-    observations: &mut Vec<SccmSiteCoreObservation>,
-    findings: &mut Vec<SccmSiteCoreFinding>,
-) {
+) -> (SccmSiteCoreObservation, Option<SccmSiteCoreFinding>) {
     let mut evidence = fragments
         .iter()
         .map(|fragment| fragment.evidence.clone())
@@ -1213,8 +1216,7 @@ fn push_observation(
             coverage: SccmCoverageState::ParseFailed,
         })
         .collect::<Vec<_>>();
-    if let Some(finding) = build_observation_finding(
-        &format!("finding:site-core:{observation_id}"),
+    let finding = build_observation_finding(
         observation_id,
         class.clone(),
         group.entry_phase(),
@@ -1222,11 +1224,9 @@ fn push_observation(
         &evidence,
         gaps,
         &next_artifacts,
-    ) {
-        findings.push(finding);
-    }
+    );
 
-    observations.push(SccmSiteCoreObservation {
+    let observation = SccmSiteCoreObservation {
         observation_id: observation_id.to_owned(),
         state: SccmSiteCoreState::ParseGap,
         last_successful_phase: None,
@@ -1236,7 +1236,8 @@ fn push_observation(
         evidence,
         coverage_gap_artifact_ids,
         next_artifacts,
-    });
+    };
+    (observation, finding)
 }
 
 fn fragment_request(
@@ -1293,26 +1294,32 @@ fn fragment_request(
 // Shared findings
 // ---------------------------------------------------------------------------
 
-#[allow(clippy::too_many_arguments)]
-fn build_finding(
-    finding_id: &str,
-    subject_id: &str,
+/// Everything a transaction finding cites. Grouping the inputs keeps the
+/// finding a projection of one reduced transaction rather than a loose
+/// argument list that could drift out of step with it.
+struct TransactionFinding<'a> {
+    subject_id: &'a str,
     class: SccmFindingClass,
     phase: SccmSiteCorePhase,
     last_successful_phase: Option<SccmSiteCorePhase>,
     confidence: SccmSiteCoreConfidence,
     state: SccmSiteCoreState,
-    evidence: &[SccmSiteCoreEvidence],
-    decisive: Option<&SiteCoreFact>,
-    coverage_gap_artifact_ids: &[String],
-    bundle: &SccmSiteCoreBundle,
-    next_artifacts: &[SccmSiteCoreArtifactRequest],
+    evidence: &'a [SccmSiteCoreEvidence],
+    decisive: Option<&'a SiteCoreFact>,
+    coverage_gap_artifact_ids: &'a [String],
+    next_artifacts: &'a [SccmSiteCoreArtifactRequest],
+}
+
+fn build_finding(
+    context: &SiteCoreContext<'_>,
+    subject: TransactionFinding<'_>,
 ) -> Option<SccmSiteCoreFinding> {
-    let cited = evidence
+    let cited = subject
+        .evidence
         .iter()
         .map(SccmSiteCoreEvidence::reference)
         .collect::<Vec<_>>();
-    let terminal_evidence = match (class.clone(), decisive) {
+    let terminal_evidence = match (&subject.class, subject.decisive) {
         (SccmFindingClass::ConfirmedFailure, Some(fact)) => {
             vec![SccmTerminalEvidence::observed_failure(
                 fact.reference.clone(),
@@ -1320,43 +1327,47 @@ fn build_finding(
         }
         _ => Vec::new(),
     };
-    let gaps = coverage_gap_artifact_ids
+    let gaps = subject
+        .coverage_gap_artifact_ids
         .iter()
-        .filter_map(|artifact_id| finding_gap(bundle, artifact_id))
+        .filter_map(|artifact_id| finding_gap(context.bundle, artifact_id))
         .collect::<Vec<_>>();
+    let summary = match subject.last_successful_phase {
+        Some(phase) => format!(
+            "The last confirmed successful phase is {}; later phases are bounded to cited evidence.",
+            phase.serialized_name()
+        ),
+        None => "No site component phase is confirmed by the cited evidence.".to_owned(),
+    };
 
-    let mut builder = SccmFindingBuilder::new(finding_id)
-        .class(class)
-        .phase(SccmPhase::Unknown(phase.serialized_name().to_owned()))
+    let finding = SccmFindingBuilder::new(format!("finding:site-core:{}", subject.subject_id))
+        .class(subject.class)
+        .phase(SccmPhase::Unknown(
+            subject.phase.serialized_name().to_owned(),
+        ))
         .role(SccmRole::SiteServer)
-        .severity(match state {
+        .severity(match subject.state {
             SccmSiteCoreState::TerminalFailure => Severity::Error,
             _ => Severity::Warning,
         })
-        .confidence(shared_confidence(confidence))
+        .confidence(shared_confidence(subject.confidence))
         .title("Site component and status evidence")
-        .summary("The site component outcome is bounded to the cited site-server evidence.")
+        .summary(summary)
         .evidence(cited)
         .terminal_evidence(terminal_evidence)
         .coverage_gaps(gaps)
-        .next_artifacts(shared_requests(next_artifacts));
-    if let Some(phase) = last_successful_phase {
-        builder = builder.summary(format!(
-            "The last confirmed successful phase is {}; later phases are bounded to cited evidence.",
-            phase.serialized_name()
-        ));
-    }
+        .next_artifacts(shared_requests(subject.next_artifacts))
+        .build()
+        .ok()?;
 
     Some(SccmSiteCoreFinding {
-        finding: builder.build().ok()?,
-        subject_id: subject_id.to_owned(),
-        last_successful_phase,
+        finding,
+        subject_id: subject.subject_id.to_owned(),
+        last_successful_phase: subject.last_successful_phase,
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 fn build_observation_finding(
-    finding_id: &str,
     subject_id: &str,
     class: SccmFindingClass,
     phase: SccmSiteCorePhase,
@@ -1365,7 +1376,7 @@ fn build_observation_finding(
     gaps: Vec<SccmFindingCoverageGap>,
     next_artifacts: &[SccmSiteCoreArtifactRequest],
 ) -> Option<SccmSiteCoreFinding> {
-    let finding = SccmFindingBuilder::new(finding_id)
+    let finding = SccmFindingBuilder::new(format!("finding:site-core:{subject_id}"))
         .class(class)
         .phase(SccmPhase::Unknown(phase.serialized_name().to_owned()))
         .role(SccmRole::SiteServer)

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
@@ -314,10 +314,7 @@ pub struct SccmSiteCoreAnalysis {
 /// source-local observations, coverage gaps and bounded next-artifact requests.
 pub fn analyze_site_core(bundle: &SccmSiteCoreBundle) -> SccmSiteCoreAnalysis {
     let site_code = normalize_site_code(&bundle.topology.site_code);
-    let context = SiteCoreContext {
-        bundle,
-        sources: admitted_sources(bundle),
-    };
+    let context = SiteCoreContext::new(bundle);
     let facts = collect_facts(&context, site_code.as_deref());
     let fragments = collect_fragments(&context);
     let coverage_gaps = collect_coverage_gaps(&context, &fragments);
@@ -375,10 +372,34 @@ pub fn analyze_site_core(bundle: &SccmSiteCoreBundle) -> SccmSiteCoreAnalysis {
 // ---------------------------------------------------------------------------
 
 /// The admitted view of one bundle. Shape admission runs once so no later
-/// stage can silently re-derive a different source set.
+/// stage can silently re-derive a different source set, and every whole-bundle
+/// question a per-record or per-transaction stage would otherwise ask is
+/// answered here once as well.
 struct SiteCoreContext<'a> {
     bundle: &'a SccmSiteCoreBundle,
     sources: BTreeMap<&'a str, AdmittedSource<'a>>,
+    /// Whether each record in `bundle.evidence`, by position, holds an identity
+    /// no other record contests.
+    evidence_identity_is_unique: Vec<bool>,
+    /// The unparsed physical tail of each admitted source, if it has one.
+    truncated_tails: BTreeMap<&'a str, SccmSiteCoreEvidence>,
+}
+
+impl<'a> SiteCoreContext<'a> {
+    fn new(bundle: &'a SccmSiteCoreBundle) -> Self {
+        let sources = admitted_sources(bundle);
+        let truncated_tails = truncated_tails(bundle, &sources);
+        Self {
+            bundle,
+            sources,
+            evidence_identity_is_unique: unique_evidence_identities(bundle),
+            truncated_tails,
+        }
+    }
+
+    fn truncated_tail(&self, artifact_id: &str) -> Option<SccmSiteCoreEvidence> {
+        self.truncated_tails.get(artifact_id).cloned()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -635,14 +656,15 @@ fn collect_facts(context: &SiteCoreContext<'_>, site_code: Option<&str>) -> Vec<
         .bundle
         .evidence
         .iter()
-        .filter_map(|evidence| {
+        .enumerate()
+        .filter_map(|(position, evidence)| {
             let admitted = context
                 .sources
                 .get(evidence.reference.artifact_id.as_str())?;
             if !source_carries_facts(admitted)
                 || evidence.role != SccmRole::SiteServer
                 || !evidence_reference_fits_source(evidence, admitted)
-                || !evidence_identity_is_unique(context.bundle, evidence)
+                || !context.evidence_identity_is_unique[position]
             {
                 return None;
             }
@@ -887,15 +909,24 @@ fn reduce_transaction(
 
 /// Two facts at the same instant, in the same phase, disagreeing about the
 /// outcome cannot select a winner without letting vector order decide.
+///
+/// Facts are bucketed by the pair that has to match rather than compared
+/// pairwise: a bucket is in conflict exactly when it does not agree with its
+/// own first outcome, and one busy component key can hold thousands of records.
 fn has_same_instant_conflict(facts: &[SiteCoreFact]) -> bool {
-    facts.iter().enumerate().any(|(index, left)| {
-        facts[index + 1..].iter().any(|right| {
-            left.marker.phase == right.marker.phase
-                && left.ordering_millis().is_some()
-                && left.ordering_millis() == right.ordering_millis()
-                && left.marker.outcome != right.marker.outcome
-        })
-    })
+    let mut outcomes: BTreeMap<(SccmSiteCorePhase, i64), FactOutcome> = BTreeMap::new();
+    for fact in facts {
+        let Some(millis) = fact.ordering_millis() else {
+            continue;
+        };
+        let first = outcomes
+            .entry((fact.marker.phase, millis))
+            .or_insert(fact.marker.outcome);
+        if *first != fact.marker.outcome {
+            return true;
+        }
+    }
+    false
 }
 
 fn confidence_ceiling(
@@ -982,7 +1013,7 @@ fn capped_recapture_request(
     let (_, admitted) = context.sources.iter().find(|(artifact_id, admitted)| {
         cited.contains(*artifact_id)
             && admitted.source.artifact.coverage == SccmCoverageState::Capped
-            && truncated_tail(context.bundle, admitted).is_some()
+            && context.truncated_tails.contains_key(*artifact_id)
     })?;
 
     let limit = admitted.source.capture_limit_bytes.unwrap_or_default();
@@ -1043,7 +1074,7 @@ fn collect_fragments(context: &SiteCoreContext<'_>) -> Vec<FragmentArtifact> {
                 && admitted.source.artifact.coverage == SccmCoverageState::Captured
         })
         .filter_map(|admitted| {
-            let tail = truncated_tail(context.bundle, admitted)?;
+            let tail = context.truncated_tail(&admitted.source.artifact.artifact_id)?;
             Some(FragmentArtifact {
                 group: admitted.group,
                 lineage: admitted.source.rotation_lineage.clone(),
@@ -1058,19 +1089,43 @@ fn collect_fragments(context: &SiteCoreContext<'_>) -> Vec<FragmentArtifact> {
     fragments
 }
 
-fn truncated_tail(
-    bundle: &SccmSiteCoreBundle,
-    admitted: &AdmittedSource<'_>,
-) -> Option<SccmSiteCoreEvidence> {
-    let artifact_id = admitted.source.artifact.artifact_id.as_str();
-    let physical_line_end = admitted.source.physical_line_end?;
-    let parsed_line_end = bundle
-        .evidence
+/// The unparsed physical tail of every admitted source, resolved in one pass
+/// over the bundle. Three stages need this answer and one of them needs it per
+/// transaction, so deriving it on demand would rescan the whole evidence vector
+/// once per caller.
+fn truncated_tails<'a>(
+    bundle: &'a SccmSiteCoreBundle,
+    sources: &BTreeMap<&'a str, AdmittedSource<'a>>,
+) -> BTreeMap<&'a str, SccmSiteCoreEvidence> {
+    let mut parsed_line_ends: BTreeMap<&str, u32> = BTreeMap::new();
+    for evidence in &bundle.evidence {
+        let line_end = parsed_line_ends
+            .entry(evidence.reference.artifact_id.as_str())
+            .or_default();
+        *line_end = (*line_end).max(evidence.reference.line_end.unwrap_or_default());
+    }
+
+    sources
         .iter()
-        .filter(|evidence| evidence.reference.artifact_id == artifact_id)
-        .filter_map(|evidence| evidence.reference.line_end)
-        .max()
-        .unwrap_or_default();
+        .filter_map(|(artifact_id, admitted)| {
+            let tail = truncated_tail(
+                artifact_id,
+                admitted.source.physical_line_end?,
+                parsed_line_ends
+                    .get(artifact_id)
+                    .copied()
+                    .unwrap_or_default(),
+            )?;
+            Some((*artifact_id, tail))
+        })
+        .collect()
+}
+
+fn truncated_tail(
+    artifact_id: &str,
+    physical_line_end: u32,
+    parsed_line_end: u32,
+) -> Option<SccmSiteCoreEvidence> {
     let tail_start = parsed_line_end.checked_add(1)?;
     if tail_start > physical_line_end {
         return None;
@@ -1132,9 +1187,9 @@ fn collect_coverage_gaps(
                     (None, _) => continue,
                 }
             }
-            (Some(admitted), SccmCoverageState::Capped) => (
+            (Some(_), SccmCoverageState::Capped) => (
                 SccmCoverageState::Capped,
-                truncated_tail(context.bundle, admitted),
+                context.truncated_tail(artifact_id),
             ),
             (Some(_), state) => (state.clone(), None),
             // A source this profile cannot interpret, or whose identity is
@@ -1627,34 +1682,106 @@ fn evidence_reference_fits_source(evidence: &SccmEvidence, admitted: &AdmittedSo
 /// Two evidence records that share an identity, or whose physical ranges
 /// overlap within one artifact, cannot both be authoritative. Neither is
 /// admitted.
-fn evidence_identity_is_unique(bundle: &SccmSiteCoreBundle, evidence: &SccmEvidence) -> bool {
-    bundle
-        .evidence
-        .iter()
-        .filter(|candidate| {
-            candidate.evidence_id == evidence.evidence_id
-                || candidate.reference.entry_id == evidence.reference.entry_id
-                || references_overlap(&candidate.reference, &evidence.reference)
-        })
-        .take(2)
-        .count()
-        == 1
+///
+/// The question is answered for the whole bundle at once, by position, because
+/// the alternative is a rescan of every record for every record: a stock
+/// ConfigMgr server log holds tens of thousands of records and none of them
+/// collide, so the scan that only stops early on a collision never stops early.
+/// A record is contested when it shares an evidence id or an entry id with
+/// another, or when its physical range meets another range in the same
+/// artifact; the three are independent, so each is decided by its own pass.
+fn unique_evidence_identities(bundle: &SccmSiteCoreBundle) -> Vec<bool> {
+    let mut unique = vec![true; bundle.evidence.len()];
+    mark_repeated_keys(
+        &mut unique,
+        bundle
+            .evidence
+            .iter()
+            .map(|evidence| evidence.evidence_id.as_str()),
+    );
+    mark_repeated_keys(
+        &mut unique,
+        bundle
+            .evidence
+            .iter()
+            .map(|evidence| evidence.reference.entry_id.as_str()),
+    );
+    mark_met_ranges(&mut unique, bundle);
+    unique
 }
 
-fn references_overlap(left: &SccmEvidenceRef, right: &SccmEvidenceRef) -> bool {
-    if left.artifact_id != right.artifact_id {
-        return false;
+fn mark_repeated_keys<'a>(unique: &mut [bool], keys: impl Iterator<Item = &'a str>) {
+    let mut positions: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+    for (position, key) in keys.enumerate() {
+        positions.entry(key).or_default().push(position);
     }
-    matches!(
-        (
-            left.line_start,
-            left.line_end,
-            right.line_start,
-            right.line_end,
-        ),
-        (Some(left_start), Some(left_end), Some(right_start), Some(right_end))
-            if left_start <= right_end && right_start <= left_end
-    )
+    for repeated in positions.into_values().filter(|group| group.len() > 1) {
+        for position in repeated {
+            unique[position] = false;
+        }
+    }
+}
+
+/// Two ranges meet when `left.start <= right.end` and `right.start <= left.end`.
+/// Sorting one artifact's ranges by start turns the first half of that test into
+/// a prefix: the candidates whose start is at or before this range's end are
+/// exactly the leading run. This range meets one of them when the largest end in
+/// that run, excluding this range itself, reaches this range's start, so the
+/// running largest and runner-up ends answer every range in one more pass.
+///
+/// The runner-up is what lets a range be excluded from its own prefix, and the
+/// arithmetic never assumes `start <= end`: a reference whose range is inverted
+/// is decided by the same test as any other rather than being read as empty.
+fn mark_met_ranges(unique: &mut [bool], bundle: &SccmSiteCoreBundle) {
+    let mut by_artifact: BTreeMap<&str, Vec<(u32, u32, usize)>> = BTreeMap::new();
+    for (position, evidence) in bundle.evidence.iter().enumerate() {
+        let reference = &evidence.reference;
+        if let (Some(start), Some(end)) = (reference.line_start, reference.line_end) {
+            by_artifact
+                .entry(reference.artifact_id.as_str())
+                .or_default()
+                .push((start, end, position));
+        }
+    }
+
+    for mut ranges in by_artifact.into_values() {
+        ranges.sort_unstable();
+        let mut largest_ends: Vec<(u32, usize, Option<u32>)> = Vec::with_capacity(ranges.len());
+        let mut largest: Option<(u32, usize)> = None;
+        let mut runner_up: Option<u32> = None;
+        for (index, &(_, end, _)) in ranges.iter().enumerate() {
+            match largest {
+                Some((current, _)) if end > current => {
+                    runner_up = Some(current);
+                    largest = Some((end, index));
+                }
+                Some(_) => {
+                    if runner_up.is_none_or(|value| end > value) {
+                        runner_up = Some(end);
+                    }
+                }
+                None => largest = Some((end, index)),
+            }
+            let (end, holder) = largest.expect("a largest end exists after the first range");
+            largest_ends.push((end, holder, runner_up));
+        }
+
+        for (index, &(start, end, position)) in ranges.iter().enumerate() {
+            let reachable = ranges.partition_point(|(candidate, _, _)| *candidate <= end);
+            if reachable == 0 {
+                continue;
+            }
+            let (largest_end, holder, runner_up) = largest_ends[reachable - 1];
+            let contender = if holder == index {
+                runner_up
+            } else {
+                Some(largest_end)
+            };
+            if contender.is_some_and(|candidate_end| candidate_end >= start) {
+                unique[position] = false;
+            }
+        }
+    }
 }
 
 fn compare_references(left: &SccmEvidenceRef, right: &SccmEvidenceRef) -> Ordering {
@@ -1696,5 +1823,149 @@ fn role_sort_key(role: &SccmRole) -> &str {
         SccmRole::Provider => "provider",
         SccmRole::AdminService => "adminService",
         SccmRole::Unknown(value) => value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two references meet when they name the same artifact and their physical
+    /// ranges intersect. This is the definition `mark_met_ranges` answers by
+    /// sorting rather than by comparing every pair, so it is stated once here
+    /// and the pre-pass is held to it.
+    fn references_overlap(left: &SccmEvidenceRef, right: &SccmEvidenceRef) -> bool {
+        if left.artifact_id != right.artifact_id {
+            return false;
+        }
+        matches!(
+            (
+                left.line_start,
+                left.line_end,
+                right.line_start,
+                right.line_end,
+            ),
+            (Some(left_start), Some(left_end), Some(right_start), Some(right_end))
+                if left_start <= right_end && right_start <= left_end
+        )
+    }
+
+    /// The pairwise definition of contested identity, kept as the reference the
+    /// bundle-wide pre-pass has to reproduce exactly.
+    fn identity_is_unique_pairwise(bundle: &SccmSiteCoreBundle, evidence: &SccmEvidence) -> bool {
+        bundle
+            .evidence
+            .iter()
+            .filter(|candidate| {
+                candidate.evidence_id == evidence.evidence_id
+                    || candidate.reference.entry_id == evidence.reference.entry_id
+                    || references_overlap(&candidate.reference, &evidence.reference)
+            })
+            .take(2)
+            .count()
+            == 1
+    }
+
+    fn evidence(
+        evidence_id: &str,
+        artifact_id: &str,
+        entry_id: &str,
+        line_start: Option<u32>,
+        line_end: Option<u32>,
+    ) -> SccmEvidence {
+        SccmEvidence {
+            evidence_id: evidence_id.to_owned(),
+            reference: SccmEvidenceRef {
+                artifact_id: artifact_id.to_owned(),
+                entry_id: entry_id.to_owned(),
+                line_start,
+                line_end,
+            },
+            role: SccmRole::SiteServer,
+            component: Some("SMS_SITE_COMPONENT_MANAGER".to_owned()),
+            ccm_source_file: None,
+            message: String::new(),
+            timestamp: SccmTimestamp {
+                original_display: None,
+                offset_minutes: None,
+                utc_millis: None,
+                ordering_state: SccmTimeOrderingState::OffsetMissing,
+            },
+            execution_context: None,
+        }
+    }
+
+    fn bundle_of(evidence: Vec<SccmEvidence>) -> SccmSiteCoreBundle {
+        SccmSiteCoreBundle {
+            topology: SccmSiteCoreTopology {
+                site_code: "LAB".to_owned(),
+            },
+            sources: Vec::new(),
+            evidence,
+        }
+    }
+
+    /// Every shape the pre-pass has to agree with the pairwise reference on:
+    /// clean records, a repeated evidence id, a shared entry id under distinct
+    /// evidence ids, touching and nested ranges, equal ranges in *different*
+    /// artifacts (which never meet), a missing bound, and an inverted range,
+    /// which meets a range that spans it but not one that does not.
+    #[test]
+    fn the_identity_pre_pass_reproduces_the_pairwise_definition() {
+        let bundle = bundle_of(vec![
+            evidence("a1", "art-a", "a1", Some(1), Some(2)),
+            evidence("a2", "art-a", "a2", Some(3), Some(4)),
+            evidence("a3", "art-a", "a3", Some(4), Some(9)),
+            evidence("a4", "art-a", "a4", Some(20), Some(40)),
+            evidence("a5", "art-a", "a5", Some(25), Some(30)),
+            evidence("a6", "art-a", "a6", Some(60), Some(60)),
+            evidence("a6", "art-a", "a7", Some(70), Some(70)),
+            evidence("a8", "art-a", "shared", Some(80), Some(80)),
+            evidence("a9", "art-a", "shared", Some(90), Some(90)),
+            evidence("a10", "art-a", "a10", None, Some(100)),
+            evidence("a11", "art-a", "a11", Some(110), None),
+            evidence("a12", "art-a", "a12", Some(500), Some(400)),
+            evidence("a13", "art-a", "a13", Some(300), Some(600)),
+            evidence("a14", "art-a", "a14", Some(1000), Some(900)),
+            evidence("b1", "art-b", "b1", Some(1), Some(2)),
+            evidence("b2", "art-b", "b2", Some(3), Some(4)),
+        ]);
+
+        let expected = bundle
+            .evidence
+            .iter()
+            .map(|record| identity_is_unique_pairwise(&bundle, record))
+            .collect::<Vec<_>>();
+        assert_eq!(unique_evidence_identities(&bundle), expected);
+        // The reference itself has to be discriminating, or agreeing with it
+        // would prove nothing.
+        assert!(expected.iter().any(|unique| *unique));
+        assert!(expected.iter().any(|unique| !*unique));
+    }
+
+    #[test]
+    fn the_identity_pre_pass_agrees_on_a_bundle_with_no_collisions() {
+        let bundle = bundle_of(
+            (0..64u32)
+                .map(|index| {
+                    let line = index * 2 + 1;
+                    evidence(
+                        &format!("clean-{index}"),
+                        "art-a",
+                        &format!("clean-{index}"),
+                        Some(line),
+                        Some(line),
+                    )
+                })
+                .collect(),
+        );
+
+        let expected = bundle
+            .evidence
+            .iter()
+            .map(|record| identity_is_unique_pairwise(&bundle, record))
+            .collect::<Vec<_>>();
+        assert!(expected.iter().all(|unique| *unique));
+        assert_eq!(unique_evidence_identities(&bundle), expected);
     }
 }

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
@@ -321,21 +321,12 @@ pub fn analyze_site_core(bundle: &SccmSiteCoreBundle) -> SccmSiteCoreAnalysis {
     let facts = collect_facts(&context, site_code.as_deref());
     let fragments = collect_fragments(&context);
     let coverage_gaps = collect_coverage_gaps(&context, &fragments);
-
-    let fragment_artifact_ids = fragments
-        .iter()
-        .map(|fragment| fragment.evidence.artifact_id.as_str())
-        .collect::<BTreeSet<_>>();
-    let transaction_gap_ids = coverage_gaps
-        .iter()
-        .map(|gap| gap.artifact_id.clone())
-        .filter(|artifact_id| !fragment_artifact_ids.contains(artifact_id.as_str()))
-        .collect::<Vec<_>>();
+    let coverage = CoverageView::new(&coverage_gaps, &fragments);
 
     let mut results = Vec::new();
     let mut findings = Vec::new();
     for (key, facts) in group_facts(facts) {
-        let reduced = reduce_transaction(&context, key, &facts, &transaction_gap_ids);
+        let reduced = reduce_transaction(&context, &coverage, key, &facts);
         if let Some(finding) = reduced.finding {
             findings.push(finding);
         }
@@ -343,7 +334,12 @@ pub fn analyze_site_core(bundle: &SccmSiteCoreBundle) -> SccmSiteCoreAnalysis {
     }
 
     let mut unlinked_observations = Vec::new();
-    append_fragment_observations(&fragments, &mut unlinked_observations, &mut findings);
+    append_fragment_observations(
+        &fragments,
+        &coverage,
+        &mut unlinked_observations,
+        &mut findings,
+    );
 
     results.sort_by(|left, right| left.result_id.cmp(&right.result_id));
     unlinked_observations.sort_by(|left, right| left.observation_id.cmp(&right.observation_id));
@@ -758,10 +754,11 @@ struct ReducedTransaction {
 
 fn reduce_transaction(
     context: &SiteCoreContext<'_>,
+    coverage: &CoverageView<'_>,
     key: SccmSiteCoreTransactionKey,
     facts: &[SiteCoreFact],
-    coverage_gap_artifact_ids: &[String],
 ) -> ReducedTransaction {
+    let coverage_gap_artifact_ids = coverage.transaction_gap_ids.as_slice();
     let chronology_usable = facts.iter().all(|fact| fact.ordering_millis().is_some());
     let conflicting = has_same_instant_conflict(facts);
 
@@ -844,7 +841,7 @@ fn reduce_transaction(
     );
     let finding = candidate_class.and_then(|class| {
         build_finding(
-            context,
+            coverage,
             TransactionFinding {
                 subject_id: &result_id,
                 class,
@@ -1031,11 +1028,20 @@ struct FragmentArtifact {
 /// its physical range. The unparsed tail is cited by its physical line range;
 /// the reference can never collide with a parsed record because it starts
 /// after the last complete record.
+///
+/// The producer gate applies here for the same reason it applies to facts: an
+/// unparsed region of a family this profile has no validated producer for says
+/// nothing about the family's records, only that bytes were collected. Reading
+/// it as a source anomaly would let an unsupported family reach a diagnosis
+/// through the fragment path that the fact path denies it.
 fn collect_fragments(context: &SiteCoreContext<'_>) -> Vec<FragmentArtifact> {
     let mut fragments = context
         .sources
         .values()
-        .filter(|admitted| admitted.source.artifact.coverage == SccmCoverageState::Captured)
+        .filter(|admitted| {
+            admitted.producer.is_some()
+                && admitted.source.artifact.coverage == SccmCoverageState::Captured
+        })
         .filter_map(|admitted| {
             let tail = truncated_tail(context.bundle, admitted)?;
             Some(FragmentArtifact {
@@ -1112,11 +1118,20 @@ fn collect_coverage_gaps(
                 (SccmCoverageState::Unsupported, None)
             }
             // An interpretable source that produced no complete record for
-            // part of its range.
-            (Some(_), SccmCoverageState::Captured) => match fragment_by_artifact.get(artifact_id) {
-                Some(evidence) => (SccmCoverageState::ParseFailed, Some(evidence.clone())),
-                None => continue,
-            },
+            // part of its range. The unparsed tail is cited where there is one,
+            // but a source the manifest already declares incomplete is a gap
+            // whether or not the incompleteness left a tail behind: the same
+            // flag withholds its facts in `source_carries_facts`.
+            (Some(_), SccmCoverageState::Captured) => {
+                match (
+                    fragment_by_artifact.get(artifact_id),
+                    source.fragment_complete,
+                ) {
+                    (Some(evidence), _) => (SccmCoverageState::ParseFailed, Some(evidence.clone())),
+                    (None, Some(false)) => (SccmCoverageState::ParseFailed, None),
+                    (None, _) => continue,
+                }
+            }
             (Some(admitted), SccmCoverageState::Capped) => (
                 SccmCoverageState::Capped,
                 truncated_tail(context.bundle, admitted),
@@ -1140,6 +1155,59 @@ fn collect_coverage_gaps(
     gaps.into_values().collect()
 }
 
+/// The single coverage view every downstream claim reads.
+///
+/// `collect_coverage_gaps` decides what each artifact's coverage state is, and
+/// nothing after it re-derives that from the manifest. A finding that cited a
+/// state of its own would let the analysis publish two answers for one
+/// artifact, and the one inside the finding is the one a reader trusts.
+struct CoverageView<'a> {
+    states: BTreeMap<&'a str, SccmCoverageState>,
+    /// Gaps a transaction cites. A fragment artifact is excluded because its
+    /// unparsed region is already carried by its own source-local observation.
+    transaction_gap_ids: Vec<String>,
+}
+
+impl<'a> CoverageView<'a> {
+    fn new(gaps: &'a [SccmSiteCoreCoverageGap], fragments: &[FragmentArtifact]) -> Self {
+        let fragment_artifact_ids = fragments
+            .iter()
+            .map(|fragment| fragment.evidence.artifact_id.as_str())
+            .collect::<BTreeSet<_>>();
+        Self {
+            states: gaps
+                .iter()
+                .map(|gap| (gap.artifact_id.as_str(), gap.state.clone()))
+                .collect(),
+            transaction_gap_ids: gaps
+                .iter()
+                .map(|gap| gap.artifact_id.clone())
+                .filter(|artifact_id| !fragment_artifact_ids.contains(artifact_id.as_str()))
+                .collect(),
+        }
+    }
+
+    /// Project one published gap onto the shared finding contract. An artifact
+    /// with no published gap has nothing to cite, so it contributes nothing.
+    fn finding_gap(&self, artifact_id: &str) -> Option<SccmFindingCoverageGap> {
+        Some(SccmFindingCoverageGap {
+            artifact_id: artifact_id.to_owned(),
+            role: SccmRole::SiteServer,
+            coverage: self.states.get(artifact_id)?.clone(),
+        })
+    }
+
+    fn finding_gaps<'b>(
+        &self,
+        artifact_ids: impl IntoIterator<Item = &'b String>,
+    ) -> Vec<SccmFindingCoverageGap> {
+        artifact_ids
+            .into_iter()
+            .filter_map(|artifact_id| self.finding_gap(artifact_id))
+            .collect()
+    }
+}
+
 /// Fragment observations are source-local: they never advance a phase, join a
 /// record across a rotation boundary, or infer a terminal outcome.
 ///
@@ -1149,6 +1217,7 @@ fn collect_coverage_gaps(
 /// it is reported as a low-confidence symptom and never as a fact.
 fn append_fragment_observations(
     fragments: &[FragmentArtifact],
+    coverage: &CoverageView<'_>,
     observations: &mut Vec<SccmSiteCoreObservation>,
     findings: &mut Vec<SccmSiteCoreFinding>,
 ) {
@@ -1190,6 +1259,7 @@ fn append_fragment_observations(
             SccmSiteCoreConfidence::None,
             rotation_boundary,
             rotation_boundary_requests,
+            coverage,
         ) {
             observations.push(observation);
             findings.push(finding);
@@ -1203,6 +1273,7 @@ fn append_fragment_observations(
             SccmSiteCoreConfidence::Low,
             group_fragments,
             requests,
+            coverage,
         ) {
             observations.push(observation);
             findings.push(finding);
@@ -1222,6 +1293,7 @@ fn build_observation(
     confidence: SccmSiteCoreConfidence,
     fragments: Vec<&FragmentArtifact>,
     mut next_artifacts: Vec<SccmSiteCoreArtifactRequest>,
+    coverage: &CoverageView<'_>,
 ) -> Option<(SccmSiteCoreObservation, SccmSiteCoreFinding)> {
     let mut evidence = fragments
         .iter()
@@ -1238,14 +1310,7 @@ fn build_observation(
     next_artifacts.sort_by(|left, right| left.sort_key().cmp(&right.sort_key()));
     next_artifacts.dedup();
 
-    let gaps = coverage_gap_artifact_ids
-        .iter()
-        .map(|artifact_id| SccmFindingCoverageGap {
-            artifact_id: artifact_id.clone(),
-            role: SccmRole::SiteServer,
-            coverage: SccmCoverageState::ParseFailed,
-        })
-        .collect::<Vec<_>>();
+    let gaps = coverage.finding_gaps(&coverage_gap_artifact_ids);
     let finding = build_observation_finding(
         observation_id,
         class.clone(),
@@ -1341,7 +1406,7 @@ struct TransactionFinding<'a> {
 }
 
 fn build_finding(
-    context: &SiteCoreContext<'_>,
+    coverage: &CoverageView<'_>,
     subject: TransactionFinding<'_>,
 ) -> Option<SccmSiteCoreFinding> {
     let cited = subject
@@ -1357,11 +1422,7 @@ fn build_finding(
         }
         _ => Vec::new(),
     };
-    let gaps = subject
-        .coverage_gap_artifact_ids
-        .iter()
-        .filter_map(|artifact_id| finding_gap(context.bundle, artifact_id))
-        .collect::<Vec<_>>();
+    let gaps = coverage.finding_gaps(subject.coverage_gap_artifact_ids);
     let summary = match subject.last_successful_phase {
         Some(phase) => format!(
             "The last confirmed successful phase is {}; later phases are bounded to cited evidence.",
@@ -1428,22 +1489,6 @@ fn build_observation_finding(
         finding,
         subject_id: subject_id.to_owned(),
         last_successful_phase: None,
-    })
-}
-
-fn finding_gap(bundle: &SccmSiteCoreBundle, artifact_id: &str) -> Option<SccmFindingCoverageGap> {
-    let source = bundle
-        .sources
-        .iter()
-        .find(|source| source.artifact.artifact_id == artifact_id)?;
-    let coverage = match source.artifact.coverage {
-        SccmCoverageState::Captured => SccmCoverageState::ParseFailed,
-        ref state => state.clone(),
-    };
-    Some(SccmFindingCoverageGap {
-        artifact_id: artifact_id.to_owned(),
-        role: SccmRole::SiteServer,
-        coverage,
     })
 }
 

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
@@ -47,9 +47,14 @@ pub const SCCM_SITE_CORE_STATUS_GROUP: &str = "server-status";
 
 /// The only ConfigMgr build this profile is validated against.
 const SITE_CORE_PROFILE_VERSION_TOKEN: &str = "5.00.TEST";
-/// Producer component recorded by each admitted source family.
-const COMPONENT_PRODUCER: &str = "SMS_SITE_COMPONENT_MANAGER";
-const STATUS_PRODUCER: &str = "SMS_STATUS_MANAGER";
+/// Producer components this profile is validated against. `hman.log` and
+/// `statesys.log` are declared members of the same groups, but no fixture
+/// validates the component they record, so they carry no entry here and can
+/// only become coverage.
+const VALIDATED_PRODUCERS: [(&str, &str); 2] = [
+    ("sitecomp", "SMS_SITE_COMPONENT_MANAGER"),
+    ("statmgr", "SMS_STATUS_MANAGER"),
+];
 /// Floor for a bounded recapture request after a capture limit truncated a
 /// source. Requests never ask for an unbounded file.
 const RECAPTURE_FLOOR_BYTES: u64 = 4096;
@@ -401,13 +406,6 @@ impl SiteCoreGroup {
         }
     }
 
-    fn producer(self) -> &'static str {
-        match self {
-            Self::Component => COMPONENT_PRODUCER,
-            Self::Status => STATUS_PRODUCER,
-        }
-    }
-
     fn family(self) -> SccmArtifactFamily {
         match self {
             Self::Component => SccmArtifactFamily::SiteComponent,
@@ -439,11 +437,14 @@ impl SiteCoreGroup {
 }
 
 /// A source that passed shape admission: role, group, catalogued basename,
-/// family, rotation, lineage and profile version all agree.
+/// family, rotation, lineage and profile version all agree. `producer` is the
+/// component whose records this profile is validated to read; a shape-admitted
+/// source without one stays visible as coverage but can never yield a fact.
 struct AdmittedSource<'a> {
     source: &'a SccmSiteCoreSource,
     group: SiteCoreGroup,
     basename: String,
+    producer: Option<&'static str>,
 }
 
 /// Sources are filtered to the site-server role and the two declared site-core
@@ -491,10 +492,14 @@ fn admit_source<'a>(
             .any(|logical_name| *logical_name == classified.logical_name)
         && classified.rotation == source.artifact.rotation
         && classified.basename == source.rotation_lineage;
-    matches_group.then_some(AdmittedSource {
+    matches_group.then(|| AdmittedSource {
         source,
         group,
         basename: source.artifact.display_name.clone(),
+        producer: VALIDATED_PRODUCERS
+            .iter()
+            .find(|(logical_name, _)| *logical_name == classified.logical_name)
+            .map(|(_, producer)| *producer),
     })
 }
 
@@ -654,6 +659,9 @@ fn collect_facts(context: &SiteCoreContext<'_>, site_code: Option<&str>) -> Vec<
 /// `capped` are coverage-only. A captured source that still carries an
 /// incomplete region is a fragment, not a fact source.
 fn source_carries_facts(admitted: &AdmittedSource<'_>) -> bool {
+    if admitted.producer.is_none() {
+        return false;
+    }
     match admitted.source.artifact.coverage {
         SccmCoverageState::Captured => admitted.source.fragment_complete != Some(false),
         SccmCoverageState::Capped => true,
@@ -666,7 +674,7 @@ fn parse_fact(
     admitted: &AdmittedSource<'_>,
     site_code: &str,
 ) -> Option<SiteCoreFact> {
-    if evidence.component.as_deref() != Some(admitted.group.producer()) {
+    if evidence.component.as_deref() != admitted.producer {
         return None;
     }
     let message = evidence.message.as_str();
@@ -1088,6 +1096,13 @@ fn collect_coverage_gaps(
         let artifact_id = source.artifact.artifact_id.as_str();
         let admitted = context.sources.get(artifact_id);
         let (state, evidence) = match (admitted, &source.artifact.coverage) {
+            // A declared source family this profile has no validated producer
+            // for. Its bytes are coverage, never a component outcome.
+            (Some(admitted), SccmCoverageState::Captured | SccmCoverageState::Capped)
+                if admitted.producer.is_none() =>
+            {
+                (SccmCoverageState::Unsupported, None)
+            }
             // An interpretable source that produced no complete record for
             // part of its range.
             (Some(_), SccmCoverageState::Captured) => match fragment_by_artifact.get(artifact_id) {

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/site_core.rs
@@ -786,7 +786,7 @@ fn reduce_transaction(
                 && success.ordering_millis() > failure.ordering_millis()
     );
 
-    let (state, finding_class, base_confidence, decisive) = if conflicting {
+    let (state, candidate_class, base_confidence, decisive) = if conflicting {
         (
             SccmSiteCoreState::Incomplete,
             Some(SccmFindingClass::InsufficientEvidence),
@@ -842,7 +842,7 @@ fn reduce_transaction(
         "site-core/{}/{}/{}",
         key.site_code, key.component_id, key.work_item_id
     );
-    let finding = finding_class.clone().and_then(|class| {
+    let finding = candidate_class.and_then(|class| {
         build_finding(
             context,
             TransactionFinding {
@@ -862,6 +862,14 @@ fn reduce_transaction(
             },
         )
     });
+    // The class a consumer reads is a projection of the finding that was
+    // actually emitted, never a parallel claim about one. A class the shared
+    // contract refused to validate is withdrawn with its finding: the state,
+    // the cited evidence and the next-artifact request still say what is known
+    // and what is missing, which is the whole of what the reducer can prove.
+    let finding_class = finding
+        .as_ref()
+        .map(|emitted| emitted.finding.class.clone());
 
     ReducedTransaction {
         result: SccmSiteCoreResult {
@@ -1175,31 +1183,38 @@ fn append_fragment_observations(
     }
 
     if !rotation_boundary.is_empty() {
-        let (observation, finding) = build_observation(
+        if let Some((observation, finding)) = build_observation(
             "rotation-boundary-fragments",
             SiteCoreGroup::Component,
             SccmFindingClass::InsufficientEvidence,
             SccmSiteCoreConfidence::None,
             rotation_boundary,
             rotation_boundary_requests,
-        );
-        observations.push(observation);
-        findings.extend(finding);
+        ) {
+            observations.push(observation);
+            findings.push(finding);
+        }
     }
     for (group, (group_fragments, requests)) in malformed {
-        let (observation, finding) = build_observation(
+        if let Some((observation, finding)) = build_observation(
             &format!("malformed-{}-record", group.slug()),
             group,
             SccmFindingClass::Symptom,
             SccmSiteCoreConfidence::Low,
             group_fragments,
             requests,
-        );
-        observations.push(observation);
-        findings.extend(finding);
+        ) {
+            observations.push(observation);
+            findings.push(finding);
+        }
     }
 }
 
+/// An observation always names a finding class, so it is published only
+/// together with the finding that carries it. If the shared contract refuses
+/// the finding, the fragment is still reported as a coverage gap by
+/// `collect_coverage_gaps`; what is withheld is the classification, not the
+/// artifact.
 fn build_observation(
     observation_id: &str,
     group: SiteCoreGroup,
@@ -1207,7 +1222,7 @@ fn build_observation(
     confidence: SccmSiteCoreConfidence,
     fragments: Vec<&FragmentArtifact>,
     mut next_artifacts: Vec<SccmSiteCoreArtifactRequest>,
-) -> (SccmSiteCoreObservation, Option<SccmSiteCoreFinding>) {
+) -> Option<(SccmSiteCoreObservation, SccmSiteCoreFinding)> {
     let mut evidence = fragments
         .iter()
         .map(|fragment| fragment.evidence.clone())
@@ -1239,20 +1254,20 @@ fn build_observation(
         &evidence,
         gaps,
         &next_artifacts,
-    );
+    )?;
 
     let observation = SccmSiteCoreObservation {
         observation_id: observation_id.to_owned(),
         state: SccmSiteCoreState::ParseGap,
         last_successful_phase: None,
-        finding_class: class,
+        finding_class: finding.finding.class.clone(),
         confidence,
         confidence_ceiling: confidence,
         evidence,
         coverage_gap_artifact_ids,
         next_artifacts,
     };
-    (observation, finding)
+    Some((observation, finding))
 }
 
 fn fragment_request(

--- a/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
@@ -1,0 +1,634 @@
+//! Contract tests for the issue #327 site-core and status-system reducer.
+//!
+//! The merged fixture corpus under `tests/fixtures/sccm/server/site_core` is the
+//! specification: every scenario declares the transactions, findings, coverage
+//! states and evidence citations `analyze_site_core` must produce. These tests
+//! read that corpus and assert the reducer reproduces it exactly.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use cmtraceopen_parser::sccm::server::windows::{
+    analyze_site_core, SccmSiteCoreBundle, SccmSiteCoreSource, SccmSiteCoreTopology,
+};
+use cmtraceopen_parser::sccm::{
+    normalize_ccm_artifact, SccmArtifact, SccmCoverageState, SccmEvidence, SccmRole, SccmRotation,
+};
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+
+const FIXTURE_ROOT: &str = "tests/fixtures/sccm/server/site_core";
+const SCENARIOS: &[&str] = &[
+    "component-failure",
+    "contradictory",
+    "healthy",
+    "inbox-backlog",
+    "incomplete",
+    "malformed",
+    "recovery",
+    "rotation-boundary",
+    "status-processing-failure",
+];
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FixtureManifest {
+    topology: FixtureTopology,
+    artifacts: Vec<FixtureArtifact>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FixtureTopology {
+    site_code: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FixtureArtifact {
+    artifact_id: String,
+    role: String,
+    source_group: String,
+    original_basename: String,
+    rotation: FixtureRotation,
+    rotation_lineage: String,
+    capture_state: String,
+    capture_limit_bytes: Option<u64>,
+    source_version: Option<String>,
+    collected_utc: Option<String>,
+    encoding: Option<String>,
+    relative_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FixtureRotation {
+    kind: String,
+    fragment_complete: Option<bool>,
+}
+
+fn fixture_directory(scenario: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(FIXTURE_ROOT)
+        .join(scenario)
+}
+
+fn load_json(path: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(path).expect("fixture JSON must be readable"))
+        .expect("fixture JSON must be valid")
+}
+
+fn coverage_state(value: &str) -> SccmCoverageState {
+    match value {
+        "captured" => SccmCoverageState::Captured,
+        "absent" => SccmCoverageState::Absent,
+        "accessDenied" => SccmCoverageState::AccessDenied,
+        "capped" => SccmCoverageState::Capped,
+        "skipped" => SccmCoverageState::Skipped,
+        "unsupported" => SccmCoverageState::Unsupported,
+        "parseFailed" => SccmCoverageState::ParseFailed,
+        other => panic!("unsupported fixture coverage state {other}"),
+    }
+}
+
+fn rotation(value: &FixtureRotation) -> SccmRotation {
+    match value.kind.as_str() {
+        "current" => SccmRotation::Current,
+        "loUnderscore" => SccmRotation::LoUnderscore,
+        other => panic!("unsupported site-core fixture rotation {other}"),
+    }
+}
+
+fn load_bundle(scenario: &str) -> SccmSiteCoreBundle {
+    let directory = fixture_directory(scenario);
+    let manifest: FixtureManifest =
+        serde_json::from_value(load_json(&directory.join("manifest.json")))
+            .expect("fixture manifest must match its declared contract");
+
+    let mut sources = Vec::new();
+    let mut evidence = Vec::new();
+    for source in manifest.artifacts {
+        let producer_role = match source.role.as_str() {
+            "siteServer" => SccmRole::SiteServer,
+            other => panic!("unsupported site-core fixture producer role {other}"),
+        };
+        let artifact = SccmArtifact {
+            artifact_id: source.artifact_id,
+            display_name: source.original_basename,
+            original_path: None,
+            host: None,
+            role: producer_role,
+            configmgr_version: source.source_version,
+            collected_at_utc: source.collected_utc,
+            rotation: rotation(&source.rotation),
+            coverage: coverage_state(&source.capture_state),
+            encoding: source.encoding,
+        };
+
+        let physical_line_end = source.relative_path.map(|relative_path| {
+            let content = fs::read_to_string(directory.join(relative_path))
+                .expect("captured site-core evidence must be readable UTF-8");
+            let line_count = u32::try_from(content.lines().count())
+                .expect("synthetic fixture line count must fit in u32");
+            evidence.extend(normalize_ccm_artifact(artifact.clone(), &content));
+            line_count.max(1)
+        });
+
+        sources.push(SccmSiteCoreSource {
+            artifact,
+            source_group: source.source_group,
+            rotation_lineage: source.rotation_lineage,
+            fragment_complete: source.rotation.fragment_complete,
+            physical_line_end,
+            capture_limit_bytes: source.capture_limit_bytes,
+        });
+    }
+
+    sources.sort_by(|left, right| left.artifact.artifact_id.cmp(&right.artifact.artifact_id));
+    evidence.sort_by(|left, right| left.evidence_id.cmp(&right.evidence_id));
+    SccmSiteCoreBundle {
+        topology: SccmSiteCoreTopology {
+            site_code: manifest.topology.site_code,
+        },
+        sources,
+        evidence,
+    }
+}
+
+fn analysis_value(bundle: &SccmSiteCoreBundle) -> Value {
+    serde_json::to_value(analyze_site_core(bundle))
+        .expect("site-core analysis must serialize under the shared finding contract")
+}
+
+/// The corpus omits `completeLogicalRecord` on the rotation-boundary coverage
+/// gap evidence while declaring it on the malformed and capped gaps. The
+/// reducer emits the flag uniformly, so gap evidence is compared without it and
+/// the stronger uniform invariant is asserted separately.
+fn gap_evidence_without_completeness(value: &Value) -> Value {
+    let mut object = value
+        .as_object()
+        .expect("coverage gap evidence must be an object")
+        .clone();
+    object.remove("completeLogicalRecord");
+    Value::Object(object)
+}
+
+fn normalized_coverage_gaps(value: &Value) -> Vec<Value> {
+    value
+        .as_array()
+        .expect("coverage gaps must be an array")
+        .iter()
+        .map(|gap| {
+            let mut object = gap
+                .as_object()
+                .expect("coverage gap must be an object")
+                .clone();
+            if let Some(evidence) = object.get("evidence") {
+                let normalized = gap_evidence_without_completeness(evidence);
+                object.insert("evidence".to_owned(), normalized);
+            }
+            Value::Object(object)
+        })
+        .collect()
+}
+
+fn projected_section(value: &Value, key: &str) -> Value {
+    value
+        .get(key)
+        .cloned()
+        .unwrap_or_else(|| panic!("analysis must expose {key}"))
+}
+
+fn result_projection(value: &Value) -> Value {
+    let entry = value.as_object().expect("result must be an object");
+    json!({
+        "resultId": entry["resultId"],
+        "transactionKey": entry["transactionKey"],
+        "state": entry["state"],
+        "lastSuccessfulPhase": entry["lastSuccessfulPhase"],
+        "findingClass": entry["findingClass"],
+        "confidence": entry["confidence"],
+        "confidenceCeiling": entry["confidenceCeiling"],
+        "evidence": entry["evidence"],
+        "coverageGapArtifactIds": entry["coverageGapArtifactIds"],
+        "nextArtifacts": entry["nextArtifacts"],
+    })
+}
+
+fn observation_projection(value: &Value) -> Value {
+    let entry = value.as_object().expect("observation must be an object");
+    json!({
+        "observationId": entry["observationId"],
+        "state": entry["state"],
+        "lastSuccessfulPhase": entry["lastSuccessfulPhase"],
+        "findingClass": entry["findingClass"],
+        "confidence": entry["confidence"],
+        "confidenceCeiling": entry["confidenceCeiling"],
+        "evidence": entry["evidence"],
+        "coverageGapArtifactIds": entry["coverageGapArtifactIds"],
+        "nextArtifacts": entry["nextArtifacts"],
+    })
+}
+
+fn project_all(value: &Value, key: &str, projector: fn(&Value) -> Value) -> Vec<Value> {
+    projected_section(value, key)
+        .as_array()
+        .unwrap_or_else(|| panic!("{key} must be an array"))
+        .iter()
+        .map(projector)
+        .collect()
+}
+
+fn expected_all(expected: &Value, key: &str, projector: fn(&Value) -> Value) -> Vec<Value> {
+    expected[key]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected {key} must be an array"))
+        .iter()
+        .map(projector)
+        .collect()
+}
+
+#[test]
+fn site_core_reproduces_every_merged_corpus_scenario() {
+    for scenario in SCENARIOS {
+        let bundle = load_bundle(scenario);
+        let analysis = analysis_value(&bundle);
+        let expected = load_json(&fixture_directory(scenario).join("expected.json"));
+
+        assert_eq!(
+            projected_section(&analysis, "profile"),
+            expected["profile"],
+            "{scenario}: analyzer profile"
+        );
+        assert_eq!(
+            projected_section(&analysis, "prohibitedClaims"),
+            expected["prohibitedClaims"],
+            "{scenario}: prohibited claims"
+        );
+        assert_eq!(
+            project_all(&analysis, "results", result_projection),
+            expected_all(&expected, "results", result_projection),
+            "{scenario}: results"
+        );
+        assert_eq!(
+            project_all(&analysis, "unlinkedObservations", observation_projection),
+            expected_all(&expected, "unlinkedObservations", observation_projection),
+            "{scenario}: unlinked observations"
+        );
+        assert_eq!(
+            normalized_coverage_gaps(&projected_section(&analysis, "coverageGaps")),
+            normalized_coverage_gaps(&expected["coverageGaps"]),
+            "{scenario}: coverage gaps"
+        );
+        assert_eq!(
+            analysis["crossSideCorrelationPerformed"],
+            Value::Bool(false),
+            "{scenario}: the role-local analyzer must never correlate across sides"
+        );
+    }
+}
+
+#[test]
+fn every_coverage_gap_evidence_is_marked_incomplete() {
+    for scenario in SCENARIOS {
+        let analysis = analysis_value(&load_bundle(scenario));
+        for gap in analysis["coverageGaps"]
+            .as_array()
+            .expect("coverage gaps must be an array")
+        {
+            let Some(evidence) = gap.get("evidence").filter(|value| !value.is_null()) else {
+                continue;
+            };
+            assert_eq!(
+                evidence["completeLogicalRecord"],
+                Value::Bool(false),
+                "{scenario}: coverage gap evidence must never claim a complete logical record"
+            );
+        }
+    }
+}
+
+#[test]
+fn evidence_flags_stay_within_the_declared_corpus_vocabulary() {
+    let allowed = ["artifactId", "entryId", "lineStart", "lineEnd"]
+        .into_iter()
+        .chain(["terminal", "recovery", "completeLogicalRecord"])
+        .collect::<BTreeSet<_>>();
+    for scenario in SCENARIOS {
+        let analysis = analysis_value(&load_bundle(scenario));
+        let mut queue = vec![analysis];
+        while let Some(value) = queue.pop() {
+            match value {
+                Value::Array(items) => queue.extend(items),
+                Value::Object(fields) => {
+                    if fields.contains_key("entryId") && fields.contains_key("artifactId") {
+                        for key in fields.keys() {
+                            assert!(
+                                allowed.contains(key.as_str()),
+                                "{scenario}: evidence carries undeclared field {key}"
+                            );
+                        }
+                    }
+                    queue.extend(fields.into_iter().map(|(_, value)| value));
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[test]
+fn declared_adversarial_assertions_hold() {
+    for scenario in SCENARIOS {
+        let expected = load_json(&fixture_directory(scenario).join("expected.json"));
+        let Some(assertions) = expected
+            .get("adversarialAssertions")
+            .and_then(Value::as_object)
+        else {
+            continue;
+        };
+        let analysis = analysis_value(&load_bundle(scenario));
+        let results = analysis["results"].as_array().expect("results array");
+
+        for (assertion, value) in assertions {
+            match assertion.as_str() {
+                "resultCount" => assert_eq!(
+                    Value::from(results.len()),
+                    *value,
+                    "{scenario}: result count"
+                ),
+                "transactionCount" => assert_eq!(
+                    Value::from(results.len()),
+                    *value,
+                    "{scenario}: transaction count"
+                ),
+                "sameMinuteMayMerge" | "crossComponentRecovery" | "timeOnlyCausalClaim" => {
+                    assert_eq!(*value, Value::Bool(false), "{scenario}: {assertion}");
+                    let keys = results
+                        .iter()
+                        .map(|result| result["transactionKey"].to_string())
+                        .collect::<Vec<_>>();
+                    let distinct = keys.iter().collect::<BTreeSet<_>>();
+                    assert_eq!(
+                        keys.len(),
+                        distinct.len(),
+                        "{scenario}: transactions merged across component keys"
+                    );
+                }
+                "phaseMayAdvance" | "terminalMayBeInferred" | "confirmedFailure"
+                | "componentKeyAdmitted" | "crossRotationFragmentJoin" => {
+                    assert_eq!(*value, Value::Bool(false), "{scenario}: {assertion}");
+                    assert!(results.is_empty(), "{scenario}: {assertion}");
+                }
+                "highConfidenceCause" => {
+                    assert_eq!(*value, Value::Bool(false), "{scenario}: {assertion}");
+                    for observation in analysis["unlinkedObservations"]
+                        .as_array()
+                        .expect("observations array")
+                    {
+                        assert_ne!(
+                            observation["confidence"],
+                            Value::String("high".to_owned()),
+                            "{scenario}: fragment observation claimed high confidence"
+                        );
+                    }
+                }
+                other => panic!("{scenario}: unhandled adversarial assertion {other}"),
+            }
+        }
+    }
+}
+
+#[test]
+fn every_classified_outcome_carries_a_validated_shared_finding() {
+    for scenario in SCENARIOS {
+        let analysis = analysis_value(&load_bundle(scenario));
+        let findings = analysis["findings"].as_array().expect("findings array");
+
+        for subject in analysis["results"]
+            .as_array()
+            .expect("results array")
+            .iter()
+            .map(|result| (result["resultId"].clone(), result["findingClass"].clone()))
+            .chain(
+                analysis["unlinkedObservations"]
+                    .as_array()
+                    .expect("observations array")
+                    .iter()
+                    .map(|observation| {
+                        (
+                            observation["observationId"].clone(),
+                            observation["findingClass"].clone(),
+                        )
+                    }),
+            )
+        {
+            let (subject_id, finding_class) = subject;
+            let matching = findings
+                .iter()
+                .filter(|finding| finding["subjectId"] == subject_id)
+                .collect::<Vec<_>>();
+            if finding_class.is_null() {
+                assert!(
+                    matching.is_empty(),
+                    "{scenario}: healthy subject {subject_id} must not raise a finding"
+                );
+                continue;
+            }
+            assert_eq!(
+                matching.len(),
+                1,
+                "{scenario}: subject {subject_id} must raise exactly one finding"
+            );
+            let finding = matching[0];
+            assert_eq!(
+                finding["class"], finding_class,
+                "{scenario}: subject {subject_id} finding class"
+            );
+            assert_eq!(
+                finding["role"],
+                Value::String("siteServer".to_owned()),
+                "{scenario}: subject {subject_id} finding role"
+            );
+            assert!(
+                !finding["evidence"]
+                    .as_array()
+                    .expect("finding evidence array")
+                    .is_empty()
+                    || !finding["coverageGaps"]
+                        .as_array()
+                        .expect("finding coverage gaps array")
+                        .is_empty(),
+                "{scenario}: subject {subject_id} finding cites nothing"
+            );
+        }
+    }
+}
+
+#[test]
+fn analysis_is_independent_of_source_and_evidence_order() {
+    for scenario in SCENARIOS {
+        let bundle = load_bundle(scenario);
+        let mut reversed = load_bundle(scenario);
+        reversed.sources.reverse();
+        reversed.evidence.reverse();
+
+        assert_eq!(
+            serde_json::to_string(&analyze_site_core(&bundle)).expect("analysis serializes"),
+            serde_json::to_string(&analyze_site_core(&reversed)).expect("analysis serializes"),
+            "{scenario}: analysis depends on input order"
+        );
+    }
+}
+
+#[test]
+fn duplicate_artifact_identity_is_rejected_rather_than_selected_by_order() {
+    let mut bundle = load_bundle("healthy");
+    let duplicate = bundle
+        .sources
+        .iter()
+        .find(|source| source.source_group == "server-sitecomp")
+        .expect("healthy bundle declares a sitecomp source")
+        .clone();
+    bundle.sources.push(duplicate);
+
+    let analysis = analyze_site_core(&bundle);
+    assert!(
+        analysis.results.is_empty(),
+        "a duplicated artifact identity must fail closed instead of selecting by vector order"
+    );
+}
+
+#[test]
+fn colliding_evidence_identity_is_rejected() {
+    let mut bundle = load_bundle("healthy");
+    let collision = bundle
+        .evidence
+        .first()
+        .cloned()
+        .expect("healthy bundle carries evidence");
+    bundle.evidence.push(collision);
+
+    let analysis = analyze_site_core(&bundle);
+    assert!(
+        analysis
+            .results
+            .iter()
+            .all(|result| result.evidence.iter().all(|evidence| evidence.entry_id
+                != bundle.evidence[0].reference.entry_id)),
+        "a colliding evidence identity must never be admitted as a fact"
+    );
+}
+
+#[test]
+fn evidence_from_another_role_is_never_admitted() {
+    let mut bundle = load_bundle("healthy");
+    for source in &mut bundle.sources {
+        source.artifact.role = SccmRole::ManagementPoint;
+    }
+    for evidence in &mut bundle.evidence {
+        evidence.role = SccmRole::ManagementPoint;
+    }
+
+    let analysis = analyze_site_core(&bundle);
+    assert!(
+        analysis.results.is_empty(),
+        "site-core must only reduce site-server produced evidence"
+    );
+}
+
+#[test]
+fn unusable_chronology_downgrades_confidence_instead_of_confirming() {
+    let mut bundle = load_bundle("component-failure");
+    for evidence in &mut bundle.evidence {
+        evidence.timestamp.offset_minutes = None;
+        evidence.timestamp.utc_millis = None;
+        evidence.timestamp.ordering_state =
+            cmtraceopen_parser::sccm::SccmTimeOrderingState::OffsetMissing;
+    }
+
+    let analysis = analyze_site_core(&bundle);
+    let serialized = serde_json::to_value(&analysis).expect("analysis serializes");
+    for result in serialized["results"].as_array().expect("results array") {
+        assert_ne!(
+            result["confidence"],
+            Value::String("high".to_owned()),
+            "incomparable chronology must not support high confidence"
+        );
+    }
+}
+
+#[test]
+fn synthesized_fragment_references_never_collide_with_parsed_records() {
+    for scenario in SCENARIOS {
+        let bundle = load_bundle(scenario);
+        let parsed = bundle
+            .evidence
+            .iter()
+            .map(|evidence: &SccmEvidence| evidence.reference.entry_id.clone())
+            .collect::<BTreeSet<_>>();
+        let analysis = analysis_value(&bundle);
+        for gap in analysis["coverageGaps"]
+            .as_array()
+            .expect("coverage gaps array")
+        {
+            let Some(evidence) = gap.get("evidence").filter(|value| !value.is_null()) else {
+                continue;
+            };
+            let entry_id = evidence["entryId"].as_str().expect("gap evidence entry id");
+            assert!(
+                !parsed.contains(entry_id),
+                "{scenario}: synthesized gap reference {entry_id} collides with a parsed record"
+            );
+        }
+    }
+}
+
+#[test]
+fn requested_next_artifacts_stay_bounded_and_declared() {
+    let declared = ["server-sitecomp", "server-status"]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    for scenario in SCENARIOS {
+        let analysis = analysis_value(&load_bundle(scenario));
+        let requests = analysis["artifactRequests"]
+            .as_array()
+            .expect("artifact requests array");
+        for request in requests {
+            let logical_name = request["logicalName"]
+                .as_str()
+                .expect("request logical name");
+            assert!(
+                declared.contains(logical_name),
+                "{scenario}: request names an undeclared source group {logical_name}"
+            );
+            assert_eq!(
+                request["role"],
+                Value::String("siteServer".to_owned()),
+                "{scenario}: request role"
+            );
+            let basenames = request["basenames"].as_array().expect("request basenames");
+            let rotations = request["rotations"].as_array().expect("request rotations");
+            let max_artifacts = request["maxArtifacts"].as_u64().expect("request bound");
+            assert!(
+                !basenames.is_empty() && !rotations.is_empty() && max_artifacts > 0,
+                "{scenario}: request must be a bounded, concrete bundle"
+            );
+            assert!(
+                max_artifacts <= 4,
+                "{scenario}: request must stay the smallest next bundle"
+            );
+        }
+        let scoped = requests
+            .iter()
+            .map(|request| request["scope"].clone())
+            .collect::<Vec<_>>();
+        assert!(
+            scoped
+                .iter()
+                .all(|scope| scope.as_object().is_some_and(Map::is_empty).eq(&false)),
+            "{scenario}: every request must carry a correlation scope"
+        );
+    }
+}

--- a/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
@@ -376,8 +376,11 @@ fn declared_adversarial_assertions_hold() {
                         "{scenario}: transactions merged across component keys"
                     );
                 }
-                "phaseMayAdvance" | "terminalMayBeInferred" | "confirmedFailure"
-                | "componentKeyAdmitted" | "crossRotationFragmentJoin" => {
+                "phaseMayAdvance"
+                | "terminalMayBeInferred"
+                | "confirmedFailure"
+                | "componentKeyAdmitted"
+                | "crossRotationFragmentJoin" => {
                     assert_eq!(*value, Value::Bool(false), "{scenario}: {assertion}");
                     assert!(results.is_empty(), "{scenario}: {assertion}");
                 }
@@ -484,6 +487,17 @@ fn analysis_is_independent_of_source_and_evidence_order() {
 
 #[test]
 fn duplicate_artifact_identity_is_rejected_rather_than_selected_by_order() {
+    let baseline = analyze_site_core(&load_bundle("healthy"));
+    assert_eq!(
+        baseline
+            .results
+            .iter()
+            .map(|result| result.confidence)
+            .collect::<Vec<_>>(),
+        vec![cmtraceopen_parser::sccm::server::windows::SccmSiteCoreConfidence::High],
+        "the healthy baseline must be a high-confidence result"
+    );
+
     let mut bundle = load_bundle("healthy");
     let duplicate = bundle
         .sources
@@ -491,12 +505,28 @@ fn duplicate_artifact_identity_is_rejected_rather_than_selected_by_order() {
         .find(|source| source.source_group == "server-sitecomp")
         .expect("healthy bundle declares a sitecomp source")
         .clone();
+    let duplicated_id = duplicate.artifact.artifact_id.clone();
     bundle.sources.push(duplicate);
 
     let analysis = analyze_site_core(&bundle);
     assert!(
-        analysis.results.is_empty(),
-        "a duplicated artifact identity must fail closed instead of selecting by vector order"
+        analysis.results.iter().all(|result| result
+            .evidence
+            .iter()
+            .all(|evidence| evidence.artifact_id != duplicated_id)),
+        "an ambiguous artifact identity must never be resolved by vector order"
+    );
+    assert!(
+        analysis.results.iter().all(|result| result.confidence
+            != cmtraceopen_parser::sccm::server::windows::SccmSiteCoreConfidence::High),
+        "losing the ambiguous source must lower confidence rather than keep the prior claim"
+    );
+    assert!(
+        analysis
+            .coverage_gaps
+            .iter()
+            .any(|gap| gap.artifact_id == duplicated_id),
+        "the ambiguous source must be surfaced as an explicit coverage gap"
     );
 }
 
@@ -512,11 +542,10 @@ fn colliding_evidence_identity_is_rejected() {
 
     let analysis = analyze_site_core(&bundle);
     assert!(
-        analysis
-            .results
+        analysis.results.iter().all(|result| result
+            .evidence
             .iter()
-            .all(|result| result.evidence.iter().all(|evidence| evidence.entry_id
-                != bundle.evidence[0].reference.entry_id)),
+            .all(|evidence| evidence.entry_id != bundle.evidence[0].reference.entry_id)),
         "a colliding evidence identity must never be admitted as a fact"
     );
 }

--- a/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use cmtraceopen_parser::sccm::server::windows::{
     analyze_site_core, SccmSiteCoreBundle, SccmSiteCoreSource, SccmSiteCoreTopology,
@@ -833,6 +834,95 @@ fn synthesized_fragment_references_never_collide_with_parsed_records() {
             );
         }
     }
+}
+
+/// One captured sitecomp source carrying `records` distinct, well-formed,
+/// non-overlapping component records. Nothing collides, which is the ordinary
+/// case and the one a per-record rescan of the bundle cannot short-circuit.
+fn probe_bundle(records: u32) -> SccmSiteCoreBundle {
+    let artifact = SccmArtifact {
+        artifact_id: "probe-sitecomp-current".to_owned(),
+        display_name: "sitecomp.log".to_owned(),
+        original_path: None,
+        host: None,
+        role: SccmRole::SiteServer,
+        configmgr_version: Some("5.00.TEST".to_owned()),
+        collected_at_utc: Some("2026-07-30T14:01:00Z".to_owned()),
+        rotation: SccmRotation::Current,
+        coverage: SccmCoverageState::Captured,
+        encoding: Some("utf-8".to_owned()),
+    };
+    let mut content = String::new();
+    for index in 0..records {
+        content.push_str(&format!(
+            "<![LOG[profileId=sccm-site-core profileVersion=1 site=LAB \
+             componentId=SMS_EXECUTIVE workItemId=SC-{index} \
+             statusId=SC_COMPONENT_START_OK outcome=success terminal=false]LOG]!>\
+             <time=\"14:00:01.000+000\" date=\"07-30-2026\" \
+             component=\"SMS_SITE_COMPONENT_MANAGER\" context=\"\" type=\"1\" \
+             thread=\"101\" file=\"sitecomp.cpp:101\">\n"
+        ));
+    }
+    let evidence = normalize_ccm_artifact(artifact.clone(), &content);
+    assert_eq!(
+        evidence.len(),
+        records as usize,
+        "the probe source must frame one record per line"
+    );
+
+    SccmSiteCoreBundle {
+        topology: SccmSiteCoreTopology {
+            site_code: "LAB".to_owned(),
+        },
+        sources: vec![SccmSiteCoreSource {
+            artifact,
+            source_group: "server-sitecomp".to_owned(),
+            rotation_lineage: "sitecomp.log".to_owned(),
+            fragment_complete: None,
+            physical_line_end: Some(records.max(1)),
+            capture_limit_bytes: None,
+        }],
+        evidence,
+    }
+}
+
+/// The fastest of three reductions. The floor is the least noisy estimate of
+/// the work the reducer actually does on a shared machine.
+fn fastest_reduction(records: u32) -> Duration {
+    let bundle = probe_bundle(records);
+    (0..3)
+        .map(|_| {
+            let start = Instant::now();
+            let analysis = analyze_site_core(&bundle);
+            let elapsed = start.elapsed();
+            assert_eq!(
+                analysis.results.len(),
+                records as usize,
+                "every probe record must reduce to its own transaction"
+            );
+            elapsed
+        })
+        .min()
+        .expect("three samples were taken")
+}
+
+/// Admission asks an identity question of every record. Answered by rescanning
+/// the whole bundle per record it is quadratic, and a stock ConfigMgr server
+/// log holds tens of thousands of records per file, so the reducer becomes
+/// unusable on exactly the input it exists for.
+///
+/// The bound is on growth rather than on a wall clock, so a slow machine cannot
+/// fail it: quadrupling the record count multiplies quadratic work by about
+/// sixteen and linearithmic work by about four.
+#[test]
+fn admission_cost_grows_with_the_records_not_their_square() {
+    let baseline = fastest_reduction(1_000);
+    let quadrupled = fastest_reduction(4_000);
+    assert!(
+        quadrupled <= baseline * 6,
+        "quadrupling the records multiplied the reduction cost by {:.1} ({baseline:?} -> {quadrupled:?})",
+        quadrupled.as_secs_f64() / baseline.as_secs_f64()
+    );
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
@@ -469,6 +469,78 @@ fn every_classified_outcome_carries_a_validated_shared_finding() {
     }
 }
 
+/// A subject that names a finding class is read as a diagnosis, so the class is
+/// only true if a validated finding backs it. The mid-work bundle below is the
+/// ordinary case: component records exist, no status terminal record does, and
+/// every declared source was captured whole, so there is no coverage gap to
+/// cite and the shared finding contract rejects the insufficient-evidence
+/// finding. The advertised class must go with it.
+#[test]
+fn a_classified_subject_never_outlives_the_finding_that_backs_it() {
+    let mut bundle = load_bundle("healthy");
+    let status_artifact_ids = bundle
+        .sources
+        .iter()
+        .filter(|source| source.source_group == "server-status")
+        .map(|source| source.artifact.artifact_id.clone())
+        .collect::<BTreeSet<_>>();
+    assert!(
+        !status_artifact_ids.is_empty(),
+        "healthy bundle declares a status source"
+    );
+    bundle
+        .sources
+        .retain(|source| source.source_group != "server-status");
+    bundle
+        .evidence
+        .retain(|evidence| !status_artifact_ids.contains(&evidence.reference.artifact_id));
+
+    let analysis = analyze_site_core(&bundle);
+    assert_eq!(
+        analysis
+            .results
+            .iter()
+            .map(|result| result.state)
+            .collect::<Vec<_>>(),
+        vec![cmtraceopen_parser::sccm::server::windows::SccmSiteCoreState::Incomplete],
+        "an uncollected status family leaves the component transaction incomplete"
+    );
+    assert!(
+        analysis.coverage_gaps.is_empty(),
+        "an uncollected source declares no artifact, so there is no gap to cite"
+    );
+
+    for (subject_id, finding_class) in analysis
+        .results
+        .iter()
+        .map(|result| (result.result_id.clone(), result.finding_class.clone()))
+        .chain(analysis.unlinked_observations.iter().map(|observation| {
+            (
+                observation.observation_id.clone(),
+                Some(observation.finding_class.clone()),
+            )
+        }))
+    {
+        let Some(class) = finding_class else {
+            continue;
+        };
+        let matching = analysis
+            .findings
+            .iter()
+            .filter(|finding| finding.subject_id == subject_id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matching.len(),
+            1,
+            "subject {subject_id} advertises {class:?} with no finding to back it"
+        );
+        assert_eq!(
+            matching[0].finding.class, class,
+            "subject {subject_id} advertises a class its finding does not carry"
+        );
+    }
+}
+
 /// `statesys.log` and `hman.log` belong to the declared site-core groups but no
 /// fixture validates their producer records, so the profile must not reduce
 /// them into facts. They still have to stay visible as explicit coverage rather

--- a/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
@@ -584,6 +584,112 @@ fn a_source_family_without_a_validated_producer_is_coverage_not_silence() {
     );
 }
 
+/// The producer gate is what makes an unvalidated family coverage rather than
+/// a diagnosis, so every stage that reads a source has to apply it. Bytes this
+/// profile has no validated producer for cannot become a source-local symptom,
+/// and the gap a transaction cites must agree with the gap the analysis
+/// publishes for the same artifact.
+#[test]
+fn an_unvalidated_source_family_is_never_read_as_a_symptom() {
+    let mut bundle = load_bundle("healthy");
+    let mut relabelled = String::new();
+    for source in &mut bundle.sources {
+        if source.source_group == "server-status" {
+            source.artifact.display_name = "statesys.log".to_owned();
+            source.rotation_lineage = "statesys.log".to_owned();
+            // Physical bytes past the last record this profile could read.
+            source.physical_line_end = source.physical_line_end.map(|end| end + 3);
+            relabelled = source.artifact.artifact_id.clone();
+        }
+    }
+    assert!(
+        !relabelled.is_empty(),
+        "healthy bundle declares a status source"
+    );
+
+    let analysis = analyze_site_core(&bundle);
+    assert!(
+        analysis.unlinked_observations.iter().all(|observation| {
+            observation
+                .evidence
+                .iter()
+                .all(|evidence| evidence.artifact_id != relabelled)
+        }),
+        "an unvalidated source family must never carry a source-local diagnosis"
+    );
+    let gap = analysis
+        .coverage_gaps
+        .iter()
+        .find(|gap| gap.artifact_id == relabelled)
+        .expect("an unvalidated source family stays visible as coverage");
+    assert_eq!(
+        gap.state,
+        SccmCoverageState::Unsupported,
+        "an unvalidated source family is unsupported coverage"
+    );
+    assert!(
+        analysis
+            .results
+            .iter()
+            .all(|result| result.coverage_gap_artifact_ids.contains(&relabelled)),
+        "every transaction must cite the unsupported source it could not read"
+    );
+    for finding in &analysis.findings {
+        for cited in &finding.finding.coverage_gaps {
+            if cited.artifact_id == relabelled {
+                assert_eq!(
+                    cited.coverage, gap.state,
+                    "a finding must not relabel the coverage gap it cites"
+                );
+            }
+        }
+    }
+}
+
+/// A captured source that yielded no complete logical record is not a fact
+/// source. Whether it also left an unparsed tail decides how it is cited, never
+/// whether it is cited at all: the gate that withholds its facts has to leave a
+/// coverage gap behind.
+#[test]
+fn a_captured_source_that_read_no_record_is_still_coverage() {
+    let mut bundle = load_bundle("healthy");
+    let mut incomplete = String::new();
+    for source in &mut bundle.sources {
+        if source.source_group == "server-status" {
+            source.fragment_complete = Some(false);
+            incomplete = source.artifact.artifact_id.clone();
+        }
+    }
+    assert!(
+        !incomplete.is_empty(),
+        "healthy bundle declares a status source"
+    );
+
+    let analysis = analyze_site_core(&bundle);
+    assert!(
+        analysis.results.iter().all(|result| result
+            .evidence
+            .iter()
+            .all(|evidence| evidence.artifact_id != incomplete)),
+        "an incomplete source must never contribute facts"
+    );
+    assert!(
+        analysis
+            .coverage_gaps
+            .iter()
+            .any(|gap| gap.artifact_id == incomplete
+                && gap.state == SccmCoverageState::ParseFailed),
+        "an incomplete source must stay visible as an explicit coverage gap"
+    );
+    assert!(
+        analysis
+            .results
+            .iter()
+            .all(|result| result.coverage_gap_artifact_ids.contains(&incomplete)),
+        "every transaction must cite the source it could not read"
+    );
+}
+
 #[test]
 fn analysis_is_independent_of_source_and_evidence_order() {
     for scenario in SCENARIOS {

--- a/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
@@ -469,6 +469,49 @@ fn every_classified_outcome_carries_a_validated_shared_finding() {
     }
 }
 
+/// `statesys.log` and `hman.log` belong to the declared site-core groups but no
+/// fixture validates their producer records, so the profile must not reduce
+/// them into facts. They still have to stay visible as explicit coverage rather
+/// than being silently dropped.
+#[test]
+fn a_source_family_without_a_validated_producer_is_coverage_not_silence() {
+    let mut bundle = load_bundle("healthy");
+    let mut relabelled = String::new();
+    for source in &mut bundle.sources {
+        if source.source_group == "server-status" {
+            source.artifact.display_name = "statesys.log".to_owned();
+            source.rotation_lineage = "statesys.log".to_owned();
+            relabelled = source.artifact.artifact_id.clone();
+        }
+    }
+    assert!(
+        !relabelled.is_empty(),
+        "healthy bundle declares a status source"
+    );
+
+    let analysis = analyze_site_core(&bundle);
+    assert!(
+        analysis.results.iter().all(|result| result
+            .evidence
+            .iter()
+            .all(|evidence| evidence.artifact_id != relabelled)),
+        "an unvalidated source family must never contribute facts"
+    );
+    assert!(
+        analysis.coverage_gaps.iter().any(|gap| gap.artifact_id
+            == relabelled
+            && gap.state == SccmCoverageState::Unsupported),
+        "an unvalidated source family must be reported as unsupported coverage"
+    );
+    assert!(
+        analysis
+            .results
+            .iter()
+            .all(|result| result.coverage_gap_artifact_ids.contains(&relabelled)),
+        "every transaction must cite the unsupported source it could not read"
+    );
+}
+
 #[test]
 fn analysis_is_independent_of_source_and_evidence_order() {
     for scenario in SCENARIOS {

--- a/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_site_core.rs
@@ -836,6 +836,78 @@ fn synthesized_fragment_references_never_collide_with_parsed_records() {
     }
 }
 
+/// A request names what the profile could read if it were collected. Naming a
+/// family the profile has no validated producer for asks the operator for
+/// bytes that could never change the answer, and it displaces the family that
+/// could.
+#[test]
+fn a_status_request_never_names_a_family_it_cannot_read() {
+    let mut bundle = load_bundle("inbox-backlog");
+    for source in &mut bundle.sources {
+        if source.source_group == "server-status" {
+            source.artifact.display_name = "statesys.log".to_owned();
+            source.rotation_lineage = "statesys.log".to_owned();
+        }
+    }
+
+    let analysis = analyze_site_core(&bundle);
+    let requests = analysis
+        .results
+        .iter()
+        .flat_map(|result| result.next_artifacts.iter())
+        .filter(|request| request.logical_name == "server-status")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        requests.len(),
+        1,
+        "a deferred transaction still asks for the missing status terminal record"
+    );
+    assert!(
+        !requests[0]
+            .basenames
+            .iter()
+            .any(|basename| basename == "statesys.log"),
+        "a request must not name a source family the profile cannot read"
+    );
+    assert!(
+        requests[0]
+            .basenames
+            .iter()
+            .any(|basename| basename == "statmgr.log"),
+        "a request must name the status family the profile is validated for"
+    );
+}
+
+/// `capture_limit_bytes` is caller supplied. Doubling and rounding it up must
+/// stay arithmetic, not a panic in debug and a silently empty bound in release.
+#[test]
+fn an_extreme_capture_limit_still_produces_a_bounded_request() {
+    let mut bundle = load_bundle("incomplete");
+    for source in &mut bundle.sources {
+        if source.capture_limit_bytes.is_some() {
+            source.capture_limit_bytes = Some(u64::MAX);
+        }
+    }
+
+    let analysis = analyze_site_core(&bundle);
+    let bounds = analysis
+        .results
+        .iter()
+        .flat_map(|result| result.next_artifacts.iter())
+        .filter_map(|request| request.max_bytes_per_artifact)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        bounds.len(),
+        1,
+        "the capped source still drives one bounded recapture request"
+    );
+    assert!(
+        bounds[0] >= 4096 && bounds[0].is_power_of_two(),
+        "a recapture bound must stay a declared power of two, not {}",
+        bounds[0]
+    );
+}
+
 /// One captured sitecomp source carrying `records` distinct, well-formed,
 /// non-overlapping component records. Nothing collides, which is the ordinary
 /// case and the one a per-record rescan of the bundle cannot short-circuit.


### PR DESCRIPTION
Implements the server site-core and status-system workflow analyzer for #327, specified by the already-merged site-core corpus.

## Public API

New `sccm/server/windows/site_core.rs`, re-exported through `windows/mod.rs`:

`analyze_site_core(&SccmSiteCoreBundle) -> SccmSiteCoreAnalysis`

Input is a typed bundle (`SccmSiteCoreTopology`, sources carrying artifact plus source group, rotation lineage, fragment completeness, physical line end, and capture limit, plus normalized evidence). Output carries schema version, workflow, profile, a five-phase state chain, results, unlinked observations, coverage gaps, findings, artifact requests, prohibited claims, and a cross-side correlation flag. All serialized fields are additive and camelCase, and `SccmSiteCoreFinding` flattens the shared `SccmFinding` so every finding passes the spine's `validate()` on serialization.

## Corpus coverage

All nine merged scenarios reproduce exactly: healthy, component-failure, inbox-backlog, status-processing-failure, recovery, contradictory, incomplete, rotation-boundary, and malformed. Notable conservatism the corpus pins: component-failure emits no artifact request because the failure is already confirmed; recovery requires a strictly later terminal success under comparable UTC; contradictory keeps two separate results because same-instant records for different components never merge; and both rotation-boundary and malformed produce zero results, surfacing observations plus a request instead.

## Verification

- `--test sccm_server_site_core`: 13 passed
- `--test sccm_site_core_fixture_contract`: 5 passed
- `--test sccm_spine_contract`: 137 passed
- `cargo test --locked -p cmtraceopen-parser`: 938 passed, 0 failed across 18 targets
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings`: clean
- `cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown`: clean, no new dependencies, no I/O, no async, no Windows or Tauri usage
- `git diff --check 26116027 HEAD` clean; `rustfmt --check` clean on all three changed files; `npx tsc --noEmit` exit 0

`intake.rs` and `catalog.rs` are untouched. `mpcontrol.log` cannot be admitted here because `server-mp-policy` is not a site-core group, preserving the boundary lane #328 established.

## Deliberately not implemented, with reasons

**1. The reducer does not consume `assess_server_intake`, because the two schemas are currently incompatible.** This is a real corpus-versus-code disagreement that needs a decision outside this lane, not a shortcut. Intake requires `producerRole`, `sourceId`, `configuredPathProvenance.pathFingerprint`, `rotation.lineageId`, `collectionLimit`, a closed artifact-id allowlist, `originalPath` matching `REDACTED_*`, and `evidence/sccm/server/site-server/server-sitecomp/...` paths. The merged site-core corpus uses `role`, `sourceGroup`, `configuredPath` as a bool, `rotationLineage`, `captureLimitBytes`, ids such as `healthy-sitecomp-current`, `originalPath: "REDACTED"`, and `evidence/sccm/server/site-core/sitecomp/...` paths. Feeding a site-core fixture to `assess_server_intake` fails at several independent gates. This PR follows lane #328's precedent of building the bundle from the fixture manifest directly and keeping the reducer input a typed bundle that an intake adapter can populate later.

**2. No new fixtures.** The merged corpus already supplies nine scenarios, eighteen artifacts, and fourteen physical files, and the fixture-contract test pins that matrix, so adding fixtures would break `site_core_uses_canonical_rotation_and_coverage_contracts`. The corpus has no retry scenario distinct from backlog; both reduce to `blockedOrDeferred`.

**3. `LikelyContributor` is never produced.** No corpus scenario defines it, and the issue's own vocabulary maps onto symptom, confirmedFailure, blockedOrDeferred, and insufficientEvidence.

**4. Correlation keys are the typed `SccmSiteCoreTransactionKey`, not shared `SccmCorrelationKey` entries.** The spine caps key confidence at `Low` unless the key names a registered stable profile, and that registry is deliberately empty. Lane #328 made the same choice.

**5. `hman.log` and `statesys.log` are coverage-visible but not fact-bearing.** They are declared members of the site-core groups and their capture states survive, which the `incomplete-statesys-absent` gap depends on, but no fixture validates the component name their records carry. Guessing `SMS_HIERARCHY_MANAGER` or `SMS_STATE_SYSTEM` would be unverified, so they report `unsupported` coverage instead. Commit `05f87450` exists specifically to close the alternative, which was silently contributing nothing.

**6. Exported status-system messages and site configuration facts** (the optional half of the issue's input contract) are not consumed; no corpus fixture declares them.

**7. Two implemented branches are unexercised by the corpus** and are covered by focused tests instead: the same-instant same-phase conflicting-outcome guard (which falls to insufficient evidence rather than letting vector order pick a winner) and the moderate confidence ceiling for a transaction with no ComponentStart entry evidence.

## Corpus inconsistency worth a decision

`rotation-boundary/expected.json` omits `completeLogicalRecord` on its coverage-gap evidence while `malformed` and `incomplete` declare `false` on theirs, and no rule distinguishes the three (all cite a synthesized physical tail reference). The reducer emits the flag uniformly; the contract test compares gap evidence without it and separately asserts the stricter invariant that every coverage-gap evidence carries `completeLogicalRecord == false`. Aligning the corpus would let that carve-out be deleted.

Refs #327. No native Windows acceptance is claimed; this is pure parser-layer work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analysis support for SCCM site-core server evidence.
  * Reports validated component, queue, status, and terminal-state results.
  * Provides confidence levels, observations, findings, coverage gaps, and targeted artifact recapture requests.
  * Handles incomplete, conflicting, malformed, capped, rotated, and recovered evidence while limiting unsupported conclusions.
  * Produces consistent, deterministic results across supported evidence bundles.

* **Tests**
  * Added comprehensive validation for evidence integrity, source compatibility, chronology, confidence handling, request limits, and result consistency.
  * Added performance coverage for large evidence sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->