### PR TITLE
ci: gate SCCM integration branch

### DIFF
--- a/.github/workflows/cmtrace-ci.yml
+++ b/.github/workflows/cmtrace-ci.yml
@@ -2,9 +2,11 @@ name: "CMTrace Open: CI"
 
 on:
   push:
-    branches: [main]
+    branches: [main, codex/parser-family-skeleton]
   pull_request:
-    branches: [main]
+    # Long-lived integration branches must be listed explicitly: a PR whose base
+    # is absent here runs no jobs at all, silently, and still reports mergeable.
+    branches: [main, codex/parser-family-skeleton]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- ports the trigger-only change from #421 onto `codex/parser-family-skeleton`
- runs this workflow for pushes to both `main` and the SCCM integration branch
- runs the same unchanged job set for pull requests targeting either branch

This is the integration-branch port of #421. That PR fixed `main`, but the SCCM implementation lanes under epic #317 are based on `codex/parser-family-skeleton`, so the trigger change must also land on that branch before those PRs receive CI.

## Scope

Only `.github/workflows/cmtrace-ci.yml` changes. No jobs or steps are modified.

Refs #317

## Verification

- RED: exact trigger assertion failed on the base with `AssertionError: ['main']`
- GREEN: PyYAML parse plus exact push/pull-request branch assertions
- GREEN: exact unchanged job IDs: `build`, `check`, `e2e`, `frontend`, `msrv`, `windows-esp`
- GREEN: `actionlint .github/workflows/cmtrace-ci.yml`
- GREEN: `git diff --check 065b8cb7e4d4184fe4141f4da882e968d7590836..HEAD`
- GREEN: changed-file assertion permits only `.github/workflows/cmtrace-ci.yml`
- GREEN: local CodeRabbit review returned no actionable findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated CI checks to run for changes pushed to or proposed against the parser-family development branch, in addition to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->