### PR TITLE
fix(tooling): harden Copilot review state evidence

### DIFF
--- a/.claude/skills/gh-copilot-review-loop/scripts/review_state.py
+++ b/.claude/skills/gh-copilot-review-loop/scripts/review_state.py
@@ -68,9 +68,9 @@ def current_pr() -> tuple[str, str, int]:
         "number,url",
     ])
     path = urlparse(data["url"]).path.strip("/").split("/")
-    if len(path) != 4 or path[2] != "pull":
+    if len(path) < 4 or path[-2] != "pull":
         raise SystemExit(f"unexpected pull request URL: {data['url']}")
-    return path[0], path[1], int(data["number"])
+    return path[-4], path[-3], int(data["number"])
 
 
 def fetch(owner: str, repo: str, number: int) -> dict[str, Any]:

--- a/.claude/skills/gh-copilot-review-loop/scripts/review_state.py
+++ b/.claude/skills/gh-copilot-review-loop/scripts/review_state.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import subprocess
 from typing import Any
+from urllib.parse import urlparse
 
 
 QUERY = r"""
@@ -64,13 +65,12 @@ def run_json(command: list[str], stdin: str | None = None) -> dict[str, Any]:
 def current_pr() -> tuple[str, str, int]:
     data = run_json([
         "gh", "pr", "view", "--json",
-        "number,headRepositoryOwner,headRepository",
+        "number,url",
     ])
-    return (
-        data["headRepositoryOwner"]["login"],
-        data["headRepository"]["name"],
-        int(data["number"]),
-    )
+    path = urlparse(data["url"]).path.strip("/").split("/")
+    if len(path) != 4 or path[2] != "pull":
+        raise SystemExit(f"unexpected pull request URL: {data['url']}")
+    return path[0], path[1], int(data["number"])
 
 
 def fetch(owner: str, repo: str, number: int) -> dict[str, Any]:
@@ -125,7 +125,10 @@ def fetch(owner: str, repo: str, number: int) -> dict[str, Any]:
     assert metadata is not None
     reviews = list({review["id"]: review for review in reviews}.values())
     threads = list({thread["id"]: thread for thread in threads}.values())
-    copilot_reviews = [review for review in reviews if is_copilot(review.get("author"))]
+    copilot_reviews = [
+        review for review in reviews
+        if is_copilot(review.get("author")) and review.get("submittedAt") is not None
+    ]
     copilot_reviews.sort(key=lambda review: review.get("submittedAt") or "")
     unresolved = [thread for thread in threads if not thread["isResolved"]]
     unresolved_copilot = [thread for thread in unresolved if thread_has_copilot(thread)]

--- a/.claude/skills/gh-copilot-review-loop/tests/test_review_state.py
+++ b/.claude/skills/gh-copilot-review-loop/tests/test_review_state.py
@@ -51,6 +51,23 @@ class CurrentPullRequestTests(unittest.TestCase):
 
         self.assertEqual(current, ("base-owner", "base-repo", 42))
 
+    def test_enterprise_url_prefix_preserves_base_repository(self) -> None:
+        response = {
+            "number": 42,
+            "url": (
+                "https://enterprise.example/github/"
+                "base-owner/base-repo/pull/42"
+            ),
+        }
+
+        with patch.object(review_state, "run_json", return_value=response):
+            try:
+                current = review_state.current_pr()
+            except SystemExit as error:
+                self.fail(f"valid enterprise pull request URL rejected: {error}")
+
+        self.assertEqual(current, ("base-owner", "base-repo", 42))
+
 
 class CopilotReviewSummaryTests(unittest.TestCase):
     def test_pending_copilot_review_does_not_count_as_submitted(self) -> None:

--- a/.claude/skills/gh-copilot-review-loop/tests/test_review_state.py
+++ b/.claude/skills/gh-copilot-review-loop/tests/test_review_state.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "review_state.py"
+SPEC = importlib.util.spec_from_file_location("review_state", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+review_state = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(review_state)
+
+
+def graphql_response(reviews: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "number": 42,
+                    "url": "https://github.com/base-owner/base-repo/pull/42",
+                    "headRefOid": "a" * 40,
+                    "isDraft": False,
+                    "reviewDecision": None,
+                    "reviews": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": reviews,
+                    },
+                    "reviewThreads": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [],
+                    },
+                }
+            }
+        }
+    }
+
+
+class CurrentPullRequestTests(unittest.TestCase):
+    def test_fork_pull_request_uses_repository_from_base_url(self) -> None:
+        response = {
+            "number": 42,
+            "url": "https://github.com/base-owner/base-repo/pull/42",
+            "headRepositoryOwner": {"login": "fork-owner"},
+            "headRepository": {"name": "fork-repo"},
+        }
+
+        with patch.object(review_state, "run_json", return_value=response):
+            current = review_state.current_pr()
+
+        self.assertEqual(current, ("base-owner", "base-repo", 42))
+
+
+class CopilotReviewSummaryTests(unittest.TestCase):
+    def test_pending_copilot_review_does_not_count_as_submitted(self) -> None:
+        pending = {
+            "id": "pending",
+            "state": "PENDING",
+            "body": "",
+            "submittedAt": None,
+            "author": {"login": "copilot-pull-request-reviewer"},
+            "commit": None,
+        }
+
+        with patch.object(
+            review_state,
+            "run_json",
+            return_value=graphql_response([pending]),
+        ):
+            summary = review_state.fetch("base-owner", "base-repo", 42)["summary"]
+
+        self.assertEqual(summary["copilot_review_count"], 0)
+        self.assertIsNone(summary["latest_copilot_review"])
+
+    def test_latest_copilot_review_ignores_pending_review(self) -> None:
+        submitted = {
+            "id": "submitted",
+            "state": "COMMENTED",
+            "body": "Review complete",
+            "submittedAt": "2026-08-01T12:00:00Z",
+            "author": {"login": "copilot-pull-request-reviewer"},
+            "commit": {"oid": "b" * 40},
+        }
+        pending = {
+            "id": "pending",
+            "state": "PENDING",
+            "body": "",
+            "submittedAt": None,
+            "author": {"login": "copilot-pull-request-reviewer"},
+            "commit": None,
+        }
+
+        with patch.object(
+            review_state,
+            "run_json",
+            return_value=graphql_response([submitted, pending]),
+        ):
+            result = review_state.fetch("base-owner", "base-repo", 42)
+
+        self.assertEqual(result["summary"]["review_count"], 2)
+        self.assertEqual(result["summary"]["copilot_review_count"], 1)
+        self.assertEqual(
+            result["summary"]["latest_copilot_review"],
+            submitted,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- derive the pull requests base repository from the canonical PR URL, so current-branch lookup works when the head branch is hosted in a fork
- accept GitHub Enterprise deployment path prefixes while selecting the owner/repository immediately before the terminal `/pull/<number>` suffix
- exclude pending Copilot review objects from the completed review count and latest-review evidence
- add focused Python regression coverage for fork routing, prefixed enterprise URLs, pending-only review state, and mixed pending/submitted reviews

## Root cause

`current_pr()` returned `headRepositoryOwner/headRepository`, but a PR number belongs to the base repository. The summary also treated every Copilot-authored review node as completed even when `submittedAt` was null.

## Verification

- RED: initial focused unittest command produced 3 expected assertion failures before implementation
- RED: enterprise-prefix regression rejected the valid prefixed URL before the review fix
- GREEN: `python3 -m unittest discover -s .claude/skills/gh-copilot-review-loop/tests -p test_\*.py -v` — 4 tests passed
- `python3 -m compileall -q .claude/skills/gh-copilot-review-loop/scripts .claude/skills/gh-copilot-review-loop/tests`
- live probe: `review_state.py --repo adamgell/cmtraceopen --pr 384` — parsed PR metadata and reported only submitted Copilot review evidence
- real current-branch `review_state.py` probe resolved PR #426
- `git diff --cached --check`
- local CodeRabbit review after each implementation round — 0 findings

Closes #423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request detection for standard, fork-based, and enterprise-hosted pull request URLs.
  * Excluded pending Copilot reviews from submitted review counts and latest-review results.

* **Tests**
  * Added coverage for pull request URL handling, including fork scenarios.
  * Added tests confirming pending reviews are excluded from review summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->