### PR TITLE
fix(sccm): harden client intake and CCM ambiguity (#319)

### DIFF
--- a/crates/cmtraceopen-parser/src/parser/ccm.rs
+++ b/crates/cmtraceopen-parser/src/parser/ccm.rs
@@ -14,6 +14,8 @@ use super::severity::detect_severity_from_text;
 use crate::models::log_entry::{LogEntry, LogFormat, ParserSpecialization, Severity};
 use std::sync::OnceLock;
 
+const CCM_RECORD_OPENER: &str = "<![LOG[";
+
 /// Compiled regex matching a complete CCM log line.
 ///
 /// Based on the binary's scanf pattern:
@@ -377,12 +379,36 @@ fn scan_ccm_content(content: &str, file_path: &str, mode: CcmScanMode) -> CcmSca
     let mut errors = 0u32;
     let mut id_counter = 0u64;
     let mut cursor = 0usize;
+    let mut search_cursor = 0usize;
     let mut matched_any = false;
 
-    for caps in ccm_re().captures_iter(content) {
-        let Some(full_match) = caps.get(0) else {
+    while let Some(caps) = ccm_re().captures_at(content, search_cursor) {
+        let full_match = caps
+            .get(0)
+            .expect("CCM regex captures always include the full match");
+
+        if newest_nested_opener(content, full_match.start(), full_match.end()).is_some()
+            && mode == CcmScanMode::SccmEvidence
+        {
+            // A line-start opener inside a complete-looking multiline record
+            // is byte-for-byte ambiguous: it can be a literal message token
+            // or a recovery boundary after partial input. SCCM evidence must
+            // not promote either interpretation. The public projection keeps
+            // the legacy full-match result to preserve LogEntry compatibility.
+            push_unmatched_plain(
+                &content[cursor..full_match.end()],
+                cursor,
+                &line_starts,
+                file_path,
+                &mut records,
+                &mut id_counter,
+                &mut errors,
+            );
+            cursor = full_match.end();
+            search_cursor = full_match.end();
+            matched_any = true;
             continue;
-        };
+        }
 
         // Emit unmatched text between the previous match and this one
         push_unmatched_plain(
@@ -426,6 +452,7 @@ fn scan_ccm_content(content: &str, file_path: &str, mode: CcmScanMode) -> CcmSca
         }
 
         cursor = full_match.end();
+        search_cursor = full_match.end();
         matched_any = true;
     }
 
@@ -460,6 +487,28 @@ fn scan_ccm_content(content: &str, file_path: &str, mode: CcmScanMode) -> CcmSca
     }
 
     CcmScan { records, errors }
+}
+
+fn newest_nested_opener(
+    content: &str,
+    full_match_start: usize,
+    full_match_end: usize,
+) -> Option<usize> {
+    // Only physical-line openers can delimit recovery records. Scan newest
+    // first so an adversarial run of partial openers is discarded in one pass.
+    let nested_search_start = full_match_start.checked_add(CCM_RECORD_OPENER.len())?;
+    content
+        .get(nested_search_start..full_match_end)?
+        .rmatch_indices(CCM_RECORD_OPENER)
+        .find_map(|(offset, _)| {
+            let absolute = nested_search_start + offset;
+            let starts_logical_line = absolute == 0
+                || content
+                    .as_bytes()
+                    .get(absolute - 1)
+                    .is_some_and(|previous| matches!(previous, b'\n' | b'\r'));
+            starts_logical_line.then_some(absolute)
+        })
 }
 
 /// Parse named captures from a CCM regex match into a CcmParsed struct.
@@ -1009,6 +1058,96 @@ mod tests {
             CcmTimestampParseState::NormalizedUtc
         );
         assert!(records[0].timestamp.utc_millis.is_some());
+    }
+
+    #[test]
+    fn logical_scanner_treats_line_start_opener_inside_multiline_message_as_ambiguous() {
+        for newline in ["\n", "\r\n"] {
+            let text = format!(
+                concat!(
+                    "<![LOG[first line{newline}",
+                    "<![LOG[literal at continuation start]LOG]!>",
+                    "<time=\"10:00:00.000-240\" date=\"07-30-2026\" ",
+                    "component=\"PolicyAgent\" context=\"\" type=\"1\" thread=\"42\">"
+                ),
+                newline = newline,
+            );
+
+            assert!(
+                scan_logical_records(&text, "PolicyAgent.log").is_empty(),
+                "{newline:?} physical-line ambiguity must remain coverage-only"
+            );
+        }
+    }
+
+    #[test]
+    fn public_projection_keeps_multiline_line_start_literal_opener_as_one_log_entry() {
+        for newline in ["\n", "\r\n"] {
+            let text = format!(
+                concat!(
+                    "<![LOG[first line{newline}",
+                    "<![LOG[literal at continuation start]LOG]!>",
+                    "<time=\"10:00:00.000-240\" date=\"07-30-2026\" ",
+                    "component=\"PolicyAgent\" context=\"\" type=\"1\" thread=\"42\">"
+                ),
+                newline = newline,
+            );
+
+            let (entries, errors) = parse_content(&text, "PolicyAgent.log", None);
+
+            assert_eq!(errors, 0, "{newline:?} public parse must remain compatible");
+            assert_eq!(entries.len(), 1, "{newline:?} must remain one LogEntry");
+            assert_eq!(entries[0].format, LogFormat::Ccm);
+            assert_eq!(
+                entries[0].message,
+                format!("first line{newline}<![LOG[literal at continuation start")
+            );
+        }
+    }
+
+    #[test]
+    fn logical_scanner_keeps_same_line_literal_opener_in_one_complete_record() {
+        let text = concat!(
+            "<![LOG[Diagnostic text retained a literal <![LOG[ token]LOG]!>",
+            "<time=\"10:00:00.000-240\" date=\"07-30-2026\" ",
+            "component=\"PolicyAgent\" context=\"\" type=\"1\" thread=\"42\">"
+        );
+
+        let records = scan_logical_records(text, "PolicyAgent.log");
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].entry.message,
+            "Diagnostic text retained a literal <![LOG[ token"
+        );
+        assert_eq!(records[0].line_start, 1);
+        assert_eq!(records[0].line_end, 1);
+    }
+
+    #[test]
+    fn ambiguity_recovery_selects_the_newest_physical_line_opener() {
+        let partial_prefix = "<![LOG[partial\n".repeat(4_096);
+        let text = format!(
+            concat!(
+                "{partial_prefix}<![LOG[complete record]LOG]!><time=\"10:00:00.000-240\" ",
+                "date=\"07-30-2026\" component=\"PolicyAgent\" context=\"\" ",
+                "type=\"1\" thread=\"42\">"
+            ),
+            partial_prefix = partial_prefix,
+        );
+        let full_match = ccm_re()
+            .find(&text)
+            .expect("the partial prefix and terminal close form one complete-looking match");
+
+        assert_eq!(
+            newest_nested_opener(&text, full_match.start(), full_match.end()),
+            text.rfind("<![LOG["),
+            "recovery must jump to the newest nested opener in one scan"
+        );
+        assert!(
+            scan_logical_records(&text, "PolicyAgent.log").is_empty(),
+            "the adversarial ambiguous segment must remain coverage-only"
+        );
     }
 
     fn logical_record_for_time_tail(tail: &str) -> CcmLogicalRecord {

--- a/crates/cmtraceopen-parser/src/parser/ccm.rs
+++ b/crates/cmtraceopen-parser/src/parser/ccm.rs
@@ -387,7 +387,11 @@ fn scan_ccm_content(content: &str, file_path: &str, mode: CcmScanMode) -> CcmSca
             .get(0)
             .expect("CCM regex captures always include the full match");
 
-        if newest_nested_opener(content, full_match.start(), full_match.end()).is_some()
+        let message_end = caps
+            .name("msg")
+            .expect("complete CCM matches always include the message capture")
+            .end();
+        if newest_nested_opener(content, full_match.start(), message_end).is_some()
             && mode == CcmScanMode::SccmEvidence
         {
             // A line-start opener inside a complete-looking multiline record
@@ -492,13 +496,15 @@ fn scan_ccm_content(content: &str, file_path: &str, mode: CcmScanMode) -> CcmSca
 fn newest_nested_opener(
     content: &str,
     full_match_start: usize,
-    full_match_end: usize,
+    message_end: usize,
 ) -> Option<usize> {
-    // Only physical-line openers can delimit recovery records. Scan newest
-    // first so an adversarial run of partial openers is discarded in one pass.
+    // Only physical-line openers inside the message can delimit recovery
+    // records. Attribute values are outside the raw CCM payload and may
+    // contain literal opener text. Scan newest first so an adversarial run of
+    // partial message openers is discarded in one pass.
     let nested_search_start = full_match_start.checked_add(CCM_RECORD_OPENER.len())?;
     content
-        .get(nested_search_start..full_match_end)?
+        .get(nested_search_start..message_end)?
         .rmatch_indices(CCM_RECORD_OPENER)
         .find_map(|(offset, _)| {
             let absolute = nested_search_start + offset;
@@ -1122,6 +1128,25 @@ mod tests {
         );
         assert_eq!(records[0].line_start, 1);
         assert_eq!(records[0].line_end, 1);
+    }
+
+    #[test]
+    fn logical_scanner_ignores_line_start_opener_inside_attribute_value() {
+        let text = concat!(
+            "<![LOG[Policy request completed]LOG]!>",
+            "<time=\"10:00:00.000-240\" date=\"07-30-2026\" ",
+            "component=\"PolicyAgent\" context=\"diagnostic continuation\n",
+            "<![LOG[literal attribute token\" type=\"1\" thread=\"42\">"
+        );
+
+        let records = scan_logical_records(text, "PolicyAgent.log");
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].entry.message, "Policy request completed");
+        assert_eq!(
+            records[0].context.as_deref(),
+            Some("diagnostic continuation\n<![LOG[literal attribute token")
+        );
     }
 
     #[test]

--- a/crates/cmtraceopen-parser/src/sccm/client/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/client/intake.rs
@@ -239,7 +239,7 @@ where
                 .is_some_and(|size| size > MAX_SCCM_CLIENT_INTAKE_ARTIFACTS)
             {
                 return Err(A::Error::custom(
-                    "client intake artifact count exceeds the supported limit",
+                    SccmClientIntakeError::ArtifactLimitExceeded,
                 ));
             }
 
@@ -257,7 +257,7 @@ where
 
             if sequence.next_element::<IgnoredAny>()?.is_some() {
                 return Err(A::Error::custom(
-                    "client intake artifact count exceeds the supported limit",
+                    SccmClientIntakeError::ArtifactLimitExceeded,
                 ));
             }
 

--- a/crates/cmtraceopen-parser/src/sccm/client/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/client/intake.rs
@@ -19,7 +19,10 @@ use crate::sccm::{
 
 /// Maximum artifact declarations admitted by one SCCM client intake bundle.
 ///
-/// This is the shared v1 manifest ceiling. Validate it before allocating
+/// This is the authoritative v1 ceiling for both pure client intake and the
+/// native SCCM client manifest/capture boundary. Native readers, writers, and
+/// collectors must import and reuse this constant rather than define a wider
+/// or otherwise parallel limit. Pure intake validates it before allocating
 /// per-artifact indexes so a malformed bundle cannot turn validation into an
 /// unbounded allocation path.
 pub const MAX_SCCM_CLIENT_INTAKE_ARTIFACTS: usize = 4096;

--- a/crates/cmtraceopen-parser/src/sccm/client/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/client/intake.rs
@@ -1,8 +1,13 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 
 use chrono::{DateTime, SecondsFormat, Utc};
-use serde::{de::Error as _, ser::Error as _, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de::{Error as _, IgnoredAny, SeqAccess, Visitor},
+    ser::Error as _,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use thiserror::Error;
 
 use crate::sccm::catalog::{
@@ -11,6 +16,13 @@ use crate::sccm::catalog::{
 use crate::sccm::{
     SccmArtifact, SccmCoverageState, SccmRole, SccmRotation, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
 };
+
+/// Maximum artifact declarations admitted by one SCCM client intake bundle.
+///
+/// This is the shared v1 manifest ceiling. Validate it before allocating
+/// per-artifact indexes so a malformed bundle cannot turn validation into an
+/// unbounded allocation path.
+pub const MAX_SCCM_CLIENT_INTAKE_ARTIFACTS: usize = 4096;
 
 const MAX_ARTIFACT_ID_CHARS: usize = 160;
 const MAX_BASENAME_CHARS: usize = 160;
@@ -172,10 +184,85 @@ pub struct SccmClientIntakeArtifact {
     pub fragment_complete: Option<bool>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SccmClientIntakeBundle {
     pub artifacts: Vec<SccmClientIntakeArtifact>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SccmClientIntakeBundleWire {
+    #[serde(deserialize_with = "deserialize_bounded_client_artifacts")]
+    artifacts: Vec<SccmClientIntakeArtifact>,
+}
+
+impl<'de> Deserialize<'de> for SccmClientIntakeBundle {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = SccmClientIntakeBundleWire::deserialize(deserializer)?;
+        Ok(Self {
+            artifacts: wire.artifacts,
+        })
+    }
+}
+
+fn deserialize_bounded_client_artifacts<'de, D>(
+    deserializer: D,
+) -> Result<Vec<SccmClientIntakeArtifact>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct BoundedArtifactVisitor;
+
+    impl<'de> Visitor<'de> for BoundedArtifactVisitor {
+        type Value = Vec<SccmClientIntakeArtifact>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                formatter,
+                "at most {MAX_SCCM_CLIENT_INTAKE_ARTIFACTS} SCCM client artifacts"
+            )
+        }
+
+        fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            if sequence
+                .size_hint()
+                .is_some_and(|size| size > MAX_SCCM_CLIENT_INTAKE_ARTIFACTS)
+            {
+                return Err(A::Error::custom(
+                    "client intake artifact count exceeds the supported limit",
+                ));
+            }
+
+            let initial_capacity = sequence
+                .size_hint()
+                .unwrap_or_default()
+                .min(MAX_SCCM_CLIENT_INTAKE_ARTIFACTS);
+            let mut artifacts = Vec::with_capacity(initial_capacity);
+            while artifacts.len() < MAX_SCCM_CLIENT_INTAKE_ARTIFACTS {
+                let Some(artifact) = sequence.next_element()? else {
+                    return Ok(artifacts);
+                };
+                artifacts.push(artifact);
+            }
+
+            if sequence.next_element::<IgnoredAny>()?.is_some() {
+                return Err(A::Error::custom(
+                    "client intake artifact count exceeds the supported limit",
+                ));
+            }
+
+            Ok(artifacts)
+        }
+    }
+
+    deserializer.deserialize_seq(BoundedArtifactVisitor)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -489,6 +576,8 @@ impl SccmClientIntakeAssessment {
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum SccmClientIntakeError {
+    #[error("client intake artifact count exceeds the supported limit")]
+    ArtifactLimitExceeded,
     #[error("client intake artifact identity is empty, unsafe, or too long")]
     InvalidArtifactId,
     #[error("client intake artifact basename is empty, unsafe, or too long")]
@@ -804,6 +893,10 @@ fn unsupported_as_intake_artifact(
 }
 
 fn validate_bundle(bundle: &SccmClientIntakeBundle) -> Result<(), SccmClientIntakeError> {
+    if bundle.artifacts.len() > MAX_SCCM_CLIENT_INTAKE_ARTIFACTS {
+        return Err(SccmClientIntakeError::ArtifactLimitExceeded);
+    }
+
     let mut artifact_ids = BTreeSet::new();
     let mut path_fingerprint_bindings: BTreeMap<String, (Option<String>, String)> = BTreeMap::new();
     let mut rotation_lineage_bindings = BTreeMap::new();

--- a/crates/cmtraceopen-parser/tests/sccm_client_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_intake.rs
@@ -465,6 +465,22 @@ fn intake_wire_rejects_more_than_the_v1_artifact_limit_while_deserializing() {
     );
 }
 
+#[test]
+fn intake_wire_rejects_more_than_the_v1_artifact_limit_from_json_text() {
+    let artifact = synthetic_artifact("wire-limit-text", "PolicyAgent.log");
+    let oversized = serde_json::json!({
+        "artifacts": vec![artifact; MAX_SCCM_CLIENT_INTAKE_ARTIFACTS + 1],
+    });
+    let text = oversized.to_string();
+
+    let error = serde_json::from_str::<SccmClientIntakeBundle>(&text)
+        .expect_err("streaming JSON must reject an oversized artifact sequence");
+    assert!(
+        error.to_string().contains("artifact count exceeds"),
+        "the streaming fallback must report the bounded-contract violation: {error}"
+    );
+}
+
 /// Every assertion that a serialized projection did not leak an identity must
 /// casefold its input and route through this helper. A bare substring check
 /// against the original-case JSON has twice missed a form this covers: the

--- a/crates/cmtraceopen-parser/tests/sccm_client_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_intake.rs
@@ -7,6 +7,7 @@ use cmtraceopen_parser::sccm::{
     SccmClientIntakeArtifact, SccmClientIntakeAssessment, SccmClientIntakeBundle,
     SccmClientIntakeCoverageGap, SccmClientIntakeError, SccmClientIntakeFragment,
     SccmClientUnsupportedArtifact, SccmCoverageState, SccmRole, SccmRotation, SccmUnknownRotation,
+    MAX_SCCM_CLIENT_INTAKE_ARTIFACTS,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -424,6 +425,44 @@ fn synthetic_marker(
     artifact.relative_path = None;
     artifact.fragment_complete = Some(false);
     artifact
+}
+
+#[test]
+fn intake_rejects_more_than_the_v1_artifact_limit_before_validation_indexes() {
+    // Keep the input otherwise invalid (all declarations collide) so this
+    // asserts that the public limit runs before the per-artifact indexes.
+    let duplicate = synthetic_artifact("limit", "PolicyAgent.log");
+    let artifacts = vec![duplicate; MAX_SCCM_CLIENT_INTAKE_ARTIFACTS + 1];
+
+    let error = assess_client_intake(&SccmClientIntakeBundle { artifacts })
+        .expect_err("the v1 client intake artifact ceiling must fail closed");
+
+    assert_eq!(
+        error.to_string(),
+        "client intake artifact count exceeds the supported limit"
+    );
+}
+
+#[test]
+fn intake_wire_rejects_more_than_the_v1_artifact_limit_while_deserializing() {
+    let artifact = serde_json::to_value(synthetic_artifact("wire-limit", "PolicyAgent.log"))
+        .expect("synthetic intake artifact serializes");
+    let boundary = serde_json::json!({
+        "artifacts": vec![artifact.clone(); MAX_SCCM_CLIENT_INTAKE_ARTIFACTS],
+    });
+    let decoded: SccmClientIntakeBundle =
+        serde_json::from_value(boundary).expect("the declared v1 boundary is accepted");
+    assert_eq!(decoded.artifacts.len(), MAX_SCCM_CLIENT_INTAKE_ARTIFACTS);
+
+    let oversized = serde_json::json!({
+        "artifacts": vec![artifact; MAX_SCCM_CLIENT_INTAKE_ARTIFACTS + 1],
+    });
+    let error = serde_json::from_value::<SccmClientIntakeBundle>(oversized)
+        .expect_err("the wire must reject an oversized artifact sequence");
+    assert!(
+        error.to_string().contains("artifact count exceeds"),
+        "the wire must report the bounded-contract violation: {error}"
+    );
 }
 
 /// Every assertion that a serialized projection did not leak an identity must


### PR DESCRIPTION
## Scope

Issue #319 pure hardening only:

- makes `MAX_SCCM_CLIENT_INTAKE_ARTIFACTS` the authoritative 4,096-entry boundary for pure and native client intake;
- rejects oversized direct bundles before validation indexes and oversized wire sequences while deserializing;
- makes nested physical-line CCM openers coverage-only for SCCM evidence;
- preserves the existing public `LogEntry` projection for LF/CRLF multiline messages;
- keeps same-line literal opener text valid and bounds adversarial recovery to one newest-first scan.

The rejected normalized text-payload bridge is deliberately absent. No `ingest.rs` change, native I/O, Windows collection, Tauri command, workflow reducer, or live-lab claim is included.

## Dependency state

Based on reviewed SCCM integration head `0b37e7a842991fd9cc9341f7602cf05186d03587`. This small contract hardening must merge before the native #319 adapter is restacked so native capture imports the single authoritative limit.

## TDD and adversarial matrix

- direct 4,097-item input fails with the limit error before duplicate/identity validation;
- wire 4,096 boundary succeeds and 4,097 fails during sequence deserialization;
- LF and CRLF line-start opener ambiguity produces no SCCM evidence;
- the same input remains one compatible public CCM `LogEntry`;
- same-line literal opener remains one record;
- 4,096 partial openers plus a final close remains coverage-only without restart rescanning.

## Verification

- `cargo test --locked -p cmtraceopen-parser --test sccm_client_intake` — 50 passed
- focused CCM unit tests — 19 passed
- `cargo test --locked -p cmtraceopen-parser` — passed
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings` — passed
- `rustup run 1.88.0 cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown` — passed
- changed-file Rust 1.88 rustfmt — passed
- `git diff --check` — passed
- independent exact-head review — GO
- local CodeRabbit exact-range review — 0 findings

Repository-wide formatting still reports the documented unrelated baseline drift; all three changed files are clean.

## Remaining #319 work

Native discovery/capture is still local and rejected on bounded enumeration, early reader cardinality, raw-path debug/error surfaces, direct-writer Windows ACL validation, and honest rollback failure reporting. Real Windows acceptance remains pending. Keep #319 open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting CCM record openers and recovering from ambiguous nested entries.
  * Limited SCCM client intake bundles to 4,096 artifacts.

* **Bug Fixes**
  * Improved handling of multiline, same-line, and nested opener patterns.
  * Oversized intake bundles are now rejected early with a clear limit-exceeded error.

* **Tests**
  * Added coverage for newline variations, nested opener sequences, artifact-count boundaries, and oversized bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->