### PR TITLE
fix(intune): validate AppId GUID identities

### DIFF
--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 
 use regex::Regex;
 
-use super::guid_registry::{extract_app_id, extract_app_name, is_fallback_name, GuidRegistry};
+use super::guid_registry::{
+    explicit_app_identity, extract_app_id, extract_app_name, is_fallback_name, ExplicitAppIdentity,
+    GuidRegistry,
+};
 use super::ime_parser::ImeLine;
 use super::models::DownloadStat;
 use super::timeline::parse_timestamp;
@@ -349,14 +352,20 @@ fn classify_download_source(source_file: &str) -> DownloadSourceKind {
 }
 
 fn extract_content_id(msg: &str) -> Option<String> {
-    // Primary: shared extraction from guid_registry (handles AppId, Id, etc.)
-    extract_app_id(msg).or_else(|| {
-        // Fallback: download-specific broader pattern (e.g. "content id: <GUID>")
-        content_id_re()
-            .captures(msg)
-            .and_then(|captures| captures.get(1))
-            .map(|value| value.as_str().to_string())
-    })
+    match explicit_app_identity(msg) {
+        ExplicitAppIdentity::Valid(guid) => Some(guid),
+        ExplicitAppIdentity::Invalid => None,
+        ExplicitAppIdentity::Absent => {
+            // Preserve named-context and download-specific heuristics only
+            // when the line has no explicit JSON identity field.
+            extract_app_id(msg).or_else(|| {
+                content_id_re()
+                    .captures(msg)
+                    .and_then(|captures| captures.get(1))
+                    .map(|value| value.as_str().to_string())
+            })
+        }
+    }
 }
 
 fn extract_display_name(msg: &str) -> Option<String> {
@@ -732,5 +741,11 @@ mod tests {
             extract_display_name(message).as_deref(),
             Some("Contoso App")
         );
+    }
+
+    #[test]
+    fn invalid_explicit_identity_suppresses_download_line_fallback() {
+        let message = r#"Starting content download for app 11111111-2222-3333-4444-555555555555 {"AppId":"not-an-app-guid","ApplicationName":"Contoso"}"#;
+        assert_eq!(extract_content_id(message), None);
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -872,4 +872,42 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn download_sibling_identity_objects_have_no_attribution() {
+        let first = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let second = "11111111-2222-3333-4444-555555555555";
+        let payloads = [
+            format!(r#"[{{"AppId":"{first}"}},{{"AppId":"{second}"}}]"#),
+            format!(r#"[{{"AppId":"{second}"}},{{"AppId":"{first}"}}]"#),
+            format!(r#"[{{"Id":"{first}"}},{{"AppId":"{second}"}}]"#),
+            format!(r#"[{{"AppId":"{second}"}},{{"Id":"{first}"}}]"#),
+            format!(r#"{{"Items":[{{"Id":"{first}"}},{{"AppId":"{second}"}}]}}"#),
+            format!(
+                r#"{{"Left":{{"AppId":"{first}"}},"Right":{{"Metadata":{{"AppId":"{second}"}}}}}}"#
+            ),
+            format!(
+                r#"{{"Left":{{"Metadata":{{"AppId":"{second}"}}}},"Right":{{"AppId":"{first}"}}}}"#
+            ),
+        ];
+
+        for payload in payloads {
+            let lines = vec![ImeLine {
+                line_number: 1,
+                timestamp: Some("01-15-2024 10:00:05.000".to_string()),
+                timestamp_utc: None,
+                message: format!("Download completed successfully {payload}"),
+                component: None,
+                thread: None,
+                timezone_offset: None,
+            }];
+
+            let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &empty_registry());
+            assert_eq!(downloads.len(), 1, "missing coverage record for {payload}");
+            assert_eq!(
+                downloads[0].content_id, "unknown",
+                "attributed sibling from {payload}"
+            );
+        }
+    }
 }

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -828,4 +828,48 @@ mod tests {
         assert_eq!(downloads.len(), 1);
         assert_eq!(downloads[0].content_id, id_guid);
     }
+
+    #[test]
+    fn download_duplicate_identity_conflicts_have_no_attribution() {
+        let first = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let second = "11111111-2222-3333-4444-555555555555";
+        let payloads = [
+            format!(r#"{{"AppId":"{first}","AppId":"{second}","Name":"Contoso"}}"#),
+            format!(r#"{{"Id":"{first}","Id":"{second}","Name":"Contoso"}}"#),
+            format!(r#"{{"AppId":"{first}",\"AppId\":\"{second}\","Name":"Contoso"}}"#),
+            format!(r#"{{"Id":"{first}",\"Id\":\"{second}\","Name":"Contoso"}}"#),
+            format!(r#"{{"AppId":"invalid","AppId":"{first}","Name":"Contoso"}}"#),
+            format!(r#"{{"Id":"invalid","Id":"{first}","Name":"Contoso"}}"#),
+        ];
+
+        for payload in payloads {
+            let lines = vec![
+                ImeLine {
+                    line_number: 1,
+                    timestamp: Some("01-15-2024 10:00:00.000".to_string()),
+                    timestamp_utc: None,
+                    message: format!("Starting content download {payload}"),
+                    component: None,
+                    thread: None,
+                    timezone_offset: None,
+                },
+                ImeLine {
+                    line_number: 2,
+                    timestamp: Some("01-15-2024 10:00:05.000".to_string()),
+                    timestamp_utc: None,
+                    message: format!("Download completed successfully {payload}"),
+                    component: None,
+                    thread: None,
+                    timezone_offset: None,
+                },
+            ];
+
+            let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &empty_registry());
+            assert_eq!(downloads.len(), 1, "missing coverage record for {payload}");
+            assert_eq!(
+                downloads[0].content_id, "unknown",
+                "attributed conflict from {payload}"
+            );
+        }
+    }
 }

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -748,4 +748,84 @@ mod tests {
         let message = r#"Starting content download for app 11111111-2222-3333-4444-555555555555 {"AppId":"not-an-app-guid","ApplicationName":"Contoso"}"#;
         assert_eq!(extract_content_id(message), None);
     }
+
+    #[test]
+    fn download_app_id_syntaxes_precede_id() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let id_guid = "11111111-2222-3333-4444-555555555555";
+        let payloads = [
+            format!(r#"{{"AppId":"{app_guid}","Id":"{id_guid}","Name":"Contoso"}}"#),
+            format!(r#"{{\"AppId\":\"{app_guid}\",\"Id\":\"{id_guid}\",\"Name\":\"Contoso\"}}"#),
+            format!(r#"{{"AppId" : "{app_guid}","Id":"{id_guid}","Name":"Contoso"}}"#),
+            format!(r#"{{\"AppId\" : \"{app_guid}\",\"Id\":\"{id_guid}\",\"Name\":\"Contoso\"}}"#),
+            format!(r#"{{"AppId":"Win32App_{app_guid}_1","Id":"{id_guid}","Name":"Contoso"}}"#),
+            format!(
+                r#"{{\"AppId\":\"Win32App_{app_guid}_1\",\"Id\":\"{id_guid}\",\"Name\":\"Contoso\"}}"#
+            ),
+            format!(r#"{{"Id":"{id_guid}","AppId" : "{app_guid}","Name":"Contoso"}}"#),
+            format!(
+                r#"{{\"Id\":\"{id_guid}\",\"AppId\":\"Win32App_{app_guid}_1\",\"Name\":\"Contoso\"}}"#
+            ),
+        ];
+
+        for payload in payloads {
+            let lines = vec![
+                ImeLine {
+                    line_number: 1,
+                    timestamp: Some("01-15-2024 10:00:00.000".to_string()),
+                    timestamp_utc: None,
+                    message: format!("Starting content download {payload}"),
+                    component: None,
+                    thread: None,
+                    timezone_offset: None,
+                },
+                ImeLine {
+                    line_number: 2,
+                    timestamp: Some("01-15-2024 10:00:05.000".to_string()),
+                    timestamp_utc: None,
+                    message: format!("Download completed successfully {payload}"),
+                    component: None,
+                    thread: None,
+                    timezone_offset: None,
+                },
+            ];
+
+            let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &empty_registry());
+            assert_eq!(downloads.len(), 1, "missing download for {payload}");
+            assert_eq!(
+                downloads[0].content_id, app_guid,
+                "wrong identity for {payload}"
+            );
+        }
+    }
+
+    #[test]
+    fn download_invalid_app_id_still_allows_valid_id_fallback() {
+        let id_guid = "11111111-2222-3333-4444-555555555555";
+        let payload = format!(r#"{{"AppId":"invalid","Id":"{id_guid}","Name":"Contoso"}}"#);
+        let lines = vec![
+            ImeLine {
+                line_number: 1,
+                timestamp: Some("01-15-2024 10:00:00.000".to_string()),
+                timestamp_utc: None,
+                message: format!("Starting content download {payload}"),
+                component: None,
+                thread: None,
+                timezone_offset: None,
+            },
+            ImeLine {
+                line_number: 2,
+                timestamp: Some("01-15-2024 10:00:05.000".to_string()),
+                timestamp_utc: None,
+                message: format!("Download completed successfully {payload}"),
+                component: None,
+                thread: None,
+                timezone_offset: None,
+            },
+        ];
+
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &empty_registry());
+        assert_eq!(downloads.len(), 1);
+        assert_eq!(downloads[0].content_id, id_guid);
+    }
 }

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -580,8 +580,15 @@ fn extract_appworkload_event(
         return None;
     };
 
-    // Try primary extract_guid, fall back to guid_registry::extract_app_id
-    let guid = extract_guid(msg).or_else(|| guid_registry::extract_app_id(msg));
+    let guid = match guid_registry::explicit_app_identity(msg) {
+        guid_registry::ExplicitAppIdentity::Valid(guid) => Some(guid),
+        guid_registry::ExplicitAppIdentity::Invalid => None,
+        guid_registry::ExplicitAppIdentity::Absent => {
+            // Preserve the established AppWorkload heuristics only when the
+            // line does not claim an explicit JSON identity field.
+            extract_guid(msg).or_else(|| guid_registry::extract_app_id(msg))
+        }
+    };
 
     if is_sidecar {
         let status = determine_sidecar_script_status(msg, flags);
@@ -2064,5 +2071,92 @@ mod tests {
         assert_eq!(utf8_prefix("aaaaaa你好世界", 8), "aaaaaa你好");
         assert_eq!(utf8_prefix("a1b2c3d4-e5f6", 8), "a1b2c3d4");
         assert_eq!(utf8_prefix("short", 8), "short");
+    }
+
+    #[test]
+    fn appworkload_invalid_explicit_identity_suppresses_unrelated_guid() {
+        let unrelated_guid = "11111111-2222-3333-4444-555555555555";
+        let messages = [
+            format!(
+                r#"tenant {unrelated_guid} SidecarScriptDetectionManager launch {{"AppId":"not-an-app-guid","ApplicationName":"Contoso"}}"#
+            ),
+            format!(
+                r#"tenant {unrelated_guid} SidecarScriptDetectionManager launch {{\"Id\":\"not-an-app-guid\",\"Name\":\"Contoso\"}}"#
+            ),
+        ];
+
+        for message in messages {
+            let events = extract_events(
+                &[line(&message, "01-15-2024 10:00:05.000", 1)],
+                "C:/Logs/AppWorkload.log",
+                &empty_registry(),
+            );
+
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].guid, None, "accepted identity from {message}");
+            assert_eq!(events[0].parent_app_guid, None);
+            assert_eq!(events[0].name, "Script Detection Running (unknown)");
+        }
+    }
+
+    #[test]
+    fn appworkload_valid_explicit_identity_beats_unrelated_guid() {
+        let unrelated_guid = "11111111-2222-3333-4444-555555555555";
+        let app_guid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+        let messages = [
+            format!(
+                r#"tenant {unrelated_guid} SidecarScriptDetectionManager launch {{"AppId" : "{app_guid}","ApplicationName":"Contoso"}}"#
+            ),
+            format!(
+                r#"tenant {unrelated_guid} SidecarScriptDetectionManager launch {{"AppId":"invalid","Id":"{app_guid}","Name":"Contoso"}}"#
+            ),
+        ];
+
+        for message in messages {
+            let events = extract_events(
+                &[line(&message, "01-15-2024 10:00:05.000", 1)],
+                "C:/Logs/AppWorkload.log",
+                &empty_registry(),
+            );
+
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].guid.as_deref(), Some(app_guid));
+            assert_eq!(events[0].parent_app_guid.as_deref(), Some(app_guid));
+        }
+    }
+
+    #[test]
+    fn appworkload_named_context_fallback_remains_without_identity_field() {
+        let app_guid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+        let message = format!(
+            r#"SidecarScriptDetectionManager launch identity {app_guid} {{"ApplicationName":"Contoso"}}"#
+        );
+        let events = extract_events(
+            &[line(&message, "01-15-2024 10:00:05.000", 1)],
+            "C:/Logs/AppWorkload.log",
+            &empty_registry(),
+        );
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].guid.as_deref(), Some(app_guid));
+        assert_eq!(events[0].parent_app_guid.as_deref(), Some(app_guid));
+    }
+
+    #[test]
+    fn appworkload_decorated_identity_uses_its_field_local_guid() {
+        let unrelated_guid = "11111111-2222-3333-4444-555555555555";
+        let app_guid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+        let message = format!(
+            r#"tenant {unrelated_guid} SidecarScriptDetectionManager launch {{"AppId":"Win32App_{app_guid}_1","ApplicationName":"Contoso"}}"#
+        );
+        let events = extract_events(
+            &[line(&message, "01-15-2024 10:00:05.000", 1)],
+            "C:/Logs/AppWorkload.log",
+            &empty_registry(),
+        );
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].guid.as_deref(), Some(app_guid));
+        assert_eq!(events[0].parent_app_guid.as_deref(), Some(app_guid));
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -2196,4 +2196,31 @@ mod tests {
             assert_eq!(events[0].parent_app_guid.as_deref(), Some(app_guid));
         }
     }
+
+    #[test]
+    fn appworkload_duplicate_identity_conflicts_have_no_attribution() {
+        let first = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let second = "11111111-2222-3333-4444-555555555555";
+        let payloads = [
+            format!(r#"{{"AppId":"{first}","AppId":"{second}","Name":"Contoso"}}"#),
+            format!(r#"{{"Id":"{first}","Id":"{second}","Name":"Contoso"}}"#),
+            format!(r#"{{"AppId":"{first}",\"AppId\":\"{second}\","Name":"Contoso"}}"#),
+            format!(r#"{{"Id":"{first}",\"Id\":\"{second}\","Name":"Contoso"}}"#),
+            format!(r#"{{"AppId":"invalid","AppId":"{first}","Name":"Contoso"}}"#),
+            format!(r#"{{"Id":"invalid","Id":"{first}","Name":"Contoso"}}"#),
+        ];
+
+        for payload in payloads {
+            let message = format!("SidecarScriptDetectionManager launch {payload}");
+            let events = extract_events(
+                &[line(&message, "01-15-2024 10:00:05.000", 1)],
+                "C:/Logs/AppWorkload.log",
+                &empty_registry(),
+            );
+
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].guid, None, "attributed conflict from {payload}");
+            assert_eq!(events[0].parent_app_guid, None);
+        }
+    }
 }

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -591,7 +591,7 @@ fn extract_appworkload_event(
             .map(|m| m.as_str().to_string());
         let short = guid
             .as_deref()
-            .map(|g| g.get(..8).unwrap_or(g))
+            .map(|g| utf8_prefix(g, 8))
             .unwrap_or("unknown");
         let phase = if flags.sidecar_script_complete {
             "Complete"
@@ -1494,6 +1494,13 @@ fn short_guid(value: &str) -> &str {
     value
 }
 
+fn utf8_prefix(value: &str, max_chars: usize) -> &str {
+    value
+        .char_indices()
+        .nth(max_chars)
+        .map_or(value, |(byte_index, _)| &value[..byte_index])
+}
+
 fn contains_case_insensitive(value: &str, needle: &str) -> bool {
     contains_ascii_case_insensitive(value, needle)
 }
@@ -2035,7 +2042,7 @@ mod tests {
     }
 
     #[test]
-    fn sidecar_non_guid_multibyte_app_id_is_not_an_identity_or_panic() {
+    fn sidecar_non_guid_multibyte_app_id_is_not_an_identity() {
         let events = extract_events(
             &[line(
                 r#"SidecarScriptDetectionManager launch {"AppId":"aaaaaa你好"}"#,
@@ -2050,5 +2057,12 @@ mod tests {
         assert_eq!(events[0].event_type, IntuneEventType::PowerShellScript);
         assert_eq!(events[0].guid, None);
         assert_eq!(events[0].name, "Script Detection Running (unknown)");
+    }
+
+    #[test]
+    fn utf8_prefix_counts_characters_without_splitting_them() {
+        assert_eq!(utf8_prefix("aaaaaa你好世界", 8), "aaaaaa你好");
+        assert_eq!(utf8_prefix("a1b2c3d4-e5f6", 8), "a1b2c3d4");
+        assert_eq!(utf8_prefix("short", 8), "short");
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -591,7 +591,7 @@ fn extract_appworkload_event(
             .map(|m| m.as_str().to_string());
         let short = guid
             .as_deref()
-            .map(|g| &g[..8.min(g.len())])
+            .map(|g| g.get(..8).unwrap_or(g))
             .unwrap_or("unknown");
         let phase = if flags.sidecar_script_complete {
             "Complete"
@@ -2032,5 +2032,23 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].status, IntuneStatus::Success);
         assert_eq!(events[0].detail, message);
+    }
+
+    #[test]
+    fn sidecar_non_guid_multibyte_app_id_is_not_an_identity_or_panic() {
+        let events = extract_events(
+            &[line(
+                r#"SidecarScriptDetectionManager launch {"AppId":"aaaaaa你好"}"#,
+                "01-15-2024 10:00:05.000",
+                1,
+            )],
+            "C:/Logs/AppWorkload.log",
+            &empty_registry(),
+        );
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, IntuneEventType::PowerShellScript);
+        assert_eq!(events[0].guid, None);
+        assert_eq!(events[0].name, "Script Detection Running (unknown)");
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -2159,4 +2159,41 @@ mod tests {
         assert_eq!(events[0].guid.as_deref(), Some(app_guid));
         assert_eq!(events[0].parent_app_guid.as_deref(), Some(app_guid));
     }
+
+    #[test]
+    fn appworkload_app_id_syntaxes_precede_id() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let id_guid = "11111111-2222-3333-4444-555555555555";
+        let payloads = [
+            format!(r#"{{"AppId":"{app_guid}","Id":"{id_guid}","Name":"Contoso"}}"#),
+            format!(r#"{{\"AppId\":\"{app_guid}\",\"Id\":\"{id_guid}\",\"Name\":\"Contoso\"}}"#),
+            format!(r#"{{"AppId" : "{app_guid}","Id":"{id_guid}","Name":"Contoso"}}"#),
+            format!(r#"{{\"AppId\" : \"{app_guid}\",\"Id\":\"{id_guid}\",\"Name\":\"Contoso\"}}"#),
+            format!(r#"{{"AppId":"Win32App_{app_guid}_1","Id":"{id_guid}","Name":"Contoso"}}"#),
+            format!(
+                r#"{{\"AppId\":\"Win32App_{app_guid}_1\",\"Id\":\"{id_guid}\",\"Name\":\"Contoso\"}}"#
+            ),
+            format!(r#"{{"Id":"{id_guid}","AppId" : "{app_guid}","Name":"Contoso"}}"#),
+            format!(
+                r#"{{\"Id\":\"{id_guid}\",\"AppId\":\"Win32App_{app_guid}_1\",\"Name\":\"Contoso\"}}"#
+            ),
+        ];
+
+        for payload in payloads {
+            let message = format!("SidecarScriptDetectionManager launch {payload}");
+            let events = extract_events(
+                &[line(&message, "01-15-2024 10:00:05.000", 1)],
+                "C:/Logs/AppWorkload.log",
+                &empty_registry(),
+            );
+
+            assert_eq!(events.len(), 1);
+            assert_eq!(
+                events[0].guid.as_deref(),
+                Some(app_guid),
+                "wrong identity for {payload}"
+            );
+            assert_eq!(events[0].parent_app_guid.as_deref(), Some(app_guid));
+        }
+    }
 }

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -2223,4 +2223,36 @@ mod tests {
             assert_eq!(events[0].parent_app_guid, None);
         }
     }
+
+    #[test]
+    fn appworkload_sibling_identity_objects_have_no_attribution() {
+        let first = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let second = "11111111-2222-3333-4444-555555555555";
+        let payloads = [
+            format!(r#"[{{"AppId":"{first}"}},{{"AppId":"{second}"}}]"#),
+            format!(r#"[{{"AppId":"{second}"}},{{"AppId":"{first}"}}]"#),
+            format!(r#"[{{"Id":"{first}"}},{{"AppId":"{second}"}}]"#),
+            format!(r#"[{{"AppId":"{second}"}},{{"Id":"{first}"}}]"#),
+            format!(r#"{{"Items":[{{"Id":"{first}"}},{{"AppId":"{second}"}}]}}"#),
+            format!(
+                r#"{{"Left":{{"AppId":"{first}"}},"Right":{{"Metadata":{{"AppId":"{second}"}}}}}}"#
+            ),
+            format!(
+                r#"{{"Left":{{"Metadata":{{"AppId":"{second}"}}}},"Right":{{"AppId":"{first}"}}}}"#
+            ),
+        ];
+
+        for payload in payloads {
+            let message = format!("SidecarScriptDetectionManager launch {payload}");
+            let events = extract_events(
+                &[line(&message, "01-15-2024 10:00:05.000", 1)],
+                "C:/Logs/AppWorkload.log",
+                &empty_registry(),
+            );
+
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].guid, None, "attributed sibling from {payload}");
+            assert_eq!(events[0].parent_app_guid, None);
+        }
+    }
 }

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -30,8 +30,7 @@ pub(crate) fn guid_re() -> &'static Regex {
     })
 }
 
-const APP_ID_FIELD_SYNTAXES: [(&str, &str); 2] = [("\"AppId\"", "\""), ("\\\"AppId\\\"", "\\\"")];
-const ID_FIELD_SYNTAXES: [(&str, &str); 2] = [("\"Id\"", "\""), ("\\\"Id\\\"", "\\\"")];
+const MAX_JSON_CONTAINER_DEPTH: usize = 128;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ExplicitAppIdentity {
@@ -117,16 +116,26 @@ impl GuidRegistry {
 
     /// Extract GUID→name pairs from a single message string.
     fn ingest_message(&mut self, msg: &str) {
-        // Multi-pair path: extract all "Id"+"Name" pairs from JSON arrays
-        // e.g. Get policies = [{"Id":"guid1","Name":"name1"},{"Id":"guid2","Name":"name2"}]
-        for (guid, name, source) in extract_all_id_name_pairs(msg) {
+        let Ok(scan) = scan_json_fields(msg) else {
+            return;
+        };
+
+        for (guid, name, source) in extract_all_identity_name_pairs(&scan) {
             self.insert_if_dominated(guid, name, source);
         }
 
-        // Single-GUID path: handles AppId, ApplicationName, SetUpFilePath
-        if let Some(guid) = extract_app_id(msg) {
-            if let Some((name, source)) = extract_app_name_with_source(msg) {
-                self.insert_if_dominated(guid, name, source);
+        // Preserve the established named-context fallback only when the line
+        // contains no explicit identity field at all. Explicit fields are
+        // always paired with names inside their own object above.
+        if !scan.has_explicit_identity_fields() {
+            let guid = guid_re()
+                .captures(msg)
+                .and_then(|captures| captures.get(1))
+                .map(|matched| matched.as_str().to_ascii_lowercase());
+            if let Some(guid) = guid {
+                if let Some((name, source)) = extract_app_name_with_source(msg) {
+                    self.insert_if_dominated(guid, name, source);
+                }
             }
         }
     }
@@ -236,60 +245,55 @@ pub struct GuidRegistryEntry {
 
 // ── Private extraction helpers ───────────────────────────────────────────────
 
-/// Extract all `"Id"` + `"Name"` pairs from a message that may contain a JSON array.
-///
-/// Handles lines like:
-/// ```text
-/// Get policies = [{"Id":"guid1","Name":"name1","Version":1},{"Id":"guid2","Name":"name2"}]
-/// ```
-///
-/// Returns one `(guid, name, NameField)` tuple per valid pair found.
-fn extract_all_id_name_pairs(msg: &str) -> Vec<(String, String, GuidNameSource)> {
-    let scopes = json_object_direct_scopes(msg);
-    if scopes.is_empty() {
-        return extract_id_name_pair(msg).into_iter().collect();
-    }
-
-    scopes
-        .iter()
-        .filter_map(|scope| extract_id_name_pair(&scope.direct))
-        .collect()
-}
-
-fn extract_id_name_pair(object: &str) -> Option<(String, String, GuidNameSource)> {
-    let allow_decorated = has_name_field(object);
-    match classify_identity_fields(object, &APP_ID_FIELD_SYNTAXES, allow_decorated) {
-        IdentityFieldState::Valid(_) | IdentityFieldState::Conflict => return None,
-        IdentityFieldState::Absent | IdentityFieldState::Malformed => {}
-    }
-
-    let id = match classify_identity_fields(object, &ID_FIELD_SYNTAXES, allow_decorated) {
-        IdentityFieldState::Valid(id) => id,
-        IdentityFieldState::Absent
-        | IdentityFieldState::Malformed
-        | IdentityFieldState::Conflict => return None,
-    };
-    let (name, source) = extract_app_name_with_source(object)?;
-    Some((id, name, source))
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum JsonFieldKind {
+    AppId,
+    Id,
+    ApplicationName,
+    Name,
+    SetUpFilePath,
 }
 
 #[derive(Clone, Copy)]
-struct ObjectRange {
+struct JsonField<'a> {
+    kind: JsonFieldKind,
+    value: Option<&'a str>,
+}
+
+struct JsonObjectScope<'a> {
     start: usize,
     end: usize,
+    tree_start: usize,
+    fields: Vec<JsonField<'a>>,
 }
 
-struct ObjectFrame {
-    start: usize,
-    depth: usize,
-    children: Vec<ObjectRange>,
+struct JsonFieldScan<'a> {
+    root: JsonObjectScope<'a>,
+    scopes: Vec<JsonObjectScope<'a>>,
 }
 
-struct JsonObjectScope {
-    start: usize,
-    depth: usize,
-    direct: String,
+impl JsonFieldScan<'_> {
+    fn has_explicit_identity_fields(&self) -> bool {
+        self.root
+            .fields
+            .iter()
+            .chain(self.scopes.iter().flat_map(|scope| scope.fields.iter()))
+            .any(|field| matches!(field.kind, JsonFieldKind::AppId | JsonFieldKind::Id))
+    }
 }
+
+struct ObjectFrame<'a> {
+    scope: JsonObjectScope<'a>,
+    expect_key: bool,
+}
+
+enum ContainerFrame<'a> {
+    Object(ObjectFrame<'a>),
+    Array,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct JsonScanError;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum QuoteStyle {
@@ -297,81 +301,147 @@ enum QuoteStyle {
     BackslashEscaped,
 }
 
-/// Return each balanced JSON-like object's direct fields from direct or
-/// one-layer escaped payloads. Nested object bytes are masked in the parent
-/// scope so identity precedence is evaluated per object rather than per line.
-fn json_object_direct_scopes(msg: &str) -> Vec<JsonObjectScope> {
+struct ActiveString {
+    style: QuoteStyle,
+    content_start: usize,
+}
+
+/// Scan only direct, relevant string fields in JSON-like objects. Values are
+/// borrowed from the input and nested objects own their own fields, keeping
+/// retained memory linear in the number of relevant fields rather than in
+/// `nesting depth * line length`.
+fn scan_json_fields(msg: &str) -> Result<JsonFieldScan<'_>, JsonScanError> {
     let bytes = msg.as_bytes();
-    let mut quote_style = None;
-    let mut stack: Vec<ObjectFrame> = Vec::new();
+    let mut active_string: Option<ActiveString> = None;
+    let mut containers: Vec<ContainerFrame<'_>> = Vec::new();
+    let mut object_depth: usize = 0;
+    let mut current_tree_start = None;
     let mut scopes = Vec::new();
+    let mut root = ObjectFrame {
+        scope: JsonObjectScope {
+            start: 0,
+            end: msg.len(),
+            tree_start: 0,
+            fields: Vec::new(),
+        },
+        expect_key: true,
+    };
 
     for (index, byte) in bytes.iter().copied().enumerate() {
         if byte == b'"' {
             let backslashes = preceding_backslash_count(bytes, index);
-            match (quote_style, backslashes) {
-                (Some(QuoteStyle::Direct), count) if count % 2 == 0 => quote_style = None,
-                (Some(QuoteStyle::BackslashEscaped), 1) => quote_style = None,
-                (None, count) if count % 2 == 0 => quote_style = Some(QuoteStyle::Direct),
-                (None, 1) => quote_style = Some(QuoteStyle::BackslashEscaped),
-                _ => {}
+            if let Some(active) = active_string.as_ref() {
+                if quote_closes(active.style, backslashes) {
+                    let content_end = match active.style {
+                        QuoteStyle::Direct => index,
+                        QuoteStyle::BackslashEscaped => index.saturating_sub(1),
+                    };
+                    if let Some(content) = msg.get(active.content_start..content_end) {
+                        if containers.is_empty() {
+                            process_string_token(&mut root, msg, content, index + 1, false);
+                        } else if let Some(ContainerFrame::Object(frame)) = containers.last_mut() {
+                            process_string_token(frame, msg, content, index + 1, true);
+                        }
+                    }
+                    active_string = None;
+                }
+            } else if let Some(style) = quote_opens(backslashes) {
+                active_string = Some(ActiveString {
+                    style,
+                    content_start: index + 1,
+                });
             }
             continue;
         }
-        if quote_style.is_some() {
+        if active_string.is_some() {
             continue;
         }
 
         match byte {
             b'{' => {
-                let depth = stack.len();
-                stack.push(ObjectFrame {
-                    start: index,
-                    depth,
-                    children: Vec::new(),
-                });
+                if containers.len() >= MAX_JSON_CONTAINER_DEPTH {
+                    return Err(JsonScanError);
+                }
+                let tree_start = current_tree_start.unwrap_or(index);
+                current_tree_start = Some(tree_start);
+                containers.push(ContainerFrame::Object(ObjectFrame {
+                    scope: JsonObjectScope {
+                        start: index,
+                        end: msg.len(),
+                        tree_start,
+                        fields: Vec::new(),
+                    },
+                    expect_key: true,
+                }));
+                object_depth += 1;
+            }
+            b'[' => {
+                if containers.len() >= MAX_JSON_CONTAINER_DEPTH {
+                    return Err(JsonScanError);
+                }
+                containers.push(ContainerFrame::Array);
             }
             b'}' => {
-                let Some(frame) = stack.pop() else {
-                    continue;
-                };
-                let range = ObjectRange {
-                    start: frame.start,
-                    end: index + 1,
-                };
-                if let Some(direct) = object_direct_scope(msg, range, &frame.children) {
-                    scopes.push(JsonObjectScope {
-                        start: frame.start,
-                        depth: frame.depth,
-                        direct,
-                    });
+                if matches!(containers.last(), Some(ContainerFrame::Object(_))) {
+                    let Some(ContainerFrame::Object(mut frame)) = containers.pop() else {
+                        unreachable!();
+                    };
+                    frame.scope.end = index + 1;
+                    object_depth = object_depth.saturating_sub(1);
+                    if object_depth == 0 {
+                        current_tree_start = None;
+                    }
+                    if !frame.scope.fields.is_empty() {
+                        scopes.push(frame.scope);
+                    }
                 }
-                if let Some(parent) = stack.last_mut() {
-                    parent.children.push(range);
+            }
+            b']' => {
+                if matches!(containers.last(), Some(ContainerFrame::Array)) {
+                    containers.pop();
+                }
+            }
+            b',' => {
+                if let Some(ContainerFrame::Object(frame)) = containers.last_mut() {
+                    frame.expect_key = true;
                 }
             }
             _ => {}
         }
     }
 
-    scopes.sort_by_key(|scope| (scope.depth, scope.start));
-    scopes
+    // Keep relevant fields from truncated raw-log payloads. The depth cap is
+    // the only scanner error because an incomplete log line is common input,
+    // while an attacker-controlled nesting explosion must fail closed.
+    for container in containers {
+        if let ContainerFrame::Object(frame) = container {
+            if !frame.scope.fields.is_empty() {
+                scopes.push(frame.scope);
+            }
+        }
+    }
+    scopes.sort_by_key(|scope| (scope.tree_start, scope.start));
+    Ok(JsonFieldScan {
+        root: root.scope,
+        scopes,
+    })
 }
 
-fn object_direct_scope(msg: &str, object: ObjectRange, children: &[ObjectRange]) -> Option<String> {
-    let mut scope = String::with_capacity(object.end.checked_sub(object.start)?);
-    let mut cursor = object.start;
-
-    for child in children {
-        scope.push_str(msg.get(cursor..child.start)?);
-        scope.extend(std::iter::repeat_n(
-            ' ',
-            child.end.checked_sub(child.start)?,
-        ));
-        cursor = child.end;
+fn quote_opens(backslashes: usize) -> Option<QuoteStyle> {
+    if backslashes & 1 == 0 {
+        Some(QuoteStyle::Direct)
+    } else if backslashes & 3 == 1 {
+        Some(QuoteStyle::BackslashEscaped)
+    } else {
+        None
     }
-    scope.push_str(msg.get(cursor..object.end)?);
-    Some(scope)
+}
+
+fn quote_closes(style: QuoteStyle, backslashes: usize) -> bool {
+    match style {
+        QuoteStyle::Direct => backslashes & 1 == 0,
+        QuoteStyle::BackslashEscaped => backslashes & 3 == 1,
+    }
 }
 
 fn preceding_backslash_count(bytes: &[u8], quote_index: usize) -> usize {
@@ -380,6 +450,125 @@ fn preceding_backslash_count(bytes: &[u8], quote_index: usize) -> usize {
         .rev()
         .take_while(|byte| **byte == b'\\')
         .count()
+}
+
+fn process_string_token<'a>(
+    frame: &mut ObjectFrame<'a>,
+    msg: &'a str,
+    content: &'a str,
+    token_end: usize,
+    enforce_object_state: bool,
+) {
+    if enforce_object_state && !frame.expect_key {
+        return;
+    }
+
+    let Some(colon) = colon_after_token(msg, token_end) else {
+        return;
+    };
+    if enforce_object_state {
+        frame.expect_key = false;
+    }
+
+    let Some(kind) = json_field_kind(content) else {
+        return;
+    };
+    frame.scope.fields.push(JsonField {
+        kind,
+        value: json_string_value_after_colon(msg, colon + 1),
+    });
+}
+
+fn colon_after_token(msg: &str, token_end: usize) -> Option<usize> {
+    let bytes = msg.as_bytes();
+    let mut index = token_end;
+    while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+        index += 1;
+    }
+    (bytes.get(index) == Some(&b':')).then_some(index)
+}
+
+fn json_string_value_after_colon(msg: &str, start: usize) -> Option<&str> {
+    let bytes = msg.as_bytes();
+    let mut index = start;
+    while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+        index += 1;
+    }
+
+    let (style, quote_index) = match (bytes.get(index), bytes.get(index + 1)) {
+        (Some(b'"'), _) => (QuoteStyle::Direct, index),
+        (Some(b'\\'), Some(b'"')) => (QuoteStyle::BackslashEscaped, index + 1),
+        _ => return None,
+    };
+    let content_start = quote_index + 1;
+
+    for closing_quote in content_start..bytes.len() {
+        if bytes[closing_quote] != b'"' {
+            continue;
+        }
+        let backslashes = preceding_backslash_count(bytes, closing_quote);
+        if quote_closes(style, backslashes) {
+            let content_end = match style {
+                QuoteStyle::Direct => closing_quote,
+                QuoteStyle::BackslashEscaped => closing_quote.checked_sub(1)?,
+            };
+            return msg.get(content_start..content_end);
+        }
+    }
+    None
+}
+
+fn json_field_kind(key: &str) -> Option<JsonFieldKind> {
+    match key {
+        "AppId" => Some(JsonFieldKind::AppId),
+        "Id" => Some(JsonFieldKind::Id),
+        "ApplicationName" => Some(JsonFieldKind::ApplicationName),
+        "Name" => Some(JsonFieldKind::Name),
+        "SetUpFilePath" => Some(JsonFieldKind::SetUpFilePath),
+        _ => None,
+    }
+}
+
+fn extract_all_identity_name_pairs(
+    scan: &JsonFieldScan<'_>,
+) -> Vec<(String, String, GuidNameSource)> {
+    std::iter::once(&scan.root)
+        .chain(scan.scopes.iter())
+        .filter_map(identity_name_pair)
+        .collect()
+}
+
+fn identity_name_pair(scope: &JsonObjectScope<'_>) -> Option<(String, String, GuidNameSource)> {
+    let guid = match classify_scope_identity(scope) {
+        ExplicitAppIdentity::Valid(guid) => guid,
+        ExplicitAppIdentity::Absent | ExplicitAppIdentity::Invalid => return None,
+    };
+    let (name, source) = scope_name(scope)?;
+    Some((guid, name, source))
+}
+
+fn scope_name(scope: &JsonObjectScope<'_>) -> Option<(String, GuidNameSource)> {
+    for kind in [
+        JsonFieldKind::ApplicationName,
+        JsonFieldKind::Name,
+        JsonFieldKind::SetUpFilePath,
+    ] {
+        let Some(value) = scope
+            .fields
+            .iter()
+            .filter(|field| field.kind == kind)
+            .find_map(|field| field.value)
+        else {
+            continue;
+        };
+        return Some(match kind {
+            JsonFieldKind::ApplicationName => (value.to_string(), GuidNameSource::ApplicationName),
+            JsonFieldKind::Name => (value.to_string(), GuidNameSource::NameField),
+            JsonFieldKind::SetUpFilePath => (setup_file_name(value), GuidNameSource::SetUpFilePath),
+            JsonFieldKind::AppId | JsonFieldKind::Id => unreachable!(),
+        });
+    }
+    None
 }
 
 /// Extract a GUID from a log message via JSON identity fields.
@@ -393,7 +582,7 @@ pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
         ExplicitAppIdentity::Absent => {
             // Only fall back to generic GUID if a name field is present
             // (avoids polluting registry with context-free GUIDs)
-            if has_name_field(msg) {
+            if scan_json_fields(msg).is_ok_and(|scan| scan_has_name_field(&scan)) {
                 guid_re()
                     .captures(msg)
                     .and_then(|c| c.get(1))
@@ -409,31 +598,59 @@ pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
 /// GUIDs on the line. An invalid explicit field is an identity boundary: its
 /// presence suppresses line-wide GUID inference.
 pub(crate) fn explicit_app_identity(msg: &str) -> ExplicitAppIdentity {
-    let scopes = json_object_direct_scopes(msg);
+    let Ok(scan) = scan_json_fields(msg) else {
+        return ExplicitAppIdentity::Invalid;
+    };
+
+    let root_identity = classify_scope_identity(&scan.root);
+    let mut selected = (root_identity != ExplicitAppIdentity::Absent).then_some(root_identity);
     let mut start = 0;
-    while start < scopes.len() {
-        let depth = scopes[start].depth;
+    while start < scan.scopes.len() {
+        let tree_start = scan.scopes[start].tree_start;
         let mut end = start;
-        let mut direct_at_depth = String::new();
-        while end < scopes.len() && scopes[end].depth == depth {
-            direct_at_depth.push_str(&scopes[end].direct);
-            direct_at_depth.push('\n');
+        let mut tree_identity = None;
+        let mut identity_span = None;
+        let mut ambiguous = false;
+        while end < scan.scopes.len() && scan.scopes[end].tree_start == tree_start {
+            let identity = classify_scope_identity(&scan.scopes[end]);
+            if identity != ExplicitAppIdentity::Absent {
+                match identity_span {
+                    None => {
+                        identity_span = Some((scan.scopes[end].start, scan.scopes[end].end));
+                        tree_identity = Some(identity);
+                    }
+                    Some((outer_start, outer_end))
+                        if scan.scopes[end].start >= outer_start
+                            && scan.scopes[end].end <= outer_end => {}
+                    Some(_) => ambiguous = true,
+                }
+            }
             end += 1;
         }
 
-        let identity = classify_explicit_identity_scope(&direct_at_depth);
-        if identity != ExplicitAppIdentity::Absent {
-            return identity;
+        if let Some(mut identity) = tree_identity {
+            if ambiguous {
+                identity = ExplicitAppIdentity::Invalid;
+            }
+            if selected.is_some() {
+                return ExplicitAppIdentity::Invalid;
+            }
+            selected = Some(identity);
         }
         start = end;
     }
 
-    classify_explicit_identity_scope(msg)
+    selected.unwrap_or(ExplicitAppIdentity::Absent)
 }
 
-fn classify_explicit_identity_scope(msg: &str) -> ExplicitAppIdentity {
-    let allow_decorated = has_name_field(msg);
-    let app_id = classify_identity_fields(msg, &APP_ID_FIELD_SYNTAXES, allow_decorated);
+fn classify_scope_identity(scope: &JsonObjectScope<'_>) -> ExplicitAppIdentity {
+    let allow_decorated = scope.fields.iter().any(|field| {
+        matches!(
+            field.kind,
+            JsonFieldKind::ApplicationName | JsonFieldKind::Name | JsonFieldKind::SetUpFilePath
+        ) && field.value.is_some()
+    });
+    let app_id = classify_identity_fields(scope, JsonFieldKind::AppId, allow_decorated);
     let app_id_absent = matches!(app_id, IdentityFieldState::Absent);
     match app_id {
         IdentityFieldState::Valid(value) => return ExplicitAppIdentity::Valid(value),
@@ -441,7 +658,7 @@ fn classify_explicit_identity_scope(msg: &str) -> ExplicitAppIdentity {
         IdentityFieldState::Absent | IdentityFieldState::Malformed => {}
     }
 
-    match classify_identity_fields(msg, &ID_FIELD_SYNTAXES, allow_decorated) {
+    match classify_identity_fields(scope, JsonFieldKind::Id, allow_decorated) {
         IdentityFieldState::Valid(value) => ExplicitAppIdentity::Valid(value),
         IdentityFieldState::Absent if app_id_absent => ExplicitAppIdentity::Absent,
         IdentityFieldState::Absent
@@ -451,17 +668,16 @@ fn classify_explicit_identity_scope(msg: &str) -> ExplicitAppIdentity {
 }
 
 fn classify_identity_fields(
-    msg: &str,
-    syntaxes: &[(&str, &str)],
+    scope: &JsonObjectScope<'_>,
+    kind: JsonFieldKind,
     allow_decorated: bool,
 ) -> IdentityFieldState {
-    let mut members = Vec::new();
-
-    for &(key, quote) in syntaxes {
-        let mut remaining = msg;
-        while let Some(key_index) = remaining.find(key) {
-            let after_key = &remaining[key_index + key.len()..];
-            let guid = json_string_value_after_key(after_key, quote).and_then(|value| {
+    let members = scope
+        .fields
+        .iter()
+        .filter(|field| field.kind == kind)
+        .map(|field| {
+            field.value.and_then(|value| {
                 exact_guid(value).or_else(|| {
                     if allow_decorated {
                         guid_re()
@@ -472,11 +688,9 @@ fn classify_identity_fields(
                         None
                     }
                 })
-            });
-            members.push(guid);
-            remaining = after_key;
-        }
-    }
+            })
+        })
+        .collect::<Vec<_>>();
 
     match members.as_slice() {
         [] => IdentityFieldState::Absent,
@@ -494,13 +708,6 @@ fn classify_identity_fields(
     }
 }
 
-fn json_string_value_after_key<'a>(after_key: &'a str, quote: &str) -> Option<&'a str> {
-    let after_colon = after_key.trim_start().strip_prefix(':')?.trim_start();
-    let value = after_colon.strip_prefix(quote)?;
-    let end = value.find(quote)?;
-    value.get(..end)
-}
-
 fn exact_guid(value: &str) -> Option<String> {
     let matched = guid_re().find(value)?;
     (matched.start() == 0 && matched.end() == value.len()).then(|| value.to_ascii_lowercase())
@@ -510,12 +717,17 @@ fn normalize_guid_key(value: &str) -> String {
     value.to_ascii_lowercase()
 }
 
-/// Returns `true` if the message contains any name-bearing JSON field.
-fn has_name_field(msg: &str) -> bool {
-    msg.contains("ApplicationName")
-        || msg.contains("\"Name\"")
-        || msg.contains("\\\"Name\\\"")
-        || msg.contains("SetUpFilePath")
+fn scan_has_name_field(scan: &JsonFieldScan<'_>) -> bool {
+    scan.root
+        .fields
+        .iter()
+        .chain(scan.scopes.iter().flat_map(|scope| scope.fields.iter()))
+        .any(|field| {
+            matches!(
+                field.kind,
+                JsonFieldKind::ApplicationName | JsonFieldKind::Name | JsonFieldKind::SetUpFilePath
+            ) && field.value.is_some()
+        })
 }
 
 /// Extract a display name, discarding the confidence source.
@@ -1283,6 +1495,9 @@ mod tests {
             format!(
                 r#"{{\"AppId\":\"{outer}\",\"Name\":\"Outer\",\"Metadata\":{{\"Id\":\"{nested}\",\"Name\":\"Nested\"}}}}"#
             ),
+            format!(
+                r#"{{"Wrapper":{{"AppId":"{outer}","Name":"Outer","Metadata":{{"AppId":"{nested}","Name":"Nested"}}}}}}"#
+            ),
         ];
 
         for message in messages {
@@ -1297,16 +1512,16 @@ mod tests {
     #[test]
     fn escaped_quote_braces_remain_inside_one_object_scope() {
         let message = r#"{\"AppId\":\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",\"ApplicationName\":\"Quoted \\\"value with { braces }\\\" tail\"}"#;
-        let scopes = json_object_direct_scopes(message);
+        let scan = scan_json_fields(message).expect("bounded payload should scan");
 
         assert_eq!(
-            scopes.len(),
+            scan.scopes.len(),
             1,
             "escaped string was split into child scopes"
         );
         assert!(
-            scopes[0].direct.contains("{ braces }"),
-            "braces inside the escaped quoted value were masked"
+            scope_name(&scan.scopes[0]).is_some_and(|(name, _)| name.contains("{ braces }")),
+            "braces inside the escaped quoted value were not retained"
         );
     }
 
@@ -1350,5 +1565,127 @@ mod tests {
         assert_eq!(serialized.len(), 1);
         assert!(serialized.contains_key(lower));
         assert!(!serialized.contains_key(upper));
+    }
+
+    #[test]
+    fn independent_sibling_identity_objects_are_ambiguous() {
+        let first = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let second = "11111111-2222-3333-4444-555555555555";
+        let messages = [
+            format!(r#"[{{"AppId":"{first}"}},{{"AppId":"{second}"}}]"#),
+            format!(r#"[{{"AppId":"{second}"}},{{"AppId":"{first}"}}]"#),
+            format!(r#"[{{"Id":"{first}"}},{{"AppId":"{second}"}}]"#),
+            format!(r#"[{{"AppId":"{second}"}},{{"Id":"{first}"}}]"#),
+            format!(r#"{{"Items":[{{"Id":"{first}"}},{{"AppId":"{second}"}}]}}"#),
+            format!(
+                r#"{{"Left":{{"AppId":"{first}"}},"Right":{{"Metadata":{{"AppId":"{second}"}}}}}}"#
+            ),
+            format!(
+                r#"{{"Left":{{"Metadata":{{"AppId":"{second}"}}}},"Right":{{"AppId":"{first}"}}}}"#
+            ),
+            format!(r#""Id":"{first}" {{"Metadata":{{"AppId":"{second}"}}}}"#),
+            format!(r#"[{{\"Id\":\"{first}\"}},{{\"AppId\":\"{second}\"}}]"#),
+        ];
+
+        for message in messages {
+            assert_eq!(
+                explicit_app_identity(&message),
+                ExplicitAppIdentity::Invalid,
+                "selected one independent sibling for {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn quoted_key_like_text_is_not_an_identity_field() {
+        let selected = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let injected = "11111111-2222-3333-4444-555555555555";
+        let messages = [
+            format!(r#"{{"AppId":"{selected}","Name":"literal \"AppId\":\"{injected}\" text"}}"#),
+            format!(r#"{{"Name":"literal \"AppId\":\"{injected}\" text","AppId":"{selected}"}}"#),
+            format!(r#"{{"Id":"{selected}","Name":"literal \"AppId\":\"{injected}\" text"}}"#),
+            format!(
+                r#"{{\"AppId\":\"{selected}\",\"Name\":\"literal \\\"AppId\\\":\\\"{injected}\\\" text\"}}"#
+            ),
+        ];
+
+        for message in messages {
+            assert_eq!(
+                explicit_app_identity(&message),
+                ExplicitAppIdentity::Valid(selected.to_string()),
+                "treated quoted value text as a field for {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn registry_never_binds_an_identity_to_a_sibling_name() {
+        let app = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let policy = "11111111-2222-3333-4444-555555555555";
+        let laundering_attempts = [
+            format!(r#"[{{"AppId":"{app}"}},{{"Name":"Wrong Name"}}]"#),
+            format!(r#"[{{"Name":"Wrong Name"}},{{"AppId":"{app}"}}]"#),
+            format!(r#"[{{"Id":"{policy}"}},{{"Name":"Wrong Name"}}]"#),
+            format!(r#"[{{"Name":"Wrong Name"}},{{"Id":"{policy}"}}]"#),
+        ];
+
+        for message in laundering_attempts {
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&[line(&message)]);
+            assert!(registry.is_empty(), "laundered sibling name for {message}");
+        }
+
+        let valid_orders = [
+            format!(
+                r#"[{{"AppId":"{app}","Name":"App Name"}},{{"Id":"{policy}","Name":"Policy Name"}}]"#
+            ),
+            format!(
+                r#"[{{"Id":"{policy}","Name":"Policy Name"}},{{"AppId":"{app}","Name":"App Name"}}]"#
+            ),
+        ];
+        for message in valid_orders {
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&[line(&message)]);
+            assert_eq!(registry.resolve(app), Some("App Name"));
+            assert_eq!(registry.resolve(policy), Some("Policy Name"));
+            assert_eq!(registry.len(), 2);
+        }
+    }
+
+    #[test]
+    fn registry_keeps_independent_root_and_object_local_pairs() {
+        let root = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let object = "11111111-2222-3333-4444-555555555555";
+        let message = format!(
+            r#""AppId":"{root}","Name":"Root Name" [{{"Id":"{object}","Name":"Object Name"}}]"#
+        );
+
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&[line(&message)]);
+
+        assert_eq!(registry.resolve(root), Some("Root Name"));
+        assert_eq!(registry.resolve(object), Some("Object Name"));
+        assert_eq!(registry.len(), 2);
+    }
+
+    #[test]
+    fn over_depth_json_fails_closed() {
+        let guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let depth = 129;
+        let mut message = format!(r#"{{"AppId":"{guid}","Name":"Outer""#);
+        for _ in 1..depth {
+            message.push_str(r#", "Metadata":{"#);
+        }
+        for _ in 0..depth {
+            message.push('}');
+        }
+
+        assert_eq!(
+            explicit_app_identity(&message),
+            ExplicitAppIdentity::Invalid
+        );
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&[line(&message)]);
+        assert!(registry.is_empty());
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -118,14 +118,20 @@ impl GuidRegistry {
 
     /// Extract GUID→name pairs from a single message string.
     fn ingest_message(&mut self, msg: &str) {
+        let (_, app_id) = explicit_app_id(msg, has_name_field(msg));
+
         // Multi-pair path: extract all "Id"+"Name" pairs from JSON arrays
         // e.g. Get policies = [{"Id":"guid1","Name":"name1"},{"Id":"guid2","Name":"name2"}]
-        for (guid, name, source) in extract_all_id_name_pairs(msg) {
-            self.insert_if_dominated(guid, name, source);
+        // A valid AppId is the higher-priority identity for the whole message,
+        // so an accompanying Id must not also enter the registry.
+        if app_id.is_none() {
+            for (guid, name, source) in extract_all_id_name_pairs(msg) {
+                self.insert_if_dominated(guid, name, source);
+            }
         }
 
         // Single-GUID path: handles AppId, ApplicationName, SetUpFilePath
-        if let Some(guid) = extract_app_id(msg) {
+        if let Some(guid) = app_id.or_else(|| extract_app_id(msg)) {
             if let Some((name, source)) = extract_app_name_with_source(msg) {
                 self.insert_if_dominated(guid, name, source);
             }
@@ -318,32 +324,18 @@ pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
 /// GUIDs on the line. An invalid explicit field is an identity boundary: its
 /// presence suppresses line-wide GUID inference.
 pub(crate) fn explicit_app_identity(msg: &str) -> ExplicitAppIdentity {
-    // Preserve the established fast paths and their ordering.
-    for (prefix, suffix) in [
-        ("\"AppId\":\"", "\""),
-        ("\\\"AppId\\\":\\\"", "\\\""),
-        ("\"Id\":\"", "\""),
-        ("\\\"Id\\\":\\\"", "\\\""),
-    ] {
+    let allow_decorated = has_name_field(msg);
+    let (app_id_present, app_id) = explicit_app_id(msg, allow_decorated);
+    if let Some(value) = app_id {
+        return ExplicitAppIdentity::Valid(value);
+    }
+
+    // AppId has higher precedence than Id, so only inspect Id after every
+    // supported AppId syntax has been exhausted.
+    for (prefix, suffix) in [("\"Id\":\"", "\""), ("\\\"Id\\\":\\\"", "\\\"")] {
         if let Some(value) = extract_guid_field(msg, prefix, suffix) {
             return ExplicitAppIdentity::Valid(value);
         }
-    }
-
-    // Preserve the whitespace-tolerant AppId path with its canonical GUID
-    // grammar. The field scanner below covers escaped spacing and Id fields.
-    if let Some(value) = app_id_json_re()
-        .captures(msg)
-        .and_then(|captures| captures.get(1))
-    {
-        return ExplicitAppIdentity::Valid(value.as_str().to_string());
-    }
-
-    let allow_decorated = has_name_field(msg);
-    let (app_id_present, app_id) =
-        scan_identity_fields(msg, &APP_ID_FIELD_SYNTAXES, allow_decorated);
-    if let Some(value) = app_id {
-        return ExplicitAppIdentity::Valid(value);
     }
 
     let (id_present, id) = scan_identity_fields(msg, &ID_FIELD_SYNTAXES, allow_decorated);
@@ -356,6 +348,27 @@ pub(crate) fn explicit_app_identity(msg: &str) -> ExplicitAppIdentity {
     } else {
         ExplicitAppIdentity::Absent
     }
+}
+
+fn explicit_app_id(msg: &str, allow_decorated: bool) -> (bool, Option<String>) {
+    // Preserve the established compact direct and escaped fast paths.
+    for (prefix, suffix) in [("\"AppId\":\"", "\""), ("\\\"AppId\\\":\\\"", "\\\"")] {
+        if let Some(value) = extract_guid_field(msg, prefix, suffix) {
+            return (true, Some(value));
+        }
+    }
+
+    // Preserve the whitespace-tolerant escaped AppId path with its canonical
+    // GUID grammar, then scan all direct/escaped forms including decorated
+    // field-local GUIDs.
+    if let Some(value) = app_id_json_re()
+        .captures(msg)
+        .and_then(|captures| captures.get(1))
+    {
+        return (true, Some(value.as_str().to_string()));
+    }
+
+    scan_identity_fields(msg, &APP_ID_FIELD_SYNTAXES, allow_decorated)
 }
 
 fn scan_identity_fields(
@@ -995,5 +1008,53 @@ mod tests {
         );
 
         assert_eq!(extract_app_id(&message), Some(app_guid.to_string()));
+    }
+
+    #[test]
+    fn app_id_syntaxes_precede_id_in_registry_identity_selection() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let id_guid = "11111111-2222-3333-4444-555555555555";
+        let messages = [
+            format!(r#"{{"AppId":"{app_guid}","Id":"{id_guid}","Name":"Contoso"}}"#),
+            format!(r#"{{\"AppId\":\"{app_guid}\",\"Id\":\"{id_guid}\",\"Name\":\"Contoso\"}}"#),
+            format!(r#"{{"AppId" : "{app_guid}","Id":"{id_guid}","Name":"Contoso"}}"#),
+            format!(r#"{{\"AppId\" : \"{app_guid}\",\"Id\":\"{id_guid}\",\"Name\":\"Contoso\"}}"#),
+            format!(r#"{{"AppId":"Win32App_{app_guid}_1","Id":"{id_guid}","Name":"Contoso"}}"#),
+            format!(
+                r#"{{\"AppId\":\"Win32App_{app_guid}_1\",\"Id\":\"{id_guid}\",\"Name\":\"Contoso\"}}"#
+            ),
+            format!(r#"{{"Id":"{id_guid}","AppId" : "{app_guid}","Name":"Contoso"}}"#),
+            format!(
+                r#"{{\"Id\":\"{id_guid}\",\"AppId\":\"Win32App_{app_guid}_1\",\"Name\":\"Contoso\"}}"#
+            ),
+        ];
+
+        for message in messages {
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&[line(&message)]);
+
+            assert_eq!(
+                registry.resolve(app_guid),
+                Some("Contoso"),
+                "AppId was not selected for {message}"
+            );
+            assert_eq!(
+                registry.resolve(id_guid),
+                None,
+                "lower-priority Id was also registered for {message}"
+            );
+            assert_eq!(registry.len(), 1, "unexpected identities for {message}");
+        }
+    }
+
+    #[test]
+    fn invalid_app_id_still_allows_valid_id_registry_fallback() {
+        let id_guid = "11111111-2222-3333-4444-555555555555";
+        let message = format!(r#"{{"AppId":"invalid","Id":"{id_guid}","Name":"Contoso"}}"#);
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&[line(&message)]);
+
+        assert_eq!(registry.resolve(id_guid), Some("Contoso"));
+        assert_eq!(registry.len(), 1);
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -10,7 +10,12 @@ use std::sync::OnceLock;
 
 pub(crate) fn app_id_json_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
-    CELL.get_or_init(|| Regex::new(r#"\"AppId\"\s*:\s*\"([0-9a-fA-F-]{36})\""#).unwrap())
+    CELL.get_or_init(|| {
+        Regex::new(
+            r#"\"AppId\"\s*:\s*\"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\""#,
+        )
+        .unwrap()
+    })
 }
 pub(crate) fn app_name_json_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
@@ -801,5 +806,40 @@ mod tests {
             r#"Processing app: {"AppId":"script-你好","ApplicationName":"Contoso Script"}"#,
         )]);
         assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn spaced_app_id_fallback_rejects_malformed_guid_shapes() {
+        let malformed_values = [
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "a1b2c3d-e5f67-890a-abcd-ef1234567890",
+        ];
+
+        for value in malformed_values {
+            let message = format!(
+                r#"Processing app: {{"AppId" : "{value}","ApplicationName":"Contoso App"}}"#
+            );
+            assert_eq!(extract_app_id(&message), None, "accepted {value}");
+
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&[line(&message)]);
+            assert!(registry.is_empty(), "registered {value}");
+        }
+    }
+
+    #[test]
+    fn spaced_app_id_and_named_context_guid_fallback_remain_supported() {
+        let valid_guid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+        assert_eq!(
+            extract_app_id(&format!(r#"launch {{"AppId" : "{valid_guid}"}}"#)),
+            Some(valid_guid.to_string())
+        );
+        assert_eq!(
+            extract_app_id(&format!(
+                r#"Processing identity {valid_guid} for {{"ApplicationName":"Contoso App"}}"#
+            )),
+            Some(valid_guid.to_string())
+        );
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -282,17 +282,17 @@ fn extract_all_field_values(msg: &str, prefix: &str, suffix: &str) -> Vec<String
 /// GUID regex when a name field is also present on the same line.
 pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
     // Try "AppId" — direct and escaped JSON
-    if let Some(value) = extract_json_field(msg, "\"AppId\":\"", "\"") {
-        return Some(value.to_string());
-    }
-    if let Some(value) = extract_json_field(msg, "\\\"AppId\\\":\\\"", "\\\"") {
-        return Some(value.to_string());
-    }
-    // Try "Id" — appears in policy payloads like Get policies = [{"Id":"<GUID>","Name":"..."}]
-    if let Some(value) = extract_guid_from_id_field(msg, "\"Id\":\"", "\"") {
+    if let Some(value) = extract_guid_field(msg, "\"AppId\":\"", "\"") {
         return Some(value);
     }
-    if let Some(value) = extract_guid_from_id_field(msg, "\\\"Id\\\":\\\"", "\\\"") {
+    if let Some(value) = extract_guid_field(msg, "\\\"AppId\\\":\\\"", "\\\"") {
+        return Some(value);
+    }
+    // Try "Id" — appears in policy payloads like Get policies = [{"Id":"<GUID>","Name":"..."}]
+    if let Some(value) = extract_guid_field(msg, "\"Id\":\"", "\"") {
+        return Some(value);
+    }
+    if let Some(value) = extract_guid_field(msg, "\\\"Id\\\":\\\"", "\\\"") {
         return Some(value);
     }
     // Try regex for "AppId" specifically
@@ -314,10 +314,8 @@ pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
         })
 }
 
-/// Extract a GUID from an `"Id"` field, validating it looks like a UUID.
-/// This is more conservative than `extract_json_field` alone because `"Id"`
-/// is a very generic key — we only accept values that are 36-char UUIDs.
-fn extract_guid_from_id_field(msg: &str, prefix: &str, suffix: &str) -> Option<String> {
+/// Extract a GUID from an identity field, rejecting arbitrary log content.
+fn extract_guid_field(msg: &str, prefix: &str, suffix: &str) -> Option<String> {
     let value = extract_json_field(msg, prefix, suffix)?;
     if value.len() == 36 && guid_re().is_match(value) {
         Some(value.to_string())
@@ -782,5 +780,26 @@ mod tests {
             json["bbbb1111-2222-3333-4444-555566667777"]["source"].as_str(),
             Some("SetUpFilePath")
         );
+    }
+
+    #[test]
+    fn app_id_fields_only_supply_valid_guid_identities() {
+        let valid_guid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+        assert_eq!(
+            extract_app_id(&format!(r#"launch {{"AppId":"{valid_guid}"}}"#)),
+            Some(valid_guid.to_string())
+        );
+        assert_eq!(extract_app_id(r#"launch {"AppId":"script-你好"}"#), None);
+        assert_eq!(
+            extract_app_id(r#"launch {"AppId":"zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"}"#),
+            None
+        );
+
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&[line(
+            r#"Processing app: {"AppId":"script-你好","ApplicationName":"Contoso Script"}"#,
+        )]);
+        assert!(registry.is_empty());
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -39,6 +39,16 @@ pub(crate) fn guid_re() -> &'static Regex {
     })
 }
 
+const APP_ID_FIELD_SYNTAXES: [(&str, &str); 2] = [("\"AppId\"", "\""), ("\\\"AppId\\\"", "\\\"")];
+const ID_FIELD_SYNTAXES: [(&str, &str); 2] = [("\"Id\"", "\""), ("\\\"Id\\\"", "\\\"")];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ExplicitAppIdentity {
+    Absent,
+    Valid(String),
+    Invalid,
+}
+
 // ── Shared helpers ───────────────────────────────────────────────────────────
 
 /// Fast prefix/suffix JSON field extraction without regex overhead.
@@ -286,26 +296,10 @@ fn extract_all_field_values(msg: &str, prefix: &str, suffix: &str) -> Vec<String
 /// Checks (in order): `"AppId"`, `"Id"`, then falls back to a generic
 /// GUID regex when a name field is also present on the same line.
 pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
-    // Try "AppId" — direct and escaped JSON
-    if let Some(value) = extract_guid_field(msg, "\"AppId\":\"", "\"") {
-        return Some(value);
-    }
-    if let Some(value) = extract_guid_field(msg, "\\\"AppId\\\":\\\"", "\\\"") {
-        return Some(value);
-    }
-    // Try "Id" — appears in policy payloads like Get policies = [{"Id":"<GUID>","Name":"..."}]
-    if let Some(value) = extract_guid_field(msg, "\"Id\":\"", "\"") {
-        return Some(value);
-    }
-    if let Some(value) = extract_guid_field(msg, "\\\"Id\\\":\\\"", "\\\"") {
-        return Some(value);
-    }
-    // Try regex for "AppId" specifically
-    app_id_json_re()
-        .captures(msg)
-        .and_then(|c| c.get(1))
-        .map(|m| m.as_str().to_string())
-        .or_else(|| {
+    match explicit_app_identity(msg) {
+        ExplicitAppIdentity::Valid(guid) => Some(guid),
+        ExplicitAppIdentity::Invalid => None,
+        ExplicitAppIdentity::Absent => {
             // Only fall back to generic GUID if a name field is present
             // (avoids polluting registry with context-free GUIDs)
             if has_name_field(msg) {
@@ -316,17 +310,103 @@ pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
             } else {
                 None
             }
-        })
+        }
+    }
+}
+
+/// Classify explicit JSON `AppId`/`Id` fields without falling back to other
+/// GUIDs on the line. An invalid explicit field is an identity boundary: its
+/// presence suppresses line-wide GUID inference.
+pub(crate) fn explicit_app_identity(msg: &str) -> ExplicitAppIdentity {
+    // Preserve the established fast paths and their ordering.
+    for (prefix, suffix) in [
+        ("\"AppId\":\"", "\""),
+        ("\\\"AppId\\\":\\\"", "\\\""),
+        ("\"Id\":\"", "\""),
+        ("\\\"Id\\\":\\\"", "\\\""),
+    ] {
+        if let Some(value) = extract_guid_field(msg, prefix, suffix) {
+            return ExplicitAppIdentity::Valid(value);
+        }
+    }
+
+    // Preserve the whitespace-tolerant AppId path with its canonical GUID
+    // grammar. The field scanner below covers escaped spacing and Id fields.
+    if let Some(value) = app_id_json_re()
+        .captures(msg)
+        .and_then(|captures| captures.get(1))
+    {
+        return ExplicitAppIdentity::Valid(value.as_str().to_string());
+    }
+
+    let allow_decorated = has_name_field(msg);
+    let (app_id_present, app_id) =
+        scan_identity_fields(msg, &APP_ID_FIELD_SYNTAXES, allow_decorated);
+    if let Some(value) = app_id {
+        return ExplicitAppIdentity::Valid(value);
+    }
+
+    let (id_present, id) = scan_identity_fields(msg, &ID_FIELD_SYNTAXES, allow_decorated);
+    if let Some(value) = id {
+        return ExplicitAppIdentity::Valid(value);
+    }
+
+    if app_id_present || id_present {
+        ExplicitAppIdentity::Invalid
+    } else {
+        ExplicitAppIdentity::Absent
+    }
+}
+
+fn scan_identity_fields(
+    msg: &str,
+    syntaxes: &[(&str, &str)],
+    allow_decorated: bool,
+) -> (bool, Option<String>) {
+    let mut present = false;
+
+    for &(key, quote) in syntaxes {
+        let mut remaining = msg;
+        while let Some(key_index) = remaining.find(key) {
+            present = true;
+            let after_key = &remaining[key_index + key.len()..];
+            if let Some(value) = json_string_value_after_key(after_key, quote) {
+                if let Some(guid) = exact_guid(value).or_else(|| {
+                    if allow_decorated {
+                        guid_re()
+                            .captures(value)
+                            .and_then(|captures| captures.get(1))
+                            .map(|matched| matched.as_str().to_string())
+                    } else {
+                        None
+                    }
+                }) {
+                    return (true, Some(guid));
+                }
+            }
+            remaining = after_key;
+        }
+    }
+
+    (present, None)
+}
+
+fn json_string_value_after_key<'a>(after_key: &'a str, quote: &str) -> Option<&'a str> {
+    let after_colon = after_key.trim_start().strip_prefix(':')?.trim_start();
+    let value = after_colon.strip_prefix(quote)?;
+    let end = value.find(quote)?;
+    value.get(..end)
+}
+
+fn exact_guid(value: &str) -> Option<String> {
+    let matched = guid_re().find(value)?;
+    (matched.start() == 0 && matched.end() == value.len()).then(|| value.to_string())
 }
 
 /// Extract a GUID from an identity field, rejecting arbitrary log content.
 fn extract_guid_field(msg: &str, prefix: &str, suffix: &str) -> Option<String> {
     let value = extract_json_field(msg, prefix, suffix)?;
-    if value.len() == 36 && guid_re().is_match(value) {
-        Some(value.to_string())
-    } else {
-        None
-    }
+    exact_guid(value)
 }
 
 /// Returns `true` if the message contains any name-bearing JSON field.
@@ -841,5 +921,79 @@ mod tests {
             )),
             Some(valid_guid.to_string())
         );
+    }
+
+    #[test]
+    fn invalid_explicit_identity_fields_suppress_line_wide_guid_fallback() {
+        let unrelated_guid = "11111111-2222-3333-4444-555555555555";
+        let messages = [
+            format!(
+                r#"tenant {unrelated_guid} {{"AppId":"not-an-app-guid","ApplicationName":"Contoso"}}"#
+            ),
+            format!(
+                r#"tenant {unrelated_guid} {{\"AppId\":\"not-an-app-guid\",\"ApplicationName\":\"Contoso\"}}"#
+            ),
+            format!(r#"tenant {unrelated_guid} {{"Id":"not-an-app-guid","Name":"Contoso"}}"#),
+            format!(
+                r#"tenant {unrelated_guid} {{\"Id\" : \"not-an-app-guid\",\"Name\":\"Contoso\"}}"#
+            ),
+        ];
+
+        for message in messages {
+            assert_eq!(extract_app_id(&message), None, "accepted {message}");
+
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&[line(&message)]);
+            assert!(registry.is_empty(), "registered from {message}");
+        }
+    }
+
+    #[test]
+    fn valid_explicit_identity_fields_beat_unrelated_line_guids() {
+        let unrelated_guid = "11111111-2222-3333-4444-555555555555";
+        let app_guid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+        let messages = [
+            format!(
+                r#"tenant {unrelated_guid} {{"AppId":"{app_guid}","ApplicationName":"Contoso"}}"#
+            ),
+            format!(
+                r#"tenant {unrelated_guid} {{\"AppId\" : \"{app_guid}\",\"ApplicationName\":\"Contoso\"}}"#
+            ),
+            format!(r#"tenant {unrelated_guid} {{"Id" : "{app_guid}","Name":"Contoso"}}"#),
+            format!(r#"tenant {unrelated_guid} {{\"Id\":\"{app_guid}\",\"Name\":\"Contoso\"}}"#),
+            format!(
+                r#"tenant {unrelated_guid} {{"AppId":"invalid","Id":"{app_guid}","Name":"Contoso"}}"#
+            ),
+        ];
+
+        for message in messages {
+            assert_eq!(
+                extract_app_id(&message),
+                Some(app_guid.to_string()),
+                "wrong identity for {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn named_context_fallback_remains_available_without_identity_fields() {
+        let app_guid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+        assert_eq!(
+            extract_app_id(&format!(
+                r#"Processing identity {app_guid} for {{"ApplicationName":"Contoso"}}"#
+            )),
+            Some(app_guid.to_string())
+        );
+    }
+
+    #[test]
+    fn decorated_identity_field_uses_its_field_local_guid() {
+        let unrelated_guid = "11111111-2222-3333-4444-555555555555";
+        let app_guid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+        let message = format!(
+            r#"tenant {unrelated_guid} {{"AppId":"Win32App_{app_guid}_1","ApplicationName":"Contoso"}}"#
+        );
+
+        assert_eq!(extract_app_id(&message), Some(app_guid.to_string()));
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -8,15 +8,6 @@ use std::sync::OnceLock;
 
 // ── Shared regexes (also used by download_stats.rs) ─────────────────────────
 
-pub(crate) fn app_id_json_re() -> &'static Regex {
-    static CELL: OnceLock<Regex> = OnceLock::new();
-    CELL.get_or_init(|| {
-        Regex::new(
-            r#"\"AppId\"\s*:\s*\"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\""#,
-        )
-        .unwrap()
-    })
-}
 pub(crate) fn app_name_json_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
@@ -47,6 +38,14 @@ pub(crate) enum ExplicitAppIdentity {
     Absent,
     Valid(String),
     Invalid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum IdentityFieldState {
+    Absent,
+    Valid(String),
+    Malformed,
+    Conflict,
 }
 
 // ── Shared helpers ───────────────────────────────────────────────────────────
@@ -118,20 +117,14 @@ impl GuidRegistry {
 
     /// Extract GUID→name pairs from a single message string.
     fn ingest_message(&mut self, msg: &str) {
-        let (_, app_id) = explicit_app_id(msg, has_name_field(msg));
-
         // Multi-pair path: extract all "Id"+"Name" pairs from JSON arrays
         // e.g. Get policies = [{"Id":"guid1","Name":"name1"},{"Id":"guid2","Name":"name2"}]
-        // A valid AppId is the higher-priority identity for the whole message,
-        // so an accompanying Id must not also enter the registry.
-        if app_id.is_none() {
-            for (guid, name, source) in extract_all_id_name_pairs(msg) {
-                self.insert_if_dominated(guid, name, source);
-            }
+        for (guid, name, source) in extract_all_id_name_pairs(msg) {
+            self.insert_if_dominated(guid, name, source);
         }
 
         // Single-GUID path: handles AppId, ApplicationName, SetUpFilePath
-        if let Some(guid) = app_id.or_else(|| extract_app_id(msg)) {
+        if let Some(guid) = extract_app_id(msg) {
             if let Some((name, source)) = extract_app_name_with_source(msg) {
                 self.insert_if_dominated(guid, name, source);
             }
@@ -140,6 +133,7 @@ impl GuidRegistry {
 
     /// Insert an entry if no higher-confidence entry already exists for this GUID.
     fn insert_if_dominated(&mut self, guid: String, name: String, source: GuidNameSource) {
+        let guid = normalize_guid_key(&guid);
         let dominated = self
             .entries
             .get(&guid)
@@ -159,7 +153,9 @@ impl GuidRegistry {
 
     /// Look up the display name for a GUID.
     pub fn resolve(&self, guid: &str) -> Option<&str> {
-        self.entries.get(guid).map(|entry| entry.name.as_str())
+        self.entries
+            .get(&normalize_guid_key(guid))
+            .map(|entry| entry.name.as_str())
     }
 
     /// If `current_name` looks like a short-id fallback (e.g. "Download (a1b2c3d4...)"),
@@ -203,7 +199,7 @@ impl GuidRegistry {
     /// Collect all GUIDs that have no resolved name.
     pub fn unresolved_guids_from<'a>(&self, guids: impl Iterator<Item = &'a str>) -> Vec<String> {
         guids
-            .filter(|g| !self.entries.contains_key(*g))
+            .filter(|guid| self.resolve(guid).is_none())
             .map(|g| g.to_string())
             .collect()
     }
@@ -249,52 +245,141 @@ pub struct GuidRegistryEntry {
 ///
 /// Returns one `(guid, name, NameField)` tuple per valid pair found.
 fn extract_all_id_name_pairs(msg: &str) -> Vec<(String, String, GuidNameSource)> {
-    // Try direct JSON, then escaped JSON
-    for &(id_pre, id_suf, name_pre, name_suf) in &[
-        ("\"Id\":\"", "\"", "\"Name\":\"", "\""),
-        ("\\\"Id\\\":\\\"", "\\\"", "\\\"Name\\\":\\\"", "\\\""),
-    ] {
-        let ids = extract_all_field_values(msg, id_pre, id_suf);
-        if ids.is_empty() {
-            continue;
-        }
-        let names = extract_all_field_values(msg, name_pre, name_suf);
-        if names.is_empty() {
-            continue;
-        }
-
-        let mut pairs = Vec::new();
-        for (id_val, name_val) in ids.into_iter().zip(names) {
-            if id_val.len() == 36 && guid_re().is_match(&id_val) {
-                pairs.push((id_val, name_val, GuidNameSource::NameField));
-            }
-        }
-        if !pairs.is_empty() {
-            return pairs;
-        }
+    let scopes = json_object_direct_scopes(msg);
+    if scopes.is_empty() {
+        return extract_id_name_pair(msg).into_iter().collect();
     }
 
-    Vec::new()
+    scopes
+        .iter()
+        .filter_map(|scope| extract_id_name_pair(&scope.direct))
+        .collect()
 }
 
-/// Find all occurrences of a `prefix…suffix` delimited field in `msg`.
-fn extract_all_field_values(msg: &str, prefix: &str, suffix: &str) -> Vec<String> {
-    let mut results = Vec::new();
-    let mut search_from = 0;
-    while let Some(pos) = msg[search_from..].find(prefix) {
-        let start = search_from + pos + prefix.len();
-        let Some(remainder) = msg.get(start..) else {
-            break;
-        };
-        let Some(end) = remainder.find(suffix) else {
-            break;
-        };
-        if let Some(value) = remainder.get(..end) {
-            results.push(value.to_string());
-        }
-        search_from = start + end + suffix.len();
+fn extract_id_name_pair(object: &str) -> Option<(String, String, GuidNameSource)> {
+    let allow_decorated = has_name_field(object);
+    match classify_identity_fields(object, &APP_ID_FIELD_SYNTAXES, allow_decorated) {
+        IdentityFieldState::Valid(_) | IdentityFieldState::Conflict => return None,
+        IdentityFieldState::Absent | IdentityFieldState::Malformed => {}
     }
-    results
+
+    let id = match classify_identity_fields(object, &ID_FIELD_SYNTAXES, allow_decorated) {
+        IdentityFieldState::Valid(id) => id,
+        IdentityFieldState::Absent
+        | IdentityFieldState::Malformed
+        | IdentityFieldState::Conflict => return None,
+    };
+    let (name, source) = extract_app_name_with_source(object)?;
+    Some((id, name, source))
+}
+
+#[derive(Clone, Copy)]
+struct ObjectRange {
+    start: usize,
+    end: usize,
+}
+
+struct ObjectFrame {
+    start: usize,
+    depth: usize,
+    children: Vec<ObjectRange>,
+}
+
+struct JsonObjectScope {
+    start: usize,
+    depth: usize,
+    direct: String,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum QuoteStyle {
+    Direct,
+    BackslashEscaped,
+}
+
+/// Return each balanced JSON-like object's direct fields from direct or
+/// one-layer escaped payloads. Nested object bytes are masked in the parent
+/// scope so identity precedence is evaluated per object rather than per line.
+fn json_object_direct_scopes(msg: &str) -> Vec<JsonObjectScope> {
+    let bytes = msg.as_bytes();
+    let mut quote_style = None;
+    let mut stack: Vec<ObjectFrame> = Vec::new();
+    let mut scopes = Vec::new();
+
+    for (index, byte) in bytes.iter().copied().enumerate() {
+        if byte == b'"' {
+            let backslashes = preceding_backslash_count(bytes, index);
+            match (quote_style, backslashes) {
+                (Some(QuoteStyle::Direct), count) if count % 2 == 0 => quote_style = None,
+                (Some(QuoteStyle::BackslashEscaped), 1) => quote_style = None,
+                (None, count) if count % 2 == 0 => quote_style = Some(QuoteStyle::Direct),
+                (None, 1) => quote_style = Some(QuoteStyle::BackslashEscaped),
+                _ => {}
+            }
+            continue;
+        }
+        if quote_style.is_some() {
+            continue;
+        }
+
+        match byte {
+            b'{' => {
+                let depth = stack.len();
+                stack.push(ObjectFrame {
+                    start: index,
+                    depth,
+                    children: Vec::new(),
+                });
+            }
+            b'}' => {
+                let Some(frame) = stack.pop() else {
+                    continue;
+                };
+                let range = ObjectRange {
+                    start: frame.start,
+                    end: index + 1,
+                };
+                if let Some(direct) = object_direct_scope(msg, range, &frame.children) {
+                    scopes.push(JsonObjectScope {
+                        start: frame.start,
+                        depth: frame.depth,
+                        direct,
+                    });
+                }
+                if let Some(parent) = stack.last_mut() {
+                    parent.children.push(range);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    scopes.sort_by_key(|scope| (scope.depth, scope.start));
+    scopes
+}
+
+fn object_direct_scope(msg: &str, object: ObjectRange, children: &[ObjectRange]) -> Option<String> {
+    let mut scope = String::with_capacity(object.end.checked_sub(object.start)?);
+    let mut cursor = object.start;
+
+    for child in children {
+        scope.push_str(msg.get(cursor..child.start)?);
+        scope.extend(std::iter::repeat_n(
+            ' ',
+            child.end.checked_sub(child.start)?,
+        ));
+        cursor = child.end;
+    }
+    scope.push_str(msg.get(cursor..object.end)?);
+    Some(scope)
+}
+
+fn preceding_backslash_count(bytes: &[u8], quote_index: usize) -> usize {
+    bytes[..quote_index]
+        .iter()
+        .rev()
+        .take_while(|byte| **byte == b'\\')
+        .count()
 }
 
 /// Extract a GUID from a log message via JSON identity fields.
@@ -312,7 +397,7 @@ pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
                 guid_re()
                     .captures(msg)
                     .and_then(|c| c.get(1))
-                    .map(|m| m.as_str().to_string())
+                    .map(|m| m.as_str().to_ascii_lowercase())
             } else {
                 None
             }
@@ -324,84 +409,89 @@ pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
 /// GUIDs on the line. An invalid explicit field is an identity boundary: its
 /// presence suppresses line-wide GUID inference.
 pub(crate) fn explicit_app_identity(msg: &str) -> ExplicitAppIdentity {
+    let scopes = json_object_direct_scopes(msg);
+    let mut start = 0;
+    while start < scopes.len() {
+        let depth = scopes[start].depth;
+        let mut end = start;
+        let mut direct_at_depth = String::new();
+        while end < scopes.len() && scopes[end].depth == depth {
+            direct_at_depth.push_str(&scopes[end].direct);
+            direct_at_depth.push('\n');
+            end += 1;
+        }
+
+        let identity = classify_explicit_identity_scope(&direct_at_depth);
+        if identity != ExplicitAppIdentity::Absent {
+            return identity;
+        }
+        start = end;
+    }
+
+    classify_explicit_identity_scope(msg)
+}
+
+fn classify_explicit_identity_scope(msg: &str) -> ExplicitAppIdentity {
     let allow_decorated = has_name_field(msg);
-    let (app_id_present, app_id) = explicit_app_id(msg, allow_decorated);
-    if let Some(value) = app_id {
-        return ExplicitAppIdentity::Valid(value);
+    let app_id = classify_identity_fields(msg, &APP_ID_FIELD_SYNTAXES, allow_decorated);
+    let app_id_absent = matches!(app_id, IdentityFieldState::Absent);
+    match app_id {
+        IdentityFieldState::Valid(value) => return ExplicitAppIdentity::Valid(value),
+        IdentityFieldState::Conflict => return ExplicitAppIdentity::Invalid,
+        IdentityFieldState::Absent | IdentityFieldState::Malformed => {}
     }
 
-    // AppId has higher precedence than Id, so only inspect Id after every
-    // supported AppId syntax has been exhausted.
-    for (prefix, suffix) in [("\"Id\":\"", "\""), ("\\\"Id\\\":\\\"", "\\\"")] {
-        if let Some(value) = extract_guid_field(msg, prefix, suffix) {
-            return ExplicitAppIdentity::Valid(value);
-        }
-    }
-
-    let (id_present, id) = scan_identity_fields(msg, &ID_FIELD_SYNTAXES, allow_decorated);
-    if let Some(value) = id {
-        return ExplicitAppIdentity::Valid(value);
-    }
-
-    if app_id_present || id_present {
-        ExplicitAppIdentity::Invalid
-    } else {
-        ExplicitAppIdentity::Absent
+    match classify_identity_fields(msg, &ID_FIELD_SYNTAXES, allow_decorated) {
+        IdentityFieldState::Valid(value) => ExplicitAppIdentity::Valid(value),
+        IdentityFieldState::Absent if app_id_absent => ExplicitAppIdentity::Absent,
+        IdentityFieldState::Absent
+        | IdentityFieldState::Malformed
+        | IdentityFieldState::Conflict => ExplicitAppIdentity::Invalid,
     }
 }
 
-fn explicit_app_id(msg: &str, allow_decorated: bool) -> (bool, Option<String>) {
-    // Preserve the established compact direct and escaped fast paths.
-    for (prefix, suffix) in [("\"AppId\":\"", "\""), ("\\\"AppId\\\":\\\"", "\\\"")] {
-        if let Some(value) = extract_guid_field(msg, prefix, suffix) {
-            return (true, Some(value));
-        }
-    }
-
-    // Preserve the whitespace-tolerant escaped AppId path with its canonical
-    // GUID grammar, then scan all direct/escaped forms including decorated
-    // field-local GUIDs.
-    if let Some(value) = app_id_json_re()
-        .captures(msg)
-        .and_then(|captures| captures.get(1))
-    {
-        return (true, Some(value.as_str().to_string()));
-    }
-
-    scan_identity_fields(msg, &APP_ID_FIELD_SYNTAXES, allow_decorated)
-}
-
-fn scan_identity_fields(
+fn classify_identity_fields(
     msg: &str,
     syntaxes: &[(&str, &str)],
     allow_decorated: bool,
-) -> (bool, Option<String>) {
-    let mut present = false;
+) -> IdentityFieldState {
+    let mut members = Vec::new();
 
     for &(key, quote) in syntaxes {
         let mut remaining = msg;
         while let Some(key_index) = remaining.find(key) {
-            present = true;
             let after_key = &remaining[key_index + key.len()..];
-            if let Some(value) = json_string_value_after_key(after_key, quote) {
-                if let Some(guid) = exact_guid(value).or_else(|| {
+            let guid = json_string_value_after_key(after_key, quote).and_then(|value| {
+                exact_guid(value).or_else(|| {
                     if allow_decorated {
                         guid_re()
                             .captures(value)
                             .and_then(|captures| captures.get(1))
-                            .map(|matched| matched.as_str().to_string())
+                            .map(|matched| matched.as_str().to_ascii_lowercase())
                     } else {
                         None
                     }
-                }) {
-                    return (true, Some(guid));
-                }
-            }
+                })
+            });
+            members.push(guid);
             remaining = after_key;
         }
     }
 
-    (present, None)
+    match members.as_slice() {
+        [] => IdentityFieldState::Absent,
+        [Some(guid)] => IdentityFieldState::Valid(guid.clone()),
+        [None] => IdentityFieldState::Malformed,
+        many if many.iter().any(Option::is_none) => IdentityFieldState::Conflict,
+        [Some(first), rest @ ..]
+            if rest
+                .iter()
+                .all(|value| value.as_ref().is_some_and(|guid| guid == first)) =>
+        {
+            IdentityFieldState::Valid(first.clone())
+        }
+        _ => IdentityFieldState::Conflict,
+    }
 }
 
 fn json_string_value_after_key<'a>(after_key: &'a str, quote: &str) -> Option<&'a str> {
@@ -413,13 +503,11 @@ fn json_string_value_after_key<'a>(after_key: &'a str, quote: &str) -> Option<&'
 
 fn exact_guid(value: &str) -> Option<String> {
     let matched = guid_re().find(value)?;
-    (matched.start() == 0 && matched.end() == value.len()).then(|| value.to_string())
+    (matched.start() == 0 && matched.end() == value.len()).then(|| value.to_ascii_lowercase())
 }
 
-/// Extract a GUID from an identity field, rejecting arbitrary log content.
-fn extract_guid_field(msg: &str, prefix: &str, suffix: &str) -> Option<String> {
-    let value = extract_json_field(msg, prefix, suffix)?;
-    exact_guid(value)
+fn normalize_guid_key(value: &str) -> String {
+    value.to_ascii_lowercase()
 }
 
 /// Returns `true` if the message contains any name-bearing JSON field.
@@ -1000,6 +1088,18 @@ mod tests {
     }
 
     #[test]
+    fn named_context_fallback_normalizes_guid_case() {
+        let upper = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
+        let lower = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        assert_eq!(
+            extract_app_id(&format!(
+                r#"Processing identity {upper} for {{"ApplicationName":"Contoso"}}"#
+            )),
+            Some(lower.to_string())
+        );
+    }
+
+    #[test]
     fn decorated_identity_field_uses_its_field_local_guid() {
         let unrelated_guid = "11111111-2222-3333-4444-555555555555";
         let app_guid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
@@ -1056,5 +1156,199 @@ mod tests {
 
         assert_eq!(registry.resolve(id_guid), Some("Contoso"));
         assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn duplicate_explicit_identity_conflicts_fail_closed() {
+        let first = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let second = "11111111-2222-3333-4444-555555555555";
+        let messages = [
+            format!(r#"{{"AppId":"{first}","AppId":"{second}","Name":"Contoso"}}"#),
+            format!(r#"{{"Id":"{first}","Id":"{second}","Name":"Contoso"}}"#),
+            format!(r#"{{"AppId":"{first}",\"AppId\":\"{second}\","Name":"Contoso"}}"#),
+            format!(r#"{{"Id":"{first}",\"Id\":\"{second}\","Name":"Contoso"}}"#),
+            format!(r#"{{"AppId":"invalid","AppId":"{first}","Name":"Contoso"}}"#),
+            format!(r#"{{"Id":"invalid","Id":"{first}","Name":"Contoso"}}"#),
+        ];
+
+        for message in messages {
+            assert_eq!(
+                explicit_app_identity(&message),
+                ExplicitAppIdentity::Invalid,
+                "did not fail closed for {message}"
+            );
+
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&[line(&message)]);
+            assert!(registry.is_empty(), "registered identity from {message}");
+        }
+    }
+
+    #[test]
+    fn duplicate_identical_normalized_identity_values_remain_valid() {
+        let lower = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let upper = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
+        let messages = [
+            format!(r#"{{"AppId":"{upper}",\"AppId\":\"{lower}\"}}"#),
+            format!(r#"{{\"Id\":\"{upper}\","Id":"{lower}"}}"#),
+            format!(r#"{{"AppId":"{lower}","AppId":"{lower}"}}"#),
+        ];
+
+        for message in messages {
+            assert_eq!(
+                explicit_app_identity(&message),
+                ExplicitAppIdentity::Valid(lower.to_string()),
+                "duplicate normalization depended on order for {message}"
+            );
+        }
+
+        let fallback = format!(r#"{{"AppId":"invalid","Id":"{lower}"}}"#);
+        assert_eq!(
+            explicit_app_identity(&fallback),
+            ExplicitAppIdentity::Valid(lower.to_string())
+        );
+    }
+
+    #[test]
+    fn registry_keeps_independent_id_name_objects_alongside_app_id() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let first_id = "11111111-2222-3333-4444-555555555555";
+        let second_id = "66666666-7777-8888-9999-000000000000";
+        let messages = [
+            format!(
+                r#"App {{"AppId":"{app_guid}","ApplicationName":"Shared Name"}} Policies [{{"Id":"{first_id}","Name":"Shared Name"}},{{"Id":"{second_id}","Name":"Policy Two"}}]"#
+            ),
+            format!(
+                r#"App {{\"AppId\":\"{app_guid}\",\"ApplicationName\":\"Contoso App\"}} Policies [{{\"Id\":\"{first_id}\",\"Name\":\"Policy One\"}},{{\"Id\":\"{second_id}\",\"Name\":\"Policy Two\"}}]"#
+            ),
+        ];
+
+        for message in messages {
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&[line(&message)]);
+
+            assert!(
+                registry.resolve(app_guid).is_some(),
+                "missing AppId mapping"
+            );
+            assert!(
+                registry.resolve(first_id).is_some(),
+                "missing first Id mapping"
+            );
+            assert_eq!(registry.resolve(second_id), Some("Policy Two"));
+            assert_eq!(
+                registry.len(),
+                3,
+                "wrong object-boundary result for {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn registry_keeps_id_pair_on_object_with_nested_metadata() {
+        let outer_id = "11111111-2222-3333-4444-555555555555";
+        let inner_id = "66666666-7777-8888-9999-000000000000";
+        let messages = [
+            format!(
+                r#"{{"Id":"{outer_id}","Name":"Outer Policy","Metadata":{{"Id":"{inner_id}","Name":"Inner Policy"}}}}"#
+            ),
+            format!(
+                r#"{{\"Id\":\"{outer_id}\",\"Name\":\"Outer Policy\",\"Metadata\":{{\"Id\":\"{inner_id}\",\"Name\":\"Inner Policy\"}}}}"#
+            ),
+        ];
+
+        for message in messages {
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&[line(&message)]);
+            assert_eq!(
+                registry.resolve(outer_id),
+                Some("Outer Policy"),
+                "lost outer object fields for {message}"
+            );
+            assert_eq!(registry.resolve(inner_id), Some("Inner Policy"));
+        }
+    }
+
+    #[test]
+    fn outer_identity_precedes_nested_identity_fields() {
+        let outer = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let nested = "11111111-2222-3333-4444-555555555555";
+        let messages = [
+            format!(
+                r#"{{"AppId":"{outer}","Name":"Outer","Metadata":{{"AppId":"{nested}","Name":"Nested"}}}}"#
+            ),
+            format!(
+                r#"{{"Id":"{outer}","Name":"Outer","Metadata":{{"AppId":"{nested}","Name":"Nested"}}}}"#
+            ),
+            format!(
+                r#"{{\"AppId\":\"{outer}\",\"Name\":\"Outer\",\"Metadata\":{{\"Id\":\"{nested}\",\"Name\":\"Nested\"}}}}"#
+            ),
+        ];
+
+        for message in messages {
+            assert_eq!(
+                explicit_app_identity(&message),
+                ExplicitAppIdentity::Valid(outer.to_string()),
+                "nested identity overrode outer scope for {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn escaped_quote_braces_remain_inside_one_object_scope() {
+        let message = r#"{\"AppId\":\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",\"ApplicationName\":\"Quoted \\\"value with { braces }\\\" tail\"}"#;
+        let scopes = json_object_direct_scopes(message);
+
+        assert_eq!(
+            scopes.len(),
+            1,
+            "escaped string was split into child scopes"
+        );
+        assert!(
+            scopes[0].direct.contains("{ braces }"),
+            "braces inside the escaped quoted value were masked"
+        );
+    }
+
+    #[test]
+    fn registry_keys_are_case_insensitive_and_serialize_once() {
+        let lower = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let upper = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
+
+        let mut graph = GuidRegistry::new();
+        graph.insert(
+            upper.to_string(),
+            "Graph Name".to_string(),
+            GuidNameSource::GraphApi,
+        );
+        assert_eq!(graph.resolve(lower), Some("Graph Name"));
+        assert_eq!(graph.resolve(upper), Some("Graph Name"));
+        assert_eq!(
+            graph.resolve_fallback_name("Download (aaaaaaaa...)", lower),
+            Some("Graph Name".to_string())
+        );
+        assert_eq!(
+            graph.enrich_event_name("Win32 App (aaaaaaaa...)", upper),
+            Some("Win32 App — Graph Name".to_string())
+        );
+        assert!(graph
+            .unresolved_guids_from([lower, upper].into_iter())
+            .is_empty());
+
+        let mut parsed = GuidRegistry::new();
+        parsed.insert(
+            lower.to_string(),
+            "Parsed Name".to_string(),
+            GuidNameSource::NameField,
+        );
+        assert_eq!(parsed.resolve(upper), Some("Parsed Name"));
+        parsed.merge(&graph);
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed.resolve(lower), Some("Graph Name"));
+        let serialized = parsed.to_serializable();
+        assert_eq!(serialized.len(), 1);
+        assert!(serialized.contains_key(lower));
+        assert!(!serialized.contains_key(upper));
     }
 }


### PR DESCRIPTION
## Recovery scope

Independent reconstruction and review hardening of the Intune batch-two AppId parser work. This branch was rebuilt from `origin/main`; it does not copy or modify Claude's worktree.

## Behavior

- Accepts direct, escaped, and whitespace-tolerant `AppId` / `Id` identity fields only when they contain canonical 8-4-4-4-12 GUIDs.
- Preserves named-context fallback only when no explicit identity field creates an identity boundary.
- Gives `AppId` precedence over `Id` inside one logical object.
- Treats duplicate malformed/conflicting fields and multiple independent identity objects as ambiguous, with no event or download attribution.
- Allows ancestor identity precedence only for a genuinely contained descendant object; asymmetric cousin subtrees fail closed.
- Skips key-like text inside direct and one-layer escaped quoted values.
- Binds registry GUID and name inside the same object while retaining independently proven root, sibling, array, and nested mappings.
- Uses a single-pass, borrowed relevant-field scanner with a 128-container nesting cap instead of retaining masked copies of the line at every depth.
- Normalizes registry ingress, lookup, merge, enrichment, unresolved checks, and serialized keys case-insensitively.
- Preserves UTF-8-safe sidecar display prefixes and parser wasm purity.

Parser input is untrusted log text and registry keys feed later correlation, so ambiguous explicit identities fail closed.

## Test-first evidence

Focused failures were captured before each correction, including:

- malformed/multibyte AppId and malformed whitespace-tolerant GUID rejection;
- invalid explicit identity fallback suppression across registry, AppWorkload, and downloads;
- direct, escaped, mixed, malformed, duplicate, and order-reversed identity conflicts;
- sibling AppId/AppId and Id/AppId objects in both orders;
- same-depth siblings and asymmetric cousin subtrees at different depths;
- true ancestor/descendant precedence;
- quoted and one-layer escaped key-like text inside Name values;
- cross-object name-to-ID laundering in favorable and adversarial order;
- independent root and object-local registry mappings;
- over-depth input failing closed;
- case-insensitive external registry insert/lookup/merge/enrichment/unresolved/serialization.

## Verification at `bf75f08646fa06ed6250c0b277ffc0b8258827c4`

- Focused conflict, containment, quoted-content, registry-binding, depth-limit, precedence, policy, and fallback regressions: PASS.
- `cargo test --locked -p cmtraceopen-parser`: PASS (515 unit, 26 macOS portal, 27 Windows package-state, 222 ESP, 26 skeleton, 25 remediation, 24 scripts, 1 doc).
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings`: PASS.
- `cargo +1.88.0 check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown`: PASS.
- Scoped `rustfmt --edition 2021 --check` and `git diff --check`: PASS.
- CodeRabbit CLI exact review of `bd440db052613c620680e2bacb90ba0d4776a1f3..bf75f08646fa06ed6250c0b277ffc0b8258827c4`: first pass found two valid issues; each received a focused RED regression and fix. Second exact-range pass: PASS, 0 findings across all three changed files.
- Fresh independent exact-range review: GO, with separate parser, strict Clippy, wasm, and diff validation.

## Review state

The current exact head is pushed. Fresh hosted CodeRabbit and GitHub Copilot reviews are requested for this head. Hosted CI is running; approvals on older commits are not treated as current acceptance.
