### PR TITLE
fix(sccm): scope server intake identities by provenance

### DIFF
--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -310,10 +310,23 @@ struct PreparedArtifact {
 }
 
 impl PreparedArtifact {
-    fn sort_key(&self) -> (&str, &str, &str, String, &str, &str) {
+    fn sort_key(&self) -> (&str, &str, &str, &str, &str, &str, String, &str, &str) {
         (
             role_sort_key(&self.assessment.producer_role),
+            self.assessment
+                .producer_host_handle
+                .as_deref()
+                .unwrap_or_default(),
             self.assessment.source_id.as_str(),
+            self.assessment
+                .workflow_subject_role
+                .as_ref()
+                .map(role_sort_key)
+                .unwrap_or_default(),
+            self.assessment
+                .workflow_subject_handle
+                .as_deref()
+                .unwrap_or_default(),
             self.assessment.path_fingerprint.as_str(),
             rotation_sort_key(self.assessment.rotation.as_ref()),
             self.assessment
@@ -1055,7 +1068,9 @@ fn safe_optional_handle(value: Option<&str>, synthetic_fixture: bool, domain: &s
             "subject" => {
                 matches!(
                     value,
-                    "synthetic:subject:dp-01" | "synthetic:subject:sup-01"
+                    "synthetic:subject:dp-01"
+                        | "synthetic:subject:dp-02"
+                        | "synthetic:subject:sup-01"
                 )
             }
             _ => false,

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -12,8 +12,25 @@ use crate::sccm::{
 
 use super::catalog::{classify_declared_server_source, expected_family, SccmServerSourceKind};
 
-type PathFingerprintKey = (String, String, String, String);
-type CanonicalArtifactIdentity = (String, String, String, String, String, String, String);
+type PathFingerprintKey = (
+    String,
+    Option<String>,
+    String,
+    String,
+    Option<String>,
+    String,
+);
+type CanonicalArtifactIdentity = (
+    String,
+    Option<String>,
+    String,
+    String,
+    Option<String>,
+    String,
+    String,
+    String,
+    String,
+);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SccmServerArtifactPayload {
@@ -463,12 +480,17 @@ fn normalize_artifact(
 
     let path_fingerprint_key = (
         role_sort_key(&artifact.producer_role).to_owned(),
+        artifact.producer_host_handle.clone(),
         artifact.source_id.clone(),
         workflow_subject_role
             .as_ref()
             .map(role_sort_key)
             .unwrap_or_default()
             .to_owned(),
+        artifact
+            .workflow_subject
+            .as_ref()
+            .and_then(|subject| subject.instance_handle.clone()),
         artifact
             .configured_path_provenance
             .path_fingerprint
@@ -487,12 +509,17 @@ fn normalize_artifact(
 
     let canonical_identity = (
         role_sort_key(&artifact.producer_role).to_owned(),
+        artifact.producer_host_handle.clone(),
         artifact.source_id.clone(),
         workflow_subject_role
             .as_ref()
             .map(role_sort_key)
             .unwrap_or_default()
             .to_owned(),
+        artifact
+            .workflow_subject
+            .as_ref()
+            .and_then(|subject| subject.instance_handle.clone()),
         artifact
             .configured_path_provenance
             .path_fingerprint

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -1,4 +1,6 @@
-use cmtraceopen_parser::sccm::server::windows::{assess_server_intake, SccmServerArtifactPayload};
+use cmtraceopen_parser::sccm::server::windows::{
+    assess_server_intake, SccmServerArtifactPayload, SccmServerIntakeError,
+};
 use cmtraceopen_parser::sccm::{SccmCoverageState, SccmRole, SccmRotation};
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
@@ -306,9 +308,103 @@ fn server_intake_rejects_relabelled_duplicate_canonical_artifact_identity() {
     manifest["artifacts"][1]["configuredPathProvenance"]["pathFingerprint"] = fingerprint;
     manifest["artifacts"][1]["rotation"]["lineageId"] = lineage;
 
-    assert!(
-        assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
-        "caller-chosen artifact and root labels must not duplicate one canonical identity"
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads),
+        Err(SccmServerIntakeError::DuplicateArtifact),
+        "caller-chosen artifact and root labels must not duplicate one canonical identity",
+    );
+}
+
+#[test]
+fn server_intake_scopes_canonical_identity_to_producer_host() {
+    let (manifest_json, payloads) = load_bundle("collision-same-basename-configured-roots");
+    let mut manifest = manifest_value(&manifest_json);
+    let fingerprint =
+        manifest["artifacts"][0]["configuredPathProvenance"]["pathFingerprint"].clone();
+    let lineage = manifest["artifacts"][0]["rotation"]["lineageId"].clone();
+    manifest["artifacts"][1]["producerHostHandle"] =
+        Value::String("synthetic:host:site-01".to_owned());
+    manifest["artifacts"][1]["configuredPathProvenance"]["pathFingerprint"] = fingerprint;
+    manifest["artifacts"][1]["rotation"]["lineageId"] = lineage;
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("the same artifact identity on a distinct producer host is independent");
+    assert_eq!(assessment.artifacts.len(), 2);
+}
+
+#[test]
+fn server_intake_scopes_path_fingerprint_lineage_to_producer_host() {
+    let (manifest_json, payloads) = load_bundle("collision-same-basename-configured-roots");
+    let mut manifest = manifest_value(&manifest_json);
+    let fingerprint =
+        manifest["artifacts"][0]["configuredPathProvenance"]["pathFingerprint"].clone();
+    manifest["artifacts"][1]["producerHostHandle"] =
+        Value::String("synthetic:host:site-01".to_owned());
+    manifest["artifacts"][1]["configuredPathProvenance"]["pathFingerprint"] = fingerprint;
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("path fingerprints are scoped to their producer host");
+    assert_eq!(assessment.artifacts.len(), 2);
+}
+
+fn configure_second_artifact_as_dp_identity(
+    manifest: &mut Value,
+    subject_handle: &str,
+    share_lineage: bool,
+) {
+    let fingerprint =
+        manifest["artifacts"][2]["configuredPathProvenance"]["pathFingerprint"].clone();
+    let lineage = manifest["artifacts"][2]["rotation"]["lineageId"].clone();
+    let artifact = &mut manifest["artifacts"][3];
+    artifact["workflowSubject"] = json!({
+        "role": "distributionPoint",
+        "instanceHandle": subject_handle,
+    });
+    artifact["sourceId"] = Value::String("server-dp-distribution".to_owned());
+    artifact["originalPath"] = Value::String("REDACTED_SITE_DP_CONTROL_ROOT_COPY".to_owned());
+    artifact["originalBasename"] = Value::String("distmgr.log".to_owned());
+    artifact["configuredPathProvenance"]["pathFingerprint"] = fingerprint;
+    if share_lineage {
+        artifact["rotation"]["lineageId"] = lineage;
+    }
+    artifact["relativePath"] = Value::String(
+        "evidence/sccm/server/site-server/server-dp-distribution/subject-distribution-point/instance-bbbbbbbb/current/distmgr.log"
+            .to_owned(),
+    );
+}
+
+#[test]
+fn server_intake_scopes_canonical_identity_to_workflow_subject() {
+    let (manifest_json, payloads) = load_bundle("complete-multi-role");
+    let mut manifest = manifest_value(&manifest_json);
+    configure_second_artifact_as_dp_identity(&mut manifest, "synthetic:subject:sup-01", true);
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("the same artifact identity for a distinct workflow subject is independent");
+    assert_eq!(assessment.artifacts.len(), 4);
+}
+
+#[test]
+fn server_intake_scopes_path_fingerprint_lineage_to_workflow_subject() {
+    let (manifest_json, payloads) = load_bundle("complete-multi-role");
+    let mut manifest = manifest_value(&manifest_json);
+    configure_second_artifact_as_dp_identity(&mut manifest, "synthetic:subject:sup-01", false);
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("path fingerprints are scoped to their workflow subject");
+    assert_eq!(assessment.artifacts.len(), 4);
+}
+
+#[test]
+fn server_intake_rejects_relabelled_duplicate_for_same_workflow_subject() {
+    let (manifest_json, payloads) = load_bundle("complete-multi-role");
+    let mut manifest = manifest_value(&manifest_json);
+    configure_second_artifact_as_dp_identity(&mut manifest, "synthetic:subject:dp-01", true);
+
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads),
+        Err(SccmServerIntakeError::DuplicateArtifact),
+        "caller labels cannot split one host-and-subject artifact identity",
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -322,14 +322,38 @@ fn server_intake_scopes_canonical_identity_to_producer_host() {
     let fingerprint =
         manifest["artifacts"][0]["configuredPathProvenance"]["pathFingerprint"].clone();
     let lineage = manifest["artifacts"][0]["rotation"]["lineageId"].clone();
-    manifest["artifacts"][1]["producerHostHandle"] =
+    manifest["artifacts"][0]["producerHostHandle"] =
         Value::String("synthetic:host:site-01".to_owned());
+    manifest["artifacts"][1]["producerHostHandle"] =
+        Value::String("synthetic:host:mp-01".to_owned());
     manifest["artifacts"][1]["configuredPathProvenance"]["pathFingerprint"] = fingerprint;
     manifest["artifacts"][1]["rotation"]["lineageId"] = lineage;
 
     let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
         .expect("the same artifact identity on a distinct producer host is independent");
     assert_eq!(assessment.artifacts.len(), 2);
+    assert_eq!(
+        assessment
+            .artifacts
+            .iter()
+            .map(|artifact| artifact.producer_host_handle.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("synthetic:host:mp-01"), Some("synthetic:host:site-01"),],
+        "producer-host provenance orders otherwise-equal artifacts before caller ids",
+    );
+
+    let mut reordered_manifest = manifest.clone();
+    reordered_manifest["artifacts"]
+        .as_array_mut()
+        .expect("artifacts are an array")
+        .reverse();
+    let reordered = assess_server_intake(&serialize_manifest(&reordered_manifest), &payloads)
+        .expect("reordered distinct-host artifacts are assessed");
+    assert_eq!(
+        serde_json::to_vec(&assessment).expect("assessment serializes"),
+        serde_json::to_vec(&reordered).expect("reordered assessment serializes"),
+        "distinct-host output is independent of manifest order",
+    );
 }
 
 #[test]
@@ -377,18 +401,46 @@ fn configure_second_artifact_as_dp_identity(
 fn server_intake_scopes_canonical_identity_to_workflow_subject() {
     let (manifest_json, payloads) = load_bundle("complete-multi-role");
     let mut manifest = manifest_value(&manifest_json);
-    configure_second_artifact_as_dp_identity(&mut manifest, "synthetic:subject:sup-01", true);
+    manifest["artifacts"][2]["workflowSubject"]["instanceHandle"] =
+        Value::String("synthetic:subject:dp-02".to_owned());
+    configure_second_artifact_as_dp_identity(&mut manifest, "synthetic:subject:dp-01", true);
 
     let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
         .expect("the same artifact identity for a distinct workflow subject is independent");
     assert_eq!(assessment.artifacts.len(), 4);
+    assert_eq!(
+        assessment
+            .artifacts
+            .iter()
+            .filter(|artifact| artifact.source_id == "server-dp-distribution")
+            .map(|artifact| artifact.workflow_subject_handle.as_deref())
+            .collect::<Vec<_>>(),
+        vec![
+            Some("synthetic:subject:dp-01"),
+            Some("synthetic:subject:dp-02"),
+        ],
+        "workflow-subject provenance orders otherwise-equal artifacts before caller ids",
+    );
+
+    let mut reordered_manifest = manifest.clone();
+    reordered_manifest["artifacts"]
+        .as_array_mut()
+        .expect("artifacts are an array")
+        .reverse();
+    let reordered = assess_server_intake(&serialize_manifest(&reordered_manifest), &payloads)
+        .expect("reordered distinct-subject artifacts are assessed");
+    assert_eq!(
+        serde_json::to_vec(&assessment).expect("assessment serializes"),
+        serde_json::to_vec(&reordered).expect("reordered assessment serializes"),
+        "distinct-subject output is independent of manifest order",
+    );
 }
 
 #[test]
 fn server_intake_scopes_path_fingerprint_lineage_to_workflow_subject() {
     let (manifest_json, payloads) = load_bundle("complete-multi-role");
     let mut manifest = manifest_value(&manifest_json);
-    configure_second_artifact_as_dp_identity(&mut manifest, "synthetic:subject:sup-01", false);
+    configure_second_artifact_as_dp_identity(&mut manifest, "synthetic:subject:dp-02", false);
 
     let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
         .expect("path fingerprints are scoped to their workflow subject");


### PR DESCRIPTION
Refs #335 and #317.

## What changed

- Scope the server intake path-fingerprint lineage reservation by the validated producer-host and workflow-subject handles.
- Scope the canonical artifact identity by the same provenance dimensions.
- Preserve exact `DuplicateArtifact` rejection when caller-chosen artifact/root labels relabel the same host-and-subject identity.
- Add focused adversarial coverage for both identity maps across distinct producer hosts and distinct workflow subjects.

## Root cause

The intake model already validated and projected `producerHostHandle` and `workflowSubject.instanceHandle`, but both internal deduplication keys stopped at role-level provenance. Artifacts from distinct hosts or distinct workflow subjects could therefore be rejected as duplicates when their remaining physical identity fields matched.

## TDD evidence

RED on test-only commit `56818acd`:

```text
cargo test --locked -p cmtraceopen-parser --test sccm_server_intake server_intake_scopes_ -- --nocapture
0 passed; 4 failed; each failed with DuplicateArtifact
```

GREEN on `2e0bd691`:

```text
producer-host and workflow-subject scope probes: 4 passed
precise true-duplicate probes: 2 passed
full server intake: 16 passed
SCCM spine: 138 passed
```

## Verification

- `cargo test --locked -p cmtraceopen-parser --test sccm_server_intake` — pass, 16/16
- `cargo test --locked -p cmtraceopen-parser --test sccm_spine_contract` — pass, 138/138
- `cargo test --locked -p cmtraceopen-parser` — pass
- `cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown` — pass
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings` — pass
- changed-file `rustfmt --check` — pass
- `npx --no-install tsc --noEmit` — pass
- `git diff --check 065b8cb7..HEAD` — pass
- local CodeRabbit exact-range review — 0 findings across both changed files

`cargo fmt --check --all` remains red only for inherited formatting drift in files outside this PR; the two changed files pass the scoped formatter gate.

## Boundaries

This is a pure-Rust internal-key repair. It changes no public serialized fields, adds no Windows/native collection code, and makes no live SCCM/Windows acceptance claim. PR remains unmerged pending exact-head hosted review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection by distinguishing artifacts from different producer hosts or workflow subjects.
  * Prevented unrelated artifacts with matching identity details from being incorrectly treated as duplicates.
  * Ensured artifact output remains consistent regardless of manifest order.
  * Preserved independent handling for artifacts associated with different hosts or workflow instances.

* **Tests**
  * Expanded coverage for duplicate identities, host-scoped paths, workflow-subject scoping, and ordering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Independent review follow-up

Independent exact-range review found that the new provenance dimensions were not yet part of `PreparedArtifact::sort_key`, and that the DP subject test used a SUP-shaped synthetic label.

Review-fix commit `b3ebb5b1`:
- orders otherwise-equal artifacts by producer host plus workflow-subject role/handle before path/rotation/basename/caller ID;
- proves byte-identical output under reordered distinct-host and distinct-subject manifests;
- adds only the synthetic `dp-02` subject handle and uses DP-shaped handles in DP tests.

Review-fix RED reproduced caller-ID ordering and rejected `dp-02` as `InvalidArtifact`; all listed gates were rerun GREEN at exact head `b3ebb5b1414a18eb180c654ae34479f3b6a51132`.