### PR TITLE
fix(ccm): validate signless time-tail offsets

### DIFF
--- a/crates/cmtraceopen-parser/src/parser/ccm.rs
+++ b/crates/cmtraceopen-parser/src/parser/ccm.rs
@@ -970,4 +970,150 @@ mod tests {
         );
         assert!(records[0].timestamp.utc_millis.is_some());
     }
+
+    fn logical_record_for_time_tail(tail: &str) -> CcmLogicalRecord {
+        let text = format!(
+            concat!(
+                r#"<![LOG[Tail {tail}]LOG]!><time="10:00:00.{tail}" date="07-30-2026" "#,
+                r#"component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+            ),
+            tail = tail
+        );
+        let mut records = scan_logical_records(&text, "PolicyAgent.log");
+        assert_eq!(records.len(), 1, "tail {tail}: expected one logical record");
+        records.remove(0)
+    }
+
+    /// Frozen answers for every shape of CCM fractional-second tail.
+    ///
+    /// Two shipped implementations resolved this ambiguity by counting digits
+    /// and both were wrong (see `split_ccm_time_tail`). This table is the
+    /// regression barrier: it pins the fractional text, the millisecond value,
+    /// the source offset, and the ordering confidence for unsigned tails of
+    /// one to eight digits and for their signed counterparts. Change a row
+    /// only with a documented grammar reason, never to let a new heuristic
+    /// pass.
+    #[test]
+    fn ccm_time_tail_ambiguity_table_is_frozen() {
+        use CcmTimestampParseState::{NormalizedUtc, OffsetInvalid, OffsetMissing};
+
+        // (time tail, fractional text, milliseconds, source offset, ordering state)
+        let cases: [(&str, &str, u32, Option<i32>, CcmTimestampParseState); 26] = [
+            // Unsigned tails that cannot be `%03u%d`: no trailing run of
+            // digits reads as a real UTC offset, so they stay fractional and
+            // the record is never promoted to UTC-normalized ordering.
+            ("1", "1", 1, None, OffsetMissing),
+            ("12", "12", 12, None, OffsetMissing),
+            ("123", "123", 123, None, OffsetMissing),
+            // `%d` prints a zero offset as "0", so a four-digit tail is not
+            // evidence of one; downgrade instead of guessing.
+            ("1234", "1234", 123, None, OffsetMissing),
+            ("12345", "12345", 123, None, OffsetMissing),
+            // Microsecond precision. 456 is not a UTC offset.
+            ("123456", "123456", 123, None, OffsetMissing),
+            // `%d` never zero-pads, so "045" is fractional text and not +45.
+            ("123045", "123045", 123, None, OffsetMissing),
+            // Same rule: a padded zero offset always arrives signed ("+000").
+            ("123000", "123000", 123, None, OffsetMissing),
+            // 481 minutes is not a whole quarter hour.
+            ("123481", "123481", 123, None, OffsetMissing),
+            // 900 minutes exceeds UTC+14:00.
+            ("123900", "123900", 123, None, OffsetMissing),
+            // Unsigned tails that are genuine `%03u%d` records: three
+            // millisecond digits followed by a positive offset.
+            ("000240", "000", 0, Some(240), NormalizedUtc),
+            ("123480", "123", 123, Some(480), NormalizedUtc),
+            ("123840", "123", 123, Some(840), NormalizedUtc),
+            ("123105", "123", 123, Some(105), NormalizedUtc),
+            // IME writes seven fractional digits, never an offset.
+            ("1234567", "1234567", 123, None, OffsetMissing),
+            ("12345678", "12345678", 123, None, OffsetMissing),
+            // Signed tails are self-delimiting: the sign is the source's own
+            // statement of provenance and is never screened for plausibility.
+            ("123+480", "123", 123, Some(480), NormalizedUtc),
+            ("123-240", "123", 123, Some(-240), NormalizedUtc),
+            ("000+000", "000", 0, Some(0), NormalizedUtc),
+            ("123+481", "123", 123, Some(481), NormalizedUtc),
+            ("123+0", "123", 123, Some(0), NormalizedUtc),
+            ("1+2", "1", 1, Some(2), NormalizedUtc),
+            ("123456+480", "123456", 123, Some(480), NormalizedUtc),
+            ("1234567-060", "1234567", 123, Some(-60), NormalizedUtc),
+            // Out-of-range signed offsets stay reported and stay uncomparable.
+            ("123+99999", "123", 123, Some(99999), OffsetInvalid),
+            ("123-99999", "123", 123, Some(-99999), OffsetInvalid),
+        ];
+
+        for (tail, fraction_text, millis, offset_minutes, ordering_state) in cases {
+            let (split_fraction, split_offset) = split_ccm_time_tail(tail);
+            assert_eq!(
+                split_fraction, fraction_text,
+                "tail {tail}: fractional text"
+            );
+            assert_eq!(
+                split_offset.is_some(),
+                offset_minutes.is_some(),
+                "tail {tail}: offset presence"
+            );
+            assert_eq!(
+                truncate_subsecond_to_millis(split_fraction),
+                Some(millis),
+                "tail {tail}: milliseconds"
+            );
+
+            let record = logical_record_for_time_tail(tail);
+            let timestamp = &record.timestamp;
+            assert_eq!(
+                timestamp.original_display,
+                Some(format!("07-30-2026 10:00:00.{fraction_text}")),
+                "tail {tail}: original display"
+            );
+            assert_eq!(
+                timestamp.offset_minutes, offset_minutes,
+                "tail {tail}: source offset"
+            );
+            assert_eq!(
+                timestamp.ordering_state, ordering_state,
+                "tail {tail}: ordering state"
+            );
+
+            let naive = chrono::NaiveDate::from_ymd_opt(2026, 7, 30)
+                .unwrap()
+                .and_hms_milli_opt(10, 0, 0, millis)
+                .unwrap();
+            let expected_utc =
+                offset_minutes.and_then(|minutes| normalized_utc_millis(naive, minutes));
+            assert_eq!(
+                timestamp.utc_millis, expected_utc,
+                "tail {tail}: normalized utc"
+            );
+            assert_eq!(
+                timestamp.utc_millis.is_some(),
+                ordering_state == NormalizedUtc,
+                "tail {tail}: utc millis must exist exactly when ordering is normalized"
+            );
+        }
+    }
+
+    /// Both shipped attempts fabricated an offset from a microsecond tail.
+    #[test]
+    fn ccm_time_tail_rejects_both_historical_offset_bugs() {
+        let timestamp = logical_record_for_time_tail("123456").timestamp;
+
+        assert_ne!(
+            timestamp.offset_minutes,
+            Some(6),
+            "greedy-regex attempt read the final digit as the offset"
+        );
+        assert_ne!(
+            timestamp.offset_minutes,
+            Some(456),
+            "digit-count attempt read the final three digits as the offset"
+        );
+        assert_eq!(timestamp.offset_minutes, None);
+        assert_eq!(
+            timestamp.ordering_state,
+            CcmTimestampParseState::OffsetMissing
+        );
+        assert_eq!(timestamp.utc_millis, None);
+    }
 }

--- a/crates/cmtraceopen-parser/src/parser/ccm.rs
+++ b/crates/cmtraceopen-parser/src/parser/ccm.rs
@@ -170,12 +170,50 @@ pub(crate) fn truncate_subsecond_to_millis(value: &str) -> Option<u32> {
     }
 }
 
+/// Longest offset any real timezone uses, in minutes (UTC-14:00..UTC+14:00).
+const MAX_UTC_OFFSET_MINUTES: u32 = 14 * 60;
+
+/// Every timezone offset in current use is a whole number of quarter hours.
+const UTC_OFFSET_STEP_MINUTES: u32 = 15;
+
+/// Decide whether a signless digit run can be a source timezone offset.
+///
+/// The legacy grammar prints the offset with `%d`, so it never zero-pads and
+/// never emits a sign for a positive value. A run that survives that shape
+/// check still has to name an offset a machine can actually be configured
+/// with; anything else is fractional-second text that happens to be numeric.
+fn signless_offset_is_real(text: &str) -> bool {
+    if text.starts_with('0') {
+        return false;
+    }
+
+    text.parse::<u32>().is_ok_and(|minutes| {
+        minutes <= MAX_UTC_OFFSET_MINUTES && minutes % UTC_OFFSET_STEP_MINUTES == 0
+    })
+}
+
 /// Split CCM's fractional-second field from its optional timezone offset.
 ///
-/// A signed offset is self-delimiting. The documented legacy `%03u%d`
-/// grammar also permits a signless three-digit offset after exactly three
-/// millisecond digits. Other digit-only tails are fractional seconds with no
-/// source offset, including the seven-digit precision emitted by IME logs.
+/// A signed offset is self-delimiting and is always taken at face value: the
+/// sign is the source stating its own provenance, so an out-of-range signed
+/// offset is reported as invalid rather than reinterpreted.
+///
+/// A signless tail is genuinely ambiguous. The documented legacy `%03u%d`
+/// grammar emits three millisecond digits followed by an unsigned positive
+/// offset, so `.000240` really is 0 ms at UTC+4; .NET writers instead emit
+/// six- or seven-digit fractional seconds, so `.123456` is 123456
+/// microseconds and carries no offset. Both shapes are six digits wide, and
+/// digit width alone cannot tell them apart.
+///
+/// Two shipped implementations tried to tell them apart positionally and both
+/// were wrong. The original greedy regex `(?P<ms>\d+)(?P<tz>[+-]*\d+)` gave
+/// the last digit to the offset, so `.123456` became 123 ms at UTC+6 minutes.
+/// Its replacement gave the last three digits to the offset whenever the tail
+/// was exactly six wide, so `.123456` became 123 ms at UTC+456 minutes, a
+/// silent 7h36m shift stamped `NormalizedUtc`. Do not add a third rule of
+/// that kind: the split is decided by whether the candidate offset is a real
+/// timezone offset, and a tail that fails that check keeps all of its digits
+/// as fractional seconds and is reported as having no source offset.
 fn split_ccm_time_tail(value: &str) -> (&str, Option<&str>) {
     if let Some(index) = value
         .as_bytes()
@@ -185,7 +223,9 @@ fn split_ccm_time_tail(value: &str) -> (&str, Option<&str>) {
         return (&value[..index], Some(&value[index..]));
     }
 
-    if value.len() == 6 {
+    // `%03u%d` with a three-digit offset is the only signless shape the
+    // legacy grammar can produce that is not also plain fractional text.
+    if value.len() == 6 && signless_offset_is_real(&value[3..]) {
         return (&value[..3], Some(&value[3..]));
     }
 

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -4478,6 +4478,39 @@ fn signless_ccm_offset_is_enriched_only_in_sccm_provenance() {
 }
 
 #[test]
+fn microsecond_precision_tail_is_not_read_as_a_source_offset() {
+    // A six-digit unsigned tail is ambiguous: `%03u%d` would read it as three
+    // millisecond digits plus a positive offset, and .NET microsecond
+    // precision writes six fractional digits. 456 is not a real UTC offset
+    // (it is neither within UTC-14..UTC+14 as a quarter-hour value nor a
+    // shape `%d` emits), so the tail stays fractional and the record is not
+    // promoted to UTC-normalized ordering.
+    let text = r#"<![LOG[Microsecond precision]LOG]!><time="10:00:00.123456" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#;
+    let (entries, errors) =
+        cmtraceopen_parser::parser::ccm::parse_content(text, "PolicyAgent.log", None);
+    let evidence = normalize_ccm_artifact(client_policy_artifact(), text);
+
+    assert_eq!(errors, 0);
+    assert_eq!(evidence.len(), 1);
+    assert_eq!(
+        evidence[0].timestamp.original_display.as_deref(),
+        Some("07-30-2026 10:00:00.123456")
+    );
+    assert_eq!(evidence[0].timestamp.offset_minutes, None);
+    assert_eq!(
+        evidence[0].timestamp.ordering_state,
+        SccmTimeOrderingState::OffsetMissing
+    );
+    assert_eq!(evidence[0].timestamp.utc_millis, None);
+
+    // The public LogEntry still carries the pre-spine greedy projection,
+    // which assigns the final digit to the offset. That divergence is
+    // deliberate compatibility, not a second reading of the grammar.
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].timezone_offset, Some(6));
+}
+
+#[test]
 fn evidence_uses_one_logical_record_and_normalized_utc_ordering() {
     let text = include_str!("fixtures/sccm/spine/multiline-policy.log");
     let evidence = normalize_ccm_artifact(client_policy_artifact(), text);


### PR DESCRIPTION
Fixes #406. A signless six-digit fractional tail was unconditionally read as three millisecond digits plus three offset digits, so `<time="10:00:00.123456">` parsed as 123 ms with a +456 minute offset, shifting UTC by 7h36m and stamping the record `NormalizedUtc`, the highest-confidence ordering state.

## Why the obvious fix is wrong

The form is genuinely ambiguous. The documented legacy grammar is `%03u%d`, and `%d` prints a positive offset unsigned, so `.123480` really does mean 123 ms plus a +480 minute offset in real CCM output. Deleting the branch would break legitimate positive-offset timestamps.

This is also the second time this split has been implemented wrongly. The original greedy regex `(?P<ms>\d+)(?P<tz>[+-]*\d+)` assigned the final digit to the offset, so `.123456` gave ms=12345, tz=6. Commit 3e53bd30 replaced it with the six-digit rule, which gives ms=123, tz=456. Both attempts resolved an ambiguous grammar with a positional heuristic. This change stops doing that.

## The rule

Digit width only nominates candidates; validity decides. A signless tail splits into `%03u%d` only when the trailing run is a real timezone offset:

1. No leading zero, since `%d` never zero-pads, so `123045` and `123000` are fractional text.
2. Magnitude at most 840 minutes (UTC-14 to UTC+14), so `123900` is fractional.
3. A whole quarter hour, since no zone in current use has a non-quarter-hour offset, so `123456` and `123481` are fractional.

`.123480` still yields +480. `.000240` still yields +240. Seven-digit IME precision and every signed tail are untouched, including out-of-range signed values, which stay `Some(99999)` with `OffsetInvalid`: an explicit sign is the source stating its own provenance and is never screened.

## Blast radius

`CcmTimestampParse` reaches exactly one surface, the SCCM evidence spine, via `scan_logical_records` (crate-private, consumed only by `sccm/ingest.rs`). So the fabricated offset corrupted SCCM evidence `offsetMinutes`, `utcMillis`, and `orderingState`, and therefore cross-artifact ordering and every finding built on it. The general viewer, timeline, ESP/Intune ingestion, and tailing all build `LogEntry` from `split_legacy_public_time_tail` instead and are unaffected by this change. IME-specialized Intune logs bypass CCM entirely.

One existing fixture uses a signless six-digit tail: `sccm_spine_contract.rs:4462` with `time="10:00:00.000240"`, asserting `offset_minutes == Some(240)` and `NormalizedUtc`. 240 is a real offset, so it keeps the legacy reading and passes unmodified. No fixture or expectation was edited to make anything pass.

## The frozen table

`ccm_time_tail_ambiguity_table_is_frozen` pins 26 rows: unsigned tails of one to eight digits covering valid and invalid offset candidates, quarter-hour and boundary cases at 105 and 840, zero-padded and over-range values, plus signed counterparts. Each row pins fractional text, milliseconds, offset minutes, ordering state, and `utcMillis`, and asserts `utcMillis.is_some() == (state == NormalizedUtc)`.

`ccm_time_tail_rejects_both_historical_offset_bugs` pins the two historical wrong answers explicitly, so a third attempt cannot silently pick a new split. The doc comment at the function names both prior implementations and the exact wrong answers they produced.

## Honest residual

Of the 1000 possible three-digit trailing runs, 50 pass all three rules, so a microsecond timestamp still has roughly a 5 percent chance of being read as an offset. I kept `NormalizedUtc` for a validated split deliberately: the current enum has no free downgrade (`OffsetMissing` would contradict a populated `offsetMinutes`), so downgrading means a new serialized variant plus frontend churn, and it would strip ordering from every genuine positive-offset CCM record, which is the common case for UTC+N tenants. If that residual is unacceptable, the clean follow-up is an explicit `OffsetAmbiguous` state rather than another split rule, and the frozen table makes that a one-column change.

## Verification

- `cargo test --locked -p cmtraceopen-parser`: 963 passed, 0 failed
- `cargo test --locked --workspace`: 1717 passed, 0 failed
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings`: clean
- `cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown`: clean
- `git diff --check e56ad387 HEAD` clean; `rustfmt --check` clean on both changed files; `npx tsc --noEmit` clean

Refs #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CCM timestamp parsing to correctly distinguish timezone offsets from fractional seconds.
  - Validated unsigned timezone offsets against supported bounds and quarter-hour increments.
  - Preserved signed offsets while reporting invalid values appropriately.
  - Fixed handling of six-digit fractional seconds, retaining full microsecond precision without incorrect timezone normalization.
- **Tests**
  - Added comprehensive regression coverage for valid, invalid, signed, and ambiguous timestamp formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->