### PR TITLE
docs(skills): keep TypeScript baseline local-only

### DIFF
--- a/.claude/skills/batch-issue-prs/SKILL.md
+++ b/.claude/skills/batch-issue-prs/SKILL.md
@@ -21,7 +21,7 @@ Turn a set of GitHub issues into separate, independently reviewable PRs, each dr
 Establish a green baseline and keep the output:
 
 ```bash
-npx tsc --noEmit
+npm exec --offline --yes=false -- tsc --noEmit
 cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets
 ```
 


### PR DESCRIPTION
## Summary

- replace the batch skill's plain `npx tsc --noEmit` baseline with `npm exec --offline --yes=false -- tsc --noEmit`
- keep the Cargo baseline and all production code unchanged
- split this repo-tooling correction away from PR #384

## Root cause

Plain `npx` may resolve and install a missing executable from the npm registry. CodeRabbit correctly identified that fallback risk on PR #384, but its literal `npx --no` suggestion still performs registry metadata resolution with npm 10.9.7 and npm 11.12.1.

The replacement uses both controls needed for a fail-closed check:

- `--offline` prevents registry access
- `--yes=false` refuses installation even when a non-local package is already cached

The repository already declares and locks `typescript` as a dev dependency, so an installed checkout continues to run the project-local compiler.

## Verification

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm exec --offline --yes=false -- tsc --noEmit` — pass (Node 22.22.2, npm 10.9.7)
- `PATH=/opt/homebrew/opt/node@25/bin:$PATH npm exec --offline --yes=false -- tsc --noEmit` — pass (Node 25.9.0, npm 11.12.1)
- empty local project/cache + unreachable registry — `ENOTCACHED`, no connection attempt, no install
- seeded non-local `tsc` cache + no local dependency — canceled, no install
- `cargo check --locked --manifest-path src-tauri/Cargo.toml --all-targets` — pass
- `git diff --check` — pass
- CodeRabbit CLI review — zero findings

Closes #425


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TypeScript baseline check to run reliably in offline environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->