### PR TITLE
fix(sccm): reject overlapping evidence ranges in the spine

### DIFF
--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -457,6 +457,7 @@ pub enum SccmFindingValidationError {
     InvalidRole,
     InvalidEvidenceReference,
     ConflictingEvidenceReference,
+    OverlappingEvidenceReference,
     MissingEvidenceOrCoverageGap,
     MissingTerminalEvidence,
     InvalidTerminalEvidence,

--- a/crates/cmtraceopen-parser/src/sccm/findings.rs
+++ b/crates/cmtraceopen-parser/src/sccm/findings.rs
@@ -645,11 +645,9 @@ fn validate_roles(finding: &SccmFinding) -> Result<(), SccmFindingValidationErro
     Ok(())
 }
 
-fn validate_all_evidence_references(
-    finding: &SccmFinding,
-) -> Result<(), SccmFindingValidationError> {
-    let mut ranges_by_identity = BTreeMap::new();
-    for reference in finding
+/// Every reference a finding cites, across all three citation surfaces.
+fn cited_evidence_references(finding: &SccmFinding) -> impl Iterator<Item = &SccmEvidenceRef> {
+    finding
         .evidence
         .iter()
         .chain(
@@ -664,15 +662,101 @@ fn validate_all_evidence_references(
                 .iter()
                 .filter_map(|key| key.evidence.as_ref()),
         )
-    {
+}
+
+fn validate_all_evidence_references(
+    finding: &SccmFinding,
+) -> Result<(), SccmFindingValidationError> {
+    let mut references_by_identity: BTreeMap<(&str, &str), &SccmEvidenceRef> = BTreeMap::new();
+    for reference in cited_evidence_references(finding) {
         validate_evidence_reference(reference)?;
-        let identity = (reference.artifact_id.as_str(), reference.entry_id.as_str());
-        let range = (reference.line_start, reference.line_end);
-        if ranges_by_identity
-            .insert(identity, range)
-            .is_some_and(|existing| existing != range)
+        if references_by_identity
+            .insert(evidence_identity(reference), reference)
+            .is_some_and(|existing| {
+                (existing.line_start, existing.line_end)
+                    != (reference.line_start, reference.line_end)
+            })
         {
             return Err(SccmFindingValidationError::ConflictingEvidenceReference);
+        }
+    }
+    validate_disjoint_evidence_spans(&references_by_identity)
+}
+
+/// Whether two references claim overlapping physical lines of one source.
+///
+/// Physical extent, not an identity tuple, is the question. Two logical
+/// records of one artifact occupy disjoint lines, so any overlap means at
+/// least one of them is not the record it claims to be. Bounds are inclusive,
+/// so equal spans are the degenerate overlap and abutting spans (`1-2` beside
+/// `3-4`) are not one. A reference that carries no bounds asserts no extent and
+/// therefore cannot be shown to claim another reference's lines.
+///
+/// This presumes bounds that already passed a validity gate. An inverted range
+/// reads as empty under an inclusive test and would be silently judged disjoint
+/// from everything, so the gate has to run first, not after: the spine calls
+/// [`validate_evidence_reference`] on every reference before any pair reaches
+/// this predicate, and a reducer that hands over unvalidated references is
+/// responsible for its own gate.
+pub(crate) fn evidence_references_overlap(left: &SccmEvidenceRef, right: &SccmEvidenceRef) -> bool {
+    if left.artifact_id != right.artifact_id {
+        return false;
+    }
+    matches!(
+        (
+            left.line_start,
+            left.line_end,
+            right.line_start,
+            right.line_end,
+        ),
+        (Some(left_start), Some(left_end), Some(right_start), Some(right_end))
+            if left_start <= right_end && right_start <= left_end
+    )
+}
+
+/// Rejects a finding whose citations claim the same physical records twice.
+///
+/// Identity equality only catches an exact repeat of one range. It leaves the
+/// wider hole open: `1-2` and `1-1` are different entry ids over the same
+/// physical line, so both survive, each cites the same record, and
+/// [`compare_evidence_refs`] then ranks one above the other on nothing but
+/// span width. Both the management-point and client-policy reducers had to
+/// close this in their own code; enforcing it here closes it for every finding
+/// regardless of which reducer, or none, assembled it.
+///
+/// References arrive keyed by identity, so each entry id contributes exactly
+/// one span and a repeated identity is already a
+/// [`SccmFindingValidationError::ConflictingEvidenceReference`]. Sorting each
+/// artifact's spans by start line lets one pass answer the question: a span
+/// that clears the widest span seen so far clears every earlier one, because
+/// no earlier span starts later or ends further.
+fn validate_disjoint_evidence_spans(
+    references_by_identity: &BTreeMap<(&str, &str), &SccmEvidenceRef>,
+) -> Result<(), SccmFindingValidationError> {
+    let mut by_artifact: BTreeMap<&str, Vec<&SccmEvidenceRef>> = BTreeMap::new();
+    for reference in references_by_identity.values() {
+        if reference.line_start.is_some() && reference.line_end.is_some() {
+            by_artifact
+                .entry(reference.artifact_id.as_str())
+                .or_default()
+                .push(reference);
+        }
+    }
+
+    for mut spans in by_artifact.into_values() {
+        spans.sort_by(|left, right| {
+            left.line_start
+                .cmp(&right.line_start)
+                .then_with(|| left.line_end.cmp(&right.line_end))
+        });
+        let mut widest: Option<&SccmEvidenceRef> = None;
+        for span in spans {
+            if widest.is_some_and(|widest| evidence_references_overlap(widest, span)) {
+                return Err(SccmFindingValidationError::OverlappingEvidenceReference);
+            }
+            if widest.is_none_or(|widest| widest.line_end < span.line_end) {
+                widest = Some(span);
+            }
         }
     }
     Ok(())

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/management_point.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/management_point.rs
@@ -15,6 +15,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::Serialize;
 
 use crate::models::log_entry::Severity;
+use crate::sccm::findings::evidence_references_overlap;
 use crate::sccm::{
     classify_artifact_name, SccmArtifact, SccmArtifactFamily, SccmArtifactRequest, SccmConfidence,
     SccmCoverageState, SccmEvidence, SccmEvidenceRef, SccmFinding, SccmFindingBuilder,
@@ -1125,22 +1126,6 @@ fn evidence_identity_is_unique(
         .take(2)
         .count()
         == 1
-}
-
-fn evidence_references_overlap(left: &SccmEvidenceRef, right: &SccmEvidenceRef) -> bool {
-    if left.artifact_id != right.artifact_id {
-        return false;
-    }
-    matches!(
-        (
-            left.line_start,
-            left.line_end,
-            right.line_start,
-            right.line_end,
-        ),
-        (Some(left_start), Some(left_end), Some(right_start), Some(right_end))
-            if left_start <= right_end && right_start <= left_end
-    )
 }
 
 fn safe_evidence_reference(reference: &SccmEvidenceRef) -> bool {

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -908,7 +908,16 @@ fn finding_unregistered_strong_or_exact_key_profiles_are_rejected() {
 #[test]
 fn finding_rejects_key_or_terminal_refs_that_are_not_cited() {
     let cited = finding_evidence_ref("client-policy-agent", "policy:1-1");
-    let missing = finding_evidence_ref("client-policy-agent", "policy:2-2");
+    // `finding_evidence_ref` pins every span to line 1, so this reference used
+    // to claim line 1 while calling itself `policy:2-2`. Two entry ids over one
+    // physical line is the shape this suite now rejects outright, and it would
+    // mask the uncited-reference rule under test. The span is spelled out to
+    // match the entry id it advertises.
+    let missing = SccmEvidenceRef {
+        line_start: Some(2),
+        line_end: Some(2),
+        ..finding_evidence_ref("client-policy-agent", "policy:2-2")
+    };
 
     let key_result = SccmFindingBuilder::new("uncited-key")
         .class(SccmFindingClass::Symptom)

--- a/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
@@ -1250,6 +1250,223 @@ fn finding_serialization_prioritizes_conflicting_evidence_identity_ranges() {
     assert!(error.contains("ConflictingEvidenceReference"), "{error}");
 }
 
+/// Builds one finding per citation surface, carrying `second` on that surface
+/// only, so a validator that scans a single surface cannot pass by accident.
+fn evidence_surface_findings(
+    label: &str,
+    first: &SccmEvidenceRef,
+    second: &SccmEvidenceRef,
+) -> Vec<(String, Result<SccmFinding, SccmFindingValidationError>)> {
+    fn scaffold(finding_id: String) -> SccmFindingBuilder {
+        SccmFindingBuilder::new(finding_id)
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+    }
+
+    vec![
+        (
+            format!("{label}/top-level"),
+            scaffold(format!("{label}-top-level"))
+                .evidence(vec![first.clone(), second.clone()])
+                .build(),
+        ),
+        (
+            format!("{label}/terminal"),
+            scaffold(format!("{label}-terminal"))
+                .evidence(vec![first.clone()])
+                .terminal_evidence(vec![SccmTerminalEvidence::observed_failure(second.clone())])
+                .build(),
+        ),
+        (
+            format!("{label}/correlation-key"),
+            scaffold(format!("{label}-correlation-key"))
+                .evidence(vec![first.clone()])
+                .correlation_keys(vec![finding_key(
+                    SccmCorrelationKeyKind::AssignmentId,
+                    "{ABCDEFAB-0000-0000-0000-000000000001}",
+                    "abcdefab-0000-0000-0000-000000000001",
+                    SccmKeyConfidence::Low,
+                    Some("sccm-keys-experimental-v1"),
+                    second.clone(),
+                )])
+                .build(),
+        ),
+    ]
+}
+
+#[test]
+fn finding_rejects_overlapping_ranges_across_distinct_evidence_identities() {
+    let first = SccmEvidenceRef {
+        artifact_id: "artifact-a".into(),
+        entry_id: "entry-a".into(),
+        line_start: Some(4),
+        line_end: Some(6),
+    };
+    // Every case claims at least one physical line of `first` under a second
+    // entry id, so the two references cannot both be the record they claim.
+    let cases = [
+        ("identical-span", Some(4), Some(6)),
+        ("shared-start-line", Some(1), Some(4)),
+        ("shared-end-line", Some(6), Some(9)),
+        ("contained-span", Some(5), Some(5)),
+        ("containing-span", Some(1), Some(9)),
+        ("straddling-span", Some(5), Some(9)),
+    ];
+
+    for (label, line_start, line_end) in cases {
+        let second = SccmEvidenceRef {
+            entry_id: "entry-b".into(),
+            line_start,
+            line_end,
+            ..first.clone()
+        };
+        for (surface, result) in evidence_surface_findings(label, &first, &second) {
+            assert_eq!(
+                result.unwrap_err(),
+                SccmFindingValidationError::OverlappingEvidenceReference,
+                "{surface}"
+            );
+        }
+    }
+}
+
+#[test]
+fn finding_overlap_rejection_survives_evidence_serde_round_trips() {
+    let first = SccmEvidenceRef {
+        artifact_id: "artifact-a".into(),
+        entry_id: "entry-a".into(),
+        line_start: Some(4),
+        line_end: Some(6),
+    };
+    let mut finding = SccmFindingBuilder::new("overlapping-serde-ranges")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![
+            first.clone(),
+            SccmEvidenceRef {
+                entry_id: "entry-b".into(),
+                line_start: Some(7),
+                line_end: Some(9),
+                ..first
+            },
+        ])
+        .build()
+        .unwrap();
+
+    let mut json = serde_json::to_value(&finding).unwrap();
+    json["evidence"][1]["lineStart"] = serde_json::json!(6);
+    let error = serde_json::from_value::<SccmFinding>(json)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("OverlappingEvidenceReference"), "{error}");
+
+    finding.evidence[1].line_start = Some(6);
+    assert_eq!(
+        finding.validate().unwrap_err(),
+        SccmFindingValidationError::OverlappingEvidenceReference
+    );
+    let error = serde_json::to_string(&finding).unwrap_err().to_string();
+    assert!(error.contains("OverlappingEvidenceReference"), "{error}");
+}
+
+#[test]
+fn finding_accepts_disjoint_and_unbounded_evidence_ranges() {
+    let anchor = SccmEvidenceRef {
+        artifact_id: "artifact-a".into(),
+        entry_id: "entry-a".into(),
+        line_start: Some(4),
+        line_end: Some(6),
+    };
+    // Overlap is a claim about physical extent within one artifact. Adjacent
+    // spans, other artifacts, and references that assert no extent at all are
+    // all citations nine lanes already emit, and must keep validating.
+    let cases = [
+        (
+            "adjacent-below",
+            SccmEvidenceRef {
+                entry_id: "entry-b".into(),
+                line_start: Some(1),
+                line_end: Some(3),
+                ..anchor.clone()
+            },
+        ),
+        (
+            "adjacent-above",
+            SccmEvidenceRef {
+                entry_id: "entry-b".into(),
+                line_start: Some(7),
+                line_end: Some(9),
+                ..anchor.clone()
+            },
+        ),
+        (
+            "same-span-other-artifact",
+            SccmEvidenceRef {
+                artifact_id: "artifact-b".into(),
+                entry_id: "entry-b".into(),
+                ..anchor.clone()
+            },
+        ),
+        (
+            "unbounded-second",
+            SccmEvidenceRef {
+                entry_id: "entry-b".into(),
+                line_start: None,
+                line_end: None,
+                ..anchor.clone()
+            },
+        ),
+    ];
+
+    for (label, second) in cases {
+        let finding = SccmFindingBuilder::new(format!("disjoint-{label}"))
+            .class(SccmFindingClass::Symptom)
+            .phase(SccmPhase::Policy)
+            .role(SccmRole::Client)
+            .severity(Severity::Warning)
+            .confidence(SccmConfidence::Low)
+            .evidence(vec![anchor.clone(), second])
+            .build()
+            .unwrap_or_else(|error| panic!("{label}: {error:?}"));
+        let json = serde_json::to_value(&finding).unwrap();
+        assert_eq!(
+            serde_json::from_value::<SccmFinding>(json).unwrap(),
+            finding,
+            "{label}"
+        );
+    }
+
+    // Two references that both assert no extent stay indistinguishable by span
+    // and must not be treated as claiming the same lines.
+    let unbounded = SccmEvidenceRef {
+        artifact_id: "artifact-a".into(),
+        entry_id: "entry-a".into(),
+        line_start: None,
+        line_end: None,
+    };
+    SccmFindingBuilder::new("disjoint-both-unbounded")
+        .class(SccmFindingClass::Symptom)
+        .phase(SccmPhase::Policy)
+        .role(SccmRole::Client)
+        .severity(Severity::Warning)
+        .confidence(SccmConfidence::Low)
+        .evidence(vec![
+            unbounded.clone(),
+            SccmEvidenceRef {
+                entry_id: "entry-b".into(),
+                ..unbounded
+            },
+        ])
+        .build()
+        .expect("unbounded references assert no physical extent");
+}
+
 #[test]
 fn finding_rejects_top_level_evidence_identity_whitespace_aliases() {
     assert_evidence_alias_is_rejected(FindingEvidenceAliasSurface::TopLevel);


### PR DESCRIPTION
Closes #418.

`findings.rs::validate_all_evidence_references` keyed on `(artifact_id, entry_id)` and rejected only the same identity carrying a different range. Two references with overlapping line ranges under different `entry_id`s inside one finding passed validation, so one physical record could be cited twice and `compare_evidence_refs` would rank the two on span width alone.

## Semantics chosen, and why

The predicate now lives in the spine as `evidence_references_overlap`:

- **Scoped to one artifact.** Line numbers only mean something relative to a source.
- **Inclusive bounds.** `line_start`/`line_end` are inclusive line numbers, so `4-6` and `6-9` share line 6 and overlap, while `1-2` and `3-4` abut and do not. Equal spans are the degenerate overlap and are rejected.
- **A reference carrying no bounds asserts no extent** and therefore cannot be shown to claim another reference's lines. `(None, None)` on either side is not an overlap. This is what keeps existing citations that omit line numbers valid.
- **Inverted ranges are handled by ordering, not by the predicate.** An inverted range reads as empty under an inclusive test and would be silently judged disjoint from everything, which is the failure mode this repo has hit before. The spine closes it by running the validity gate first: every reference clears `validate_evidence_reference` (both bounds present or both absent, `start > 0`, `end >= start`) inside the same function before any pair reaches the overlap sweep, so `InvalidEvidenceReference` still wins and an inverted range can never be mistaken for an empty span.

The deliberate choice not to make the predicate itself fail closed on inverted input is load bearing for the duplication collapse. `management_point.rs` calls it from `evidence_identity_is_unique`, which compares a candidate against every bundle entry, including entries that never passed the reducer's own `safe_evidence_reference` gate. A fail-closed predicate would let one malformed bundle entry suppress good evidence there. Validity is a separate question from extent, and each caller already answers it.

Precedence inside `validate_all_evidence_references` is now: `InvalidEvidenceReference` (per reference) -> `ConflictingEvidenceReference` (one identity, two ranges) -> `OverlappingEvidenceReference` (two identities, one physical line). The first two are unchanged.

The sweep is `O(n log n)`, not pairwise: references are keyed by identity so each entry id contributes exactly one span, spans are sorted per artifact by start line, and a span that clears the widest span seen so far clears every earlier one. `SccmFinding` deserialization has no cap on evidence count, so a quadratic validator on the wire path was not acceptable.

## Did the two reducer copies agree?

Yes, byte-identical. Verified by extracting both and diffing:

- `src/sccm/server/windows/management_point.rs` lines 1130-1144 (merged, #328)
- `src/sccm/client/policy.rs` lines 755-769 on `origin/codex/sccm-321-policy-analysis` (in flight, #391)

Both produced the same text for artifact scoping, inclusive-bounds comparison, and missing-bound handling. No edge case disagreed, so there was no semantics dispute to resolve, and the spine predicate is that text with the reasoning written down.

## Duplication collapse

The management-point copy is deleted; the reducer imports the spine predicate. The removed body is byte-identical to the spine one, so admission there is unchanged, and `sccm_server_management_point` passes unmodified (26/26).

`policy.rs` does not exist on `codex/parser-family-skeleton` yet, so its copy cannot be collapsed here. **#391 should drop `evidence_references_overlap` from `policy.rs` when it rebases** and import `crate::sccm::findings::evidence_references_overlap` instead. `quarantine_overlapping_evidence` stays where it is: it is a reducer policy (quarantine every participant rather than reject the bundle), not the predicate.

## Shipped-fixture audit

Every `expected.json` in the tree was scanned for two references with distinct `entryId` and overlapping ranges inside one artifact, across all three citation surfaces (`evidence`, `terminalEvidence[].reference`, `correlationKeys[].evidence`). The same scan was run against every in-flight SCCM lane branch, since this rejection lands under work already in review.

| Branch | findings | references | violations |
| --- | --- | --- | --- |
| `codex/parser-family-skeleton` (065b8cb7) | 57 | 79 | 0 |
| `codex/sccm-321-policy-analysis` (#391) | 24 | 28 | 0 |
| `codex/sccm-320-health-analysis` (#392) | 24 | 28 | 0 |
| `codex/sccm-319-pure-intake` (#394) | 24 | 28 | 0 |
| `codex/sccm-spine-findings-hardening` (#404) | 24 | 28 | 0 |
| `codex/sccm-327-site-core-reducer` (#405) | 24 | 28 | 0 |
| `codex/sccm-322-deployment-reducer` (#407) | 24 | 28 | 0 |

No shipped fixture carries the shape. Reducer output is covered by the fixture contract suites: they run each reducer over its corpus and diff against `expected.json`, and management point in particular does `builder.build().ok()?`, so a newly rejected finding would silently vanish and fail the comparison. All of them stay green, so no reducer emits an overlapping citation today either.

**One test fixture did carry the shape**, and it is reported rather than papered over. `finding_rejects_key_or_terminal_refs_that_are_not_cited` built its uncited reference with `finding_evidence_ref("client-policy-agent", "policy:2-2")`, and that helper pins every span to line 1 regardless of the entry id. So `policy:2-2` claimed line 1 alongside `policy:1-1`, which is exactly the defect: two entry ids over one physical line, with entry ids that advertise ranges contradicting their own bounds. The fix spells the span out as `2-2` to match the entry id it advertises. The test's subject, that an uncited reference is rejected, is unchanged and still asserts `CorrelationKeyEvidenceNotCited` / `TerminalEvidenceNotCited`. This was a latent inconsistency in the fixture, not a semantics disagreement.

## RED / GREEN

- RED `19addcdb` added the contract plus the inert `OverlappingEvidenceReference` variant so it compiles, and failed with the spine accepting the shape: `called Result::unwrap_err() on an Ok value: SccmFinding { ... evidence: [SccmEvidenceRef { artifact_id: "artifact-a", entry_id: "entry-a", line_start: Some(4), line_end: Some(6) }, SccmEvidenceRef { artifact_id: "artifact-a", entry_id: "entry-b", line_start: Some(4), line_end: Some(6) }] }`. 139 passed, 2 failed.
- GREEN `8b487a35` wired the predicate into the validator and collapsed the management-point copy. 141 passed, 0 failed.

New coverage goes through the real `SccmFinding::validate` path, not a unit helper: builder, direct `validate()`, `serde` deserialization, and the validating serializer. Six overlap shapes (identical, shared start line, shared end line, contained, containing, straddling) are each exercised on all three citation surfaces, and the shapes that must keep validating are pinned too: adjacent spans, equal spans in different artifacts, one bounded plus one unbounded, and both unbounded.

## Verification

All from the worktree, all clean.

- `cargo test --locked -p cmtraceopen-parser --test sccm_spine_contract`: **141 passed, 0 failed** (138 before).
- `cargo test --locked -p cmtraceopen-parser`: **1039 passed, 0 failed** across 21 binaries. Baseline on 065b8cb7 was 1036; the delta is exactly the 3 new spine tests, every other binary count is identical.
- `cargo test --locked --workspace`: **1793 passed, 0 failed** across 36 binaries.
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings`: clean.
- `cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown`: clean.
- `npx tsc --noEmit`: clean.
- `git diff --check 065b8cb7 HEAD`: clean.
- `rustfmt --check` on all three changed files: clean.

Every SCCM contract suite in the tree, run individually, all green:

| Suite | Tests |
| --- | --- |
| `sccm_client_deployment_fixture_contract` | 8 |
| `sccm_client_health_fixture_contract` | 3 |
| `sccm_client_intake_fixture_contract` | 3 |
| `sccm_client_inventory_compliance_metering_fixture_contract` | 47 |
| `sccm_client_management_fixture_contract` | 29 |
| `sccm_client_task_sequence_fixture_contract` | 30 |
| `sccm_client_updates_fixture_contract` | 17 |
| `sccm_correlation_contract` | 12 |
| `sccm_server_advanced_roles_catalog` | 6 |
| `sccm_server_distribution_point_fixture_contract` | 48 |
| `sccm_server_hierarchy_and_replication_fixture_contract` | 28 |
| `sccm_server_intake` | 11 |
| `sccm_server_intake_fixture_contract` | 1 |
| `sccm_server_management_point` | 26 |
| `sccm_server_provider_and_admin_service_fixture_contract` | 30 |
| `sccm_server_software_update_point_fixture_contract` | 18 |
| `sccm_site_core_fixture_contract` | 5 |
| `sccm_spine_contract` | 141 |
| **Total** | **463** |

## Reviewer attention

`SccmFindingValidationError` gains a variant. It is `#[derive(Debug, Clone, Copy, PartialEq, Eq)]` with no `#[non_exhaustive]`, and nothing in the tree matches on it exhaustively, but any lane holding a match should be checked on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Evidence validation now detects and rejects overlapping bounded references for the same artifact and entry.
  - References from primary, terminal, and correlation-key evidence are validated consistently.
  - Valid disjoint, adjacent, cross-artifact, and unbounded references continue to be accepted.
  - Clear validation errors are reported when evidence references conflict.

- **Tests**
  - Expanded coverage for validation, serialization, deserialization, citation ranges, and evidence reference handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->