### PR TITLE
fix(sccm): harden server intake boundaries

### DIFF
--- a/crates/cmtraceopen-parser/Cargo.toml
+++ b/crates/cmtraceopen-parser/Cargo.toml
@@ -26,6 +26,6 @@ encoding_rs = "0.8"
 log = "0.4"
 thiserror = "2"
 base64 = "0.22"
+sha2 = "0.11"
 
 [dev-dependencies]
-sha2 = "0.11"

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -1153,7 +1153,12 @@ fn decode_server_payload(
                 .map(Some)
                 .map_err(|_| SccmServerIntakeError::InvalidPayloadEncoding)
         }
-        "windows-1252" => Ok(Some(encoding_rs::WINDOWS_1252.decode(bytes).0.into_owned())),
+        "windows-1252" => Ok(Some(
+            encoding_rs::WINDOWS_1252
+                .decode_without_bom_handling(bytes)
+                .0
+                .into_owned(),
+        )),
         "unknown" => Ok(None),
         _ => Err(SccmServerIntakeError::InvalidPayloadEncoding),
     }

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -1045,8 +1045,15 @@ fn normalize_artifact(
 }
 
 fn payload_sha256(bytes: &[u8]) -> String {
+    const LOWER_HEX: &[u8; 16] = b"0123456789abcdef";
+
     let digest = Sha256::digest(bytes);
-    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        encoded.push(char::from(LOWER_HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(LOWER_HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
 }
 
 fn validate_payload_contract<'a>(
@@ -2008,6 +2015,9 @@ fn preflight_server_manifest_extensions(manifest_json: &str) -> Result<(), SccmS
         )?;
     }
     if let Some(PreservedJsonValue::Array(artifacts)) = preserved_field(manifest, "artifacts") {
+        if artifacts.len() > MAX_SCCM_SERVER_MANIFEST_ARTIFACTS {
+            return Err(SccmServerIntakeError::ManifestLimitExceeded);
+        }
         for artifact in artifacts {
             let PreservedJsonValue::Object(artifact) = artifact else {
                 continue;

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -20,6 +20,7 @@ pub const MAX_SCCM_SERVER_MANIFEST_BYTES: usize = 8 * 1024 * 1024;
 pub const MAX_SCCM_SERVER_MANIFEST_ARTIFACTS: usize = 512;
 pub const MAX_SCCM_SERVER_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
 pub const MAX_SCCM_SERVER_TOTAL_DECLARED_BYTES: u64 = 1024 * 1024 * 1024;
+const MAX_SCCM_SERVER_OPAQUE_EXTENSIONS: usize = 32;
 
 type PathFingerprintKey = (
     String,
@@ -57,6 +58,22 @@ pub struct SccmServerIntakeAssessment {
     pub evidence: Vec<SccmEvidence>,
     pub findings: Vec<SccmFinding>,
     pub next_artifact_requests: Vec<SccmArtifactRequest>,
+    /// Versioned opaque manifest extensions retained without interpreting them.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<SccmServerOpaqueExtension>,
+}
+
+/// A public, deterministic representation of a recognized opaque manifest extension.
+///
+/// Extension names use `x-cmtraceopen-opaque-v1-<token>` and values use
+/// `cmtraceopen.extension.sha256.v1:<64 lowercase hexadecimal characters>`.
+/// The parser retains this provenance but never interprets it as diagnostic input.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmServerOpaqueExtension {
+    pub schema_version: u32,
+    pub name: String,
+    pub value: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -65,6 +82,8 @@ pub struct SccmServerTopologyAssessment {
     pub capture_host_handle: String,
     pub site_handle: String,
     pub roles_observed: Vec<SccmRole>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<SccmServerOpaqueExtension>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -95,6 +114,8 @@ pub struct SccmServerArtifactAssessment {
     pub fragment_complete: Option<bool>,
     pub capture_provenance: Option<SccmServerCaptureProvenance>,
     pub parser_eligible: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<SccmServerOpaqueExtension>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -183,6 +204,15 @@ pub fn assess_server_intake(
     validate_manifest_bounds(&manifest, payloads)?;
 
     let topology = normalize_topology(&manifest)?;
+    if topology.roles_observed.iter().any(|role| {
+        is_opaque_future_role(role)
+            && !manifest.artifacts.iter().any(|artifact| {
+                artifact.producer_role == *role
+                    && artifact.capture_state == SccmCoverageState::Unsupported
+            })
+    }) {
+        return Err(SccmServerIntakeError::InvalidTopology);
+    }
     let mut payload_by_id = BTreeMap::new();
     for payload in payloads {
         if !safe_manifest_artifact_id(&payload.manifest_artifact_id, manifest.synthetic_fixture)
@@ -321,6 +351,7 @@ pub fn assess_server_intake(
         evidence,
         findings: Vec::new(),
         next_artifact_requests,
+        extensions: normalize_opaque_extensions(&manifest.extensions)?,
     })
 }
 
@@ -476,7 +507,7 @@ fn normalize_topology(
             .topology
             .roles_observed
             .iter()
-            .any(|role| !is_declared_server_role(role))
+            .any(|role| !is_declared_server_role(role) && !is_opaque_future_role(role))
     {
         return Err(SccmServerIntakeError::InvalidTopology);
     }
@@ -490,6 +521,7 @@ fn normalize_topology(
         capture_host_handle,
         site_handle,
         roles_observed,
+        extensions: normalize_opaque_extensions(&manifest.topology.extensions)?,
     })
 }
 
@@ -502,8 +534,11 @@ fn normalize_artifact(
     canonical_artifact_identities: &mut BTreeSet<CanonicalArtifactIdentity>,
     payload_by_id: &BTreeMap<&str, &[u8]>,
 ) -> Result<PreparedArtifact, SccmServerIntakeError> {
+    let synthetic_unclassified =
+        artifact.producer_role == SccmRole::Unknown("unclassified".to_owned());
+    let opaque_future_role = is_opaque_future_role(&artifact.producer_role);
     let unsupported_unknown = artifact.capture_state == SccmCoverageState::Unsupported
-        && artifact.producer_role == SccmRole::Unknown("unclassified".to_owned());
+        && (synthetic_unclassified || opaque_future_role);
     validate_artifact_annotations(&artifact, synthetic_fixture)?;
     let source_version =
         normalize_source_version(artifact.source_version.as_deref(), synthetic_fixture)?;
@@ -541,8 +576,8 @@ fn normalize_artifact(
     }
 
     let producer_is_observed = roles_observed.contains(&artifact.producer_role);
-    if (!producer_is_observed && !unsupported_unknown)
-        || (producer_is_observed && !is_declared_server_role(&artifact.producer_role))
+    if (!producer_is_observed && !synthetic_unclassified)
+        || (!is_declared_server_role(&artifact.producer_role) && !unsupported_unknown)
     {
         return Err(SccmServerIntakeError::InvalidArtifact);
     }
@@ -762,6 +797,7 @@ fn normalize_artifact(
             fragment_complete: artifact.fragment_complete,
             capture_provenance,
             parser_eligible,
+            extensions: normalize_opaque_extensions(&artifact.extensions)?,
         },
         evidence,
     })
@@ -1351,7 +1387,47 @@ fn safe_original_path_marker(value: &str, synthetic_fixture: bool) -> bool {
                 .bytes()
                 .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_');
     }
-    !value.is_empty() && value.len() <= 1024 && !value.chars().any(char::is_control)
+    value == "REDACTED" || opaque_sha256_handle(value, "cmtraceopen.original-path.sha256.v1:")
+}
+
+fn normalize_opaque_extensions(
+    extensions: &BTreeMap<String, Value>,
+) -> Result<Vec<SccmServerOpaqueExtension>, SccmServerIntakeError> {
+    if extensions.len() > MAX_SCCM_SERVER_OPAQUE_EXTENSIONS {
+        return Err(SccmServerIntakeError::ManifestLimitExceeded);
+    }
+
+    extensions
+        .iter()
+        .map(|(name, value)| {
+            let value = value
+                .as_str()
+                .ok_or(SccmServerIntakeError::InvalidArtifact)?;
+            if !safe_opaque_extension_name(name)
+                || !opaque_sha256_handle(value, "cmtraceopen.extension.sha256.v1:")
+            {
+                return Err(SccmServerIntakeError::InvalidArtifact);
+            }
+            Ok(SccmServerOpaqueExtension {
+                schema_version: 1,
+                name: name.clone(),
+                value: value.to_owned(),
+            })
+        })
+        .collect()
+}
+
+fn safe_opaque_extension_name(value: &str) -> bool {
+    value
+        .strip_prefix("x-cmtraceopen-opaque-v1-")
+        .is_some_and(|token| {
+            (1..=64).contains(&token.len())
+                && token.as_bytes().first().is_some_and(u8::is_ascii_lowercase)
+                && !token.ends_with('-')
+                && token
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        })
 }
 
 fn safe_optional_handle(value: Option<&str>, synthetic_fixture: bool, domain: &str) -> bool {
@@ -1397,6 +1473,11 @@ fn is_declared_server_role(role: &SccmRole) -> bool {
     )
 }
 
+fn is_opaque_future_role(role: &SccmRole) -> bool {
+    matches!(role, SccmRole::Unknown(value)
+        if opaque_sha256_handle(value, "cmtraceopen.role.sha256.v1:"))
+}
+
 fn role_sort_key(role: &SccmRole) -> &str {
     match role {
         SccmRole::Client => "client",
@@ -1437,7 +1518,7 @@ fn rotation_sort_key(rotation: Option<&SccmRotation>) -> String {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 struct RawServerManifest {
     sccm_manifest_version: u32,
     #[serde(default)]
@@ -1451,6 +1532,8 @@ struct RawServerManifest {
     #[serde(default)]
     input_order_is_deliberately_unsorted: Option<bool>,
     artifacts: Vec<RawServerArtifact>,
+    #[serde(flatten)]
+    extensions: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1461,15 +1544,17 @@ struct RawServerPrivacy {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 struct RawServerTopology {
     capture_host: String,
     site_code: String,
     roles_observed: Vec<SccmRole>,
+    #[serde(flatten)]
+    extensions: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 struct RawServerArtifact {
     artifact_id: String,
     producer_role: SccmRole,
@@ -1500,6 +1585,8 @@ struct RawServerArtifact {
     collected_utc: String,
     relative_path: Option<String>,
     bytes_copied: u64,
+    #[serde(flatten)]
+    extensions: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+use crate::sccm::rotation::is_canonical_rotation_timestamp;
 use crate::sccm::{
     classify_artifact_name, normalize_ccm_artifact, SccmArtifact, SccmArtifactFamily,
     SccmArtifactRequest, SccmCoverageState, SccmEvidence, SccmFinding, SccmRole, SccmRotation,
@@ -368,8 +369,15 @@ fn validate_manifest_bounds(
     }
 
     let mut declared_bytes = 0u64;
+    let mut copied_bytes = 0u64;
     for artifact in &manifest.artifacts {
         if artifact.bytes_copied > MAX_SCCM_SERVER_ARTIFACT_BYTES {
+            return Err(SccmServerIntakeError::ManifestLimitExceeded);
+        }
+        copied_bytes = copied_bytes
+            .checked_add(artifact.bytes_copied)
+            .ok_or(SccmServerIntakeError::ManifestLimitExceeded)?;
+        if copied_bytes > MAX_SCCM_SERVER_TOTAL_DECLARED_BYTES {
             return Err(SccmServerIntakeError::ManifestLimitExceeded);
         }
         if let Some(limit) = &artifact.collection_limit {
@@ -1010,6 +1018,7 @@ fn parse_declared_rotation(
                 .value
                 .as_ref()
                 .and_then(Value::as_str)
+                .filter(|value| is_canonical_rotation_timestamp(value))
                 .ok_or(SccmServerIntakeError::InvalidArtifact)?;
             SccmRotation::Timestamped(timestamp.to_owned())
         }
@@ -1024,7 +1033,9 @@ fn parse_retained_rotation(
     if rotation.kind == "none" && rotation.value.is_none() {
         return Ok(None);
     }
-    parse_declared_rotation(rotation)
+    parse_declared_rotation(rotation)?
+        .ok_or(SccmServerIntakeError::InvalidArtifact)
+        .map(Some)
 }
 
 fn parse_configured_path_state(

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -12,6 +12,13 @@ use crate::sccm::{
 
 use super::catalog::{classify_declared_server_source, expected_family, SccmServerSourceKind};
 
+/// Keep parser-side work bounded even when the manifest did not come from the
+/// native collector. These match the existing bounded bundle intake envelope.
+pub const MAX_SCCM_SERVER_MANIFEST_BYTES: usize = 8 * 1024 * 1024;
+pub const MAX_SCCM_SERVER_MANIFEST_ARTIFACTS: usize = 512;
+pub const MAX_SCCM_SERVER_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
+pub const MAX_SCCM_SERVER_TOTAL_DECLARED_BYTES: u64 = 1024 * 1024 * 1024;
+
 type PathFingerprintKey = (
     String,
     Option<String>,
@@ -67,6 +74,7 @@ pub struct SccmServerArtifactAssessment {
     pub workflow_subject_role: Option<SccmRole>,
     pub workflow_subject_handle: Option<String>,
     pub source_id: String,
+    pub source_kind: String,
     pub family: SccmArtifactFamily,
     pub original_basename: Option<String>,
     pub rotation: Option<SccmRotation>,
@@ -140,6 +148,8 @@ pub enum SccmServerIntakeError {
     PayloadLengthMismatch,
     #[error("server artifact payload encoding is unsupported or malformed")]
     InvalidPayloadEncoding,
+    #[error("server manifest exceeds a bounded intake limit")]
+    ManifestLimitExceeded,
 }
 
 pub fn normalize_server_bundle(
@@ -153,6 +163,9 @@ pub fn assess_server_intake(
     manifest_json: &str,
     payloads: &[SccmServerArtifactPayload],
 ) -> Result<SccmServerIntakeAssessment, SccmServerIntakeError> {
+    if manifest_json.len() > MAX_SCCM_SERVER_MANIFEST_BYTES {
+        return Err(SccmServerIntakeError::ManifestLimitExceeded);
+    }
     let manifest: RawServerManifest = serde_json::from_str(manifest_json)
         .map_err(|_| SccmServerIntakeError::MalformedManifest)?;
     if manifest.sccm_manifest_version != 1 {
@@ -161,6 +174,7 @@ pub fn assess_server_intake(
     if manifest.bundle_role != "server" {
         return Err(SccmServerIntakeError::InvalidBundleRole);
     }
+    validate_manifest_bounds(&manifest, payloads)?;
 
     let topology = normalize_topology(&manifest)?;
     let mut payload_by_id = BTreeMap::new();
@@ -338,6 +352,50 @@ impl PreparedArtifact {
     }
 }
 
+fn validate_manifest_bounds(
+    manifest: &RawServerManifest,
+    payloads: &[SccmServerArtifactPayload],
+) -> Result<(), SccmServerIntakeError> {
+    if manifest.artifacts.len() > MAX_SCCM_SERVER_MANIFEST_ARTIFACTS
+        || payloads.len() > MAX_SCCM_SERVER_MANIFEST_ARTIFACTS
+    {
+        return Err(SccmServerIntakeError::ManifestLimitExceeded);
+    }
+
+    let mut declared_bytes = 0u64;
+    for artifact in &manifest.artifacts {
+        if artifact.bytes_copied > MAX_SCCM_SERVER_ARTIFACT_BYTES {
+            return Err(SccmServerIntakeError::ManifestLimitExceeded);
+        }
+        if let Some(limit) = &artifact.collection_limit {
+            if limit.byte_limit > MAX_SCCM_SERVER_ARTIFACT_BYTES {
+                return Err(SccmServerIntakeError::ManifestLimitExceeded);
+            }
+            declared_bytes = declared_bytes
+                .checked_add(limit.byte_limit)
+                .ok_or(SccmServerIntakeError::ManifestLimitExceeded)?;
+            if declared_bytes > MAX_SCCM_SERVER_TOTAL_DECLARED_BYTES {
+                return Err(SccmServerIntakeError::ManifestLimitExceeded);
+            }
+        }
+    }
+
+    let mut payload_bytes = 0u64;
+    for payload in payloads {
+        payload_bytes = payload_bytes
+            .checked_add(
+                u64::try_from(payload.bytes.len())
+                    .map_err(|_| SccmServerIntakeError::ManifestLimitExceeded)?,
+            )
+            .ok_or(SccmServerIntakeError::ManifestLimitExceeded)?;
+        if payload_bytes > MAX_SCCM_SERVER_TOTAL_DECLARED_BYTES {
+            return Err(SccmServerIntakeError::ManifestLimitExceeded);
+        }
+    }
+
+    Ok(())
+}
+
 fn normalize_topology(
     manifest: &RawServerManifest,
 ) -> Result<SccmServerTopologyAssessment, SccmServerIntakeError> {
@@ -404,10 +462,13 @@ fn normalize_artifact(
     canonical_artifact_identities: &mut BTreeSet<CanonicalArtifactIdentity>,
     payload_by_id: &BTreeMap<&str, &[u8]>,
 ) -> Result<PreparedArtifact, SccmServerIntakeError> {
+    let unsupported_unknown = artifact.capture_state == SccmCoverageState::Unsupported
+        && artifact.producer_role == SccmRole::Unknown("unclassified".to_owned());
     let source_version =
         normalize_source_version(artifact.source_version.as_deref(), synthetic_fixture)?;
     if !safe_manifest_artifact_id(&artifact.artifact_id, synthetic_fixture)
-        || !safe_source_id(&artifact.source_id)
+        || !safe_source_id(&artifact.source_id, unsupported_unknown)
+        || !safe_source_kind(&artifact.source_kind, unsupported_unknown)
         || !safe_lineage_id(&artifact.rotation.lineage_id, synthetic_fixture)
         || !safe_path_fingerprint(
             &artifact.configured_path_provenance.path_fingerprint,
@@ -427,13 +488,13 @@ fn normalize_artifact(
             synthetic_fixture,
             "subject",
         )
+        || (!unsupported_unknown && artifact.producer_host_handle.is_none())
+        || (unsupported_unknown && !safe_public_basename(&artifact.original_basename))
     {
         return Err(SccmServerIntakeError::InvalidArtifact);
     }
 
     let producer_is_observed = roles_observed.contains(&artifact.producer_role);
-    let unsupported_unknown = artifact.capture_state == SccmCoverageState::Unsupported
-        && artifact.producer_role == SccmRole::Unknown("unclassified".to_owned());
     if (!producer_is_observed && !unsupported_unknown)
         || (producer_is_observed && !is_declared_server_role(&artifact.producer_role))
     {
@@ -459,7 +520,7 @@ fn normalize_artifact(
         &artifact.original_basename,
     );
 
-    let (family, original_basename, rotation, parser_eligible) =
+    let (family, original_basename, rotation, mut parser_eligible) =
         if let Some((spec, classified)) = classification {
             let family =
                 expected_family(spec.source_id).ok_or(SccmServerIntakeError::InvalidArtifact)?;
@@ -482,9 +543,9 @@ fn normalize_artifact(
             }
         } else if unsupported_unknown {
             (
-                SccmArtifactFamily::Unknown("unsupported".to_owned()),
-                None,
-                None,
+                SccmArtifactFamily::Unknown(artifact.source_id.clone()),
+                Some(artifact.original_basename.clone()),
+                parse_retained_rotation(&artifact.rotation)?,
                 false,
             )
         } else {
@@ -555,6 +616,11 @@ fn normalize_artifact(
         Some("nonDefault") => Some(SccmServerConfiguredPathClass::NonDefault),
         Some(_) => return Err(SccmServerIntakeError::InvalidArtifact),
     };
+    if configured_path_class.is_some()
+        && configured_path_state != SccmServerConfiguredPathState::Configured
+    {
+        return Err(SccmServerIntakeError::InvalidArtifact);
+    }
     let collected_at_utc = normalize_collected_utc(&artifact.collected_utc)?;
     let relative_path = validate_relative_path(
         artifact.relative_path.clone(),
@@ -573,32 +639,50 @@ fn normalize_artifact(
     let mut state = artifact.capture_state.clone();
     if artifact.capture_state == SccmCoverageState::Captured && parser_eligible {
         let bytes = bytes.ok_or(SccmServerIntakeError::MissingPayload)?;
-        if artifact.encoding.as_deref() != Some("utf-8") {
-            return Err(SccmServerIntakeError::InvalidPayloadEncoding);
-        }
-        let content = std::str::from_utf8(bytes)
-            .map_err(|_| SccmServerIntakeError::InvalidPayloadEncoding)?;
-        evidence = normalize_ccm_artifact(
-            SccmArtifact {
-                artifact_id: artifact.artifact_id.clone(),
-                display_name: original_basename
-                    .clone()
-                    .ok_or(SccmServerIntakeError::InvalidArtifact)?,
-                original_path: None,
-                host: artifact.producer_host_handle.clone(),
-                role: artifact.producer_role.clone(),
-                configmgr_version: source_version.clone(),
-                collected_at_utc: Some(collected_at_utc.clone()),
-                rotation: rotation
-                    .clone()
-                    .ok_or(SccmServerIntakeError::InvalidArtifact)?,
-                coverage: artifact.capture_state.clone(),
-                encoding: artifact.encoding.clone(),
-            },
-            content,
-        );
-        if evidence.is_empty() {
-            state = SccmCoverageState::ParseFailed;
+        let encoding = artifact
+            .encoding
+            .as_deref()
+            .ok_or(SccmServerIntakeError::InvalidArtifact)?;
+        if let Some(content) = decode_server_payload(bytes, encoding)? {
+            let display_name = original_basename
+                .clone()
+                .ok_or(SccmServerIntakeError::InvalidArtifact)?;
+            let (_, parse_errors) =
+                crate::parser::ccm::parse_content(&content, &display_name, None);
+            evidence = normalize_ccm_artifact(
+                SccmArtifact {
+                    artifact_id: artifact.artifact_id.clone(),
+                    display_name,
+                    original_path: None,
+                    host: artifact.producer_host_handle.clone(),
+                    role: artifact.producer_role.clone(),
+                    configmgr_version: source_version.clone(),
+                    collected_at_utc: Some(collected_at_utc.clone()),
+                    rotation: rotation
+                        .clone()
+                        .ok_or(SccmServerIntakeError::InvalidArtifact)?,
+                    coverage: artifact.capture_state.clone(),
+                    encoding: artifact.encoding.clone(),
+                },
+                &content,
+            );
+            let collected_utc_millis = DateTime::parse_from_rfc3339(&collected_at_utc)
+                .map_err(|_| SccmServerIntakeError::InvalidArtifact)?
+                .timestamp_millis();
+            if evidence.iter().any(|record| {
+                record
+                    .timestamp
+                    .utc_millis
+                    .is_some_and(|instant| instant > collected_utc_millis)
+            }) {
+                return Err(SccmServerIntakeError::InvalidArtifact);
+            }
+            if parse_errors > 0 {
+                state = SccmCoverageState::ParseFailed;
+            }
+        } else {
+            state = SccmCoverageState::Unsupported;
+            parser_eligible = false;
         }
     }
 
@@ -611,11 +695,8 @@ fn normalize_artifact(
             workflow_subject_handle: artifact
                 .workflow_subject
                 .and_then(|subject| subject.instance_handle),
-            source_id: if unsupported_unknown {
-                "unsupported".to_owned()
-            } else {
-                artifact.source_id
-            },
+            source_id: artifact.source_id,
+            source_kind: artifact.source_kind,
             family,
             original_basename,
             rotation,
@@ -700,6 +781,43 @@ fn validate_payload_contract<'a>(
         return Err(SccmServerIntakeError::UnexpectedPayload);
     }
     Ok((None, None))
+}
+
+fn decode_server_payload(
+    bytes: &[u8],
+    encoding: &str,
+) -> Result<Option<String>, SccmServerIntakeError> {
+    match encoding {
+        "utf-8" => {
+            let bytes = bytes.strip_prefix(&[0xef, 0xbb, 0xbf]).unwrap_or(bytes);
+            std::str::from_utf8(bytes)
+                .map(|content| Some(content.to_owned()))
+                .map_err(|_| SccmServerIntakeError::InvalidPayloadEncoding)
+        }
+        "utf-16le" => {
+            let bytes = bytes.strip_prefix(&[0xff, 0xfe]).unwrap_or(bytes);
+            if bytes.len() % 2 != 0 {
+                return Err(SccmServerIntakeError::InvalidPayloadEncoding);
+            }
+            let units = bytes
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .collect::<Vec<_>>();
+            String::from_utf16(&units)
+                .map(Some)
+                .map_err(|_| SccmServerIntakeError::InvalidPayloadEncoding)
+        }
+        "windows-1252" => {
+            let (content, _, had_errors) = encoding_rs::WINDOWS_1252.decode(bytes);
+            if had_errors {
+                Err(SccmServerIntakeError::InvalidPayloadEncoding)
+            } else {
+                Ok(Some(content.into_owned()))
+            }
+        }
+        "unknown" => Ok(None),
+        _ => Err(SccmServerIntakeError::InvalidPayloadEncoding),
+    }
 }
 
 fn validate_relative_path(
@@ -853,6 +971,15 @@ fn parse_declared_rotation(
     Ok(Some(parsed))
 }
 
+fn parse_retained_rotation(
+    rotation: &RawServerRotation,
+) -> Result<Option<SccmRotation>, SccmServerIntakeError> {
+    if rotation.kind == "none" && rotation.value.is_none() {
+        return Ok(None);
+    }
+    parse_declared_rotation(rotation)
+}
+
 fn parse_configured_path_state(
     value: &str,
 ) -> Result<SccmServerConfiguredPathState, SccmServerIntakeError> {
@@ -913,6 +1040,7 @@ fn request_for_gap(
         SccmCoverageState::Absent
             | SccmCoverageState::AccessDenied
             | SccmCoverageState::Capped
+            | SccmCoverageState::Unsupported
             | SccmCoverageState::ParseFailed
     ) {
         return None;
@@ -1006,7 +1134,7 @@ fn safe_manifest_artifact_id(value: &str, synthetic_fixture: bool) -> bool {
     opaque_sha256_handle(value, "cmtraceopen.artifact.sha256.v1:")
 }
 
-fn safe_source_id(value: &str) -> bool {
+fn safe_source_id(value: &str, allow_unknown: bool) -> bool {
     matches!(
         value,
         "server-sitecomp"
@@ -1017,7 +1145,27 @@ fn safe_source_id(value: &str) -> bool {
             | "server-dp-distribution"
             | "server-sup-sync"
             | "unknown-db-supplement"
-    )
+    ) || (allow_unknown
+        && (1..=64).contains(&value.len())
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_')
+        }))
+}
+
+fn safe_source_kind(value: &str, allow_unknown: bool) -> bool {
+    matches!(value, "ccmLog" | "iisW3c" | "structuredSupplement")
+        || (allow_unknown
+            && (1..=64).contains(&value.len())
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')))
+}
+
+fn safe_public_basename(value: &str) -> bool {
+    (1..=255).contains(&value.len())
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
 }
 
 fn safe_lineage_id(value: &str, synthetic_fixture: bool) -> bool {
@@ -1150,9 +1298,11 @@ fn coverage_sort_key(state: &SccmCoverageState) -> &'static str {
 
 fn rotation_sort_key(rotation: Option<&SccmRotation>) -> String {
     match rotation {
-        Some(SccmRotation::LoUnderscore) => "0-lo-underscore".to_owned(),
-        Some(SccmRotation::Numbered(value)) => format!("1-numbered-{value:010}"),
-        Some(SccmRotation::Timestamped(value)) => format!("2-timestamped-{value}"),
+        Some(SccmRotation::Timestamped(value)) => format!("0-timestamped-{value}"),
+        Some(SccmRotation::Numbered(value)) => {
+            format!("1-numbered-{:010}", u32::MAX - value)
+        }
+        Some(SccmRotation::LoUnderscore) => "2-lo-underscore".to_owned(),
         Some(SccmRotation::Current) => "3-current".to_owned(),
         Some(SccmRotation::Unknown(_)) => "4-unknown".to_owned(),
         None => "5-not-applicable".to_owned(),

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -82,6 +82,8 @@ pub struct SccmServerOpaqueExtension {
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum SccmServerOpaqueExtensionError {
+    #[error("unsupported opaque extension schema version {schema_version}")]
+    UnsupportedSchemaVersion { schema_version: u32 },
     #[error("opaque extension name is invalid or unsafe")]
     InvalidName,
     #[error("opaque extension value is invalid or unsafe")]
@@ -115,7 +117,12 @@ impl SccmServerOpaqueExtension {
     }
 
     fn validate(&self) -> Result<(), SccmServerOpaqueExtensionError> {
-        if self.schema_version != 1 || !safe_opaque_extension_name(&self.name) {
+        if self.schema_version != 1 {
+            return Err(SccmServerOpaqueExtensionError::UnsupportedSchemaVersion {
+                schema_version: self.schema_version,
+            });
+        }
+        if !safe_opaque_extension_name(&self.name) {
             return Err(SccmServerOpaqueExtensionError::InvalidName);
         }
         if !opaque_sha256_handle(&self.value, "cmtraceopen.extension.sha256.v1:") {
@@ -774,16 +781,16 @@ fn normalize_artifact(
         })
         .transpose()?
         .unwrap_or_default();
-    let synthetic_unclassified =
+    let unclassified_producer =
         artifact.producer_role == SccmRole::Unknown("unclassified".to_owned());
     let opaque_future_role = !synthetic_fixture && is_opaque_future_role(&artifact.producer_role);
     let retained_unknown = opaque_future_role
-        || (synthetic_unclassified && artifact.capture_state == SccmCoverageState::Unsupported);
+        || (unclassified_producer && artifact.capture_state == SccmCoverageState::Unsupported);
     validate_artifact_annotations(&artifact, synthetic_fixture)?;
     let source_version =
         normalize_source_version(artifact.source_version.as_deref(), synthetic_fixture)?;
     if !safe_manifest_artifact_id(&artifact.artifact_id, synthetic_fixture)
-        || !safe_source_id(&artifact.source_id, retained_unknown, synthetic_fixture)
+        || !safe_source_id(&artifact.source_id, retained_unknown)
         || !safe_source_kind(&artifact.source_kind, retained_unknown, synthetic_fixture)
         || !safe_lineage_id(&artifact.rotation.lineage_id, synthetic_fixture)
         || !safe_path_fingerprint(
@@ -813,7 +820,7 @@ fn normalize_artifact(
     }
 
     let producer_is_observed = roles_observed.contains(&artifact.producer_role);
-    if (!producer_is_observed && !synthetic_unclassified)
+    if (!producer_is_observed && !unclassified_producer)
         || (!is_declared_server_role(&artifact.producer_role) && !retained_unknown)
     {
         return Err(SccmServerIntakeError::InvalidArtifact);
@@ -1146,14 +1153,7 @@ fn decode_server_payload(
                 .map(Some)
                 .map_err(|_| SccmServerIntakeError::InvalidPayloadEncoding)
         }
-        "windows-1252" => {
-            let (content, _, had_errors) = encoding_rs::WINDOWS_1252.decode(bytes);
-            if had_errors {
-                Err(SccmServerIntakeError::InvalidPayloadEncoding)
-            } else {
-                Ok(Some(content.into_owned()))
-            }
-        }
+        "windows-1252" => Ok(Some(encoding_rs::WINDOWS_1252.decode(bytes).0.into_owned())),
         "unknown" => Ok(None),
         _ => Err(SccmServerIntakeError::InvalidPayloadEncoding),
     }
@@ -1561,7 +1561,7 @@ fn safe_manifest_artifact_id(value: &str, synthetic_fixture: bool) -> bool {
     opaque_sha256_handle(value, "cmtraceopen.artifact.sha256.v1:")
 }
 
-fn safe_source_id(value: &str, allow_unknown: bool, synthetic_fixture: bool) -> bool {
+fn safe_source_id(value: &str, allow_unknown: bool) -> bool {
     matches!(
         value,
         "server-sitecomp"
@@ -1572,12 +1572,7 @@ fn safe_source_id(value: &str, allow_unknown: bool, synthetic_fixture: bool) -> 
             | "server-dp-distribution"
             | "server-sup-sync"
             | "unknown-db-supplement"
-    ) || (allow_unknown
-        && if synthetic_fixture {
-            value == "unknown-db-supplement"
-        } else {
-            opaque_sha256_handle(value, "cmtraceopen.source.sha256.v1:")
-        })
+    ) || (allow_unknown && opaque_sha256_handle(value, "cmtraceopen.source.sha256.v1:"))
 }
 
 fn safe_source_kind(value: &str, allow_unknown: bool, synthetic_fixture: bool) -> bool {
@@ -1982,16 +1977,7 @@ fn preflight_server_manifest_extensions(manifest_json: &str) -> Result<(), SccmS
     let mut totals = OpaqueExtensionTotals::default();
     validate_preserved_extensions(
         manifest,
-        &[
-            "sccmManifestVersion",
-            "syntheticFixture",
-            "proposalOnly",
-            "privacy",
-            "bundleRole",
-            "topology",
-            "inputOrderIsDeliberatelyUnsorted",
-            "artifacts",
-        ],
+        RawServerManifest::KNOWN_FIELDS,
         SccmServerIntakeError::MalformedManifest,
         &mut totals,
     )?;
@@ -2000,7 +1986,7 @@ fn preflight_server_manifest_extensions(manifest_json: &str) -> Result<(), SccmS
         validate_unique_object_fields(privacy, SccmServerIntakeError::MalformedManifest)?;
         validate_preserved_extensions(
             privacy,
-            &["synthetic", "rawPaths"],
+            RawServerPrivacy::KNOWN_FIELDS,
             SccmServerIntakeError::MalformedManifest,
             &mut totals,
         )?;
@@ -2009,7 +1995,7 @@ fn preflight_server_manifest_extensions(manifest_json: &str) -> Result<(), SccmS
         validate_unique_object_fields(topology, SccmServerIntakeError::InvalidTopology)?;
         validate_preserved_extensions(
             topology,
-            &["captureHost", "siteCode", "rolesObserved"],
+            RawServerTopology::KNOWN_FIELDS,
             SccmServerIntakeError::InvalidTopology,
             &mut totals,
         )?;
@@ -2025,42 +2011,18 @@ fn preflight_server_manifest_extensions(manifest_json: &str) -> Result<(), SccmS
             validate_unique_object_fields(artifact, SccmServerIntakeError::InvalidArtifact)?;
             validate_preserved_extensions(
                 artifact,
-                &[
-                    "artifactId",
-                    "producerRole",
-                    "producerHostHandle",
-                    "workflowSubject",
-                    "sourceId",
-                    "sourceKind",
-                    "sourceVersion",
-                    "originalPath",
-                    "originalBasename",
-                    "configuredPathProvenance",
-                    "defaultCandidateState",
-                    "rotation",
-                    "captureState",
-                    "collectionDetail",
-                    "skipReason",
-                    "unsupportedReason",
-                    "encoding",
-                    "collectionLimit",
-                    "truncated",
-                    "fragmentComplete",
-                    "collectedUtc",
-                    "relativePath",
-                    "bytesCopied",
-                ],
+                RawServerArtifact::KNOWN_FIELDS,
                 SccmServerIntakeError::InvalidArtifact,
                 &mut totals,
             )?;
             for (field, known) in [
-                ("workflowSubject", &["role", "instanceHandle", "basis"][..]),
+                ("workflowSubject", RawWorkflowSubject::KNOWN_FIELDS),
                 (
                     "configuredPathProvenance",
-                    &["state", "pathClass", "pathFingerprint"][..],
+                    RawConfiguredPathProvenance::KNOWN_FIELDS,
                 ),
-                ("rotation", &["kind", "value", "lineageId"][..]),
-                ("collectionLimit", &["byteLimit", "limitApplied"][..]),
+                ("rotation", RawServerRotation::KNOWN_FIELDS),
+                ("collectionLimit", RawCollectionLimit::KNOWN_FIELDS),
             ] {
                 if let Some(PreservedJsonValue::Object(nested)) = preserved_field(artifact, field) {
                     validate_unique_object_fields(nested, SccmServerIntakeError::InvalidArtifact)?;
@@ -2131,118 +2093,118 @@ fn validate_preserved_extensions(
     Ok(())
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RawServerManifest {
-    sccm_manifest_version: u32,
-    #[serde(default)]
-    synthetic_fixture: bool,
-    #[serde(default)]
-    proposal_only: Option<bool>,
-    #[serde(default)]
-    privacy: Option<RawServerPrivacy>,
-    bundle_role: String,
-    topology: RawServerTopology,
-    #[serde(default)]
-    input_order_is_deliberately_unsorted: Option<bool>,
-    artifacts: Vec<RawServerArtifact>,
-    #[serde(flatten)]
-    extensions: BTreeMap<String, Value>,
+macro_rules! define_raw_server_wire {
+    (
+        struct $name:ident {
+            $(
+                $(#[$field_meta:meta])*
+                $wire_name:literal => $field_name:ident: $field_type:ty
+            ),* $(,)?
+        }
+    ) => {
+        #[derive(Debug, Deserialize)]
+        struct $name {
+            $(
+                $(#[$field_meta])*
+                #[serde(rename = $wire_name)]
+                $field_name: $field_type,
+            )*
+            #[serde(flatten)]
+            extensions: BTreeMap<String, Value>,
+        }
+
+        impl $name {
+            const KNOWN_FIELDS: &'static [&'static str] = &[$($wire_name),*];
+        }
+    };
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RawServerPrivacy {
-    synthetic: bool,
-    raw_paths: String,
-    #[serde(flatten)]
-    extensions: BTreeMap<String, Value>,
+define_raw_server_wire! {
+    struct RawServerManifest {
+        "sccmManifestVersion" => sccm_manifest_version: u32,
+        #[serde(default)]
+        "syntheticFixture" => synthetic_fixture: bool,
+        "proposalOnly" => proposal_only: Option<bool>,
+        "privacy" => privacy: Option<RawServerPrivacy>,
+        "bundleRole" => bundle_role: String,
+        "topology" => topology: RawServerTopology,
+        "inputOrderIsDeliberatelyUnsorted" => input_order_is_deliberately_unsorted: Option<bool>,
+        "artifacts" => artifacts: Vec<RawServerArtifact>,
+    }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RawServerTopology {
-    capture_host: String,
-    site_code: String,
-    roles_observed: Vec<SccmRole>,
-    #[serde(flatten)]
-    extensions: BTreeMap<String, Value>,
+define_raw_server_wire! {
+    struct RawServerPrivacy {
+        "synthetic" => synthetic: bool,
+        "rawPaths" => raw_paths: String,
+    }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RawServerArtifact {
-    artifact_id: String,
-    producer_role: SccmRole,
-    producer_host_handle: Option<String>,
-    workflow_subject: Option<RawWorkflowSubject>,
-    source_id: String,
-    source_kind: String,
-    source_version: Option<String>,
-    original_path: String,
-    original_basename: String,
-    configured_path_provenance: RawConfiguredPathProvenance,
-    #[serde(default)]
-    default_candidate_state: Option<String>,
-    rotation: RawServerRotation,
-    capture_state: SccmCoverageState,
-    #[serde(default)]
-    collection_detail: Option<String>,
-    #[serde(default)]
-    skip_reason: Option<String>,
-    #[serde(default)]
-    unsupported_reason: Option<String>,
-    encoding: Option<String>,
-    collection_limit: Option<RawCollectionLimit>,
-    #[serde(default)]
-    truncated: Option<bool>,
-    #[serde(default)]
-    fragment_complete: Option<bool>,
-    collected_utc: String,
-    relative_path: Option<String>,
-    bytes_copied: u64,
-    #[serde(flatten)]
-    extensions: BTreeMap<String, Value>,
+define_raw_server_wire! {
+    struct RawServerTopology {
+        "captureHost" => capture_host: String,
+        "siteCode" => site_code: String,
+        "rolesObserved" => roles_observed: Vec<SccmRole>,
+    }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RawWorkflowSubject {
-    role: SccmRole,
-    instance_handle: Option<String>,
-    #[serde(default)]
-    basis: Option<String>,
-    #[serde(flatten)]
-    extensions: BTreeMap<String, Value>,
+define_raw_server_wire! {
+    struct RawServerArtifact {
+        "artifactId" => artifact_id: String,
+        "producerRole" => producer_role: SccmRole,
+        "producerHostHandle" => producer_host_handle: Option<String>,
+        "workflowSubject" => workflow_subject: Option<RawWorkflowSubject>,
+        "sourceId" => source_id: String,
+        "sourceKind" => source_kind: String,
+        "sourceVersion" => source_version: Option<String>,
+        "originalPath" => original_path: String,
+        "originalBasename" => original_basename: String,
+        "configuredPathProvenance" => configured_path_provenance: RawConfiguredPathProvenance,
+        "defaultCandidateState" => default_candidate_state: Option<String>,
+        "rotation" => rotation: RawServerRotation,
+        "captureState" => capture_state: SccmCoverageState,
+        "collectionDetail" => collection_detail: Option<String>,
+        "skipReason" => skip_reason: Option<String>,
+        "unsupportedReason" => unsupported_reason: Option<String>,
+        "encoding" => encoding: Option<String>,
+        "collectionLimit" => collection_limit: Option<RawCollectionLimit>,
+        "truncated" => truncated: Option<bool>,
+        "fragmentComplete" => fragment_complete: Option<bool>,
+        "collectedUtc" => collected_utc: String,
+        "relativePath" => relative_path: Option<String>,
+        "bytesCopied" => bytes_copied: u64,
+    }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RawConfiguredPathProvenance {
-    state: String,
-    path_class: Option<String>,
-    path_fingerprint: String,
-    #[serde(flatten)]
-    extensions: BTreeMap<String, Value>,
+define_raw_server_wire! {
+    struct RawWorkflowSubject {
+        "role" => role: SccmRole,
+        "instanceHandle" => instance_handle: Option<String>,
+        "basis" => basis: Option<String>,
+    }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RawServerRotation {
-    kind: String,
-    value: Option<Value>,
-    lineage_id: String,
-    #[serde(flatten)]
-    extensions: BTreeMap<String, Value>,
+define_raw_server_wire! {
+    struct RawConfiguredPathProvenance {
+        "state" => state: String,
+        "pathClass" => path_class: Option<String>,
+        "pathFingerprint" => path_fingerprint: String,
+    }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RawCollectionLimit {
-    byte_limit: u64,
-    limit_applied: bool,
-    #[serde(flatten)]
-    extensions: BTreeMap<String, Value>,
+define_raw_server_wire! {
+    struct RawServerRotation {
+        "kind" => kind: String,
+        "value" => value: Option<Value>,
+        "lineageId" => lineage_id: String,
+    }
+}
+
+define_raw_server_wire! {
+    struct RawCollectionLimit {
+        "byteLimit" => byte_limit: u64,
+        "limitApplied" => limit_applied: bool,
+    }
 }
 
 #[cfg(test)]
@@ -2257,6 +2219,87 @@ mod opaque_extension_boundary_tests {
             name: name.to_owned(),
             value: format!("cmtraceopen.extension.sha256.v1:{ordinal:064x}"),
         }
+    }
+
+    #[test]
+    fn opaque_extension_validation_distinguishes_unsupported_schema_version() {
+        let extension = SccmServerOpaqueExtension {
+            schema_version: 2,
+            name: "x-cmtraceopen-opaque-v1-safe".to_owned(),
+            value: "cmtraceopen.extension.sha256.v1:0000000000000000000000000000000000000000000000000000000000000001"
+                .to_owned(),
+        };
+
+        assert_eq!(
+            extension.validate(),
+            Err(SccmServerOpaqueExtensionError::UnsupportedSchemaVersion { schema_version: 2 })
+        );
+    }
+
+    #[test]
+    fn raw_manifest_known_fields_match_the_generated_wire_contracts() {
+        assert_eq!(
+            RawServerManifest::KNOWN_FIELDS,
+            [
+                "sccmManifestVersion",
+                "syntheticFixture",
+                "proposalOnly",
+                "privacy",
+                "bundleRole",
+                "topology",
+                "inputOrderIsDeliberatelyUnsorted",
+                "artifacts",
+            ]
+        );
+        assert_eq!(RawServerPrivacy::KNOWN_FIELDS, ["synthetic", "rawPaths"]);
+        assert_eq!(
+            RawServerTopology::KNOWN_FIELDS,
+            ["captureHost", "siteCode", "rolesObserved"]
+        );
+        assert_eq!(
+            RawWorkflowSubject::KNOWN_FIELDS,
+            ["role", "instanceHandle", "basis"]
+        );
+        assert_eq!(
+            RawConfiguredPathProvenance::KNOWN_FIELDS,
+            ["state", "pathClass", "pathFingerprint"]
+        );
+        assert_eq!(
+            RawServerRotation::KNOWN_FIELDS,
+            ["kind", "value", "lineageId"]
+        );
+        assert_eq!(
+            RawCollectionLimit::KNOWN_FIELDS,
+            ["byteLimit", "limitApplied"]
+        );
+        assert_eq!(
+            RawServerArtifact::KNOWN_FIELDS,
+            [
+                "artifactId",
+                "producerRole",
+                "producerHostHandle",
+                "workflowSubject",
+                "sourceId",
+                "sourceKind",
+                "sourceVersion",
+                "originalPath",
+                "originalBasename",
+                "configuredPathProvenance",
+                "defaultCandidateState",
+                "rotation",
+                "captureState",
+                "collectionDetail",
+                "skipReason",
+                "unsupportedReason",
+                "encoding",
+                "collectionLimit",
+                "truncated",
+                "fragmentComplete",
+                "collectedUtc",
+                "relativePath",
+                "bytesCopied",
+            ]
+        );
     }
 
     fn empty_assessment() -> SccmServerIntakeAssessment {
@@ -2355,6 +2398,10 @@ mod opaque_extension_boundary_tests {
 
     #[test]
     fn assessment_serialize_bounds_per_scope_and_aggregate_extensions() {
+        assert_eq!(
+            EXPECTED_MAX_TOTAL_OPAQUE_EXTENSIONS, MAX_SCCM_SERVER_TOTAL_OPAQUE_EXTENSIONS,
+            "the pinned aggregate extension bound must track the production contract"
+        );
         let mut per_scope = empty_assessment();
         per_scope.extensions = (0..=MAX_SCCM_SERVER_OPAQUE_EXTENSIONS)
             .map(|ordinal| {

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -1,7 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 
 use chrono::{DateTime, SecondsFormat, Utc};
-use serde::{Deserialize, Serialize};
+use serde::de::{Error as _, MapAccess, SeqAccess, Visitor};
+use serde::ser::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -21,6 +24,9 @@ pub const MAX_SCCM_SERVER_MANIFEST_ARTIFACTS: usize = 512;
 pub const MAX_SCCM_SERVER_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
 pub const MAX_SCCM_SERVER_TOTAL_DECLARED_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_SCCM_SERVER_OPAQUE_EXTENSIONS: usize = 32;
+const MAX_SCCM_SERVER_OPAQUE_EXTENSION_BYTES_PER_SCOPE: usize = 8 * 1024;
+const MAX_SCCM_SERVER_TOTAL_OPAQUE_EXTENSIONS: usize = 1_024;
+const MAX_SCCM_SERVER_TOTAL_OPAQUE_EXTENSION_BYTES: usize = 256 * 1024;
 
 type PathFingerprintKey = (
     String,
@@ -48,8 +54,7 @@ pub struct SccmServerArtifactPayload {
     pub bytes: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SccmServerIntakeAssessment {
     pub schema_version: u32,
     pub topology: SccmServerTopologyAssessment,
@@ -59,8 +64,8 @@ pub struct SccmServerIntakeAssessment {
     pub findings: Vec<SccmFinding>,
     pub next_artifact_requests: Vec<SccmArtifactRequest>,
     /// Versioned opaque manifest extensions retained without interpreting them.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub extensions: Vec<SccmServerOpaqueExtension>,
+    extensions: Vec<SccmServerOpaqueExtension>,
+    privacy_extensions: Vec<SccmServerOpaqueExtension>,
 }
 
 /// A public, deterministic representation of a recognized opaque manifest extension.
@@ -68,12 +73,150 @@ pub struct SccmServerIntakeAssessment {
 /// Extension names use `x-cmtraceopen-opaque-v1-<token>` and values use
 /// `cmtraceopen.extension.sha256.v1:<64 lowercase hexadecimal characters>`.
 /// The parser retains this provenance but never interprets it as diagnostic input.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SccmServerOpaqueExtension {
-    pub schema_version: u32,
-    pub name: String,
-    pub value: String,
+    schema_version: u32,
+    name: String,
+    value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum SccmServerOpaqueExtensionError {
+    #[error("opaque extension name is invalid or unsafe")]
+    InvalidName,
+    #[error("opaque extension value is invalid or unsafe")]
+    InvalidValue,
+}
+
+impl SccmServerOpaqueExtension {
+    pub fn try_new(
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<Self, SccmServerOpaqueExtensionError> {
+        let extension = Self {
+            schema_version: 1,
+            name: name.into(),
+            value: value.into(),
+        };
+        extension.validate()?;
+        Ok(extension)
+    }
+
+    pub fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    fn validate(&self) -> Result<(), SccmServerOpaqueExtensionError> {
+        if self.schema_version != 1 || !safe_opaque_extension_name(&self.name) {
+            return Err(SccmServerOpaqueExtensionError::InvalidName);
+        }
+        if !opaque_sha256_handle(&self.value, "cmtraceopen.extension.sha256.v1:") {
+            return Err(SccmServerOpaqueExtensionError::InvalidValue);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SccmServerOpaqueExtensionSerializeWire<'a> {
+    schema_version: u32,
+    name: &'a str,
+    value: &'a str,
+}
+
+impl Serialize for SccmServerOpaqueExtension {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.validate().map_err(S::Error::custom)?;
+        SccmServerOpaqueExtensionSerializeWire {
+            schema_version: self.schema_version,
+            name: &self.name,
+            value: &self.value,
+        }
+        .serialize(serializer)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SccmServerOpaqueExtensionDeserializeWire {
+    schema_version: u32,
+    name: String,
+    value: String,
+}
+
+impl<'de> Deserialize<'de> for SccmServerOpaqueExtension {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = SccmServerOpaqueExtensionDeserializeWire::deserialize(deserializer)?;
+        let extension = Self {
+            schema_version: wire.schema_version,
+            name: wire.name,
+            value: wire.value,
+        };
+        extension.validate().map_err(D::Error::custom)?;
+        Ok(extension)
+    }
+}
+
+impl SccmServerIntakeAssessment {
+    pub fn extensions(&self) -> &[SccmServerOpaqueExtension] {
+        &self.extensions
+    }
+
+    pub fn privacy_extensions(&self) -> &[SccmServerOpaqueExtension] {
+        &self.privacy_extensions
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SccmServerIntakeAssessmentSerializeWire<'a> {
+    schema_version: u32,
+    topology: &'a SccmServerTopologyAssessment,
+    artifacts: &'a [SccmServerArtifactAssessment],
+    coverage: &'a [SccmServerCoverage],
+    evidence: &'a [SccmEvidence],
+    findings: &'a [SccmFinding],
+    next_artifact_requests: &'a [SccmArtifactRequest],
+    #[serde(skip_serializing_if = "<[SccmServerOpaqueExtension]>::is_empty")]
+    extensions: &'a [SccmServerOpaqueExtension],
+    #[serde(skip_serializing_if = "<[SccmServerOpaqueExtension]>::is_empty")]
+    privacy_extensions: &'a [SccmServerOpaqueExtension],
+}
+
+impl Serialize for SccmServerIntakeAssessment {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        validate_assessment_extensions(self).map_err(S::Error::custom)?;
+        SccmServerIntakeAssessmentSerializeWire {
+            schema_version: self.schema_version,
+            topology: &self.topology,
+            artifacts: &self.artifacts,
+            coverage: &self.coverage,
+            evidence: &self.evidence,
+            findings: &self.findings,
+            next_artifact_requests: &self.next_artifact_requests,
+            extensions: &self.extensions,
+            privacy_extensions: &self.privacy_extensions,
+        }
+        .serialize(serializer)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -82,8 +225,17 @@ pub struct SccmServerTopologyAssessment {
     pub capture_host_handle: String,
     pub site_handle: String,
     pub roles_observed: Vec<SccmRole>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub extensions: Vec<SccmServerOpaqueExtension>,
+    #[serde(
+        skip_serializing_if = "Vec::is_empty",
+        serialize_with = "serialize_opaque_extensions"
+    )]
+    extensions: Vec<SccmServerOpaqueExtension>,
+}
+
+impl SccmServerTopologyAssessment {
+    pub fn extensions(&self) -> &[SccmServerOpaqueExtension] {
+        &self.extensions
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -114,8 +266,53 @@ pub struct SccmServerArtifactAssessment {
     pub fragment_complete: Option<bool>,
     pub capture_provenance: Option<SccmServerCaptureProvenance>,
     pub parser_eligible: bool,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub extensions: Vec<SccmServerOpaqueExtension>,
+    #[serde(
+        skip_serializing_if = "Vec::is_empty",
+        serialize_with = "serialize_opaque_extensions"
+    )]
+    extensions: Vec<SccmServerOpaqueExtension>,
+    #[serde(
+        skip_serializing_if = "Vec::is_empty",
+        serialize_with = "serialize_opaque_extensions"
+    )]
+    workflow_subject_extensions: Vec<SccmServerOpaqueExtension>,
+    #[serde(
+        skip_serializing_if = "Vec::is_empty",
+        serialize_with = "serialize_opaque_extensions"
+    )]
+    configured_path_provenance_extensions: Vec<SccmServerOpaqueExtension>,
+    #[serde(
+        skip_serializing_if = "Vec::is_empty",
+        serialize_with = "serialize_opaque_extensions"
+    )]
+    rotation_extensions: Vec<SccmServerOpaqueExtension>,
+    #[serde(
+        skip_serializing_if = "Vec::is_empty",
+        serialize_with = "serialize_opaque_extensions"
+    )]
+    collection_limit_extensions: Vec<SccmServerOpaqueExtension>,
+}
+
+impl SccmServerArtifactAssessment {
+    pub fn extensions(&self) -> &[SccmServerOpaqueExtension] {
+        &self.extensions
+    }
+
+    pub fn workflow_subject_extensions(&self) -> &[SccmServerOpaqueExtension] {
+        &self.workflow_subject_extensions
+    }
+
+    pub fn configured_path_provenance_extensions(&self) -> &[SccmServerOpaqueExtension] {
+        &self.configured_path_provenance_extensions
+    }
+
+    pub fn rotation_extensions(&self) -> &[SccmServerOpaqueExtension] {
+        &self.rotation_extensions
+    }
+
+    pub fn collection_limit_extensions(&self) -> &[SccmServerOpaqueExtension] {
+        &self.collection_limit_extensions
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -192,6 +389,7 @@ pub fn assess_server_intake(
     if manifest_json.len() > MAX_SCCM_SERVER_MANIFEST_BYTES {
         return Err(SccmServerIntakeError::ManifestLimitExceeded);
     }
+    preflight_server_manifest_extensions(manifest_json)?;
     let manifest: RawServerManifest = serde_json::from_str(manifest_json)
         .map_err(|_| SccmServerIntakeError::MalformedManifest)?;
     if manifest.sccm_manifest_version != 1 {
@@ -351,7 +549,21 @@ pub fn assess_server_intake(
         evidence,
         findings: Vec::new(),
         next_artifact_requests,
-        extensions: normalize_opaque_extensions(&manifest.extensions)?,
+        extensions: normalize_opaque_extensions(
+            &manifest.extensions,
+            SccmServerIntakeError::MalformedManifest,
+        )?,
+        privacy_extensions: manifest
+            .privacy
+            .as_ref()
+            .map(|privacy| {
+                normalize_opaque_extensions(
+                    &privacy.extensions,
+                    SccmServerIntakeError::MalformedManifest,
+                )
+            })
+            .transpose()?
+            .unwrap_or_default(),
     })
 }
 
@@ -503,11 +715,10 @@ fn normalize_topology(
     };
 
     if manifest.topology.roles_observed.is_empty()
-        || manifest
-            .topology
-            .roles_observed
-            .iter()
-            .any(|role| !is_declared_server_role(role) && !is_opaque_future_role(role))
+        || manifest.topology.roles_observed.iter().any(|role| {
+            !is_declared_server_role(role)
+                && (manifest.synthetic_fixture || !is_opaque_future_role(role))
+        })
     {
         return Err(SccmServerIntakeError::InvalidTopology);
     }
@@ -521,7 +732,10 @@ fn normalize_topology(
         capture_host_handle,
         site_handle,
         roles_observed,
-        extensions: normalize_opaque_extensions(&manifest.topology.extensions)?,
+        extensions: normalize_opaque_extensions(
+            &manifest.topology.extensions,
+            SccmServerIntakeError::InvalidTopology,
+        )?,
     })
 }
 
@@ -534,9 +748,35 @@ fn normalize_artifact(
     canonical_artifact_identities: &mut BTreeSet<CanonicalArtifactIdentity>,
     payload_by_id: &BTreeMap<&str, &[u8]>,
 ) -> Result<PreparedArtifact, SccmServerIntakeError> {
+    let extensions =
+        normalize_opaque_extensions(&artifact.extensions, SccmServerIntakeError::InvalidArtifact)?;
+    let workflow_subject_extensions = artifact
+        .workflow_subject
+        .as_ref()
+        .map(|subject| {
+            normalize_opaque_extensions(&subject.extensions, SccmServerIntakeError::InvalidArtifact)
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let configured_path_provenance_extensions = normalize_opaque_extensions(
+        &artifact.configured_path_provenance.extensions,
+        SccmServerIntakeError::InvalidArtifact,
+    )?;
+    let rotation_extensions = normalize_opaque_extensions(
+        &artifact.rotation.extensions,
+        SccmServerIntakeError::InvalidArtifact,
+    )?;
+    let collection_limit_extensions = artifact
+        .collection_limit
+        .as_ref()
+        .map(|limit| {
+            normalize_opaque_extensions(&limit.extensions, SccmServerIntakeError::InvalidArtifact)
+        })
+        .transpose()?
+        .unwrap_or_default();
     let synthetic_unclassified =
         artifact.producer_role == SccmRole::Unknown("unclassified".to_owned());
-    let opaque_future_role = is_opaque_future_role(&artifact.producer_role);
+    let opaque_future_role = !synthetic_fixture && is_opaque_future_role(&artifact.producer_role);
     let unsupported_unknown = artifact.capture_state == SccmCoverageState::Unsupported
         && (synthetic_unclassified || opaque_future_role);
     validate_artifact_annotations(&artifact, synthetic_fixture)?;
@@ -797,7 +1037,11 @@ fn normalize_artifact(
             fragment_complete: artifact.fragment_complete,
             capture_provenance,
             parser_eligible,
-            extensions: normalize_opaque_extensions(&artifact.extensions)?,
+            extensions,
+            workflow_subject_extensions,
+            configured_path_provenance_extensions,
+            rotation_extensions,
+            collection_limit_extensions,
         },
         evidence,
     })
@@ -1392,29 +1636,90 @@ fn safe_original_path_marker(value: &str, synthetic_fixture: bool) -> bool {
 
 fn normalize_opaque_extensions(
     extensions: &BTreeMap<String, Value>,
+    scope_error: SccmServerIntakeError,
 ) -> Result<Vec<SccmServerOpaqueExtension>, SccmServerIntakeError> {
-    if extensions.len() > MAX_SCCM_SERVER_OPAQUE_EXTENSIONS {
-        return Err(SccmServerIntakeError::ManifestLimitExceeded);
-    }
-
-    extensions
+    let normalized = extensions
         .iter()
         .map(|(name, value)| {
-            let value = value
-                .as_str()
-                .ok_or(SccmServerIntakeError::InvalidArtifact)?;
-            if !safe_opaque_extension_name(name)
-                || !opaque_sha256_handle(value, "cmtraceopen.extension.sha256.v1:")
-            {
-                return Err(SccmServerIntakeError::InvalidArtifact);
-            }
-            Ok(SccmServerOpaqueExtension {
-                schema_version: 1,
-                name: name.clone(),
-                value: value.to_owned(),
-            })
+            let value = value.as_str().ok_or_else(|| scope_error.clone())?;
+            SccmServerOpaqueExtension::try_new(name.clone(), value.to_owned())
+                .map_err(|_| scope_error.clone())
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    validate_opaque_extension_collection(&normalized).map_err(|_| scope_error)?;
+    Ok(normalized)
+}
+
+fn validate_opaque_extension_collection(
+    extensions: &[SccmServerOpaqueExtension],
+) -> Result<(usize, usize), &'static str> {
+    if extensions.len() > MAX_SCCM_SERVER_OPAQUE_EXTENSIONS {
+        return Err("opaque extension scope exceeds its count bound");
+    }
+    let mut bytes = 0usize;
+    let mut previous_name: Option<&str> = None;
+    for extension in extensions {
+        extension
+            .validate()
+            .map_err(|_| "opaque extension record is invalid")?;
+        if previous_name.is_some_and(|previous| previous >= extension.name()) {
+            return Err("opaque extensions are duplicated or not canonically sorted");
+        }
+        previous_name = Some(extension.name());
+        bytes = bytes
+            .checked_add(extension.name().len())
+            .and_then(|bytes| bytes.checked_add(extension.value().len()))
+            .ok_or("opaque extension byte count overflowed")?;
+    }
+    if bytes > MAX_SCCM_SERVER_OPAQUE_EXTENSION_BYTES_PER_SCOPE {
+        return Err("opaque extension scope exceeds its byte bound");
+    }
+    Ok((extensions.len(), bytes))
+}
+
+fn serialize_opaque_extensions<S>(
+    extensions: &[SccmServerOpaqueExtension],
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    validate_opaque_extension_collection(extensions).map_err(S::Error::custom)?;
+    extensions.serialize(serializer)
+}
+
+fn validate_assessment_extensions(
+    assessment: &SccmServerIntakeAssessment,
+) -> Result<(), &'static str> {
+    let mut total_count = 0usize;
+    let mut total_bytes = 0usize;
+    let mut add_scope = |extensions: &[SccmServerOpaqueExtension]| {
+        let (count, bytes) = validate_opaque_extension_collection(extensions)?;
+        total_count = total_count
+            .checked_add(count)
+            .ok_or("opaque extension aggregate count overflowed")?;
+        total_bytes = total_bytes
+            .checked_add(bytes)
+            .ok_or("opaque extension aggregate bytes overflowed")?;
+        if total_count > MAX_SCCM_SERVER_TOTAL_OPAQUE_EXTENSIONS
+            || total_bytes > MAX_SCCM_SERVER_TOTAL_OPAQUE_EXTENSION_BYTES
+        {
+            return Err("opaque extension aggregate exceeds its bound");
+        }
+        Ok(())
+    };
+
+    add_scope(&assessment.extensions)?;
+    add_scope(&assessment.privacy_extensions)?;
+    add_scope(&assessment.topology.extensions)?;
+    for artifact in &assessment.artifacts {
+        add_scope(&artifact.extensions)?;
+        add_scope(&artifact.workflow_subject_extensions)?;
+        add_scope(&artifact.configured_path_provenance_extensions)?;
+        add_scope(&artifact.rotation_extensions)?;
+        add_scope(&artifact.collection_limit_extensions)?;
+    }
+    Ok(())
 }
 
 fn safe_opaque_extension_name(value: &str) -> bool {
@@ -1517,6 +1822,286 @@ fn rotation_sort_key(rotation: Option<&SccmRotation>) -> String {
     }
 }
 
+#[derive(Debug)]
+enum PreservedJsonValue {
+    Unsigned(u64),
+    String(String),
+    Array(Vec<Self>),
+    Object(Vec<(String, Self)>),
+    Other,
+}
+
+struct PreservedJsonValueVisitor;
+
+impl<'de> Visitor<'de> for PreservedJsonValueVisitor {
+    type Value = PreservedJsonValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("any JSON value while preserving duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E> {
+        Ok(PreservedJsonValue::Other)
+    }
+
+    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E> {
+        Ok(PreservedJsonValue::Other)
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(PreservedJsonValue::Unsigned(value))
+    }
+
+    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E> {
+        Ok(PreservedJsonValue::Other)
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(PreservedJsonValue::String(value.to_owned()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(PreservedJsonValue::String(value))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(PreservedJsonValue::Other)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(PreservedJsonValue::Other)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(Self)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element()? {
+            values.push(value);
+        }
+        Ok(PreservedJsonValue::Array(values))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut fields = Vec::new();
+        while let Some(name) = map.next_key()? {
+            fields.push((name, map.next_value()?));
+        }
+        Ok(PreservedJsonValue::Object(fields))
+    }
+}
+
+impl<'de> Deserialize<'de> for PreservedJsonValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(PreservedJsonValueVisitor)
+    }
+}
+
+#[derive(Default)]
+struct OpaqueExtensionTotals {
+    count: usize,
+    bytes: usize,
+}
+
+impl OpaqueExtensionTotals {
+    fn add(&mut self, name: &str, value: &str) -> Result<(), SccmServerIntakeError> {
+        self.count = self
+            .count
+            .checked_add(1)
+            .ok_or(SccmServerIntakeError::ManifestLimitExceeded)?;
+        self.bytes = self
+            .bytes
+            .checked_add(name.len())
+            .and_then(|bytes| bytes.checked_add(value.len()))
+            .ok_or(SccmServerIntakeError::ManifestLimitExceeded)?;
+        if self.count > MAX_SCCM_SERVER_TOTAL_OPAQUE_EXTENSIONS
+            || self.bytes > MAX_SCCM_SERVER_TOTAL_OPAQUE_EXTENSION_BYTES
+        {
+            return Err(SccmServerIntakeError::ManifestLimitExceeded);
+        }
+        Ok(())
+    }
+}
+
+fn preflight_server_manifest_extensions(manifest_json: &str) -> Result<(), SccmServerIntakeError> {
+    let document: PreservedJsonValue = serde_json::from_str(manifest_json)
+        .map_err(|_| SccmServerIntakeError::MalformedManifest)?;
+    let PreservedJsonValue::Object(manifest) = &document else {
+        return Err(SccmServerIntakeError::MalformedManifest);
+    };
+    validate_unique_object_fields(manifest, SccmServerIntakeError::MalformedManifest)?;
+    if !matches!(
+        preserved_field(manifest, "sccmManifestVersion"),
+        Some(PreservedJsonValue::Unsigned(1))
+    ) {
+        return Ok(());
+    }
+    let mut totals = OpaqueExtensionTotals::default();
+    validate_preserved_extensions(
+        manifest,
+        &[
+            "sccmManifestVersion",
+            "syntheticFixture",
+            "proposalOnly",
+            "privacy",
+            "bundleRole",
+            "topology",
+            "inputOrderIsDeliberatelyUnsorted",
+            "artifacts",
+        ],
+        SccmServerIntakeError::MalformedManifest,
+        &mut totals,
+    )?;
+
+    if let Some(PreservedJsonValue::Object(privacy)) = preserved_field(manifest, "privacy") {
+        validate_unique_object_fields(privacy, SccmServerIntakeError::MalformedManifest)?;
+        validate_preserved_extensions(
+            privacy,
+            &["synthetic", "rawPaths"],
+            SccmServerIntakeError::MalformedManifest,
+            &mut totals,
+        )?;
+    }
+    if let Some(PreservedJsonValue::Object(topology)) = preserved_field(manifest, "topology") {
+        validate_unique_object_fields(topology, SccmServerIntakeError::InvalidTopology)?;
+        validate_preserved_extensions(
+            topology,
+            &["captureHost", "siteCode", "rolesObserved"],
+            SccmServerIntakeError::InvalidTopology,
+            &mut totals,
+        )?;
+    }
+    if let Some(PreservedJsonValue::Array(artifacts)) = preserved_field(manifest, "artifacts") {
+        for artifact in artifacts {
+            let PreservedJsonValue::Object(artifact) = artifact else {
+                continue;
+            };
+            validate_unique_object_fields(artifact, SccmServerIntakeError::InvalidArtifact)?;
+            validate_preserved_extensions(
+                artifact,
+                &[
+                    "artifactId",
+                    "producerRole",
+                    "producerHostHandle",
+                    "workflowSubject",
+                    "sourceId",
+                    "sourceKind",
+                    "sourceVersion",
+                    "originalPath",
+                    "originalBasename",
+                    "configuredPathProvenance",
+                    "defaultCandidateState",
+                    "rotation",
+                    "captureState",
+                    "collectionDetail",
+                    "skipReason",
+                    "unsupportedReason",
+                    "encoding",
+                    "collectionLimit",
+                    "truncated",
+                    "fragmentComplete",
+                    "collectedUtc",
+                    "relativePath",
+                    "bytesCopied",
+                ],
+                SccmServerIntakeError::InvalidArtifact,
+                &mut totals,
+            )?;
+            for (field, known) in [
+                ("workflowSubject", &["role", "instanceHandle", "basis"][..]),
+                (
+                    "configuredPathProvenance",
+                    &["state", "pathClass", "pathFingerprint"][..],
+                ),
+                ("rotation", &["kind", "value", "lineageId"][..]),
+                ("collectionLimit", &["byteLimit", "limitApplied"][..]),
+            ] {
+                if let Some(PreservedJsonValue::Object(nested)) = preserved_field(artifact, field) {
+                    validate_unique_object_fields(nested, SccmServerIntakeError::InvalidArtifact)?;
+                    validate_preserved_extensions(
+                        nested,
+                        known,
+                        SccmServerIntakeError::InvalidArtifact,
+                        &mut totals,
+                    )?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_unique_object_fields(
+    object: &[(String, PreservedJsonValue)],
+    scope_error: SccmServerIntakeError,
+) -> Result<(), SccmServerIntakeError> {
+    let mut seen = BTreeSet::new();
+    if object.iter().any(|(name, _)| !seen.insert(name.as_str())) {
+        return Err(scope_error);
+    }
+    Ok(())
+}
+
+fn preserved_field<'a>(
+    object: &'a [(String, PreservedJsonValue)],
+    name: &str,
+) -> Option<&'a PreservedJsonValue> {
+    object
+        .iter()
+        .find_map(|(field, value)| (field == name).then_some(value))
+}
+
+fn validate_preserved_extensions(
+    object: &[(String, PreservedJsonValue)],
+    known_fields: &[&str],
+    scope_error: SccmServerIntakeError,
+    totals: &mut OpaqueExtensionTotals,
+) -> Result<(), SccmServerIntakeError> {
+    let mut seen = BTreeSet::new();
+    let mut count = 0usize;
+    let mut bytes = 0usize;
+    for (name, value) in object {
+        if known_fields.contains(&name.as_str()) {
+            continue;
+        }
+        let PreservedJsonValue::String(value) = value else {
+            return Err(scope_error);
+        };
+        if !seen.insert(name.as_str())
+            || !safe_opaque_extension_name(name)
+            || !opaque_sha256_handle(value, "cmtraceopen.extension.sha256.v1:")
+        {
+            return Err(scope_error);
+        }
+        count += 1;
+        bytes += name.len() + value.len();
+        if count > MAX_SCCM_SERVER_OPAQUE_EXTENSIONS
+            || bytes > MAX_SCCM_SERVER_OPAQUE_EXTENSION_BYTES_PER_SCOPE
+        {
+            return Err(scope_error);
+        }
+        totals.add(name, value)?;
+    }
+    Ok(())
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RawServerManifest {
@@ -1537,10 +2122,12 @@ struct RawServerManifest {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 struct RawServerPrivacy {
     synthetic: bool,
     raw_paths: String,
+    #[serde(flatten)]
+    extensions: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1590,33 +2177,211 @@ struct RawServerArtifact {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 struct RawWorkflowSubject {
     role: SccmRole,
     instance_handle: Option<String>,
     #[serde(default)]
     basis: Option<String>,
+    #[serde(flatten)]
+    extensions: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 struct RawConfiguredPathProvenance {
     state: String,
     path_class: Option<String>,
     path_fingerprint: String,
+    #[serde(flatten)]
+    extensions: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 struct RawServerRotation {
     kind: String,
     value: Option<Value>,
     lineage_id: String,
+    #[serde(flatten)]
+    extensions: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 struct RawCollectionLimit {
     byte_limit: u64,
     limit_applied: bool,
+    #[serde(flatten)]
+    extensions: BTreeMap<String, Value>,
+}
+
+#[cfg(test)]
+mod opaque_extension_boundary_tests {
+    use super::*;
+
+    const EXPECTED_MAX_TOTAL_OPAQUE_EXTENSIONS: usize = 1_024;
+
+    fn valid_extension(name: &str, ordinal: usize) -> SccmServerOpaqueExtension {
+        SccmServerOpaqueExtension {
+            schema_version: 1,
+            name: name.to_owned(),
+            value: format!("cmtraceopen.extension.sha256.v1:{ordinal:064x}"),
+        }
+    }
+
+    fn empty_assessment() -> SccmServerIntakeAssessment {
+        assess_server_intake(
+            r#"{
+                "sccmManifestVersion": 1,
+                "bundleRole": "server",
+                "topology": {
+                    "captureHost": "cmtraceopen.host.sha256.v1:0000000000000000000000000000000000000000000000000000000000000001",
+                    "siteCode": "cmtraceopen.site.sha256.v1:0000000000000000000000000000000000000000000000000000000000000001",
+                    "rolesObserved": ["managementPoint"]
+                },
+                "artifacts": []
+            }"#,
+            &[],
+        )
+        .expect("minimal production assessment is valid")
+    }
+
+    #[test]
+    fn opaque_extension_serialize_rejects_unsafe_internal_mutation() {
+        let extension = SccmServerOpaqueExtension {
+            schema_version: 1,
+            name: "real-user-extension".to_owned(),
+            value: "Real User <real.user@example.com>".repeat(512),
+        };
+
+        assert!(
+            serde_json::to_string(&extension).is_err(),
+            "unsafe identity-bearing extensions cannot cross public serialization"
+        );
+    }
+
+    #[test]
+    fn opaque_extension_public_construction_and_serde_are_validated() {
+        assert_eq!(
+            SccmServerOpaqueExtension::try_new(
+                "real-user-extension",
+                "cmtraceopen.extension.sha256.v1:0000000000000000000000000000000000000000000000000000000000000001",
+            ),
+            Err(SccmServerOpaqueExtensionError::InvalidName)
+        );
+        let extension = SccmServerOpaqueExtension::try_new(
+            "x-cmtraceopen-opaque-v1-safe",
+            "cmtraceopen.extension.sha256.v1:0000000000000000000000000000000000000000000000000000000000000001",
+        )
+        .expect("safe extension construction succeeds");
+        let public = serde_json::to_value(&extension).expect("safe extension serializes");
+        let round_trip = serde_json::from_value::<SccmServerOpaqueExtension>(public)
+            .expect("safe extension deserializes");
+        assert_eq!(round_trip, extension);
+
+        for invalid in [
+            serde_json::json!({
+                "schemaVersion": 2,
+                "name": "x-cmtraceopen-opaque-v1-safe",
+                "value": "cmtraceopen.extension.sha256.v1:0000000000000000000000000000000000000000000000000000000000000001",
+            }),
+            serde_json::json!({
+                "schemaVersion": 1,
+                "name": "real-user-extension",
+                "value": "cmtraceopen.extension.sha256.v1:0000000000000000000000000000000000000000000000000000000000000001",
+            }),
+            serde_json::json!({
+                "schemaVersion": 1,
+                "name": "x-cmtraceopen-opaque-v1-safe",
+                "value": "Real User <real.user@example.com>",
+            }),
+            serde_json::json!({
+                "schemaVersion": 1,
+                "name": "x-cmtraceopen-opaque-v1-safe",
+                "value": "cmtraceopen.extension.sha256.v1:0000000000000000000000000000000000000000000000000000000000000001",
+                "extra": "cmtraceopen.extension.sha256.v1:0000000000000000000000000000000000000000000000000000000000000002",
+            }),
+        ] {
+            assert!(serde_json::from_value::<SccmServerOpaqueExtension>(invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn assessment_serialize_rejects_duplicate_or_unsorted_extensions() {
+        let mut duplicate = empty_assessment();
+        duplicate.extensions = vec![
+            valid_extension("x-cmtraceopen-opaque-v1-same", 1),
+            valid_extension("x-cmtraceopen-opaque-v1-same", 2),
+        ];
+        assert!(serde_json::to_string(&duplicate).is_err());
+
+        let mut unsorted = empty_assessment();
+        unsorted.extensions = vec![
+            valid_extension("x-cmtraceopen-opaque-v1-zulu", 3),
+            valid_extension("x-cmtraceopen-opaque-v1-alpha", 4),
+        ];
+        assert!(serde_json::to_string(&unsorted).is_err());
+    }
+
+    #[test]
+    fn assessment_serialize_bounds_per_scope_and_aggregate_extensions() {
+        let mut per_scope = empty_assessment();
+        per_scope.extensions = (0..=MAX_SCCM_SERVER_OPAQUE_EXTENSIONS)
+            .map(|ordinal| {
+                valid_extension(
+                    &format!("x-cmtraceopen-opaque-v1-item-{ordinal:02}"),
+                    ordinal,
+                )
+            })
+            .collect();
+        assert!(serde_json::to_string(&per_scope).is_err());
+
+        let mut aggregate = empty_assessment();
+        let mut artifact = SccmServerArtifactAssessment {
+            artifact_id: "unused".to_owned(),
+            producer_role: SccmRole::ManagementPoint,
+            producer_host_handle: None,
+            workflow_subject_role: None,
+            workflow_subject_handle: None,
+            source_id: "unused".to_owned(),
+            source_kind: "unused".to_owned(),
+            family: SccmArtifactFamily::Unknown("unused".to_owned()),
+            original_basename: None,
+            rotation: None,
+            rotation_lineage_handle: "unused".to_owned(),
+            state: SccmCoverageState::Unsupported,
+            configured_path_state: SccmServerConfiguredPathState::Supplied,
+            configured_path_class: None,
+            path_fingerprint: "unused".to_owned(),
+            source_version: None,
+            profile_eligible: false,
+            collected_at_utc: "2026-07-30T00:00:00Z".to_owned(),
+            relative_path: None,
+            bytes_copied: 0,
+            content_sha256: None,
+            truncated: None,
+            fragment_complete: None,
+            capture_provenance: None,
+            parser_eligible: false,
+            extensions: (0..MAX_SCCM_SERVER_OPAQUE_EXTENSIONS)
+                .map(|ordinal| {
+                    valid_extension(
+                        &format!("x-cmtraceopen-opaque-v1-item-{ordinal:02}"),
+                        ordinal,
+                    )
+                })
+                .collect(),
+            workflow_subject_extensions: Vec::new(),
+            configured_path_provenance_extensions: Vec::new(),
+            rotation_extensions: Vec::new(),
+            collection_limit_extensions: Vec::new(),
+        };
+        for ordinal in 0..=EXPECTED_MAX_TOTAL_OPAQUE_EXTENSIONS / MAX_SCCM_SERVER_OPAQUE_EXTENSIONS
+        {
+            artifact.artifact_id = format!("unused-{ordinal}");
+            aggregate.artifacts.push(artifact.clone());
+        }
+        assert!(serde_json::to_string(&aggregate).is_err());
+    }
 }

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -404,10 +404,10 @@ pub fn assess_server_intake(
     let topology = normalize_topology(&manifest)?;
     if topology.roles_observed.iter().any(|role| {
         is_opaque_future_role(role)
-            && !manifest.artifacts.iter().any(|artifact| {
-                artifact.producer_role == *role
-                    && artifact.capture_state == SccmCoverageState::Unsupported
-            })
+            && !manifest
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.producer_role == *role)
     }) {
         return Err(SccmServerIntakeError::InvalidTopology);
     }
@@ -657,12 +657,12 @@ fn validate_manifest_metadata(manifest: &RawServerManifest) -> Result<(), SccmSe
         let privacy = manifest
             .privacy
             .as_ref()
-            .ok_or(SccmServerIntakeError::InvalidArtifact)?;
+            .ok_or(SccmServerIntakeError::MalformedManifest)?;
         if manifest.proposal_only != Some(true)
             || !privacy.synthetic
             || privacy.raw_paths != "redacted"
         {
-            return Err(SccmServerIntakeError::InvalidArtifact);
+            return Err(SccmServerIntakeError::MalformedManifest);
         }
     } else if manifest.proposal_only == Some(true)
         || manifest
@@ -670,11 +670,11 @@ fn validate_manifest_metadata(manifest: &RawServerManifest) -> Result<(), SccmSe
             .as_ref()
             .is_some_and(|privacy| privacy.synthetic || privacy.raw_paths != "redacted")
     {
-        return Err(SccmServerIntakeError::InvalidArtifact);
+        return Err(SccmServerIntakeError::MalformedManifest);
     }
 
     if manifest.input_order_is_deliberately_unsorted == Some(false) {
-        return Err(SccmServerIntakeError::InvalidArtifact);
+        return Err(SccmServerIntakeError::MalformedManifest);
     }
     Ok(())
 }
@@ -777,18 +777,14 @@ fn normalize_artifact(
     let synthetic_unclassified =
         artifact.producer_role == SccmRole::Unknown("unclassified".to_owned());
     let opaque_future_role = !synthetic_fixture && is_opaque_future_role(&artifact.producer_role);
-    let unsupported_unknown = artifact.capture_state == SccmCoverageState::Unsupported
-        && (synthetic_unclassified || opaque_future_role);
+    let retained_unknown = opaque_future_role
+        || (synthetic_unclassified && artifact.capture_state == SccmCoverageState::Unsupported);
     validate_artifact_annotations(&artifact, synthetic_fixture)?;
     let source_version =
         normalize_source_version(artifact.source_version.as_deref(), synthetic_fixture)?;
     if !safe_manifest_artifact_id(&artifact.artifact_id, synthetic_fixture)
-        || !safe_source_id(&artifact.source_id, unsupported_unknown, synthetic_fixture)
-        || !safe_source_kind(
-            &artifact.source_kind,
-            unsupported_unknown,
-            synthetic_fixture,
-        )
+        || !safe_source_id(&artifact.source_id, retained_unknown, synthetic_fixture)
+        || !safe_source_kind(&artifact.source_kind, retained_unknown, synthetic_fixture)
         || !safe_lineage_id(&artifact.rotation.lineage_id, synthetic_fixture)
         || !safe_path_fingerprint(
             &artifact.configured_path_provenance.path_fingerprint,
@@ -808,8 +804,9 @@ fn normalize_artifact(
             synthetic_fixture,
             "subject",
         )
-        || (!unsupported_unknown && artifact.producer_host_handle.is_none())
-        || (unsupported_unknown
+        || ((!retained_unknown || is_physical_state(&artifact.capture_state))
+            && artifact.producer_host_handle.is_none())
+        || (retained_unknown
             && !safe_public_basename(&artifact.original_basename, synthetic_fixture))
     {
         return Err(SccmServerIntakeError::InvalidArtifact);
@@ -817,7 +814,7 @@ fn normalize_artifact(
 
     let producer_is_observed = roles_observed.contains(&artifact.producer_role);
     if (!producer_is_observed && !synthetic_unclassified)
-        || (!is_declared_server_role(&artifact.producer_role) && !unsupported_unknown)
+        || (!is_declared_server_role(&artifact.producer_role) && !retained_unknown)
     {
         return Err(SccmServerIntakeError::InvalidArtifact);
     }
@@ -862,7 +859,7 @@ fn normalize_artifact(
             } else {
                 (family, None, None, false)
             }
-        } else if unsupported_unknown {
+        } else if retained_unknown {
             (
                 SccmArtifactFamily::Unknown(artifact.source_id.clone()),
                 Some(artifact.original_basename.clone()),
@@ -1172,16 +1169,18 @@ fn validate_relative_path(
     let components = relative_path.split('/').collect::<Vec<_>>();
     let expected_role =
         role_path_segment(&artifact.producer_role).ok_or(SccmServerIntakeError::InvalidArtifact)?;
+    let expected_source = source_path_segment(&artifact.source_id);
     let expected_rotation =
         rotation_path_segment(rotation).ok_or(SccmServerIntakeError::InvalidArtifact)?;
     let basename = original_basename.ok_or(SccmServerIntakeError::InvalidArtifact)?;
+    let expected_basename = basename_path_segment(basename);
     let mut cursor = 0;
     let fixed_prefix = [
         "evidence",
         "sccm",
         "server",
-        expected_role,
-        artifact.source_id.as_str(),
+        expected_role.as_str(),
+        expected_source.as_str(),
     ];
     if components.get(..fixed_prefix.len()) != Some(fixed_prefix.as_slice()) {
         return Err(SccmServerIntakeError::InvalidArtifact);
@@ -1216,7 +1215,7 @@ fn validate_relative_path(
     }
 
     if components.get(cursor).copied() != Some(expected_rotation.as_str())
-        || components.get(cursor + 1).copied() != Some(basename)
+        || components.get(cursor + 1).copied() != Some(expected_basename.as_str())
         || components.len() != cursor + 2
         || relative_path.contains('\\')
         || relative_path.split('/').any(|segment| {
@@ -1245,17 +1244,33 @@ fn safe_encoding(encoding: &str) -> bool {
     matches!(encoding, "utf-8" | "utf-16le" | "windows-1252" | "unknown")
 }
 
-fn role_path_segment(role: &SccmRole) -> Option<&'static str> {
-    match role {
-        SccmRole::SiteServer => Some("site-server"),
-        SccmRole::ManagementPoint => Some("management-point"),
-        SccmRole::DistributionPoint => Some("distribution-point"),
-        SccmRole::SoftwareUpdatePoint => Some("software-update-point"),
-        SccmRole::WsUs => Some("wsus"),
-        SccmRole::Provider => Some("provider"),
-        SccmRole::AdminService => Some("admin-service"),
-        SccmRole::Client | SccmRole::Unknown(_) => None,
-    }
+fn role_path_segment(role: &SccmRole) -> Option<String> {
+    Some(match role {
+        SccmRole::SiteServer => "site-server".to_owned(),
+        SccmRole::ManagementPoint => "management-point".to_owned(),
+        SccmRole::DistributionPoint => "distribution-point".to_owned(),
+        SccmRole::SoftwareUpdatePoint => "software-update-point".to_owned(),
+        SccmRole::WsUs => "wsus".to_owned(),
+        SccmRole::Provider => "provider".to_owned(),
+        SccmRole::AdminService => "admin-service".to_owned(),
+        SccmRole::Unknown(value) => format!(
+            "role-{}",
+            opaque_sha256_digest(value, "cmtraceopen.role.sha256.v1:")?
+        ),
+        SccmRole::Client => return None,
+    })
+}
+
+fn source_path_segment(source_id: &str) -> String {
+    opaque_sha256_digest(source_id, "cmtraceopen.source.sha256.v1:")
+        .map(|digest| format!("source-{digest}"))
+        .unwrap_or_else(|| source_id.to_owned())
+}
+
+fn basename_path_segment(basename: &str) -> String {
+    opaque_sha256_digest(basename, "cmtraceopen.basename.sha256.v1:")
+        .map(|digest| format!("basename-{digest}"))
+        .unwrap_or_else(|| basename.to_owned())
 }
 
 fn rotation_path_segment(rotation: Option<&SccmRotation>) -> Option<String> {
@@ -1756,13 +1771,17 @@ fn safe_optional_handle(value: Option<&str>, synthetic_fixture: bool, domain: &s
     opaque_sha256_handle(value, &format!("cmtraceopen.{domain}.sha256.v1:"))
 }
 
-fn opaque_sha256_handle(value: &str, prefix: &str) -> bool {
-    value.strip_prefix(prefix).is_some_and(|digest| {
+fn opaque_sha256_digest<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
+    value.strip_prefix(prefix).filter(|digest| {
         digest.len() == 64
             && digest
                 .bytes()
                 .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
     })
+}
+
+fn opaque_sha256_handle(value: &str, prefix: &str) -> bool {
+    opaque_sha256_digest(value, prefix).is_some()
 }
 
 fn is_declared_server_role(role: &SccmRole) -> bool {

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use chrono::{DateTime, SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use crate::sccm::{
@@ -88,6 +89,9 @@ pub struct SccmServerArtifactAssessment {
     pub collected_at_utc: String,
     pub relative_path: Option<String>,
     pub bytes_copied: u64,
+    pub content_sha256: Option<String>,
+    pub truncated: Option<bool>,
+    pub fragment_complete: Option<bool>,
     pub capture_provenance: Option<SccmServerCaptureProvenance>,
     pub parser_eligible: bool,
 }
@@ -174,6 +178,7 @@ pub fn assess_server_intake(
     if manifest.bundle_role != "server" {
         return Err(SccmServerIntakeError::InvalidBundleRole);
     }
+    validate_manifest_metadata(&manifest)?;
     validate_manifest_bounds(&manifest, payloads)?;
 
     let topology = normalize_topology(&manifest)?;
@@ -396,6 +401,33 @@ fn validate_manifest_bounds(
     Ok(())
 }
 
+fn validate_manifest_metadata(manifest: &RawServerManifest) -> Result<(), SccmServerIntakeError> {
+    if manifest.synthetic_fixture {
+        let privacy = manifest
+            .privacy
+            .as_ref()
+            .ok_or(SccmServerIntakeError::InvalidArtifact)?;
+        if manifest.proposal_only != Some(true)
+            || !privacy.synthetic
+            || privacy.raw_paths != "redacted"
+        {
+            return Err(SccmServerIntakeError::InvalidArtifact);
+        }
+    } else if manifest.proposal_only == Some(true)
+        || manifest
+            .privacy
+            .as_ref()
+            .is_some_and(|privacy| privacy.synthetic || privacy.raw_paths != "redacted")
+    {
+        return Err(SccmServerIntakeError::InvalidArtifact);
+    }
+
+    if manifest.input_order_is_deliberately_unsorted == Some(false) {
+        return Err(SccmServerIntakeError::InvalidArtifact);
+    }
+    Ok(())
+}
+
 fn normalize_topology(
     manifest: &RawServerManifest,
 ) -> Result<SccmServerTopologyAssessment, SccmServerIntakeError> {
@@ -464,11 +496,16 @@ fn normalize_artifact(
 ) -> Result<PreparedArtifact, SccmServerIntakeError> {
     let unsupported_unknown = artifact.capture_state == SccmCoverageState::Unsupported
         && artifact.producer_role == SccmRole::Unknown("unclassified".to_owned());
+    validate_artifact_annotations(&artifact, synthetic_fixture)?;
     let source_version =
         normalize_source_version(artifact.source_version.as_deref(), synthetic_fixture)?;
     if !safe_manifest_artifact_id(&artifact.artifact_id, synthetic_fixture)
-        || !safe_source_id(&artifact.source_id, unsupported_unknown)
-        || !safe_source_kind(&artifact.source_kind, unsupported_unknown)
+        || !safe_source_id(&artifact.source_id, unsupported_unknown, synthetic_fixture)
+        || !safe_source_kind(
+            &artifact.source_kind,
+            unsupported_unknown,
+            synthetic_fixture,
+        )
         || !safe_lineage_id(&artifact.rotation.lineage_id, synthetic_fixture)
         || !safe_path_fingerprint(
             &artifact.configured_path_provenance.path_fingerprint,
@@ -489,7 +526,8 @@ fn normalize_artifact(
             "subject",
         )
         || (!unsupported_unknown && artifact.producer_host_handle.is_none())
-        || (unsupported_unknown && !safe_public_basename(&artifact.original_basename))
+        || (unsupported_unknown
+            && !safe_public_basename(&artifact.original_basename, synthetic_fixture))
     {
         return Err(SccmServerIntakeError::InvalidArtifact);
     }
@@ -631,6 +669,7 @@ fn normalize_artifact(
     )?;
     let (bytes, capture_provenance) =
         validate_payload_contract(&artifact, relative_path.as_deref(), payload_by_id)?;
+    let content_sha256 = bytes.map(payload_sha256);
     let profile_eligible = source_version
         .as_deref()
         .is_some_and(|version| source_version_is_profile_eligible(version, synthetic_fixture));
@@ -710,11 +749,19 @@ fn normalize_artifact(
             collected_at_utc,
             relative_path,
             bytes_copied: artifact.bytes_copied,
+            content_sha256,
+            truncated: artifact.truncated,
+            fragment_complete: artifact.fragment_complete,
             capture_provenance,
             parser_eligible,
         },
         evidence,
     })
+}
+
+fn payload_sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 fn validate_payload_contract<'a>(
@@ -796,7 +843,7 @@ fn decode_server_payload(
         }
         "utf-16le" => {
             let bytes = bytes.strip_prefix(&[0xff, 0xfe]).unwrap_or(bytes);
-            if bytes.len() % 2 != 0 {
+            if !bytes.len().is_multiple_of(2) {
                 return Err(SccmServerIntakeError::InvalidPayloadEncoding);
             }
             let units = bytes
@@ -1083,6 +1130,73 @@ fn normalize_source_version(
     Ok(Some(value.to_owned()))
 }
 
+fn validate_artifact_annotations(
+    artifact: &RawServerArtifact,
+    synthetic_fixture: bool,
+) -> Result<(), SccmServerIntakeError> {
+    if artifact
+        .workflow_subject
+        .as_ref()
+        .and_then(|subject| subject.basis.as_deref())
+        .is_some_and(|basis| {
+            if synthetic_fixture {
+                basis != "incidentScopeOnly"
+            } else {
+                !opaque_sha256_handle(basis, "cmtraceopen.subject-basis.sha256.v1:")
+            }
+        })
+    {
+        return Err(SccmServerIntakeError::InvalidArtifact);
+    }
+    if artifact
+        .default_candidate_state
+        .as_deref()
+        .is_some_and(|value| value != "absentCandidateOnly")
+    {
+        return Err(SccmServerIntakeError::InvalidArtifact);
+    }
+
+    for (detail, expected_state, synthetic_value, domain) in [
+        (
+            artifact.collection_detail.as_deref(),
+            SccmCoverageState::AccessDenied,
+            "synthetic permission denial",
+            "collection-detail",
+        ),
+        (
+            artifact.skip_reason.as_deref(),
+            SccmCoverageState::Skipped,
+            "optional supplemental source not requested",
+            "skip-reason",
+        ),
+        (
+            artifact.unsupported_reason.as_deref(),
+            SccmCoverageState::Unsupported,
+            "no approved server source contract",
+            "unsupported-reason",
+        ),
+    ] {
+        if let Some(detail) = detail {
+            if artifact.capture_state != expected_state
+                || if synthetic_fixture {
+                    detail != synthetic_value
+                } else {
+                    !opaque_sha256_handle(detail, &format!("cmtraceopen.{domain}.sha256.v1:"))
+                }
+            {
+                return Err(SccmServerIntakeError::InvalidArtifact);
+            }
+        }
+    }
+
+    match (artifact.truncated, artifact.fragment_complete) {
+        (None, None) => {}
+        (Some(true), Some(false)) if artifact.capture_state == SccmCoverageState::Capped => {}
+        _ => return Err(SccmServerIntakeError::InvalidArtifact),
+    }
+    Ok(())
+}
+
 fn source_version_is_profile_eligible(value: &str, synthetic_fixture: bool) -> bool {
     if synthetic_fixture && value == "5.00.TEST" {
         return true;
@@ -1134,7 +1248,7 @@ fn safe_manifest_artifact_id(value: &str, synthetic_fixture: bool) -> bool {
     opaque_sha256_handle(value, "cmtraceopen.artifact.sha256.v1:")
 }
 
-fn safe_source_id(value: &str, allow_unknown: bool) -> bool {
+fn safe_source_id(value: &str, allow_unknown: bool, synthetic_fixture: bool) -> bool {
     matches!(
         value,
         "server-sitecomp"
@@ -1146,26 +1260,28 @@ fn safe_source_id(value: &str, allow_unknown: bool) -> bool {
             | "server-sup-sync"
             | "unknown-db-supplement"
     ) || (allow_unknown
-        && (1..=64).contains(&value.len())
-        && value.bytes().all(|byte| {
-            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_')
-        }))
+        && if synthetic_fixture {
+            value == "unknown-db-supplement"
+        } else {
+            opaque_sha256_handle(value, "cmtraceopen.source.sha256.v1:")
+        })
 }
 
-fn safe_source_kind(value: &str, allow_unknown: bool) -> bool {
-    matches!(value, "ccmLog" | "iisW3c" | "structuredSupplement")
-        || (allow_unknown
-            && (1..=64).contains(&value.len())
-            && value
-                .bytes()
-                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')))
+fn safe_source_kind(value: &str, allow_unknown: bool, synthetic_fixture: bool) -> bool {
+    matches!(
+        value,
+        "ccmLog" | "iisW3c" | "structuredSupplement" | "unknown"
+    ) || (allow_unknown
+        && !synthetic_fixture
+        && opaque_sha256_handle(value, "cmtraceopen.source-kind.sha256.v1:"))
 }
 
-fn safe_public_basename(value: &str) -> bool {
-    (1..=255).contains(&value.len())
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+fn safe_public_basename(value: &str, synthetic_fixture: bool) -> bool {
+    if synthetic_fixture {
+        value == "synthetic-db-export.txt"
+    } else {
+        opaque_sha256_handle(value, "cmtraceopen.basename.sha256.v1:")
+    }
 }
 
 fn safe_lineage_id(value: &str, synthetic_fixture: bool) -> bool {
@@ -1310,18 +1426,31 @@ fn rotation_sort_key(rotation: Option<&SccmRotation>) -> String {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RawServerManifest {
     sccm_manifest_version: u32,
     #[serde(default)]
     synthetic_fixture: bool,
+    #[serde(default)]
+    proposal_only: Option<bool>,
+    #[serde(default)]
+    privacy: Option<RawServerPrivacy>,
     bundle_role: String,
     topology: RawServerTopology,
+    #[serde(default)]
+    input_order_is_deliberately_unsorted: Option<bool>,
     artifacts: Vec<RawServerArtifact>,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RawServerPrivacy {
+    synthetic: bool,
+    raw_paths: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RawServerTopology {
     capture_host: String,
     site_code: String,
@@ -1329,7 +1458,7 @@ struct RawServerTopology {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RawServerArtifact {
     artifact_id: String,
     producer_role: SccmRole,
@@ -1341,24 +1470,38 @@ struct RawServerArtifact {
     original_path: String,
     original_basename: String,
     configured_path_provenance: RawConfiguredPathProvenance,
+    #[serde(default)]
+    default_candidate_state: Option<String>,
     rotation: RawServerRotation,
     capture_state: SccmCoverageState,
+    #[serde(default)]
+    collection_detail: Option<String>,
+    #[serde(default)]
+    skip_reason: Option<String>,
+    #[serde(default)]
+    unsupported_reason: Option<String>,
     encoding: Option<String>,
     collection_limit: Option<RawCollectionLimit>,
+    #[serde(default)]
+    truncated: Option<bool>,
+    #[serde(default)]
+    fragment_complete: Option<bool>,
     collected_utc: String,
     relative_path: Option<String>,
     bytes_copied: u64,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RawWorkflowSubject {
     role: SccmRole,
     instance_handle: Option<String>,
+    #[serde(default)]
+    basis: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RawConfiguredPathProvenance {
     state: String,
     path_class: Option<String>,
@@ -1366,7 +1509,7 @@ struct RawConfiguredPathProvenance {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RawServerRotation {
     kind: String,
     value: Option<Value>,
@@ -1374,7 +1517,7 @@ struct RawServerRotation {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RawCollectionLimit {
     byte_limit: u64,
     limit_applied: bool,

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -790,7 +790,7 @@ fn normalize_artifact(
     let source_version =
         normalize_source_version(artifact.source_version.as_deref(), synthetic_fixture)?;
     if !safe_manifest_artifact_id(&artifact.artifact_id, synthetic_fixture)
-        || !safe_source_id(&artifact.source_id, retained_unknown)
+        || !safe_source_id(&artifact.source_id, retained_unknown, synthetic_fixture)
         || !safe_source_kind(&artifact.source_kind, retained_unknown, synthetic_fixture)
         || !safe_lineage_id(&artifact.rotation.lineage_id, synthetic_fixture)
         || !safe_path_fingerprint(
@@ -1561,7 +1561,7 @@ fn safe_manifest_artifact_id(value: &str, synthetic_fixture: bool) -> bool {
     opaque_sha256_handle(value, "cmtraceopen.artifact.sha256.v1:")
 }
 
-fn safe_source_id(value: &str, allow_unknown: bool) -> bool {
+fn safe_source_id(value: &str, allow_unknown: bool, synthetic_fixture: bool) -> bool {
     matches!(
         value,
         "server-sitecomp"
@@ -1572,7 +1572,9 @@ fn safe_source_id(value: &str, allow_unknown: bool) -> bool {
             | "server-dp-distribution"
             | "server-sup-sync"
             | "unknown-db-supplement"
-    ) || (allow_unknown && opaque_sha256_handle(value, "cmtraceopen.source.sha256.v1:"))
+    ) || (allow_unknown
+        && !synthetic_fixture
+        && opaque_sha256_handle(value, "cmtraceopen.source.sha256.v1:"))
 }
 
 fn safe_source_kind(value: &str, allow_unknown: bool, synthetic_fixture: bool) -> bool {

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/intake/collision-same-basename-configured-roots/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/intake/collision-same-basename-configured-roots/expected.json
@@ -6,15 +6,12 @@
     "sameBasename": "MP_GetPolicy.log",
     "distinctPathFingerprints": true,
     "distinctOpaqueRootSegments": true,
-    "destinationsPrecomputed": true,
-    "atomicCreateNoOverwrite": true,
-    "neitherOverwritten": true,
     "notMerged": true,
     "normalizedArtifactCount": 2,
     "exactReferencesResolve": true
   },
   "artifactProvenance": [
-    { "artifactId": "mp-policy-root-a-current", "encoding": "utf-8", "byteLimit": 4096, "limitApplied": false, "bytesCopied": 173 },
-    { "artifactId": "mp-policy-root-b-current", "encoding": "utf-8", "byteLimit": 4096, "limitApplied": false, "bytesCopied": 172 }
+    { "artifactId": "mp-policy-root-a-current", "encoding": "utf-8", "byteLimit": 4096, "limitApplied": false, "bytesCopied": 173, "relativePath": "evidence/sccm/server/management-point/server-mp-policy/root-7d4a9c2e/current/MP_GetPolicy.log", "sha256": "021ea9b3a82c25f42095ee2fe460ed25718193b3798f624041a0621a62ed6cd0" },
+    { "artifactId": "mp-policy-root-b-current", "encoding": "utf-8", "byteLimit": 4096, "limitApplied": false, "bytesCopied": 172, "relativePath": "evidence/sccm/server/management-point/server-mp-policy/root-b83f10d6/current/MP_GetPolicy.log", "sha256": "b95b8b26b4d87f9a6a9b708a8290a4ac9bb30b9c95849e20d6b434d14d91f909" }
   ]
 }

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/intake/unsorted-manifest/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/intake/unsorted-manifest/expected.json
@@ -5,7 +5,7 @@
   "artifactIdDerivationIgnoresDiscoveryOrder": true,
   "artifactIdUniquenessScope": "manifest",
   "crossBundleArtifactIdReuseAllowed": true,
-  "deterministicEvidenceIds": "pending #318 deterministic evidence contract",
+  "deterministicEvidenceIds": true,
   "coverage": [
     { "producerRole": "managementPoint", "sourceId": "server-mp-policy", "state": "captured" },
     { "producerRole": "siteServer", "sourceId": "server-sitecomp", "state": "captured" },

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -46,6 +46,56 @@ fn serialize_manifest(manifest: &Value) -> String {
     serde_json::to_string(manifest).expect("manifest serializes")
 }
 
+fn manifest_with_duplicate_extension(
+    manifest_json: &str,
+    scope: &str,
+    extension_name: &str,
+    first_value: &str,
+    second_value: &str,
+) -> String {
+    let needle = match scope {
+        "manifest" => "{",
+        "privacy" => "\"privacy\":{",
+        "topology" => "\"topology\":{",
+        "artifact" => "\"artifacts\":[{",
+        "workflowSubject" => "\"workflowSubject\":{",
+        "configuredPathProvenance" => "\"configuredPathProvenance\":{",
+        "rotation" => "\"rotation\":{",
+        "collectionLimit" => "\"collectionLimit\":{",
+        _ => panic!("unknown extension scope: {scope}"),
+    };
+    let prefix = format!(
+        "{needle}\"{extension_name}\":\"{first_value}\",\"{extension_name}\":\"{second_value}\","
+    );
+    let mutated = manifest_json.replacen(needle, &prefix, 1);
+    assert_ne!(mutated, manifest_json, "scope marker must be present");
+    mutated
+}
+
+fn manifest_with_duplicate_known_field(
+    manifest_json: &str,
+    scope: &str,
+    field_name: &str,
+    field_value: &Value,
+) -> String {
+    let needle = match scope {
+        "manifest" => "{",
+        "privacy" => "\"privacy\":{",
+        "topology" => "\"topology\":{",
+        "artifact" => "\"artifacts\":[{",
+        "workflowSubject" => "\"workflowSubject\":{",
+        "configuredPathProvenance" => "\"configuredPathProvenance\":{",
+        "rotation" => "\"rotation\":{",
+        "collectionLimit" => "\"collectionLimit\":{",
+        _ => panic!("unknown extension scope: {scope}"),
+    };
+    let field_value = serde_json::to_string(field_value).expect("duplicate field value serializes");
+    let prefix = format!("{needle}\"{field_name}\":{field_value},");
+    let mutated = manifest_json.replacen(needle, &prefix, 1);
+    assert_ne!(mutated, manifest_json, "scope marker must be present");
+    mutated
+}
+
 fn load_expected(scenario: &str) -> Value {
     let path = intake_root().join(scenario).join("expected.json");
     let json = std::fs::read_to_string(path).expect("expected intake output is readable");
@@ -1401,7 +1451,7 @@ fn server_intake_accepts_only_opaque_future_unsupported_provenance() {
 
     let assessment = assess_server_intake(&serialize_manifest(&manifest), &[])
         .expect("opaque future unsupported provenance remains retainable");
-    let public = serde_json::to_value(assessment).expect("assessment serializes");
+    let public = serde_json::to_value(&assessment).expect("assessment serializes");
     assert_eq!(public["artifacts"][0]["sourceId"], source_id);
     assert_eq!(public["artifacts"][0]["sourceKind"], source_kind);
     assert_eq!(public["artifacts"][0]["originalBasename"], basename);
@@ -1447,6 +1497,20 @@ fn server_manifest_v1_retains_only_versioned_opaque_extensions_deterministically
 }
 
 #[test]
+fn server_manifest_version_gate_precedes_v1_extension_validation() {
+    let (manifest_json, payloads) = bounded_manifest(1, 4_096);
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["sccmManifestVersion"] = Value::from(2);
+    manifest["futureManifestField"] = json!({ "shape": "belongs-to-v2" });
+
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads),
+        Err(SccmServerIntakeError::UnsupportedManifestVersion),
+        "unsupported versions are rejected by the version gate before applying the v1 extension grammar"
+    );
+}
+
+#[test]
 fn server_manifest_v1_rejects_unversioned_or_nonopaque_unknown_fields() {
     let (manifest_json, payloads) = bounded_manifest(1, 4_096);
 
@@ -1465,12 +1529,266 @@ fn server_manifest_v1_rejects_unversioned_or_nonopaque_unknown_fields() {
                 "artifact" => manifest["artifacts"][0][name] = value,
                 _ => unreachable!(),
             }
-            assert!(
-                assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
-                "{path} must reject arbitrary extension {name}"
+            let expected = match path {
+                "manifest" => SccmServerIntakeError::MalformedManifest,
+                "topology" => SccmServerIntakeError::InvalidTopology,
+                "artifact" => SccmServerIntakeError::InvalidArtifact,
+                _ => unreachable!(),
+            };
+            assert_eq!(
+                assess_server_intake(&serialize_manifest(&manifest), &payloads),
+                Err(expected),
+                "{path} must reject arbitrary extension {name} in its own scope"
             );
         }
     }
+}
+
+#[test]
+fn server_manifest_v1_rejects_duplicate_opaque_fields_in_every_scope() {
+    let (production_json, production_payloads) = bounded_manifest(1, 4_096);
+    let (synthetic_json, synthetic_payloads) = load_bundle("complete-multi-role");
+    let synthetic_json = serialize_manifest(&manifest_value(&synthetic_json));
+    let extension_name = "x-cmtraceopen-opaque-v1-duplicate";
+    let first_value = opaque_handle("cmtraceopen.extension.sha256.v1:", 31);
+    let second_value = opaque_handle("cmtraceopen.extension.sha256.v1:", 32);
+    let mut wrong_results = Vec::new();
+
+    for (scope, manifest_json, payloads, expected) in [
+        (
+            "manifest",
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::MalformedManifest,
+        ),
+        (
+            "privacy",
+            synthetic_json.as_str(),
+            synthetic_payloads.as_slice(),
+            SccmServerIntakeError::MalformedManifest,
+        ),
+        (
+            "topology",
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::InvalidTopology,
+        ),
+        (
+            "artifact",
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::InvalidArtifact,
+        ),
+        (
+            "workflowSubject",
+            synthetic_json.as_str(),
+            synthetic_payloads.as_slice(),
+            SccmServerIntakeError::InvalidArtifact,
+        ),
+        (
+            "configuredPathProvenance",
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::InvalidArtifact,
+        ),
+        (
+            "rotation",
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::InvalidArtifact,
+        ),
+        (
+            "collectionLimit",
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::InvalidArtifact,
+        ),
+    ] {
+        let manifest = manifest_with_duplicate_extension(
+            manifest_json,
+            scope,
+            extension_name,
+            &first_value,
+            &second_value,
+        );
+        let actual = assess_server_intake(&manifest, payloads);
+        if actual != Err(expected.clone()) {
+            wrong_results.push((scope, actual, expected));
+        }
+    }
+
+    assert!(
+        wrong_results.is_empty(),
+        "duplicate extension results must be scope exact: {wrong_results:?}"
+    );
+}
+
+#[test]
+fn server_manifest_v1_rejects_duplicate_known_fields_in_every_extension_scope() {
+    let (production_json, production_payloads) = bounded_manifest(1, 4_096);
+    let (synthetic_json, synthetic_payloads) = load_bundle("complete-multi-role");
+    let synthetic_json = serialize_manifest(&manifest_value(&synthetic_json));
+    let mut wrong_results = Vec::new();
+
+    for (scope, field, value, manifest_json, payloads, expected) in [
+        (
+            "manifest",
+            "sccmManifestVersion",
+            json!(1),
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::MalformedManifest,
+        ),
+        (
+            "privacy",
+            "synthetic",
+            json!(true),
+            synthetic_json.as_str(),
+            synthetic_payloads.as_slice(),
+            SccmServerIntakeError::MalformedManifest,
+        ),
+        (
+            "topology",
+            "captureHost",
+            json!("duplicate-host"),
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::InvalidTopology,
+        ),
+        (
+            "artifact",
+            "sourceId",
+            json!("server-mp-policy"),
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::InvalidArtifact,
+        ),
+        (
+            "workflowSubject",
+            "role",
+            json!("distributionPoint"),
+            synthetic_json.as_str(),
+            synthetic_payloads.as_slice(),
+            SccmServerIntakeError::InvalidArtifact,
+        ),
+        (
+            "configuredPathProvenance",
+            "state",
+            json!("configured"),
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::InvalidArtifact,
+        ),
+        (
+            "rotation",
+            "kind",
+            json!("current"),
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::InvalidArtifact,
+        ),
+        (
+            "collectionLimit",
+            "byteLimit",
+            json!(4_096),
+            production_json.as_str(),
+            production_payloads.as_slice(),
+            SccmServerIntakeError::InvalidArtifact,
+        ),
+    ] {
+        let manifest = manifest_with_duplicate_known_field(manifest_json, scope, field, &value);
+        let actual = assess_server_intake(&manifest, payloads);
+        if actual != Err(expected.clone()) {
+            wrong_results.push((scope, actual, expected));
+        }
+    }
+
+    assert!(
+        wrong_results.is_empty(),
+        "duplicate known-field results must be scope exact: {wrong_results:?}"
+    );
+}
+
+#[test]
+fn server_manifest_v1_retains_safe_nested_extensions_without_interpreting_them() {
+    let (manifest_json, payloads) = load_bundle("complete-multi-role");
+    let mut manifest = manifest_value(&manifest_json);
+    let extension_name = "x-cmtraceopen-opaque-v1-nested";
+    let extension_value = opaque_handle("cmtraceopen.extension.sha256.v1:", 41);
+    manifest["privacy"][extension_name] = Value::String(extension_value.clone());
+    let artifact = &mut manifest["artifacts"][2];
+    artifact["workflowSubject"][extension_name] = Value::String(extension_value.clone());
+    artifact["configuredPathProvenance"][extension_name] = Value::String(extension_value.clone());
+    artifact["rotation"][extension_name] = Value::String(extension_value.clone());
+    artifact["collectionLimit"][extension_name] = Value::String(extension_value.clone());
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("safe nested extensions are retained as inert provenance");
+    let public = serde_json::to_value(&assessment).expect("assessment serializes");
+    let expected = json!([{
+        "schemaVersion": 1,
+        "name": extension_name,
+        "value": extension_value,
+    }]);
+    assert_eq!(public["privacyExtensions"], expected);
+    let artifact = artifact_json(&public, "dp-dist-current");
+    assert_eq!(artifact["workflowSubjectExtensions"], expected);
+    assert_eq!(artifact["configuredPathProvenanceExtensions"], expected);
+    assert_eq!(artifact["rotationExtensions"], expected);
+    assert_eq!(artifact["collectionLimitExtensions"], expected);
+    assert!(assessment.evidence.iter().all(|evidence| {
+        !evidence.message.contains(extension_name) && !evidence.message.contains(&extension_value)
+    }));
+    assert!(assessment.findings.is_empty());
+}
+
+#[test]
+fn server_manifest_v1_rejects_unsafe_nested_extensions_in_their_scope() {
+    let (manifest_json, payloads) = load_bundle("complete-multi-role");
+    let extension_name = "x-cmtraceopen-opaque-v1-nested-unsafe";
+    let mut wrong_results = Vec::new();
+
+    for (scope, expected) in [
+        ("privacy", SccmServerIntakeError::MalformedManifest),
+        ("workflowSubject", SccmServerIntakeError::InvalidArtifact),
+        (
+            "configuredPathProvenance",
+            SccmServerIntakeError::InvalidArtifact,
+        ),
+        ("rotation", SccmServerIntakeError::InvalidArtifact),
+        ("collectionLimit", SccmServerIntakeError::InvalidArtifact),
+    ] {
+        let mut manifest = manifest_value(&manifest_json);
+        match scope {
+            "privacy" => manifest["privacy"][extension_name] = json!({ "identity": "real-user" }),
+            "workflowSubject" => {
+                manifest["artifacts"][2]["workflowSubject"][extension_name] =
+                    json!({ "identity": "real-user" });
+            }
+            "configuredPathProvenance" => {
+                manifest["artifacts"][2]["configuredPathProvenance"][extension_name] =
+                    json!({ "identity": "real-user" });
+            }
+            "rotation" => {
+                manifest["artifacts"][2]["rotation"][extension_name] =
+                    json!({ "identity": "real-user" });
+            }
+            "collectionLimit" => {
+                manifest["artifacts"][2]["collectionLimit"][extension_name] =
+                    json!({ "identity": "real-user" });
+            }
+            _ => unreachable!(),
+        }
+        let actual = assess_server_intake(&serialize_manifest(&manifest), &payloads);
+        if actual != Err(expected.clone()) {
+            wrong_results.push((scope, actual, expected));
+        }
+    }
+
+    assert!(
+        wrong_results.is_empty(),
+        "unsafe nested extension results must be scope exact: {wrong_results:?}"
+    );
 }
 
 #[test]
@@ -1545,6 +1863,21 @@ fn server_intake_rejects_future_roles_without_unsupported_capture() {
     assert!(
         assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
         "future roles are valid only when retained by an unsupported capture"
+    );
+}
+
+#[test]
+fn server_intake_rejects_hashed_future_roles_in_synthetic_fixtures() {
+    let (manifest_json, _) = load_bundle("unsupported-db-supplement");
+    let mut manifest = manifest_value(&manifest_json);
+    let future_role = opaque_handle("cmtraceopen.role.sha256.v1:", 42);
+    manifest["topology"]["rolesObserved"] = json!(["managementPoint", future_role]);
+    manifest["artifacts"][0]["producerRole"] = Value::String(future_role);
+
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &[]),
+        Err(SccmServerIntakeError::InvalidTopology),
+        "synthetic fixtures keep the finite committed role vocabulary"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -7,6 +7,7 @@ use cmtraceopen_parser::sccm::{
     SccmFindingCoverageGap, SccmPhase, SccmRole, SccmRotation,
 };
 use serde_json::{json, Value};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 fn intake_root() -> PathBuf {
@@ -147,6 +148,313 @@ fn artifact_json<'a>(assessment: &'a Value, artifact_id: &str) -> &'a Value {
         .iter()
         .find(|artifact| artifact["artifactId"] == artifact_id)
         .expect("artifact is present")
+}
+
+fn reversed_assessment_json(manifest_json: &str, payloads: &[SccmServerArtifactPayload]) -> Value {
+    let mut manifest = manifest_value(manifest_json);
+    manifest["artifacts"]
+        .as_array_mut()
+        .expect("manifest artifacts are an array")
+        .reverse();
+    let mut reversed_payloads = payloads.to_vec();
+    reversed_payloads.reverse();
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &reversed_payloads)
+        .expect("reordered manifest remains assessable");
+    serde_json::to_value(assessment).expect("reordered assessment serializes")
+}
+
+fn assert_unique_public_relative_paths(scenario: &str, actual: &Value) {
+    let paths = actual["artifacts"]
+        .as_array()
+        .expect("assessment artifacts are an array")
+        .iter()
+        .filter_map(|artifact| artifact["relativePath"].as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        paths.iter().copied().collect::<BTreeSet<_>>().len(),
+        paths.len(),
+        "{scenario}: relative paths are collision-safe"
+    );
+}
+
+fn assert_collision_contract(scenario: &str, expected: &Value, actual: &Value) {
+    let artifacts = actual["artifacts"]
+        .as_array()
+        .expect("assessment artifacts are an array");
+    for (key, value) in expected
+        .as_object()
+        .expect("collision assertions are an object")
+    {
+        match key.as_str() {
+            "sameBasename" => assert!(artifacts
+                .iter()
+                .all(|artifact| { artifact["originalBasename"].as_str() == value.as_str() })),
+            "distinctPathFingerprints" => {
+                let fingerprints = artifacts
+                    .iter()
+                    .map(|artifact| artifact["pathFingerprint"].as_str().expect("fingerprint"))
+                    .collect::<BTreeSet<_>>();
+                assert_eq!(fingerprints.len(), artifacts.len(), "{scenario}: {key}");
+                assert_eq!(value, true, "{scenario}: {key} expectation");
+            }
+            "distinctOpaqueRootSegments" => {
+                assert_eq!(value, true, "{scenario}: {key} expectation");
+                let root_segments = artifacts
+                    .iter()
+                    .map(|artifact| {
+                        artifact["relativePath"]
+                            .as_str()
+                            .expect("relative path")
+                            .split('/')
+                            .nth(5)
+                            .filter(|segment| segment.starts_with("root-"))
+                            .expect("opaque configured-root segment")
+                    })
+                    .collect::<BTreeSet<_>>();
+                assert_eq!(root_segments.len(), artifacts.len(), "{scenario}: {key}");
+            }
+            "notMerged" => {
+                assert_eq!(value, true, "{scenario}: {key} expectation");
+                let content_digests = artifacts
+                    .iter()
+                    .map(|artifact| artifact["contentSha256"].as_str().expect("content digest"))
+                    .collect::<BTreeSet<_>>();
+                assert_eq!(content_digests.len(), artifacts.len(), "{scenario}: {key}");
+            }
+            "exactReferencesResolve" => {
+                assert_eq!(value, true, "{scenario}: {key} expectation");
+                let artifact_ids = artifacts
+                    .iter()
+                    .map(|artifact| artifact["artifactId"].as_str().expect("artifact ID"))
+                    .collect::<BTreeSet<_>>();
+                for coverage in actual["coverage"].as_array().expect("coverage is an array") {
+                    for artifact_id in coverage["artifactIds"]
+                        .as_array()
+                        .expect("coverage artifact IDs are an array")
+                    {
+                        assert!(artifact_ids.contains(artifact_id.as_str().expect("artifact ID")));
+                    }
+                }
+                for evidence in actual["evidence"].as_array().expect("evidence is an array") {
+                    assert!(artifact_ids.contains(
+                        evidence["reference"]["artifactId"]
+                            .as_str()
+                            .expect("evidence artifact ID")
+                    ));
+                }
+            }
+            "normalizedArtifactCount" => assert_eq!(
+                artifacts.len() as u64,
+                value.as_u64().expect("artifact count is an integer"),
+                "{scenario}: {key}"
+            ),
+            other => panic!("{scenario}: unhandled collision assertion {other}"),
+        }
+    }
+}
+
+fn assert_remaining_expected_contracts(
+    scenario: &str,
+    expected: &Value,
+    manifest_json: &str,
+    payloads: &[SccmServerArtifactPayload],
+    actual: &Value,
+) {
+    let manifest = manifest_value(manifest_json);
+    let actual_artifacts = actual["artifacts"]
+        .as_array()
+        .expect("assessment artifacts are an array");
+    for (key, value) in expected
+        .as_object()
+        .expect("expected contract is an object")
+    {
+        match key.as_str() {
+            "pre318ExpectedVersion"
+            | "artifactId"
+            | "artifactProvenance"
+            | "canonicalArtifactIds"
+            | "canonicalRotationArtifactIds"
+            | "configuredPathProvenance"
+            | "coverage"
+            | "evidence"
+            | "retainedUnclassifiedArtifactIds"
+            | "rolesObserved" => {}
+            "nonCapturedProvenance" => {
+                assert_eq!(value["encoding"], "omitted", "{scenario}: encoding");
+                assert_eq!(
+                    value["collectionLimit"], "omitted",
+                    "{scenario}: collection limit"
+                );
+                for artifact in manifest["artifacts"]
+                    .as_array()
+                    .expect("manifest artifacts are an array")
+                    .iter()
+                    .filter(|artifact| artifact["relativePath"].is_null())
+                {
+                    assert!(artifact.get("encoding").is_none_or(Value::is_null));
+                    assert!(artifact.get("collectionLimit").is_none_or(Value::is_null));
+                }
+                assert!(actual_artifacts
+                    .iter()
+                    .filter(|artifact| artifact["relativePath"].is_null())
+                    .all(|artifact| artifact["captureProvenance"].is_null()));
+            }
+            "nextArtifactRequest" => {
+                let requests = actual["nextArtifactRequests"]
+                    .as_array()
+                    .expect("requests are an array");
+                assert_eq!(requests.len(), 1, "{scenario}: one bounded request");
+                match value.as_str().expect("request expectation is a string") {
+                    "read-only capture of server-mp-policy from the observed management point" => {
+                        assert_eq!(requests[0]["logicalId"], "mpGetPolicy");
+                        assert_eq!(requests[0]["role"], "managementPoint");
+                    }
+                    "bounded recapture of server-sup-sync with a cap sufficient for complete logical records" => {
+                        assert_eq!(requests[0]["logicalId"], "wsyncmgr");
+                        assert_eq!(requests[0]["role"], "siteServer");
+                    }
+                    other => panic!("{scenario}: unhandled request contract {other}"),
+                }
+            }
+            "terminalManagementPointDiagnosis"
+            | "terminalSoftwareUpdatePointHealth"
+            | "partialPhysicalFragmentCreatesTerminalResult"
+            | "requiredSourceFailure" => {
+                assert_eq!(value, false, "{scenario}: {key} expectation");
+                assert!(actual["findings"]
+                    .as_array()
+                    .expect("findings are an array")
+                    .is_empty());
+            }
+            "roleHealthFinding" | "databaseOrRoleFinding" => {
+                assert_eq!(value, "none", "{scenario}: {key} expectation");
+                assert!(actual["findings"]
+                    .as_array()
+                    .expect("findings are an array")
+                    .is_empty());
+            }
+            "forbiddenConclusion" => {
+                let serialized = serde_json::to_string(actual).expect("assessment serializes");
+                assert!(!serialized
+                    .to_ascii_lowercase()
+                    .contains(&value.as_str().expect("forbidden text").to_ascii_lowercase()));
+            }
+            "privacy" => {
+                assert_eq!(value, "synthetic", "{scenario}: privacy declaration");
+                assert_eq!(manifest["syntheticFixture"], true);
+                assert_eq!(manifest["privacy"]["synthetic"], true);
+                assert_eq!(manifest["privacy"]["rawPaths"], "redacted");
+                let serialized = serde_json::to_string(actual).expect("assessment serializes");
+                assert!(!serialized.contains("REDACTED"));
+            }
+            "defaultCandidateInterpretation" => {
+                assert_eq!(value, "candidateAbsentOnly");
+                assert_eq!(
+                    manifest["artifacts"][0]["defaultCandidateState"],
+                    "absentCandidateOnly"
+                );
+            }
+            "roleInference" => {
+                assert_eq!(
+                    value,
+                    "managementPoint is observed from topology, not from default path"
+                );
+                assert!(actual["topology"]["rolesObserved"]
+                    .as_array()
+                    .expect("roles are an array")
+                    .contains(&Value::String("managementPoint".to_owned())));
+            }
+            "lineageId" => assert!(actual_artifacts
+                .iter()
+                .all(|artifact| { artifact["rotationLineageHandle"] == *value })),
+            "totalRotationSort" => {
+                assert_eq!(value, true);
+                let ids = actual_artifacts
+                    .iter()
+                    .map(|artifact| artifact["artifactId"].clone())
+                    .collect::<Value>();
+                assert_eq!(ids, expected["canonicalRotationArtifactIds"]);
+            }
+            "serializationOrderIsChronology" => {
+                assert_eq!(value, false);
+                let instants = actual_artifacts
+                    .iter()
+                    .map(|artifact| artifact["collectedAtUtc"].as_str().expect("timestamp"))
+                    .collect::<BTreeSet<_>>();
+                assert_eq!(
+                    instants.len(),
+                    1,
+                    "{scenario}: chronology cannot choose order"
+                );
+            }
+            "uniqueRelativePaths" | "collisionSafe" => {
+                assert_eq!(value, true, "{scenario}: {key} expectation");
+                assert_unique_public_relative_paths(scenario, actual);
+            }
+            "collisionAssertions" => assert_collision_contract(scenario, value, actual),
+            "normalizedOutputByteIdenticalWhenReordered"
+            | "artifactIdDerivationIgnoresDiscoveryOrder" => {
+                assert_eq!(value, true, "{scenario}: {key} expectation");
+                assert_eq!(
+                    reversed_assessment_json(manifest_json, payloads),
+                    *actual,
+                    "{scenario}: {key}"
+                );
+            }
+            "artifactIdUniquenessScope" => {
+                assert_eq!(value, "manifest");
+                let ids = actual_artifacts
+                    .iter()
+                    .map(|artifact| artifact["artifactId"].as_str().expect("artifact ID"))
+                    .collect::<BTreeSet<_>>();
+                assert_eq!(ids.len(), actual_artifacts.len());
+            }
+            "crossBundleArtifactIdReuseAllowed" => {
+                assert_eq!(value, true);
+                let repeated = assess_server_intake(manifest_json, payloads)
+                    .expect("a separate assessment may reuse manifest-scoped IDs");
+                assert_eq!(
+                    serde_json::to_value(repeated).expect("repeat serializes"),
+                    *actual
+                );
+            }
+            "deterministicEvidenceIds" => {
+                assert_eq!(value, true);
+                assert_eq!(
+                    reversed_assessment_json(manifest_json, payloads)["evidence"],
+                    actual["evidence"]
+                );
+            }
+            "rawByteCountedBeforeDecoding" => {
+                assert_eq!(value, true);
+                for payload in payloads {
+                    let artifact = artifact_json(actual, &payload.manifest_artifact_id);
+                    assert_eq!(artifact["bytesCopied"], payload.bytes.len() as u64);
+                }
+            }
+            "completeCcmRecordCount" => assert_eq!(
+                actual["evidence"]
+                    .as_array()
+                    .expect("evidence is an array")
+                    .len() as u64,
+                value.as_u64().expect("record count is an integer")
+            ),
+            "logicalRecordParseable" => {
+                assert_eq!(value, false);
+                assert!(actual["evidence"]
+                    .as_array()
+                    .expect("evidence is an array")
+                    .is_empty());
+            }
+            "eligibleForRoleReducer" => {
+                assert_eq!(value, false);
+                assert!(actual_artifacts
+                    .iter()
+                    .all(|artifact| artifact["parserEligible"] == false));
+            }
+            other => panic!("{scenario}: unhandled expected contract key {other}"),
+        }
+    }
 }
 
 fn assert_request_passes_finding_boundaries(
@@ -314,6 +622,7 @@ fn server_intake_does_not_request_unknown_or_non_ccm_sources() {
     let (iis_manifest, iis_payloads) = load_bundle("skipped-iis");
     let mut denied_iis = manifest_value(&iis_manifest);
     denied_iis["artifacts"][0]["captureState"] = Value::String("accessDenied".to_owned());
+    denied_iis["artifacts"][0]["skipReason"] = Value::Null;
     let iis = assess_server_intake(&serialize_manifest(&denied_iis), &iis_payloads)
         .expect("non-CCM coverage remains assessable");
     assert!(
@@ -713,6 +1022,7 @@ fn server_intake_suppresses_absent_default_request_when_configured_source_is_usa
     let (absent_manifest, _absent_payloads) = load_bundle("access-denied-mp");
     let mut absent = manifest_value(&absent_manifest)["artifacts"][0].clone();
     absent["captureState"] = Value::String("absent".to_owned());
+    absent["collectionDetail"] = Value::Null;
     absent["configuredPathProvenance"]["state"] = Value::String("defaultCandidate".to_owned());
     combined["artifacts"]
         .as_array_mut()
@@ -744,6 +1054,7 @@ fn server_intake_does_not_suppress_default_request_across_producer_hosts() {
     let mut absent = manifest_value(&absent_manifest)["artifacts"][0].clone();
     absent["producerHostHandle"] = Value::String("synthetic:host:site-01".to_owned());
     absent["captureState"] = Value::String("absent".to_owned());
+    absent["collectionDetail"] = Value::Null;
     absent["configuredPathProvenance"]["state"] = Value::String("defaultCandidate".to_owned());
     combined["artifacts"]
         .as_array_mut()
@@ -994,20 +1305,171 @@ fn server_intake_retains_unsupported_source_provenance() {
 }
 
 #[test]
-fn server_intake_tolerates_future_safe_unsupported_source_labels() {
+fn server_intake_rejects_unversioned_future_unsupported_source_labels() {
     let (manifest_json, payloads) = load_bundle("unsupported-db-supplement");
     let mut manifest = manifest_value(&manifest_json);
     manifest["artifacts"][0]["sourceId"] = Value::String("future-server-supplement".to_owned());
     manifest["artifacts"][0]["sourceKind"] = Value::String("futureSupplement".to_owned());
 
-    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
-        .expect("a privacy-safe future unsupported label remains forward-compatible");
-    let serialized = serde_json::to_value(&assessment).expect("assessment serializes");
-    let artifact = artifact_json(&serialized, "unknown-db-export");
+    assert!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
+        "future provenance needs a versioned opaque handle, not an arbitrary public label"
+    );
+}
 
-    assert_eq!(artifact["sourceId"], "future-server-supplement");
-    assert_eq!(artifact["sourceKind"], "futureSupplement");
-    assert_eq!(artifact["family"], "future-server-supplement");
+#[test]
+fn server_intake_rejects_identity_bearing_unsupported_public_provenance() {
+    for (field, marker) in [
+        ("sourceId", "realuser-example"),
+        ("sourceKind", "RealUser"),
+        ("originalBasename", "RealUser.log"),
+    ] {
+        assert_unsafe_mutation_is_rejected("unsupported-db-supplement", marker, |manifest, _| {
+            manifest["artifacts"][0][field] = Value::String(marker.to_owned());
+        });
+    }
+}
+
+#[test]
+fn server_intake_accepts_only_opaque_future_unsupported_provenance() {
+    let (manifest_json, _) = bounded_manifest(1, 4_096);
+    let mut manifest = manifest_value(&manifest_json);
+    let source_id = opaque_handle("cmtraceopen.source.sha256.v1:", 1);
+    let source_kind = opaque_handle("cmtraceopen.source-kind.sha256.v1:", 2);
+    let basename = opaque_handle("cmtraceopen.basename.sha256.v1:", 3);
+    let artifact = &mut manifest["artifacts"][0];
+    artifact["producerRole"] = Value::String("unclassified".to_owned());
+    artifact["producerHostHandle"] = Value::Null;
+    artifact["sourceId"] = Value::String(source_id.clone());
+    artifact["sourceKind"] = Value::String(source_kind.clone());
+    artifact["originalBasename"] = Value::String(basename.clone());
+    artifact["rotation"] = json!({
+        "kind": "none",
+        "lineageId": opaque_handle("cmtraceopen.lineage.sha256.v1:", 4),
+    });
+    artifact["captureState"] = Value::String("unsupported".to_owned());
+    artifact["encoding"] = Value::Null;
+    artifact["collectionLimit"] = Value::Null;
+    artifact["relativePath"] = Value::Null;
+    artifact["bytesCopied"] = Value::from(0);
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &[])
+        .expect("opaque future unsupported provenance remains retainable");
+    let public = serde_json::to_value(assessment).expect("assessment serializes");
+    assert_eq!(public["artifacts"][0]["sourceId"], source_id);
+    assert_eq!(public["artifacts"][0]["sourceKind"], source_kind);
+    assert_eq!(public["artifacts"][0]["originalBasename"], basename);
+}
+
+#[test]
+fn server_manifest_v1_rejects_unknown_fields_instead_of_dropping_them() {
+    let (manifest_json, payloads) = load_bundle("multiline");
+
+    for path in ["manifest", "topology", "artifact"] {
+        let mut manifest = manifest_value(&manifest_json);
+        match path {
+            "manifest" => manifest["unexpectedEvidence"] = Value::Bool(true),
+            "topology" => manifest["topology"]["unexpectedEvidence"] = Value::Bool(true),
+            "artifact" => manifest["artifacts"][0]["unexpectedEvidence"] = Value::Bool(true),
+            _ => unreachable!(),
+        }
+        assert!(
+            assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
+            "unknown {path} fields require a schema change; they cannot be silently discarded"
+        );
+    }
+}
+
+#[test]
+fn server_intake_expected_oracle_has_no_unhandled_contract_keys() {
+    let currently_asserted = [
+        "artifactId",
+        "artifactIdDerivationIgnoresDiscoveryOrder",
+        "artifactIdUniquenessScope",
+        "artifactProvenance",
+        "canonicalArtifactIds",
+        "canonicalRotationArtifactIds",
+        "collisionAssertions",
+        "collisionSafe",
+        "completeCcmRecordCount",
+        "configuredPathProvenance",
+        "coverage",
+        "crossBundleArtifactIdReuseAllowed",
+        "databaseOrRoleFinding",
+        "defaultCandidateInterpretation",
+        "deterministicEvidenceIds",
+        "eligibleForRoleReducer",
+        "evidence",
+        "forbiddenConclusion",
+        "lineageId",
+        "logicalRecordParseable",
+        "nextArtifactRequest",
+        "nonCapturedProvenance",
+        "normalizedOutputByteIdenticalWhenReordered",
+        "partialPhysicalFragmentCreatesTerminalResult",
+        "pre318ExpectedVersion",
+        "privacy",
+        "rawByteCountedBeforeDecoding",
+        "requiredSourceFailure",
+        "retainedUnclassifiedArtifactIds",
+        "roleHealthFinding",
+        "roleInference",
+        "rolesObserved",
+        "serializationOrderIsChronology",
+        "terminalManagementPointDiagnosis",
+        "terminalSoftwareUpdatePointHealth",
+        "totalRotationSort",
+        "uniqueRelativePaths",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect::<BTreeSet<_>>();
+    let all_expected = std::fs::read_dir(intake_root())
+        .expect("intake fixture root is readable")
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().join("expected.json").is_file())
+        .flat_map(|entry| {
+            let scenario = entry.file_name().to_string_lossy().into_owned();
+            load_expected(&scenario)
+                .as_object()
+                .expect("expected contract is an object")
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        currently_asserted, all_expected,
+        "every committed expected.json key must drive an assertion"
+    );
+}
+
+#[test]
+fn server_intake_expected_oracles_do_not_claim_native_collection_acceptance() {
+    let forbidden_native_claims = BTreeSet::from([
+        "atomicCreateNoOverwrite",
+        "destinationsPrecomputed",
+        "neitherOverwritten",
+    ]);
+
+    for entry in std::fs::read_dir(intake_root()).expect("intake fixture root is readable") {
+        let entry = entry.expect("fixture directory entry is readable");
+        let expected_path = entry.path().join("expected.json");
+        if !expected_path.is_file() {
+            continue;
+        }
+        let scenario = entry.file_name().to_string_lossy().into_owned();
+        let expected = load_expected(&scenario);
+        let asserted_collision_keys = expected["collisionAssertions"]
+            .as_object()
+            .map(|assertions| assertions.keys().map(String::as_str).collect())
+            .unwrap_or_default();
+        assert!(
+            forbidden_native_claims.is_disjoint(&asserted_collision_keys),
+            "{scenario}: pure parser oracles cannot claim native collection acceptance"
+        );
+    }
 }
 
 #[test]
@@ -1129,12 +1591,53 @@ fn server_intake_exercises_committed_expected_contracts() {
             "{scenario}: coverage row count"
         );
         for (actual_row, expected_row) in actual_coverage.iter().zip(expected_coverage) {
-            for key in ["producerRole", "workflowSubjectRole", "sourceId", "state"] {
-                if let Some(expected_value) = expected_row.get(key) {
-                    assert_eq!(
-                        &actual_row[key], expected_value,
-                        "{scenario}: coverage {key}"
-                    );
+            for (key, expected_value) in expected_row
+                .as_object()
+                .expect("expected coverage row is an object")
+            {
+                match key.as_str() {
+                    "producerRole" | "workflowSubjectRole" | "sourceId" | "state" => {
+                        assert_eq!(
+                            &actual_row[key], expected_value,
+                            "{scenario}: coverage {key}"
+                        );
+                    }
+                    "gap" => {
+                        assert_eq!(expected_value, "candidate absent only");
+                        assert_eq!(actual_row["state"], "absent");
+                        let artifact = artifact_json(
+                            &actual,
+                            actual_row["artifactIds"][0]
+                                .as_str()
+                                .expect("coverage artifact ID"),
+                        );
+                        assert_eq!(artifact["configuredPathState"], "defaultCandidate");
+                    }
+                    "configuredRootInstances" => assert_eq!(
+                        actual_row["artifactIds"]
+                            .as_array()
+                            .expect("coverage artifact IDs")
+                            .len() as u64,
+                        expected_value.as_u64().expect("root count is an integer")
+                    ),
+                    "truncated" => {
+                        assert_eq!(expected_value, true);
+                        let artifact = artifact_json(
+                            &actual,
+                            actual_row["artifactIds"][0]
+                                .as_str()
+                                .expect("coverage artifact ID"),
+                        );
+                        assert_eq!(artifact["truncated"], true);
+                    }
+                    "requiredness" => {
+                        assert_eq!(expected_value, "optionalSupplemental");
+                        assert!(actual["nextArtifactRequests"]
+                            .as_array()
+                            .expect("requests are an array")
+                            .is_empty());
+                    }
+                    other => panic!("{scenario}: unhandled coverage key {other}"),
                 }
             }
         }
@@ -1148,23 +1651,22 @@ fn server_intake_exercises_committed_expected_contracts() {
                     .as_str()
                     .expect("expected artifactId is a string");
                 let actual_artifact = artifact_json(&actual, artifact_id);
-                for (expected_key, actual_value) in [
-                    (
-                        "encoding",
-                        &actual_artifact["captureProvenance"]["encoding"],
-                    ),
-                    (
-                        "byteLimit",
-                        &actual_artifact["captureProvenance"]["byteLimit"],
-                    ),
-                    (
-                        "limitApplied",
-                        &actual_artifact["captureProvenance"]["limitApplied"],
-                    ),
-                    ("bytesCopied", &actual_artifact["bytesCopied"]),
-                    ("relativePath", &actual_artifact["relativePath"]),
-                ] {
-                    if let Some(expected_value) = expected_artifact.get(expected_key) {
+                for (expected_key, expected_value) in expected_artifact
+                    .as_object()
+                    .expect("expected provenance is an object")
+                {
+                    let actual_value = match expected_key.as_str() {
+                        "artifactId" => &actual_artifact["artifactId"],
+                        "encoding" => &actual_artifact["captureProvenance"]["encoding"],
+                        "byteLimit" => &actual_artifact["captureProvenance"]["byteLimit"],
+                        "limitApplied" => &actual_artifact["captureProvenance"]["limitApplied"],
+                        "bytesCopied" => &actual_artifact["bytesCopied"],
+                        "relativePath" => &actual_artifact["relativePath"],
+                        "fragmentComplete" => &actual_artifact["fragmentComplete"],
+                        "sha256" => &actual_artifact["contentSha256"],
+                        other => panic!("{scenario}: unhandled provenance key {other}"),
+                    };
+                    if expected_key != "artifactId" {
                         assert_eq!(
                             actual_value, expected_value,
                             "{scenario}: {artifact_id} {expected_key}"
@@ -1199,6 +1701,17 @@ fn server_intake_exercises_committed_expected_contracts() {
                     assert_eq!(records[0]["reference"]["lineStart"], line_range["start"]);
                     assert_eq!(records[0]["reference"]["lineEnd"], line_range["end"]);
                 }
+                let keys = expected_row
+                    .as_object()
+                    .expect("expected evidence row is an object")
+                    .keys()
+                    .map(String::as_str)
+                    .collect::<BTreeSet<_>>();
+                assert_eq!(
+                    keys,
+                    BTreeSet::from(["artifactId", "lineRange", "logicalRecordCount"]),
+                    "{scenario}: every evidence expectation is asserted"
+                );
             }
         }
 
@@ -1224,5 +1737,13 @@ fn server_intake_exercises_committed_expected_contracts() {
         if let Some(expected_roles) = expected.get("rolesObserved") {
             assert_eq!(actual["topology"]["rolesObserved"], *expected_roles);
         }
+
+        assert_remaining_expected_contracts(
+            &scenario,
+            &expected,
+            &manifest_json,
+            &payloads,
+            &actual,
+        );
     }
 }

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -46,14 +46,8 @@ fn serialize_manifest(manifest: &Value) -> String {
     serde_json::to_string(manifest).expect("manifest serializes")
 }
 
-fn manifest_with_duplicate_extension(
-    manifest_json: &str,
-    scope: &str,
-    extension_name: &str,
-    first_value: &str,
-    second_value: &str,
-) -> String {
-    let needle = match scope {
+fn manifest_scope_needle(scope: &str) -> &'static str {
+    match scope {
         "manifest" => "{",
         "privacy" => "\"privacy\":{",
         "topology" => "\"topology\":{",
@@ -63,7 +57,17 @@ fn manifest_with_duplicate_extension(
         "rotation" => "\"rotation\":{",
         "collectionLimit" => "\"collectionLimit\":{",
         _ => panic!("unknown extension scope: {scope}"),
-    };
+    }
+}
+
+fn manifest_with_duplicate_extension(
+    manifest_json: &str,
+    scope: &str,
+    extension_name: &str,
+    first_value: &str,
+    second_value: &str,
+) -> String {
+    let needle = manifest_scope_needle(scope);
     let prefix = format!(
         "{needle}\"{extension_name}\":\"{first_value}\",\"{extension_name}\":\"{second_value}\","
     );
@@ -78,21 +82,37 @@ fn manifest_with_duplicate_known_field(
     field_name: &str,
     field_value: &Value,
 ) -> String {
-    let needle = match scope {
-        "manifest" => "{",
-        "privacy" => "\"privacy\":{",
-        "topology" => "\"topology\":{",
-        "artifact" => "\"artifacts\":[{",
-        "workflowSubject" => "\"workflowSubject\":{",
-        "configuredPathProvenance" => "\"configuredPathProvenance\":{",
-        "rotation" => "\"rotation\":{",
-        "collectionLimit" => "\"collectionLimit\":{",
-        _ => panic!("unknown extension scope: {scope}"),
-    };
+    let needle = manifest_scope_needle(scope);
     let field_value = serde_json::to_string(field_value).expect("duplicate field value serializes");
     let prefix = format!("{needle}\"{field_name}\":{field_value},");
     let mutated = manifest_json.replacen(needle, &prefix, 1);
     assert_ne!(mutated, manifest_json, "scope marker must be present");
+    mutated
+}
+
+fn manifest_with_ordered_extensions(
+    manifest_json: &str,
+    scopes: &[&str],
+    extensions: &[(&str, &str)],
+) -> String {
+    let fields = extensions
+        .iter()
+        .map(|(name, value)| {
+            format!(
+                "{}:{},",
+                serde_json::to_string(name).expect("extension name serializes"),
+                serde_json::to_string(value).expect("extension value serializes")
+            )
+        })
+        .collect::<String>();
+    let mut mutated = manifest_json.to_owned();
+    for scope in scopes {
+        let needle = manifest_scope_needle(scope);
+        let replacement = format!("{needle}{fields}");
+        let next = mutated.replacen(needle, &replacement, 1);
+        assert_ne!(next, mutated, "scope marker must be present: {scope}");
+        mutated = next;
+    }
     mutated
 }
 
@@ -383,8 +403,7 @@ fn assert_collision_contract(scenario: &str, expected: &Value, actual: &Value) {
                             .as_str()
                             .expect("relative path")
                             .split('/')
-                            .nth(5)
-                            .filter(|segment| segment.starts_with("root-"))
+                            .find(|segment| segment.starts_with("root-"))
                             .expect("opaque configured-root segment")
                     })
                     .collect::<BTreeSet<_>>();
@@ -591,7 +610,17 @@ fn assert_remaining_expected_contracts(
                 let mut second_manifest = manifest_value(manifest_json);
                 second_manifest["topology"]["captureHost"] =
                     if second_manifest["syntheticFixture"] == true {
-                        Value::String("LAB-MP01".to_owned())
+                        let current_host = second_manifest["topology"]["captureHost"]
+                            .as_str()
+                            .expect("synthetic capture host is a string");
+                        Value::String(
+                            if current_host == "LAB-MP01" {
+                                "LAB-CM01"
+                            } else {
+                                "LAB-MP01"
+                            }
+                            .to_owned(),
+                        )
                     } else {
                         Value::String(opaque_handle("cmtraceopen.host.sha256.v1:", 999))
                     };
@@ -1560,20 +1589,51 @@ fn server_intake_accepts_only_opaque_future_unsupported_provenance() {
 #[test]
 fn server_manifest_v1_retains_only_versioned_opaque_extensions_deterministically() {
     let (manifest_json, payloads) = bounded_manifest(1, 4_096);
-    let mut manifest = manifest_value(&manifest_json);
     let extension_name_a = "x-cmtraceopen-opaque-v1-alpha";
     let extension_name_b = "x-cmtraceopen-opaque-v1-beta";
     let extension_value_a = opaque_handle("cmtraceopen.extension.sha256.v1:", 1);
     let extension_value_b = opaque_handle("cmtraceopen.extension.sha256.v1:", 2);
+    let scopes = ["manifest", "topology", "artifact"];
+    let beta_then_alpha = manifest_with_ordered_extensions(
+        &manifest_json,
+        &scopes,
+        &[
+            (extension_name_b, extension_value_b.as_str()),
+            (extension_name_a, extension_value_a.as_str()),
+        ],
+    );
+    let alpha_then_beta = manifest_with_ordered_extensions(
+        &manifest_json,
+        &scopes,
+        &[
+            (extension_name_a, extension_value_a.as_str()),
+            (extension_name_b, extension_value_b.as_str()),
+        ],
+    );
+    assert_ne!(
+        beta_then_alpha, alpha_then_beta,
+        "the test inputs must preserve genuinely different extension arrival orders"
+    );
+    assert!(
+        beta_then_alpha
+            .find(extension_name_b)
+            .expect("beta extension is present")
+            < beta_then_alpha
+                .find(extension_name_a)
+                .expect("alpha extension is present"),
+        "the first raw manifest must place beta before alpha"
+    );
+    assert!(
+        alpha_then_beta
+            .find(extension_name_a)
+            .expect("alpha extension is present")
+            < alpha_then_beta
+                .find(extension_name_b)
+                .expect("beta extension is present"),
+        "the reordered raw manifest must place alpha before beta"
+    );
 
-    manifest[extension_name_b] = Value::String(extension_value_b.clone());
-    manifest[extension_name_a] = Value::String(extension_value_a.clone());
-    manifest["topology"][extension_name_b] = Value::String(extension_value_b.clone());
-    manifest["topology"][extension_name_a] = Value::String(extension_value_a.clone());
-    manifest["artifacts"][0][extension_name_b] = Value::String(extension_value_b.clone());
-    manifest["artifacts"][0][extension_name_a] = Value::String(extension_value_a.clone());
-
-    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+    let assessment = assess_server_intake(&beta_then_alpha, &payloads)
         .expect("versioned opaque extensions are retained");
     let public = serde_json::to_value(&assessment).expect("assessment serializes");
     let expected = json!([
@@ -1584,14 +1644,7 @@ fn server_manifest_v1_retains_only_versioned_opaque_extensions_deterministically
     assert_eq!(public["topology"]["extensions"], expected);
     assert_eq!(public["artifacts"][0]["extensions"], expected);
 
-    let mut reordered = manifest_value(&manifest_json);
-    reordered[extension_name_a] = Value::String(extension_value_a.clone());
-    reordered[extension_name_b] = Value::String(extension_value_b.clone());
-    reordered["topology"][extension_name_a] = Value::String(extension_value_a.clone());
-    reordered["topology"][extension_name_b] = Value::String(extension_value_b.clone());
-    reordered["artifacts"][0][extension_name_a] = Value::String(extension_value_a.clone());
-    reordered["artifacts"][0][extension_name_b] = Value::String(extension_value_b.clone());
-    let reordered_assessment = assess_server_intake(&serialize_manifest(&reordered), &payloads)
+    let reordered_assessment = assess_server_intake(&alpha_then_beta, &payloads)
         .expect("extension arrival order does not change normalized output");
     assert_eq!(assessment, reordered_assessment);
 }

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -2287,6 +2287,20 @@ fn server_intake_bounds_manifest_artifact_count() {
 }
 
 #[test]
+fn server_intake_artifact_count_limit_precedes_per_artifact_extension_work() {
+    let (manifest_json, payloads) = bounded_manifest(513, 4_096);
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["artifacts"][0]["unsafeIdentityField"] =
+        Value::String("Real User <real.user@example.com>".to_owned());
+
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads),
+        Err(SccmServerIntakeError::ManifestLimitExceeded),
+        "the artifact-count gate must stop nested preflight work before artifact validation"
+    );
+}
+
+#[test]
 fn server_intake_bounds_aggregate_declared_bytes() {
     let (manifest_json, payloads) = bounded_manifest(5, 268_435_456);
 

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -45,6 +45,77 @@ fn serialize_manifest(manifest: &Value) -> String {
     serde_json::to_string(manifest).expect("manifest serializes")
 }
 
+fn load_expected(scenario: &str) -> Value {
+    let path = intake_root().join(scenario).join("expected.json");
+    let json = std::fs::read_to_string(path).expect("expected intake output is readable");
+    serde_json::from_str(&json).expect("expected intake output is valid JSON")
+}
+
+fn opaque_handle(prefix: &str, ordinal: usize) -> String {
+    format!("{prefix}{ordinal:064x}")
+}
+
+fn bounded_manifest(
+    artifact_count: usize,
+    byte_limit: u64,
+) -> (String, Vec<SccmServerArtifactPayload>) {
+    let capture_host = opaque_handle("cmtraceopen.host.sha256.v1:", 1);
+    let site_code = opaque_handle("cmtraceopen.site.sha256.v1:", 1);
+    let producer_host = opaque_handle("cmtraceopen.host.sha256.v1:", 2);
+    let mut artifacts = Vec::with_capacity(artifact_count);
+    let mut payloads = Vec::with_capacity(artifact_count);
+
+    for ordinal in 0..artifact_count {
+        let artifact_id = opaque_handle("cmtraceopen.artifact.sha256.v1:", ordinal);
+        artifacts.push(json!({
+            "artifactId": artifact_id.clone(),
+            "producerRole": "managementPoint",
+            "producerHostHandle": producer_host.clone(),
+            "sourceId": "server-mp-policy",
+            "sourceKind": "ccmLog",
+            "sourceVersion": "5.00.9999.9999",
+            "originalPath": "REDACTED",
+            "originalBasename": "MP_GetPolicy.log",
+            "configuredPathProvenance": {
+                "state": "configured",
+                "pathFingerprint": opaque_handle("cmtraceopen.path.sha256.v1:", ordinal),
+            },
+            "rotation": {
+                "kind": "current",
+                "lineageId": opaque_handle("cmtraceopen.lineage.sha256.v1:", ordinal),
+            },
+            "captureState": "captured",
+            "encoding": "utf-8",
+            "collectionLimit": { "byteLimit": byte_limit, "limitApplied": false },
+            "collectedUtc": "2026-07-30T00:03:00Z",
+            "relativePath": format!(
+                "evidence/sccm/server/management-point/server-mp-policy/root-{ordinal:08x}/current/MP_GetPolicy.log"
+            ),
+            "bytesCopied": 0,
+        }));
+        payloads.push(SccmServerArtifactPayload {
+            manifest_artifact_id: artifact_id,
+            bytes: Vec::new(),
+        });
+    }
+
+    (
+        serde_json::to_string(&json!({
+            "sccmManifestVersion": 1,
+            "syntheticFixture": false,
+            "bundleRole": "server",
+            "topology": {
+                "captureHost": capture_host,
+                "siteCode": site_code,
+                "rolesObserved": ["managementPoint"],
+            },
+            "artifacts": artifacts,
+        }))
+        .expect("bounded manifest serializes"),
+        payloads,
+    )
+}
+
 fn assert_unsafe_mutation_is_rejected(
     scenario: &str,
     marker: &str,
@@ -756,9 +827,9 @@ fn server_intake_exercises_role_state_rotation_and_privacy_matrix() {
             .map(|artifact| artifact.rotation.clone())
             .collect::<Vec<_>>(),
         vec![
-            Some(SccmRotation::LoUnderscore),
-            Some(SccmRotation::Numbered(2)),
             Some(SccmRotation::Timestamped("20260729-235700".to_owned())),
+            Some(SccmRotation::Numbered(2)),
+            Some(SccmRotation::LoUnderscore),
             Some(SccmRotation::Current),
         ]
     );
@@ -787,4 +858,371 @@ fn server_intake_exercises_role_state_rotation_and_privacy_matrix() {
             SccmRole::SoftwareUpdatePoint,
         ]
     );
+}
+
+#[test]
+fn server_intake_marks_an_incomplete_tail_as_a_parse_gap_even_after_valid_evidence() {
+    let (manifest_json, mut payloads) = load_bundle("multiline");
+    let mut manifest = manifest_value(&manifest_json);
+    payloads[0]
+        .bytes
+        .extend_from_slice(b"\n<![LOG[SYNTHETIC FIXTURE incomplete rotation tail");
+    manifest["artifacts"][0]["bytesCopied"] = Value::from(payloads[0].bytes.len() as u64);
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("complete evidence plus a partial tail remains assessable");
+
+    assert_eq!(
+        assessment.evidence.len(),
+        1,
+        "the complete record is retained"
+    );
+    assert_eq!(
+        assessment.artifacts[0].state,
+        SccmCoverageState::ParseFailed,
+        "the unmatched tail is an explicit parse gap"
+    );
+    assert_eq!(assessment.next_artifact_requests.len(), 1);
+}
+
+#[test]
+fn server_intake_keeps_a_zero_byte_capture_distinct_from_parse_failure() {
+    let (manifest_json, mut payloads) = load_bundle("multiline");
+    let mut manifest = manifest_value(&manifest_json);
+    payloads[0].bytes.clear();
+    manifest["artifacts"][0]["bytesCopied"] = Value::from(0);
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("a bounded zero-byte capture remains valid capture provenance");
+
+    assert_eq!(assessment.artifacts[0].state, SccmCoverageState::Captured);
+    assert_eq!(assessment.coverage[0].state, SccmCoverageState::Captured);
+    assert!(assessment.evidence.is_empty());
+    assert!(assessment.next_artifact_requests.is_empty());
+}
+
+#[test]
+fn server_intake_decodes_declared_utf16le_ccm_payloads() {
+    let (manifest_json, mut payloads) = load_bundle("multiline");
+    let mut manifest = manifest_value(&manifest_json);
+    let content = String::from_utf8(payloads[0].bytes.clone()).expect("fixture is UTF-8");
+    let mut utf16le = vec![0xff, 0xfe];
+    for unit in content.encode_utf16() {
+        utf16le.extend_from_slice(&unit.to_le_bytes());
+    }
+    payloads[0].bytes = utf16le;
+    manifest["artifacts"][0]["encoding"] = Value::String("utf-16le".to_owned());
+    manifest["artifacts"][0]["bytesCopied"] = Value::from(payloads[0].bytes.len() as u64);
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("the declared UTF-16LE contract is decoded");
+
+    assert_eq!(assessment.artifacts[0].state, SccmCoverageState::Captured);
+    assert_eq!(assessment.evidence.len(), 1);
+    assert!(assessment.evidence[0].message.contains("SYNTHETIC FIXTURE"));
+}
+
+#[test]
+fn server_intake_decodes_declared_windows_1252_ccm_payloads() {
+    let (manifest_json, mut payloads) = load_bundle("multiline");
+    let mut manifest = manifest_value(&manifest_json);
+    let marker = b"SYNTHETIC FIXTURE";
+    let marker_start = payloads[0]
+        .bytes
+        .windows(marker.len())
+        .position(|window| window == marker)
+        .expect("fixture contains its synthetic marker");
+    let marker_end = marker_start + marker.len();
+    let mut windows_1252 = payloads[0].bytes[..marker_end].to_vec();
+    windows_1252.extend_from_slice(b" caf");
+    windows_1252.push(0xe9);
+    windows_1252.push(b' ');
+    windows_1252.push(0x80);
+    windows_1252.extend_from_slice(&payloads[0].bytes[marker_end..]);
+    payloads[0].bytes = windows_1252;
+    manifest["artifacts"][0]["encoding"] = Value::String("windows-1252".to_owned());
+    manifest["artifacts"][0]["bytesCopied"] = Value::from(payloads[0].bytes.len() as u64);
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("the declared Windows-1252 contract is decoded");
+
+    assert_eq!(assessment.artifacts[0].state, SccmCoverageState::Captured);
+    assert_eq!(assessment.evidence.len(), 1);
+    assert!(assessment.evidence[0].message.contains("café €"));
+}
+
+#[test]
+fn server_intake_keeps_unknown_encoding_as_unsupported_coverage() {
+    let (manifest_json, payloads) = load_bundle("multiline");
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["artifacts"][0]["encoding"] = Value::String("unknown".to_owned());
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("unknown encoding is retained without guessing a decoder");
+
+    assert_eq!(
+        assessment.artifacts[0].state,
+        SccmCoverageState::Unsupported
+    );
+    assert!(!assessment.artifacts[0].parser_eligible);
+    assert!(assessment.evidence.is_empty());
+    assert_eq!(assessment.next_artifact_requests.len(), 1);
+    let serialized = serde_json::to_value(&assessment).expect("assessment serializes");
+    assert_eq!(
+        serialized["artifacts"][0]["captureProvenance"]["encoding"],
+        "unknown"
+    );
+}
+
+#[test]
+fn server_intake_retains_unsupported_source_provenance() {
+    let (manifest_json, payloads) = load_bundle("unsupported-db-supplement");
+    let assessment = assess_server_intake(&manifest_json, &payloads)
+        .expect("unsupported source remains assessable");
+    let serialized = serde_json::to_value(&assessment).expect("assessment serializes");
+    let artifact = artifact_json(&serialized, "unknown-db-export");
+
+    assert_eq!(artifact["sourceId"], "unknown-db-supplement");
+    assert_eq!(artifact["sourceKind"], "unknown");
+    assert_eq!(artifact["family"], "unknown-db-supplement");
+    assert_eq!(artifact["originalBasename"], "synthetic-db-export.txt");
+    assert_eq!(artifact["rotationLineageHandle"], "unknown-db-export");
+    assert_eq!(
+        serialized["coverage"][0]["sourceId"],
+        "unknown-db-supplement"
+    );
+}
+
+#[test]
+fn server_intake_tolerates_future_safe_unsupported_source_labels() {
+    let (manifest_json, payloads) = load_bundle("unsupported-db-supplement");
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["artifacts"][0]["sourceId"] = Value::String("future-server-supplement".to_owned());
+    manifest["artifacts"][0]["sourceKind"] = Value::String("futureSupplement".to_owned());
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("a privacy-safe future unsupported label remains forward-compatible");
+    let serialized = serde_json::to_value(&assessment).expect("assessment serializes");
+    let artifact = artifact_json(&serialized, "unknown-db-export");
+
+    assert_eq!(artifact["sourceId"], "future-server-supplement");
+    assert_eq!(artifact["sourceKind"], "futureSupplement");
+    assert_eq!(artifact["family"], "future-server-supplement");
+}
+
+#[test]
+fn server_intake_bounds_each_declared_artifact_limit() {
+    let (manifest_json, payloads) = bounded_manifest(1, 268_435_457);
+
+    assert!(
+        assess_server_intake(&manifest_json, &payloads).is_err(),
+        "a single artifact may not declare more than 256 MiB"
+    );
+}
+
+#[test]
+fn server_intake_bounds_manifest_artifact_count() {
+    let (manifest_json, payloads) = bounded_manifest(513, 4_096);
+
+    assert!(
+        assess_server_intake(&manifest_json, &payloads).is_err(),
+        "a manifest may not force unbounded per-artifact work"
+    );
+}
+
+#[test]
+fn server_intake_bounds_aggregate_declared_bytes() {
+    let (manifest_json, payloads) = bounded_manifest(5, 268_435_456);
+
+    assert!(
+        assess_server_intake(&manifest_json, &payloads).is_err(),
+        "aggregate declared collection work may not exceed 1 GiB"
+    );
+}
+
+#[test]
+fn server_intake_rejects_evidence_later_than_collection_time() {
+    let (manifest_json, payloads) = load_bundle("multiline");
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["artifacts"][0]["collectedUtc"] = Value::String("2026-07-30T00:02:58Z".to_owned());
+
+    assert!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
+        "a comparable record instant cannot be later than collection"
+    );
+}
+
+#[test]
+fn server_intake_rejects_incoherent_configured_path_class() {
+    let (manifest_json, payloads) = load_bundle("absent-dp");
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["artifacts"][0]["configuredPathProvenance"]["pathClass"] =
+        Value::String("nonDefault".to_owned());
+
+    assert!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
+        "a default candidate cannot claim non-default configured provenance"
+    );
+}
+
+#[test]
+fn server_intake_requires_producer_host_for_declared_sources() {
+    let (manifest_json, payloads) = load_bundle("multiline");
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["artifacts"][0]["producerHostHandle"] = Value::Null;
+
+    assert!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
+        "declared server evidence must retain its producer-host provenance"
+    );
+}
+
+#[test]
+fn server_intake_exercises_committed_expected_contracts() {
+    let mut scenarios = std::fs::read_dir(intake_root())
+        .expect("intake fixture root is readable")
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().join("expected.json").is_file())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    scenarios.sort();
+
+    for scenario in scenarios {
+        let expected = load_expected(&scenario);
+        let (manifest_json, payloads) = load_bundle(&scenario);
+        let assessment = assess_server_intake(&manifest_json, &payloads)
+            .unwrap_or_else(|error| panic!("{scenario} should be assessed: {error}"));
+        let actual = serde_json::to_value(&assessment).expect("assessment serializes");
+
+        assert_eq!(
+            actual["schemaVersion"], expected["pre318ExpectedVersion"],
+            "{scenario}: expected contract version"
+        );
+
+        for key in [
+            "canonicalArtifactIds",
+            "canonicalRotationArtifactIds",
+            "retainedUnclassifiedArtifactIds",
+        ] {
+            if let Some(expected_ids) = expected.get(key) {
+                let actual_ids = Value::Array(
+                    actual["artifacts"]
+                        .as_array()
+                        .expect("assessment artifacts are an array")
+                        .iter()
+                        .map(|artifact| artifact["artifactId"].clone())
+                        .collect(),
+                );
+                assert_eq!(actual_ids, *expected_ids, "{scenario}: {key}");
+            }
+        }
+
+        let expected_coverage = expected["coverage"]
+            .as_array()
+            .expect("expected coverage is an array");
+        let actual_coverage = actual["coverage"]
+            .as_array()
+            .expect("assessment coverage is an array");
+        assert_eq!(
+            actual_coverage.len(),
+            expected_coverage.len(),
+            "{scenario}: coverage row count"
+        );
+        for (actual_row, expected_row) in actual_coverage.iter().zip(expected_coverage) {
+            for key in ["producerRole", "workflowSubjectRole", "sourceId", "state"] {
+                if let Some(expected_value) = expected_row.get(key) {
+                    assert_eq!(
+                        &actual_row[key], expected_value,
+                        "{scenario}: coverage {key}"
+                    );
+                }
+            }
+        }
+
+        if let Some(expected_provenance) = expected.get("artifactProvenance") {
+            for expected_artifact in expected_provenance
+                .as_array()
+                .expect("artifact provenance is an array")
+            {
+                let artifact_id = expected_artifact["artifactId"]
+                    .as_str()
+                    .expect("expected artifactId is a string");
+                let actual_artifact = artifact_json(&actual, artifact_id);
+                for (expected_key, actual_value) in [
+                    (
+                        "encoding",
+                        &actual_artifact["captureProvenance"]["encoding"],
+                    ),
+                    (
+                        "byteLimit",
+                        &actual_artifact["captureProvenance"]["byteLimit"],
+                    ),
+                    (
+                        "limitApplied",
+                        &actual_artifact["captureProvenance"]["limitApplied"],
+                    ),
+                    ("bytesCopied", &actual_artifact["bytesCopied"]),
+                    ("relativePath", &actual_artifact["relativePath"]),
+                ] {
+                    if let Some(expected_value) = expected_artifact.get(expected_key) {
+                        assert_eq!(
+                            actual_value, expected_value,
+                            "{scenario}: {artifact_id} {expected_key}"
+                        );
+                    }
+                }
+            }
+        }
+
+        if let Some(expected_evidence) = expected.get("evidence") {
+            for expected_row in expected_evidence
+                .as_array()
+                .expect("expected evidence is an array")
+            {
+                let artifact_id = expected_row["artifactId"]
+                    .as_str()
+                    .expect("expected evidence artifactId is a string");
+                let records = actual["evidence"]
+                    .as_array()
+                    .expect("assessment evidence is an array")
+                    .iter()
+                    .filter(|row| row["reference"]["artifactId"] == artifact_id)
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    records.len() as u64,
+                    expected_row["logicalRecordCount"]
+                        .as_u64()
+                        .expect("logicalRecordCount is an integer"),
+                    "{scenario}: logical record count"
+                );
+                if let Some(line_range) = expected_row.get("lineRange") {
+                    assert_eq!(records[0]["reference"]["lineStart"], line_range["start"]);
+                    assert_eq!(records[0]["reference"]["lineEnd"], line_range["end"]);
+                }
+            }
+        }
+
+        if let Some(expected_path) = expected.get("configuredPathProvenance") {
+            let artifact_id = expected["artifactId"]
+                .as_str()
+                .expect("configured-path expected artifactId is a string");
+            let actual_artifact = artifact_json(&actual, artifact_id);
+            assert_eq!(
+                actual_artifact["configuredPathState"],
+                expected_path["state"]
+            );
+            assert_eq!(
+                actual_artifact["configuredPathClass"],
+                expected_path["pathClass"]
+            );
+            assert_eq!(
+                actual_artifact["pathFingerprint"],
+                expected_path["pathFingerprint"]
+            );
+        }
+
+        if let Some(expected_roles) = expected.get("rolesObserved") {
+            assert_eq!(actual["topology"]["rolesObserved"], *expected_roles);
+        }
+    }
 }

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -1488,6 +1488,37 @@ fn server_intake_decodes_declared_windows_1252_ccm_payloads() {
 }
 
 #[test]
+fn server_intake_declared_windows_1252_does_not_sniff_a_conflicting_bom() {
+    let (manifest_json, mut payloads) = load_bundle("multiline");
+    let mut manifest = manifest_value(&manifest_json);
+    let marker = b"SYNTHETIC FIXTURE";
+    let marker_end = payloads[0]
+        .bytes
+        .windows(marker.len())
+        .position(|window| window == marker)
+        .expect("fixture contains its synthetic marker")
+        + marker.len();
+    let mut declared_windows_1252 = vec![0xef, 0xbb, 0xbf];
+    declared_windows_1252.extend_from_slice(&payloads[0].bytes[..marker_end]);
+    declared_windows_1252.extend_from_slice(b" \xc3\xa9");
+    declared_windows_1252.extend_from_slice(&payloads[0].bytes[marker_end..]);
+    payloads[0].bytes = declared_windows_1252;
+    manifest["artifacts"][0]["encoding"] = Value::String("windows-1252".to_owned());
+    manifest["artifacts"][0]["bytesCopied"] = Value::from(payloads[0].bytes.len() as u64);
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("the declared Windows-1252 contract wins over payload BOM bytes");
+
+    assert_eq!(assessment.evidence.len(), 1);
+    assert!(
+        assessment.evidence[0]
+            .message
+            .contains("SYNTHETIC FIXTURE Ã©"),
+        "BOM sniffing must not reinterpret a manifest-declared Windows-1252 payload as UTF-8"
+    );
+}
+
+#[test]
 fn server_intake_keeps_unknown_encoding_as_unsupported_coverage() {
     let (manifest_json, payloads) = load_bundle("multiline");
     let mut manifest = manifest_value(&manifest_json);

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -1408,22 +1408,164 @@ fn server_intake_accepts_only_opaque_future_unsupported_provenance() {
 }
 
 #[test]
-fn server_manifest_v1_rejects_unknown_fields_instead_of_dropping_them() {
-    let (manifest_json, payloads) = load_bundle("multiline");
+fn server_manifest_v1_retains_only_versioned_opaque_extensions_deterministically() {
+    let (manifest_json, payloads) = bounded_manifest(1, 4_096);
+    let mut manifest = manifest_value(&manifest_json);
+    let extension_name_a = "x-cmtraceopen-opaque-v1-alpha";
+    let extension_name_b = "x-cmtraceopen-opaque-v1-beta";
+    let extension_value_a = opaque_handle("cmtraceopen.extension.sha256.v1:", 1);
+    let extension_value_b = opaque_handle("cmtraceopen.extension.sha256.v1:", 2);
+
+    manifest[extension_name_b] = Value::String(extension_value_b.clone());
+    manifest[extension_name_a] = Value::String(extension_value_a.clone());
+    manifest["topology"][extension_name_b] = Value::String(extension_value_b.clone());
+    manifest["topology"][extension_name_a] = Value::String(extension_value_a.clone());
+    manifest["artifacts"][0][extension_name_b] = Value::String(extension_value_b.clone());
+    manifest["artifacts"][0][extension_name_a] = Value::String(extension_value_a.clone());
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("versioned opaque extensions are retained");
+    let public = serde_json::to_value(&assessment).expect("assessment serializes");
+    let expected = json!([
+        { "schemaVersion": 1, "name": extension_name_a, "value": extension_value_a },
+        { "schemaVersion": 1, "name": extension_name_b, "value": extension_value_b },
+    ]);
+    assert_eq!(public["extensions"], expected);
+    assert_eq!(public["topology"]["extensions"], expected);
+    assert_eq!(public["artifacts"][0]["extensions"], expected);
+
+    let mut reordered = manifest_value(&manifest_json);
+    reordered[extension_name_a] = Value::String(extension_value_a.clone());
+    reordered[extension_name_b] = Value::String(extension_value_b.clone());
+    reordered["topology"][extension_name_a] = Value::String(extension_value_a.clone());
+    reordered["topology"][extension_name_b] = Value::String(extension_value_b.clone());
+    reordered["artifacts"][0][extension_name_a] = Value::String(extension_value_a.clone());
+    reordered["artifacts"][0][extension_name_b] = Value::String(extension_value_b.clone());
+    let reordered_assessment = assess_server_intake(&serialize_manifest(&reordered), &payloads)
+        .expect("extension arrival order does not change normalized output");
+    assert_eq!(assessment, reordered_assessment);
+}
+
+#[test]
+fn server_manifest_v1_rejects_unversioned_or_nonopaque_unknown_fields() {
+    let (manifest_json, payloads) = bounded_manifest(1, 4_096);
 
     for path in ["manifest", "topology", "artifact"] {
-        let mut manifest = manifest_value(&manifest_json);
-        match path {
-            "manifest" => manifest["unexpectedEvidence"] = Value::Bool(true),
-            "topology" => manifest["topology"]["unexpectedEvidence"] = Value::Bool(true),
-            "artifact" => manifest["artifacts"][0]["unexpectedEvidence"] = Value::Bool(true),
-            _ => unreachable!(),
+        for (name, value) in [
+            ("unexpectedEvidence", Value::Bool(true)),
+            (
+                "x-cmtraceopen-opaque-v1-arbitrary",
+                Value::String("identity-bearing text".to_owned()),
+            ),
+        ] {
+            let mut manifest = manifest_value(&manifest_json);
+            match path {
+                "manifest" => manifest[name] = value,
+                "topology" => manifest["topology"][name] = value,
+                "artifact" => manifest["artifacts"][0][name] = value,
+                _ => unreachable!(),
+            }
+            assert!(
+                assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
+                "{path} must reject arbitrary extension {name}"
+            );
         }
-        assert!(
-            assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
-            "unknown {path} fields require a schema change; they cannot be silently discarded"
-        );
     }
+}
+
+#[test]
+fn server_intake_retains_only_opaque_future_roles_as_unsupported_coverage() {
+    let (manifest_json, _) = bounded_manifest(1, 4_096);
+    let mut manifest = manifest_value(&manifest_json);
+    let future_role = opaque_handle("cmtraceopen.role.sha256.v1:", 9);
+    manifest["topology"]["rolesObserved"] = json!(["managementPoint", future_role]);
+    let artifact = &mut manifest["artifacts"][0];
+    artifact["producerRole"] = Value::String(future_role.clone());
+    artifact["producerHostHandle"] = Value::Null;
+    artifact["sourceId"] = Value::String(opaque_handle("cmtraceopen.source.sha256.v1:", 1));
+    artifact["sourceKind"] = Value::String(opaque_handle("cmtraceopen.source-kind.sha256.v1:", 2));
+    artifact["originalBasename"] =
+        Value::String(opaque_handle("cmtraceopen.basename.sha256.v1:", 3));
+    artifact["originalPath"] =
+        Value::String(opaque_handle("cmtraceopen.original-path.sha256.v1:", 4));
+    artifact["rotation"] = json!({
+        "kind": "none",
+        "lineageId": opaque_handle("cmtraceopen.lineage.sha256.v1:", 5),
+    });
+    artifact["captureState"] = Value::String("unsupported".to_owned());
+    artifact["encoding"] = Value::Null;
+    artifact["collectionLimit"] = Value::Null;
+    artifact["relativePath"] = Value::Null;
+    artifact["bytesCopied"] = Value::from(0);
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &[])
+        .expect("opaque future role is retained as unsupported provenance");
+    let public = serde_json::to_value(&assessment).expect("assessment serializes");
+    assert!(public["topology"]["rolesObserved"]
+        .as_array()
+        .expect("roles observed is an array")
+        .contains(&Value::String(future_role.clone())));
+    assert_eq!(public["artifacts"][0]["producerRole"], future_role);
+    assert_eq!(public["coverage"][0]["state"], "unsupported");
+    assert!(!assessment.artifacts[0].parser_eligible);
+    assert!(assessment.evidence.is_empty());
+    assert!(assessment.findings.is_empty());
+    assert!(assessment.next_artifact_requests.is_empty());
+}
+
+#[test]
+fn server_intake_rejects_identity_bearing_future_roles() {
+    let (manifest_json, _) = bounded_manifest(1, 4_096);
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["topology"]["rolesObserved"] = json!(["managementPoint", "real-server-role"]);
+    let artifact = &mut manifest["artifacts"][0];
+    artifact["producerRole"] = Value::String("real-server-role".to_owned());
+    artifact["producerHostHandle"] = Value::Null;
+    artifact["captureState"] = Value::String("unsupported".to_owned());
+    artifact["encoding"] = Value::Null;
+    artifact["collectionLimit"] = Value::Null;
+    artifact["relativePath"] = Value::Null;
+    artifact["bytesCopied"] = Value::from(0);
+
+    assert!(
+        assess_server_intake(&serialize_manifest(&manifest), &[]).is_err(),
+        "identity-bearing future roles are not public provenance"
+    );
+}
+
+#[test]
+fn server_intake_rejects_future_roles_without_unsupported_capture() {
+    let (manifest_json, payloads) = bounded_manifest(1, 4_096);
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["topology"]["rolesObserved"] = json!([
+        "managementPoint",
+        opaque_handle("cmtraceopen.role.sha256.v1:", 10),
+    ]);
+
+    assert!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
+        "future roles are valid only when retained by an unsupported capture"
+    );
+}
+
+#[test]
+fn server_intake_production_original_path_must_be_redacted_or_opaque() {
+    let (manifest_json, payloads) = bounded_manifest(1, 4_096);
+    let mut arbitrary = manifest_value(&manifest_json);
+    arbitrary["artifacts"][0]["originalPath"] =
+        Value::String("C:/Users/real-user/SMS_CCM/Logs/MP_GetPolicy.log".to_owned());
+    assert!(
+        assess_server_intake(&serialize_manifest(&arbitrary), &payloads).is_err(),
+        "production originalPath cannot contradict the redacted privacy declaration"
+    );
+
+    let mut opaque = manifest_value(&manifest_json);
+    let path_handle = opaque_handle("cmtraceopen.original-path.sha256.v1:", 6);
+    opaque["artifacts"][0]["originalPath"] = Value::String(path_handle.clone());
+    let assessment = assess_server_intake(&serialize_manifest(&opaque), &payloads)
+        .expect("an opaque production originalPath marker is safe");
+    let serialized = serde_json::to_string(&assessment).expect("assessment serializes");
+    assert!(!serialized.contains(&path_handle));
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -1543,6 +1543,20 @@ fn server_intake_rejects_unversioned_future_unsupported_source_labels() {
 }
 
 #[test]
+fn server_intake_rejects_opaque_future_source_ids_in_synthetic_fixtures() {
+    let (manifest_json, payloads) = load_bundle("unsupported-db-supplement");
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["artifacts"][0]["sourceId"] =
+        Value::String(opaque_handle("cmtraceopen.source.sha256.v1:", 77));
+
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads),
+        Err(SccmServerIntakeError::InvalidArtifact),
+        "synthetic fixtures must use the frozen public source vocabulary"
+    );
+}
+
+#[test]
 fn server_intake_rejects_identity_bearing_unsupported_public_provenance() {
     for (field, marker) in [
         ("sourceId", "realuser-example"),

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -1473,6 +1473,27 @@ fn server_intake_expected_oracles_do_not_claim_native_collection_acceptance() {
 }
 
 #[test]
+fn server_intake_rejects_ambiguous_retained_unknown_rotations() {
+    for (kind, value) in [
+        ("future", Value::Null),
+        ("current", Value::String("unexpected".to_owned())),
+        ("none", Value::String("unexpected".to_owned())),
+        ("timestamped", Value::String("not-a-timestamp".to_owned())),
+    ] {
+        let (manifest_json, payloads) = load_bundle("unsupported-db-supplement");
+        let mut manifest = manifest_value(&manifest_json);
+        manifest["artifacts"][0]["rotation"]["kind"] = Value::String(kind.to_owned());
+        manifest["artifacts"][0]["rotation"]["value"] = value;
+
+        assert_eq!(
+            assess_server_intake(&serialize_manifest(&manifest), &payloads),
+            Err(SccmServerIntakeError::InvalidArtifact),
+            "retained unknown evidence needs an unambiguous rotation identity"
+        );
+    }
+}
+
+#[test]
 fn server_intake_bounds_each_declared_artifact_limit() {
     let (manifest_json, payloads) = bounded_manifest(1, 268_435_457);
 
@@ -1499,6 +1520,25 @@ fn server_intake_bounds_aggregate_declared_bytes() {
     assert!(
         assess_server_intake(&manifest_json, &payloads).is_err(),
         "aggregate declared collection work may not exceed 1 GiB"
+    );
+}
+
+#[test]
+fn server_intake_bounds_aggregate_bytes_copied_without_collection_limits() {
+    let (manifest_json, payloads) = bounded_manifest(5, 1);
+    let mut manifest = manifest_value(&manifest_json);
+    for artifact in manifest["artifacts"]
+        .as_array_mut()
+        .expect("artifacts are an array")
+    {
+        artifact["bytesCopied"] = Value::from(268_435_456_u64);
+        artifact["collectionLimit"] = Value::Null;
+    }
+
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads),
+        Err(SccmServerIntakeError::ManifestLimitExceeded),
+        "aggregate copied-byte claims stay bounded even before payload validation"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -52,6 +52,21 @@ fn load_expected(scenario: &str) -> Value {
     serde_json::from_str(&json).expect("expected intake output is valid JSON")
 }
 
+fn intake_scenarios() -> Vec<String> {
+    let mut scenarios = std::fs::read_dir(intake_root())
+        .expect("intake fixture root is readable")
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().join("expected.json").is_file())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    scenarios.sort();
+    assert!(
+        !scenarios.is_empty(),
+        "the intake fixture root must contain committed expected.json oracles"
+    );
+    scenarios
+}
+
 fn opaque_handle(prefix: &str, ordinal: usize) -> String {
     format!("{prefix}{ordinal:064x}")
 }
@@ -186,9 +201,21 @@ fn assert_collision_contract(scenario: &str, expected: &Value, actual: &Value) {
         .expect("collision assertions are an object")
     {
         match key.as_str() {
-            "sameBasename" => assert!(artifacts
-                .iter()
-                .all(|artifact| { artifact["originalBasename"].as_str() == value.as_str() })),
+            "sameBasename" => {
+                let expected_basename = value
+                    .as_str()
+                    .expect("sameBasename expectation is a string");
+                let actual_basenames = artifacts
+                    .iter()
+                    .map(|artifact| artifact["originalBasename"].as_str())
+                    .collect::<Vec<_>>();
+                assert!(
+                    actual_basenames
+                        .iter()
+                        .all(|basename| *basename == Some(expected_basename)),
+                    "{scenario}: expected every basename to be {expected_basename:?}, got {actual_basenames:?}"
+                );
+            }
             "distinctPathFingerprints" => {
                 let fingerprints = artifacts
                     .iter()
@@ -411,12 +438,31 @@ fn assert_remaining_expected_contracts(
             }
             "crossBundleArtifactIdReuseAllowed" => {
                 assert_eq!(value, true);
-                let repeated = assess_server_intake(manifest_json, payloads)
-                    .expect("a separate assessment may reuse manifest-scoped IDs");
+                let mut second_manifest = manifest_value(manifest_json);
+                second_manifest["topology"]["captureHost"] =
+                    if second_manifest["syntheticFixture"] == true {
+                        Value::String("LAB-MP01".to_owned())
+                    } else {
+                        Value::String(opaque_handle("cmtraceopen.host.sha256.v1:", 999))
+                    };
+                let repeated =
+                    assess_server_intake(&serialize_manifest(&second_manifest), payloads)
+                        .expect("a distinct bundle may reuse manifest-scoped IDs");
+                let repeated = serde_json::to_value(repeated).expect("repeat serializes");
                 assert_eq!(
-                    serde_json::to_value(repeated).expect("repeat serializes"),
-                    *actual
+                    repeated["artifacts"]
+                        .as_array()
+                        .expect("repeat artifacts are an array")
+                        .iter()
+                        .map(|artifact| artifact["artifactId"].clone())
+                        .collect::<Vec<_>>(),
+                    actual_artifacts
+                        .iter()
+                        .map(|artifact| artifact["artifactId"].clone())
+                        .collect::<Vec<_>>(),
+                    "{scenario}: distinct bundles may reuse manifest-scoped IDs"
                 );
+                assert_ne!(repeated["topology"], actual["topology"]);
             }
             "deterministicEvidenceIds" => {
                 assert_eq!(value, true);
@@ -1424,12 +1470,9 @@ fn server_intake_expected_oracle_has_no_unhandled_contract_keys() {
     .into_iter()
     .map(str::to_owned)
     .collect::<BTreeSet<_>>();
-    let all_expected = std::fs::read_dir(intake_root())
-        .expect("intake fixture root is readable")
-        .filter_map(Result::ok)
-        .filter(|entry| entry.path().join("expected.json").is_file())
-        .flat_map(|entry| {
-            let scenario = entry.file_name().to_string_lossy().into_owned();
+    let all_expected = intake_scenarios()
+        .into_iter()
+        .flat_map(|scenario| {
             load_expected(&scenario)
                 .as_object()
                 .expect("expected contract is an object")
@@ -1453,13 +1496,7 @@ fn server_intake_expected_oracles_do_not_claim_native_collection_acceptance() {
         "neitherOverwritten",
     ]);
 
-    for entry in std::fs::read_dir(intake_root()).expect("intake fixture root is readable") {
-        let entry = entry.expect("fixture directory entry is readable");
-        let expected_path = entry.path().join("expected.json");
-        if !expected_path.is_file() {
-            continue;
-        }
-        let scenario = entry.file_name().to_string_lossy().into_owned();
+    for scenario in intake_scenarios() {
         let expected = load_expected(&scenario);
         let asserted_collision_keys = expected["collisionAssertions"]
             .as_object()
@@ -1497,9 +1534,20 @@ fn server_intake_rejects_ambiguous_retained_unknown_rotations() {
 fn server_intake_bounds_each_declared_artifact_limit() {
     let (manifest_json, payloads) = bounded_manifest(1, 268_435_457);
 
-    assert!(
-        assess_server_intake(&manifest_json, &payloads).is_err(),
+    assert_eq!(
+        assess_server_intake(&manifest_json, &payloads),
+        Err(SccmServerIntakeError::ManifestLimitExceeded),
         "a single artifact may not declare more than 256 MiB"
+    );
+}
+
+#[test]
+fn server_intake_accepts_a_manifest_within_all_resource_limits() {
+    let (manifest_json, payloads) = bounded_manifest(1, 4_096);
+
+    assert!(
+        assess_server_intake(&manifest_json, &payloads).is_ok(),
+        "the bounded-manifest helper must represent a valid baseline"
     );
 }
 
@@ -1507,8 +1555,9 @@ fn server_intake_bounds_each_declared_artifact_limit() {
 fn server_intake_bounds_manifest_artifact_count() {
     let (manifest_json, payloads) = bounded_manifest(513, 4_096);
 
-    assert!(
-        assess_server_intake(&manifest_json, &payloads).is_err(),
+    assert_eq!(
+        assess_server_intake(&manifest_json, &payloads),
+        Err(SccmServerIntakeError::ManifestLimitExceeded),
         "a manifest may not force unbounded per-artifact work"
     );
 }
@@ -1517,8 +1566,9 @@ fn server_intake_bounds_manifest_artifact_count() {
 fn server_intake_bounds_aggregate_declared_bytes() {
     let (manifest_json, payloads) = bounded_manifest(5, 268_435_456);
 
-    assert!(
-        assess_server_intake(&manifest_json, &payloads).is_err(),
+    assert_eq!(
+        assess_server_intake(&manifest_json, &payloads),
+        Err(SccmServerIntakeError::ManifestLimitExceeded),
         "aggregate declared collection work may not exceed 1 GiB"
     );
 }
@@ -1581,15 +1631,7 @@ fn server_intake_requires_producer_host_for_declared_sources() {
 
 #[test]
 fn server_intake_exercises_committed_expected_contracts() {
-    let mut scenarios = std::fs::read_dir(intake_root())
-        .expect("intake fixture root is readable")
-        .filter_map(Result::ok)
-        .filter(|entry| entry.path().join("expected.json").is_file())
-        .map(|entry| entry.file_name().to_string_lossy().into_owned())
-        .collect::<Vec<_>>();
-    scenarios.sort();
-
-    for scenario in scenarios {
+    for scenario in intake_scenarios() {
         let expected = load_expected(&scenario);
         let (manifest_json, payloads) = load_bundle(&scenario);
         let assessment = assess_server_intake(&manifest_json, &payloads)
@@ -1601,22 +1643,46 @@ fn server_intake_exercises_committed_expected_contracts() {
             "{scenario}: expected contract version"
         );
 
-        for key in [
-            "canonicalArtifactIds",
-            "canonicalRotationArtifactIds",
-            "retainedUnclassifiedArtifactIds",
-        ] {
-            if let Some(expected_ids) = expected.get(key) {
-                let actual_ids = Value::Array(
-                    actual["artifacts"]
-                        .as_array()
-                        .expect("assessment artifacts are an array")
-                        .iter()
-                        .map(|artifact| artifact["artifactId"].clone())
-                        .collect(),
-                );
-                assert_eq!(actual_ids, *expected_ids, "{scenario}: {key}");
-            }
+        let actual_artifacts = actual["artifacts"]
+            .as_array()
+            .expect("assessment artifacts are an array");
+        if let Some(expected_ids) = expected.get("canonicalArtifactIds") {
+            let actual_ids = Value::Array(
+                actual_artifacts
+                    .iter()
+                    .map(|artifact| artifact["artifactId"].clone())
+                    .collect(),
+            );
+            assert_eq!(
+                actual_ids, *expected_ids,
+                "{scenario}: canonicalArtifactIds"
+            );
+        }
+        if let Some(expected_ids) = expected.get("canonicalRotationArtifactIds") {
+            let actual_ids = Value::Array(
+                actual_artifacts
+                    .iter()
+                    .filter(|artifact| !artifact["rotation"].is_null())
+                    .map(|artifact| artifact["artifactId"].clone())
+                    .collect(),
+            );
+            assert_eq!(
+                actual_ids, *expected_ids,
+                "{scenario}: canonicalRotationArtifactIds"
+            );
+        }
+        if let Some(expected_ids) = expected.get("retainedUnclassifiedArtifactIds") {
+            let actual_ids = Value::Array(
+                actual_artifacts
+                    .iter()
+                    .filter(|artifact| artifact["producerRole"] == "unclassified")
+                    .map(|artifact| artifact["artifactId"].clone())
+                    .collect(),
+            );
+            assert_eq!(
+                actual_ids, *expected_ids,
+                "{scenario}: retainedUnclassifiedArtifactIds"
+            );
         }
 
         let expected_coverage = expected["coverage"]
@@ -1737,10 +1803,18 @@ fn server_intake_exercises_committed_expected_contracts() {
                         .expect("logicalRecordCount is an integer"),
                     "{scenario}: logical record count"
                 );
-                if let Some(line_range) = expected_row.get("lineRange") {
-                    assert_eq!(records[0]["reference"]["lineStart"], line_range["start"]);
-                    assert_eq!(records[0]["reference"]["lineEnd"], line_range["end"]);
-                }
+                let line_range = &expected_row["lineRange"];
+                let first = records.first().unwrap_or_else(|| {
+                    panic!("{scenario}: {artifact_id} has no evidence record for lineRange")
+                });
+                assert_eq!(
+                    first["reference"]["lineStart"], line_range["start"],
+                    "{scenario}: {artifact_id} line start"
+                );
+                assert_eq!(
+                    first["reference"]["lineEnd"], line_range["end"],
+                    "{scenario}: {artifact_id} line end"
+                );
                 let keys = expected_row
                     .as_object()
                     .expect("expected evidence row is an object")

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -182,6 +182,106 @@ fn bounded_manifest(
     )
 }
 
+fn opaque_future_role_manifest(
+    capture_state: &str,
+    ordinal: usize,
+) -> (
+    String,
+    Vec<SccmServerArtifactPayload>,
+    String,
+    Option<String>,
+) {
+    let (manifest_json, _) = bounded_manifest(1, 4_096);
+    let mut manifest = manifest_value(&manifest_json);
+    let role_digest = format!("{ordinal:064x}");
+    let source_digest = format!("{:064x}", ordinal + 1);
+    let basename_digest = format!("{:064x}", ordinal + 2);
+    let future_role = format!("cmtraceopen.role.sha256.v1:{role_digest}");
+    let source_id = format!("cmtraceopen.source.sha256.v1:{source_digest}");
+    let source_kind = opaque_handle("cmtraceopen.source-kind.sha256.v1:", ordinal + 3);
+    let original_basename = format!("cmtraceopen.basename.sha256.v1:{basename_digest}");
+    manifest["topology"]["rolesObserved"] = json!(["managementPoint", future_role]);
+
+    let artifact = &mut manifest["artifacts"][0];
+    let artifact_id = artifact["artifactId"]
+        .as_str()
+        .expect("bounded artifact ID is a string")
+        .to_owned();
+    artifact["producerRole"] = Value::String(future_role.clone());
+    artifact["producerHostHandle"] =
+        Value::String(opaque_handle("cmtraceopen.host.sha256.v1:", ordinal + 4));
+    artifact["sourceId"] = Value::String(source_id);
+    artifact["sourceKind"] = Value::String(source_kind);
+    artifact["sourceVersion"] = Value::Null;
+    artifact["originalPath"] = Value::String(opaque_handle(
+        "cmtraceopen.original-path.sha256.v1:",
+        ordinal + 5,
+    ));
+    artifact["originalBasename"] = Value::String(original_basename);
+    artifact["configuredPathProvenance"] = json!({
+        "state": "supplied",
+        "pathFingerprint": opaque_handle("cmtraceopen.path.sha256.v1:", ordinal + 6),
+    });
+    artifact["captureState"] = Value::String(capture_state.to_owned());
+    artifact["collectionDetail"] = Value::Null;
+    artifact["skipReason"] = Value::Null;
+    artifact["unsupportedReason"] = Value::Null;
+    artifact["truncated"] = Value::Null;
+    artifact["fragmentComplete"] = Value::Null;
+
+    let (payloads, relative_path) = if capture_state == "capped" {
+        let bytes = vec![b'x'; 16];
+        let relative_path = format!(
+            "evidence/sccm/server/role-{role_digest}/source-{source_digest}/current/basename-{basename_digest}"
+        );
+        artifact["rotation"] = json!({
+            "kind": "current",
+            "lineageId": opaque_handle("cmtraceopen.lineage.sha256.v1:", ordinal + 7),
+        });
+        artifact["encoding"] = Value::String("utf-8".to_owned());
+        artifact["collectionLimit"] = json!({ "byteLimit": 16, "limitApplied": true });
+        artifact["bytesCopied"] = Value::from(16);
+        artifact["truncated"] = Value::Bool(true);
+        artifact["fragmentComplete"] = Value::Bool(false);
+        artifact["relativePath"] = Value::String(relative_path.clone());
+        (
+            vec![SccmServerArtifactPayload {
+                manifest_artifact_id: artifact_id,
+                bytes,
+            }],
+            Some(relative_path),
+        )
+    } else {
+        artifact["rotation"] = json!({
+            "kind": "none",
+            "lineageId": opaque_handle("cmtraceopen.lineage.sha256.v1:", ordinal + 7),
+        });
+        artifact["encoding"] = Value::Null;
+        artifact["collectionLimit"] = Value::Null;
+        artifact["bytesCopied"] = Value::from(0);
+        artifact["relativePath"] = Value::Null;
+        if capture_state == "accessDenied" {
+            artifact["collectionDetail"] = Value::String(opaque_handle(
+                "cmtraceopen.collection-detail.sha256.v1:",
+                ordinal + 8,
+            ));
+        } else if capture_state == "unsupported" {
+            artifact["unsupportedReason"] = Value::String(opaque_handle(
+                "cmtraceopen.unsupported-reason.sha256.v1:",
+                ordinal + 8,
+            ));
+        }
+        (Vec::new(), None)
+    };
+
+    (
+        serialize_manifest(&manifest),
+        payloads,
+        future_role,
+        relative_path,
+    )
+}
+
 fn assert_unsafe_mutation_is_rejected(
     scenario: &str,
     marker: &str,
@@ -1511,6 +1611,55 @@ fn server_manifest_version_gate_precedes_v1_extension_validation() {
 }
 
 #[test]
+fn server_manifest_known_metadata_errors_route_to_manifest_scope() {
+    let (manifest_json, payloads) = load_bundle("complete-multi-role");
+    let mut wrong_results = Vec::new();
+
+    for case in [
+        "missingPrivacy",
+        "invalidPrivacySynthetic",
+        "invalidPrivacyRawPaths",
+        "missingProposalOnly",
+        "invalidProposalOnly",
+        "invalidInputOrderDeclaration",
+    ] {
+        let mut manifest = manifest_value(&manifest_json);
+        match case {
+            "missingPrivacy" => {
+                manifest
+                    .as_object_mut()
+                    .expect("manifest is an object")
+                    .remove("privacy");
+            }
+            "invalidPrivacySynthetic" => manifest["privacy"]["synthetic"] = Value::Bool(false),
+            "invalidPrivacyRawPaths" => {
+                manifest["privacy"]["rawPaths"] = Value::String("raw".to_owned());
+            }
+            "missingProposalOnly" => {
+                manifest
+                    .as_object_mut()
+                    .expect("manifest is an object")
+                    .remove("proposalOnly");
+            }
+            "invalidProposalOnly" => manifest["proposalOnly"] = Value::Bool(false),
+            "invalidInputOrderDeclaration" => {
+                manifest["inputOrderIsDeliberatelyUnsorted"] = Value::Bool(false);
+            }
+            _ => unreachable!(),
+        }
+        let actual = assess_server_intake(&serialize_manifest(&manifest), &payloads);
+        if actual != Err(SccmServerIntakeError::MalformedManifest) {
+            wrong_results.push((case, actual));
+        }
+    }
+
+    assert!(
+        wrong_results.is_empty(),
+        "manifest/privacy known-field errors must stay in manifest scope: {wrong_results:?}"
+    );
+}
+
+#[test]
 fn server_manifest_v1_rejects_unversioned_or_nonopaque_unknown_fields() {
     let (manifest_json, payloads) = bounded_manifest(1, 4_096);
 
@@ -1832,6 +1981,92 @@ fn server_intake_retains_only_opaque_future_roles_as_unsupported_coverage() {
 }
 
 #[test]
+fn server_intake_retains_opaque_future_roles_across_conservative_coverage_states() {
+    let mut failures = Vec::new();
+
+    for (wire_state, expected_state, ordinal) in [
+        ("absent", SccmCoverageState::Absent, 101),
+        ("accessDenied", SccmCoverageState::AccessDenied, 102),
+        ("capped", SccmCoverageState::Capped, 103),
+        ("unsupported", SccmCoverageState::Unsupported, 104),
+    ] {
+        let (manifest_json, payloads, future_role, expected_relative_path) =
+            opaque_future_role_manifest(wire_state, ordinal);
+        let result = (|| -> Result<(), String> {
+            let assessment = assess_server_intake(&manifest_json, &payloads)
+                .map_err(|error| format!("intake rejected the state: {error:?}"))?;
+            let expected_role = SccmRole::Unknown(future_role.clone());
+            if !assessment.topology.roles_observed.contains(&expected_role) {
+                return Err("future role was not retained in topology".to_owned());
+            }
+            let artifact = assessment
+                .artifacts
+                .iter()
+                .find(|artifact| artifact.producer_role == expected_role)
+                .ok_or_else(|| "future-role artifact was not retained".to_owned())?;
+            if artifact.state != expected_state {
+                return Err(format!(
+                    "coverage changed from {expected_state:?} to {:?}",
+                    artifact.state
+                ));
+            }
+            if artifact.parser_eligible {
+                return Err("future-role artifact became parser eligible".to_owned());
+            }
+            if artifact.relative_path != expected_relative_path {
+                return Err(format!(
+                    "relative path mismatch: {:?}",
+                    artifact.relative_path
+                ));
+            }
+            if expected_state == SccmCoverageState::Capped {
+                let provenance = artifact
+                    .capture_provenance
+                    .as_ref()
+                    .ok_or_else(|| "capped artifact lost capture provenance".to_owned())?;
+                if provenance.schema_version != 1
+                    || provenance.encoding != "utf-8"
+                    || provenance.byte_limit != 16
+                    || !provenance.limit_applied
+                    || artifact.bytes_copied != 16
+                    || artifact.truncated != Some(true)
+                    || artifact.fragment_complete != Some(false)
+                    || artifact.content_sha256.is_none()
+                {
+                    return Err(format!("capped provenance was incoherent: {artifact:?}"));
+                }
+            } else if artifact.capture_provenance.is_some()
+                || artifact.content_sha256.is_some()
+                || artifact.bytes_copied != 0
+            {
+                return Err(format!(
+                    "nonphysical state retained physical provenance: {artifact:?}"
+                ));
+            }
+            if assessment.coverage.len() != 1
+                || assessment.coverage[0].state != expected_state
+                || !assessment.evidence.is_empty()
+                || !assessment.findings.is_empty()
+                || !assessment.next_artifact_requests.is_empty()
+            {
+                return Err(format!(
+                    "future-role state influenced diagnostics: {assessment:?}"
+                ));
+            }
+            Ok(())
+        })();
+        if let Err(error) = result {
+            failures.push((wire_state, error));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "future-role coverage states must remain inert and exact: {failures:?}"
+    );
+}
+
+#[test]
 fn server_intake_rejects_identity_bearing_future_roles() {
     let (manifest_json, _) = bounded_manifest(1, 4_096);
     let mut manifest = manifest_value(&manifest_json);
@@ -1852,7 +2087,7 @@ fn server_intake_rejects_identity_bearing_future_roles() {
 }
 
 #[test]
-fn server_intake_rejects_future_roles_without_unsupported_capture() {
+fn server_intake_rejects_future_topology_roles_without_a_matching_artifact() {
     let (manifest_json, payloads) = bounded_manifest(1, 4_096);
     let mut manifest = manifest_value(&manifest_json);
     manifest["topology"]["rolesObserved"] = json!([
@@ -1860,9 +2095,23 @@ fn server_intake_rejects_future_roles_without_unsupported_capture() {
         opaque_handle("cmtraceopen.role.sha256.v1:", 10),
     ]);
 
-    assert!(
-        assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
-        "future roles are valid only when retained by an unsupported capture"
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads),
+        Err(SccmServerIntakeError::InvalidTopology),
+        "every future topology role must have retained artifact provenance"
+    );
+}
+
+#[test]
+fn server_intake_rejects_future_role_artifacts_missing_from_topology() {
+    let (manifest_json, payloads, _, _) = opaque_future_role_manifest("unsupported", 105);
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["topology"]["rolesObserved"] = json!(["managementPoint"]);
+
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads),
+        Err(SccmServerIntakeError::InvalidArtifact),
+        "future producer provenance must be declared by topology"
     );
 }
 


### PR DESCRIPTION
## What changed

This follow-up hardens the pure SCCM Server intake contract already integrated for issue #335.

- bounds manifest, artifact, payload, and opaque-extension intake
- validates and retains only versioned opaque forward-compatible fields
- preserves future server-role coverage without letting unknown roles enter parsing, evidence, findings, or artifact requests
- binds role, topology, source, path, rotation, payload, and collision provenance
- routes malformed known metadata to the correct manifest error boundary
- keeps production path and identity provenance opaque
- adds adversarial fixtures for malformed fields, duplicate identities, future roles, payload limits, rotation, topology, and deterministic output

## Why

Independent review of the earlier server-intake slice found that forward-compatible fields were either rejected too broadly or could carry unsafe semantics, metadata errors were mis-scoped, and future roles could not preserve real coverage states. This correction keeps the reader tolerant only through a narrow, versioned, privacy-safe opaque form while remaining evidence-first and conservative.

## Validation

- `cargo test --locked -p cmtraceopen-parser --test sccm_server_intake` — 56 passed
- `cargo test --locked -p cmtraceopen-parser --test sccm_spine_contract` — 161 passed
- `cargo test --locked -p cmtraceopen-parser` — passed
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings` — passed
- Rust 1.88.0 `cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown` — passed
- changed-file `rustfmt --check` — passed
- `git diff --check d1bb525b4462b4ea5e2f1426be23568ca469cc3f..ceb487e60d9b9d1de635c9eef5d83a054ffa3e2d` — passed
- independent full-range no-edit review — GO
- CodeRabbit exact final delta — no findings

Repository-wide `cargo fmt --check --all` still reports pre-existing unrelated ESP/Tauri formatting drift identically at the base commit; this range does not change those files.

No native server collection or live Windows acceptance is claimed here.

Refs #335 and #317.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for safely preserving opaque extension data across SCCM server intake records.
  * Added SHA-256 checksums and relative paths to artifact provenance details.
  * Added support for multiple text encodings, unknown identifiers, and future artifact roles.
  * Added deterministic ordering and access to extension and privacy-related metadata.

* **Bug Fixes**
  * Improved validation for malformed metadata, duplicate fields, unsafe paths, and inconsistent artifact configuration.
  * Added safeguards against oversized manifests, artifacts, payloads, and extension data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->