### PR TITLE
docs(skills): record review-loop MIT provenance

### DIFF
--- a/.claude/skills/gh-copilot-review-loop/LICENSE.txt
+++ b/.claude/skills/gh-copilot-review-loop/LICENSE.txt
@@ -1,10 +1,3 @@
-Third-party attribution for gh-copilot-review-loop
-
-Source: https://github.com/jorgeasaurus/agent-skills/tree/72ef3d3322ee0ac8db02cf324c2030f13d3bb68d/gh-copilot-review-loop
-Upstream author: Jorge Suarez (jorgeasaurus)
-Upstream commit: 72ef3d3322ee0ac8db02cf324c2030f13d3bb68d
-License: MIT, as declared by the upstream repository README
-
 MIT License
 
 Copyright (c) 2026 Jorge Suarez
@@ -26,3 +19,12 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Third-party attribution for gh-copilot-review-loop
+
+Source: https://github.com/jorgeasaurus/agent-skills/tree/72ef3d3322ee0ac8db02cf324c2030f13d3bb68d/gh-copilot-review-loop
+Upstream author: Jorge Suarez (jorgeasaurus)
+Upstream commit: 72ef3d3322ee0ac8db02cf324c2030f13d3bb68d
+License identifier: MIT, as declared by the upstream repository README. The
+upstream repository did not publish a root license file at this commit, so the
+standard MIT license text and source attribution are recorded locally.

--- a/.claude/skills/gh-copilot-review-loop/LICENSE.txt
+++ b/.claude/skills/gh-copilot-review-loop/LICENSE.txt
@@ -1,0 +1,28 @@
+Third-party attribution for gh-copilot-review-loop
+
+Source: https://github.com/jorgeasaurus/agent-skills/tree/72ef3d3322ee0ac8db02cf324c2030f13d3bb68d/gh-copilot-review-loop
+Upstream author: Jorge Suarez (jorgeasaurus)
+Upstream commit: 72ef3d3322ee0ac8db02cf324c2030f13d3bb68d
+License: MIT, as declared by the upstream repository README
+
+MIT License
+
+Copyright (c) 2026 Jorge Suarez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/gh-copilot-review-loop/SKILL.md
+++ b/.claude/skills/gh-copilot-review-loop/SKILL.md
@@ -65,4 +65,6 @@ Report the PR URL, final commit, review-cycle count, resolved threads, verificat
 
 ## Provenance
 
-Adapted from `gh-copilot-review-loop` in https://github.com/jorgeasaurus/agent-skills (upstream states no license). The only change is the state-script path, which upstream resolves under `$CODEX_HOME`.
+Adapted from [`gh-copilot-review-loop`](https://github.com/jorgeasaurus/agent-skills/tree/72ef3d3322ee0ac8db02cf324c2030f13d3bb68d/gh-copilot-review-loop) by Jorge Suarez (`jorgeasaurus`). The upstream repository declares the work under the MIT License in its README. This copy pins upstream commit `72ef3d3322ee0ac8db02cf324c2030f13d3bb68d`; see `LICENSE.txt` in this directory for the preserved license and attribution.
+
+Local changes use the repository-relative state-script path, add the explicit `--repo`/`--pr` example, and format the reviewer-request command on one line. `scripts/review_state.py` is byte-identical to the pinned upstream version.

--- a/.claude/skills/gh-copilot-review-loop/SKILL.md
+++ b/.claude/skills/gh-copilot-review-loop/SKILL.md
@@ -65,6 +65,6 @@ Report the PR URL, final commit, review-cycle count, resolved threads, verificat
 
 ## Provenance
 
-Adapted from [`gh-copilot-review-loop`](https://github.com/jorgeasaurus/agent-skills/tree/72ef3d3322ee0ac8db02cf324c2030f13d3bb68d/gh-copilot-review-loop) by Jorge Suarez (`jorgeasaurus`). The upstream repository declares the work under the MIT License in its README. This copy pins upstream commit `72ef3d3322ee0ac8db02cf324c2030f13d3bb68d`; see `LICENSE.txt` in this directory for the preserved license and attribution.
+Adapted from [`gh-copilot-review-loop`](https://github.com/jorgeasaurus/agent-skills/tree/72ef3d3322ee0ac8db02cf324c2030f13d3bb68d/gh-copilot-review-loop) by Jorge Suarez (`jorgeasaurus`). The upstream repository declares the work under the MIT License in its README. This copy pins upstream commit `72ef3d3322ee0ac8db02cf324c2030f13d3bb68d`; see `LICENSE.txt` in this directory for the standard MIT license text recorded locally together with source attribution.
 
 Local changes use the repository-relative state-script path, add the explicit `--repo`/`--pr` example, and format the reviewer-request command on one line. `scripts/review_state.py` is byte-identical to the pinned upstream version.


### PR DESCRIPTION
## What changed

- Correct the inaccurate claim that the upstream `gh-copilot-review-loop` has no license.
- Pin the copied/adapted material to upstream commit `72ef3d3322ee0ac8db02cf324c2030f13d3bb68d`.
- Preserve the MIT license text and upstream attribution in a colocated `LICENSE.txt`.
- Record the actual local `SKILL.md` edits and the byte-identical helper-script state.

## Independent provenance verification

- Upstream repository: https://github.com/jorgeasaurus/agent-skills
- Upstream README has declared `MIT` since the initial commit.
- GitHub's API returns `license: null` because the project has no root license file; that detector result was the source of the incorrect note.
- The pinned skill commit was authored by Jorge Suarez (`jorgeasaurus`).
- Local and pinned-upstream `review_state.py` SHA-256: `71703606bcf171b9e7f8035466d41806622be7a6f04b8157ef86f16fb3ecdfad`.

## Verification

- `python3 .claude/skills/gh-copilot-review-loop/scripts/review_state.py --help`
- upstream/local SHA-256 comparison
- `git diff --check`
- CodeRabbit CLI 0.7.1 review: zero findings

This is intentionally separate from PR #384; that PR currently changes no `.claude/skills/` files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated attribution and provenance details for the `gh-copilot-review-loop` skill.
  * Documented its MIT license and included the complete license text.
  * Clarified the upstream source commit and local command/path adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->