### PR TITLE
ci: run CI for pull requests targeting the SCCM integration branch

### DIFF
--- a/.github/workflows/cmtrace-ci.yml
+++ b/.github/workflows/cmtrace-ci.yml
@@ -2,9 +2,11 @@ name: "CMTrace Open: CI"
 
 on:
   push:
-    branches: [main]
+    branches: [main, codex/parser-family-skeleton]
   pull_request:
-    branches: [main]
+    # Long-lived integration branches must be listed explicitly: a PR whose base
+    # is absent here runs no jobs at all, silently, and still reports mergeable.
+    branches: [main, codex/parser-family-skeleton]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

`.github/workflows/cmtrace-ci.yml` triggers only on `main`:

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
```

The entire SCCM program stacks on `codex/parser-family-skeleton`, an integration branch currently 276 commits ahead of `main`. Every open SCCM lane PR targets it:

| PR | Lane |
|----|------|
| #391 | client policy transactions |
| #392 | client health and location evidence |
| #394 | pure client intake coverage |
| #404 | spine hardening |
| #405 | site core status evidence |
| #407 | client deployment transactions |
| #420 | spine overlap validation |

None of them run any of the workflow's six jobs: `check` (cargo check/test/clippy), `msrv`, `frontend` (`tsc --noEmit`), `e2e` (Playwright), `windows-esp`, or `build` (macOS-arm64 / Windows-x64 / Linux-x64).

What makes this easy to miss is that GitHub reports nothing at all. A PR whose base branch is absent from the trigger list does not show pending or skipped checks -- it shows only the CodeRabbit and labeler entries, which reads like a PR with light gating rather than one with no gating. All seven currently report as mergeable.

## Change

Add `codex/parser-family-skeleton` to both triggers, so lane PRs are gated before they land on the integration branch and the branch itself is verified after each merge.

## Tradeoff

Adding the branch to the `push` trigger means full CI, including the three platform builds, on every merge into the integration branch. That is real CI time, and it is the point: 276 commits have accumulated there without a single automated check.

## Verification

- YAML parses; triggers resolve to `{push: [main, codex/parser-family-skeleton], pull_request: [main, codex/parser-family-skeleton]}`
- All six job definitions unchanged
- `git diff --check` clean; the diff touches only the `on:` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to run for pushes and pull requests targeting both supported branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #317
