### PR TITLE
ci(coderabbit): fit tone guidance within schema limit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,9 +6,9 @@ language: en-US
 
 tone_instructions: >-
   Review as a senior, perfectionist engineer. Be direct and concise: lead with the
-  concrete defect and the fix, skip praise and restatement of the diff. Prefer one
-  well-evidenced comment over several speculative ones. Never use em dashes or en
-  dashes in any output; restructure the sentence instead.
+  concrete defect and fix; skip praise and diff restatement. Prefer one evidenced
+  comment to speculative ones. Never use em or en dashes; rewrite the sentence
+  instead.
 
 reviews:
   profile: assertive


### PR DESCRIPTION
Closes #424.

## What changed

- shortened only `tone_instructions` from 297 to 246 characters
- preserved the senior, direct, concise, evidence-first, no-dash review guidance
- left all other CodeRabbit settings unchanged

## Root cause

The official CodeRabbit schema caps `tone_instructions` at 250 characters. The repository value resolved to 297 characters, so CodeRabbit rejected the complete configuration and fell back to defaults.

## Impact

CodeRabbit can load the repository-specific review profile again instead of ignoring the configuration.

## Verification

- `coderabbit config validate`: valid against the current official schema
- `coderabbit review --agent --uncommitted`: 0 findings, reviewed `.coderabbit.yaml`
- `ruby -ryaml ...`: resolved scalar is 246 characters
- `npm exec tsc -- --noEmit`: passed
- `npm test -- --run`: 41 files, 529 tests passed
- `cargo build --locked --workspace`: passed
- `cargo test --locked --workspace`: passed
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined review guidance for more concise, direct, evidence-based feedback.
  * Preserved the requirement to avoid em and en dashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->