### PR TITLE
feat(sccm): preserve client intake capture gaps

### DIFF
--- a/crates/cmtraceopen-parser/src/sccm/client/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/client/intake.rs
@@ -4,8 +4,8 @@ use std::fmt;
 
 use chrono::{DateTime, SecondsFormat, Utc};
 use serde::{
-    de::{Error as _, IgnoredAny, SeqAccess, Visitor},
-    ser::Error as _,
+    de::{DeserializeSeed, Error as _, IgnoredAny, MapAccess, SeqAccess, Visitor},
+    ser::{Error as _, SerializeStruct},
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use thiserror::Error;
@@ -192,8 +192,7 @@ pub struct SccmClientIntakeArtifact {
 /// it never contains a bundle-relative path, bytes, or fragment-boundary
 /// claim. The versioned opaque identity, configured-source fingerprint, and
 /// rotation lineage retain only the provenance needed to prevent collisions.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SccmClientIntakeCaptureGap {
     pub artifact_id: String,
     pub basename: String,
@@ -203,23 +202,87 @@ pub struct SccmClientIntakeCaptureGap {
     pub rotation_lineage: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SccmClientIntakeCaptureGapWire {
+    artifact_id: String,
+    basename: String,
+    rotation: SccmRotation,
+    coverage: SccmCoverageState,
+    path_fingerprint: String,
+    rotation_lineage: String,
+}
+
+impl From<SccmClientIntakeCaptureGapWire> for SccmClientIntakeCaptureGap {
+    fn from(wire: SccmClientIntakeCaptureGapWire) -> Self {
+        Self {
+            artifact_id: wire.artifact_id,
+            basename: wire.basename,
+            rotation: wire.rotation,
+            coverage: wire.coverage,
+            path_fingerprint: wire.path_fingerprint,
+            rotation_lineage: wire.rotation_lineage,
+        }
+    }
+}
+
+impl From<&SccmClientIntakeCaptureGap> for SccmClientIntakeCaptureGapWire {
+    fn from(capture_gap: &SccmClientIntakeCaptureGap) -> Self {
+        Self {
+            artifact_id: capture_gap.artifact_id.clone(),
+            basename: capture_gap.basename.clone(),
+            rotation: capture_gap.rotation.clone(),
+            coverage: capture_gap.coverage.clone(),
+            path_fingerprint: capture_gap.path_fingerprint.clone(),
+            rotation_lineage: capture_gap.rotation_lineage.clone(),
+        }
+    }
+}
+
+impl Serialize for SccmClientIntakeCaptureGap {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        validate_capture_gap_shape(self).map_err(S::Error::custom)?;
+        SccmClientIntakeCaptureGapWire::from(self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SccmClientIntakeCaptureGap {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let capture_gap = Self::from(SccmClientIntakeCaptureGapWire::deserialize(deserializer)?);
+        validate_capture_gap_shape(&capture_gap).map_err(D::Error::custom)?;
+        Ok(capture_gap)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct SccmClientIntakeBundle {
     pub artifacts: Vec<SccmClientIntakeArtifact>,
     /// Additive v1 coverage-only declarations. Empty remains omitted on the
     /// wire so pre-gap bundle JSON round-trips unchanged.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub capture_gaps: Vec<SccmClientIntakeCaptureGap>,
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct SccmClientIntakeBundleWire {
-    #[serde(deserialize_with = "deserialize_bounded_client_artifacts")]
-    artifacts: Vec<SccmClientIntakeArtifact>,
-    #[serde(default, deserialize_with = "deserialize_bounded_client_capture_gaps")]
-    capture_gaps: Vec<SccmClientIntakeCaptureGap>,
+impl Serialize for SccmClientIntakeBundle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        validate_bundle(self).map_err(S::Error::custom)?;
+
+        let field_count = 1 + usize::from(!self.capture_gaps.is_empty());
+        let mut state = serializer.serialize_struct("SccmClientIntakeBundle", field_count)?;
+        state.serialize_field("artifacts", &self.artifacts)?;
+        if !self.capture_gaps.is_empty() {
+            state.serialize_field("captureGaps", &self.capture_gaps)?;
+        }
+        state.end()
+    }
 }
 
 impl<'de> Deserialize<'de> for SccmClientIntakeBundle {
@@ -227,131 +290,176 @@ impl<'de> Deserialize<'de> for SccmClientIntakeBundle {
     where
         D: Deserializer<'de>,
     {
-        let wire = SccmClientIntakeBundleWire::deserialize(deserializer)?;
-        if wire.artifacts.len().saturating_add(wire.capture_gaps.len())
-            > MAX_SCCM_CLIENT_INTAKE_ARTIFACTS
-        {
-            return Err(D::Error::custom(
-                "client intake artifact count exceeds the supported limit",
-            ));
+        const FIELDS: &[&str] = &["artifacts", "captureGaps"];
+        deserializer.deserialize_struct(
+            "SccmClientIntakeBundle",
+            FIELDS,
+            SccmClientIntakeBundleVisitor,
+        )
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(field_identifier, rename_all = "camelCase")]
+enum SccmClientIntakeBundleField {
+    Artifacts,
+    CaptureGaps,
+}
+
+struct SccmClientIntakeBundleVisitor;
+
+impl<'de> Visitor<'de> for SccmClientIntakeBundleVisitor {
+    type Value = SccmClientIntakeBundle;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("an SCCM client intake bundle")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut artifacts = None;
+        let mut capture_gaps = None;
+        let mut remaining = MAX_SCCM_CLIENT_INTAKE_ARTIFACTS;
+
+        while let Some(field) = map.next_key()? {
+            match field {
+                SccmClientIntakeBundleField::Artifacts => {
+                    if artifacts.is_some() {
+                        return Err(A::Error::duplicate_field("artifacts"));
+                    }
+                    let decoded = map.next_value_seed(BoundedArtifactsSeed { limit: remaining })?;
+                    remaining -= decoded.len();
+                    artifacts = Some(decoded);
+                }
+                SccmClientIntakeBundleField::CaptureGaps => {
+                    if capture_gaps.is_some() {
+                        return Err(A::Error::duplicate_field("captureGaps"));
+                    }
+                    let decoded =
+                        map.next_value_seed(BoundedCaptureGapsSeed { limit: remaining })?;
+                    remaining -= decoded.len();
+                    capture_gaps = Some(decoded);
+                }
+            }
         }
-        Ok(Self {
-            artifacts: wire.artifacts,
-            capture_gaps: wire.capture_gaps,
+
+        Ok(SccmClientIntakeBundle {
+            artifacts: artifacts.ok_or_else(|| A::Error::missing_field("artifacts"))?,
+            capture_gaps: capture_gaps.unwrap_or_default(),
         })
     }
 }
 
-fn deserialize_bounded_client_capture_gaps<'de, D>(
-    deserializer: D,
-) -> Result<Vec<SccmClientIntakeCaptureGap>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    struct BoundedCaptureGapVisitor;
-
-    impl<'de> Visitor<'de> for BoundedCaptureGapVisitor {
-        type Value = Vec<SccmClientIntakeCaptureGap>;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(
-                formatter,
-                "at most {MAX_SCCM_CLIENT_INTAKE_ARTIFACTS} SCCM client capture gaps"
-            )
-        }
-
-        fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
-        where
-            A: SeqAccess<'de>,
-        {
-            if sequence
-                .size_hint()
-                .is_some_and(|size| size > MAX_SCCM_CLIENT_INTAKE_ARTIFACTS)
-            {
-                return Err(A::Error::custom(
-                    "client intake capture-gap count exceeds the supported limit",
-                ));
-            }
-
-            let initial_capacity = sequence
-                .size_hint()
-                .unwrap_or_default()
-                .min(MAX_SCCM_CLIENT_INTAKE_ARTIFACTS);
-            let mut capture_gaps = Vec::with_capacity(initial_capacity);
-            while capture_gaps.len() < MAX_SCCM_CLIENT_INTAKE_ARTIFACTS {
-                let Some(capture_gap) = sequence.next_element()? else {
-                    return Ok(capture_gaps);
-                };
-                capture_gaps.push(capture_gap);
-            }
-
-            if sequence.next_element::<IgnoredAny>()?.is_some() {
-                return Err(A::Error::custom(
-                    "client intake capture-gap count exceeds the supported limit",
-                ));
-            }
-
-            Ok(capture_gaps)
-        }
-    }
-
-    deserializer.deserialize_seq(BoundedCaptureGapVisitor)
+struct BoundedCaptureGapsSeed {
+    limit: usize,
 }
 
-fn deserialize_bounded_client_artifacts<'de, D>(
-    deserializer: D,
-) -> Result<Vec<SccmClientIntakeArtifact>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    struct BoundedArtifactVisitor;
+impl<'de> DeserializeSeed<'de> for BoundedCaptureGapsSeed {
+    type Value = Vec<SccmClientIntakeCaptureGap>;
 
-    impl<'de> Visitor<'de> for BoundedArtifactVisitor {
-        type Value = Vec<SccmClientIntakeArtifact>;
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(BoundedCaptureGapVisitor { limit: self.limit })
+    }
+}
 
-        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(
-                formatter,
-                "at most {MAX_SCCM_CLIENT_INTAKE_ARTIFACTS} SCCM client artifacts"
-            )
-        }
+struct BoundedCaptureGapVisitor {
+    limit: usize,
+}
 
-        fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
-        where
-            A: SeqAccess<'de>,
-        {
-            if sequence
-                .size_hint()
-                .is_some_and(|size| size > MAX_SCCM_CLIENT_INTAKE_ARTIFACTS)
-            {
-                return Err(A::Error::custom(
-                    SccmClientIntakeError::ArtifactLimitExceeded,
-                ));
-            }
+impl<'de> Visitor<'de> for BoundedCaptureGapVisitor {
+    type Value = Vec<SccmClientIntakeCaptureGap>;
 
-            let initial_capacity = sequence
-                .size_hint()
-                .unwrap_or_default()
-                .min(MAX_SCCM_CLIENT_INTAKE_ARTIFACTS);
-            let mut artifacts = Vec::with_capacity(initial_capacity);
-            while artifacts.len() < MAX_SCCM_CLIENT_INTAKE_ARTIFACTS {
-                let Some(artifact) = sequence.next_element()? else {
-                    return Ok(artifacts);
-                };
-                artifacts.push(artifact);
-            }
-
-            if sequence.next_element::<IgnoredAny>()?.is_some() {
-                return Err(A::Error::custom(
-                    SccmClientIntakeError::ArtifactLimitExceeded,
-                ));
-            }
-
-            Ok(artifacts)
-        }
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "at most {} SCCM client capture gaps", self.limit)
     }
 
-    deserializer.deserialize_seq(BoundedArtifactVisitor)
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        if sequence.size_hint().is_some_and(|size| size > self.limit) {
+            return Err(A::Error::custom(
+                SccmClientIntakeError::ArtifactLimitExceeded,
+            ));
+        }
+
+        let initial_capacity = sequence.size_hint().unwrap_or_default().min(self.limit);
+        let mut capture_gaps = Vec::with_capacity(initial_capacity);
+        while capture_gaps.len() < self.limit {
+            let Some(capture_gap) = sequence.next_element()? else {
+                return Ok(capture_gaps);
+            };
+            capture_gaps.push(capture_gap);
+        }
+
+        if sequence.next_element::<IgnoredAny>()?.is_some() {
+            return Err(A::Error::custom(
+                SccmClientIntakeError::ArtifactLimitExceeded,
+            ));
+        }
+
+        Ok(capture_gaps)
+    }
+}
+
+struct BoundedArtifactsSeed {
+    limit: usize,
+}
+
+impl<'de> DeserializeSeed<'de> for BoundedArtifactsSeed {
+    type Value = Vec<SccmClientIntakeArtifact>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(BoundedArtifactVisitor { limit: self.limit })
+    }
+}
+
+struct BoundedArtifactVisitor {
+    limit: usize,
+}
+
+impl<'de> Visitor<'de> for BoundedArtifactVisitor {
+    type Value = Vec<SccmClientIntakeArtifact>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "at most {} SCCM client artifacts", self.limit)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        if sequence.size_hint().is_some_and(|size| size > self.limit) {
+            return Err(A::Error::custom(
+                SccmClientIntakeError::ArtifactLimitExceeded,
+            ));
+        }
+
+        let initial_capacity = sequence.size_hint().unwrap_or_default().min(self.limit);
+        let mut artifacts = Vec::with_capacity(initial_capacity);
+        while artifacts.len() < self.limit {
+            let Some(artifact) = sequence.next_element()? else {
+                return Ok(artifacts);
+            };
+            artifacts.push(artifact);
+        }
+
+        if sequence.next_element::<IgnoredAny>()?.is_some() {
+            return Err(A::Error::custom(
+                SccmClientIntakeError::ArtifactLimitExceeded,
+            ));
+        }
+
+        Ok(artifacts)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1020,6 +1128,27 @@ fn unsupported_as_intake_artifact(
     }
 }
 
+fn validate_capture_gap_shape(
+    capture_gap: &SccmClientIntakeCaptureGap,
+) -> Result<(), SccmClientIntakeError> {
+    if !is_safe_artifact_id(&capture_gap.artifact_id)
+        || serde_json::to_value(&capture_gap.rotation).is_err()
+        || !is_safe_unknown_rotation(&capture_gap.rotation)
+        || !is_safe_basename(&capture_gap.basename, &capture_gap.rotation)
+        || !matches!(
+            capture_gap.coverage,
+            SccmCoverageState::Capped | SccmCoverageState::ParseFailed
+        )
+        || !is_safe_path_identity(&capture_gap.path_fingerprint)
+        || !is_safe_rotation_lineage(&capture_gap.rotation_lineage)
+        || matching_groups(&capture_gap.basename, &capture_gap.rotation).is_empty()
+    {
+        return Err(SccmClientIntakeError::InvalidCaptureGap);
+    }
+
+    Ok(())
+}
+
 fn validate_bundle(bundle: &SccmClientIntakeBundle) -> Result<(), SccmClientIntakeError> {
     if bundle
         .artifacts
@@ -1217,20 +1346,7 @@ fn validate_bundle(bundle: &SccmClientIntakeBundle) -> Result<(), SccmClientInta
     }
 
     for capture_gap in &bundle.capture_gaps {
-        if !is_safe_artifact_id(&capture_gap.artifact_id)
-            || serde_json::to_value(&capture_gap.rotation).is_err()
-            || !is_safe_unknown_rotation(&capture_gap.rotation)
-            || !is_safe_basename(&capture_gap.basename, &capture_gap.rotation)
-            || !matches!(
-                capture_gap.coverage,
-                SccmCoverageState::Capped | SccmCoverageState::ParseFailed
-            )
-            || !is_safe_path_identity(&capture_gap.path_fingerprint)
-            || !is_safe_rotation_lineage(&capture_gap.rotation_lineage)
-            || matching_groups(&capture_gap.basename, &capture_gap.rotation).is_empty()
-        {
-            return Err(SccmClientIntakeError::InvalidCaptureGap);
-        }
+        validate_capture_gap_shape(capture_gap)?;
         if !artifact_ids.insert(capture_gap.artifact_id.to_ascii_lowercase()) {
             return Err(SccmClientIntakeError::DuplicateArtifactId);
         }

--- a/crates/cmtraceopen-parser/src/sccm/client/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/client/intake.rs
@@ -345,10 +345,12 @@ impl<'de> Visitor<'de> for SccmClientIntakeBundleVisitor {
             }
         }
 
-        Ok(SccmClientIntakeBundle {
+        let bundle = SccmClientIntakeBundle {
             artifacts: artifacts.ok_or_else(|| A::Error::missing_field("artifacts"))?,
             capture_gaps: capture_gaps.unwrap_or_default(),
-        })
+        };
+        validate_bundle(&bundle).map_err(A::Error::custom)?;
+        Ok(bundle)
     }
 }
 
@@ -706,9 +708,30 @@ struct SccmClientIntakeAssessmentWire {
     groups: Vec<SccmClientIntakeGroupWire>,
     physical_artifacts: Vec<SccmClientIntakeFragmentWire>,
     unsupported_artifacts: Vec<SccmClientUnsupportedArtifactWire>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_bounded_assessment_capture_gaps"
+    )]
     capture_gaps: Vec<SccmClientIntakeCaptureGap>,
     coverage_gaps: Vec<SccmClientIntakeCoverageGapWire>,
+}
+
+fn deserialize_bounded_assessment_capture_gaps<'de, D>(
+    deserializer: D,
+) -> Result<Vec<SccmClientIntakeCaptureGap>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Each assessment capture gap reconstructs one canonical bundle
+    // declaration in `validate_assessment_projection`. Decode no more than
+    // that authoritative shared ceiling; the final projection validation
+    // accounts for physical, nonphysical, unsupported, and gap declarations
+    // together.
+    BoundedCaptureGapsSeed {
+        limit: MAX_SCCM_CLIENT_INTAKE_ARTIFACTS,
+    }
+    .deserialize(deserializer)
 }
 
 impl From<&SccmClientIntakeAssessment> for SccmClientIntakeAssessmentWire {

--- a/crates/cmtraceopen-parser/src/sccm/client/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/client/intake.rs
@@ -187,10 +187,30 @@ pub struct SccmClientIntakeArtifact {
     pub fragment_complete: Option<bool>,
 }
 
+/// A coverage-only declaration for a recognized client source rotation that
+/// was intentionally not retained. This is distinct from a physical artifact:
+/// it never contains a bundle-relative path, bytes, or fragment-boundary
+/// claim. The versioned opaque identity, configured-source fingerprint, and
+/// rotation lineage retain only the provenance needed to prevent collisions.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SccmClientIntakeCaptureGap {
+    pub artifact_id: String,
+    pub basename: String,
+    pub rotation: SccmRotation,
+    pub coverage: SccmCoverageState,
+    pub path_fingerprint: String,
+    pub rotation_lineage: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SccmClientIntakeBundle {
     pub artifacts: Vec<SccmClientIntakeArtifact>,
+    /// Additive v1 coverage-only declarations. Empty remains omitted on the
+    /// wire so pre-gap bundle JSON round-trips unchanged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capture_gaps: Vec<SccmClientIntakeCaptureGap>,
 }
 
 #[derive(Deserialize)]
@@ -198,6 +218,8 @@ pub struct SccmClientIntakeBundle {
 struct SccmClientIntakeBundleWire {
     #[serde(deserialize_with = "deserialize_bounded_client_artifacts")]
     artifacts: Vec<SccmClientIntakeArtifact>,
+    #[serde(default, deserialize_with = "deserialize_bounded_client_capture_gaps")]
+    capture_gaps: Vec<SccmClientIntakeCaptureGap>,
 }
 
 impl<'de> Deserialize<'de> for SccmClientIntakeBundle {
@@ -206,10 +228,74 @@ impl<'de> Deserialize<'de> for SccmClientIntakeBundle {
         D: Deserializer<'de>,
     {
         let wire = SccmClientIntakeBundleWire::deserialize(deserializer)?;
+        if wire.artifacts.len().saturating_add(wire.capture_gaps.len())
+            > MAX_SCCM_CLIENT_INTAKE_ARTIFACTS
+        {
+            return Err(D::Error::custom(
+                "client intake artifact count exceeds the supported limit",
+            ));
+        }
         Ok(Self {
             artifacts: wire.artifacts,
+            capture_gaps: wire.capture_gaps,
         })
     }
+}
+
+fn deserialize_bounded_client_capture_gaps<'de, D>(
+    deserializer: D,
+) -> Result<Vec<SccmClientIntakeCaptureGap>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct BoundedCaptureGapVisitor;
+
+    impl<'de> Visitor<'de> for BoundedCaptureGapVisitor {
+        type Value = Vec<SccmClientIntakeCaptureGap>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                formatter,
+                "at most {MAX_SCCM_CLIENT_INTAKE_ARTIFACTS} SCCM client capture gaps"
+            )
+        }
+
+        fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            if sequence
+                .size_hint()
+                .is_some_and(|size| size > MAX_SCCM_CLIENT_INTAKE_ARTIFACTS)
+            {
+                return Err(A::Error::custom(
+                    "client intake capture-gap count exceeds the supported limit",
+                ));
+            }
+
+            let initial_capacity = sequence
+                .size_hint()
+                .unwrap_or_default()
+                .min(MAX_SCCM_CLIENT_INTAKE_ARTIFACTS);
+            let mut capture_gaps = Vec::with_capacity(initial_capacity);
+            while capture_gaps.len() < MAX_SCCM_CLIENT_INTAKE_ARTIFACTS {
+                let Some(capture_gap) = sequence.next_element()? else {
+                    return Ok(capture_gaps);
+                };
+                capture_gaps.push(capture_gap);
+            }
+
+            if sequence.next_element::<IgnoredAny>()?.is_some() {
+                return Err(A::Error::custom(
+                    "client intake capture-gap count exceeds the supported limit",
+                ));
+            }
+
+            Ok(capture_gaps)
+        }
+    }
+
+    deserializer.deserialize_seq(BoundedCaptureGapVisitor)
 }
 
 fn deserialize_bounded_client_artifacts<'de, D>(
@@ -327,6 +413,9 @@ pub struct SccmClientIntakeAssessment {
     /// but never masquerade as captured bundle artifacts.
     pub physical_artifacts: Vec<SccmClientIntakeFragment>,
     pub unsupported_artifacts: Vec<SccmClientUnsupportedArtifact>,
+    /// Canonical coverage-only declarations. They preserve capture-limit
+    /// provenance without becoming physical artifacts or log fragments.
+    pub capture_gaps: Vec<SccmClientIntakeCaptureGap>,
     pub coverage_gaps: Vec<SccmClientIntakeCoverageGap>,
 }
 
@@ -509,6 +598,8 @@ struct SccmClientIntakeAssessmentWire {
     groups: Vec<SccmClientIntakeGroupWire>,
     physical_artifacts: Vec<SccmClientIntakeFragmentWire>,
     unsupported_artifacts: Vec<SccmClientUnsupportedArtifactWire>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    capture_gaps: Vec<SccmClientIntakeCaptureGap>,
     coverage_gaps: Vec<SccmClientIntakeCoverageGapWire>,
 }
 
@@ -527,6 +618,7 @@ impl From<&SccmClientIntakeAssessment> for SccmClientIntakeAssessmentWire {
                 .iter()
                 .map(Into::into)
                 .collect(),
+            capture_gaps: assessment.capture_gaps.clone(),
             coverage_gaps: assessment.coverage_gaps.iter().map(Into::into).collect(),
         }
     }
@@ -561,6 +653,7 @@ impl<'de> Deserialize<'de> for SccmClientIntakeAssessment {
                 .into_iter()
                 .map(Into::into)
                 .collect(),
+            capture_gaps: wire.capture_gaps,
             coverage_gaps: wire.coverage_gaps.into_iter().map(Into::into).collect(),
         };
 
@@ -611,6 +704,8 @@ pub enum SccmClientIntakeError {
     MissingFragmentCompleteness,
     #[error("client intake fragment completeness contradicts its declared coverage state")]
     InvalidFragmentCompleteness,
+    #[error("client intake capture gap is malformed, unsupported, or not coverage-only")]
+    InvalidCaptureGap,
 }
 
 #[derive(Clone, Copy)]
@@ -713,6 +808,8 @@ pub fn assess_client_intake(
     let mut physical_artifacts = Vec::new();
     let mut unsupported_artifacts = Vec::new();
     let mut memberships: BTreeMap<&str, Vec<SccmClientIntakeFragment>> = BTreeMap::new();
+    let mut capture_gap_memberships: BTreeMap<&str, Vec<SccmClientIntakeCaptureGap>> =
+        BTreeMap::new();
 
     for source in &bundle.artifacts {
         let matching_groups =
@@ -749,12 +846,23 @@ pub fn assess_client_intake(
         }
     }
 
+    for capture_gap in &bundle.capture_gaps {
+        for group in matching_groups(&capture_gap.basename, &capture_gap.rotation) {
+            capture_gap_memberships
+                .entry(group.logical_artifact_id)
+                .or_default()
+                .push(capture_gap.clone());
+        }
+    }
+
     physical_artifacts.sort_by(compare_fragments);
     unsupported_artifacts.sort_by(|left, right| {
         left.artifact_id
             .cmp(&right.artifact_id)
             .then_with(|| left.basename.cmp(&right.basename))
     });
+    let mut capture_gaps = bundle.capture_gaps.clone();
+    capture_gaps.sort_by(compare_capture_gaps);
 
     let mut groups = Vec::with_capacity(CLIENT_SOURCE_GROUPS.len());
     let mut coverage_gaps = Vec::new();
@@ -763,8 +871,12 @@ pub fn assess_client_intake(
             .remove(definition.logical_artifact_id)
             .unwrap_or_default();
         fragments.sort_by(compare_fragments);
-        let coverage = group_coverage(&fragments);
-        if fragments.is_empty() {
+        let mut group_capture_gaps = capture_gap_memberships
+            .remove(definition.logical_artifact_id)
+            .unwrap_or_default();
+        group_capture_gaps.sort_by(compare_capture_gaps);
+        let coverage = group_coverage(&fragments, &group_capture_gaps);
+        if fragments.is_empty() && group_capture_gaps.is_empty() {
             coverage_gaps.push(SccmClientIntakeCoverageGap {
                 logical_artifact_id: definition.logical_artifact_id.to_owned(),
                 artifact_id: None,
@@ -784,6 +896,15 @@ pub fn assess_client_intake(
                     });
                 }
             }
+            for capture_gap in &group_capture_gaps {
+                coverage_gaps.push(SccmClientIntakeCoverageGap {
+                    logical_artifact_id: definition.logical_artifact_id.to_owned(),
+                    artifact_id: Some(capture_gap.artifact_id.clone()),
+                    role: SccmRole::Client,
+                    coverage: capture_gap.coverage.clone(),
+                    reason: capture_gap_coverage_reason(capture_gap),
+                });
+            }
         }
         groups.push(SccmClientIntakeGroup {
             logical_artifact_id: definition.logical_artifact_id.to_owned(),
@@ -797,6 +918,7 @@ pub fn assess_client_intake(
         groups,
         physical_artifacts,
         unsupported_artifacts,
+        capture_gaps,
         coverage_gaps,
     })
 }
@@ -840,8 +962,11 @@ fn validate_assessment_projection(assessment: &SccmClientIntakeAssessment) -> Re
             .map(unsupported_as_intake_artifact),
     );
 
-    let canonical = assess_client_intake(&SccmClientIntakeBundle { artifacts })
-        .map_err(|error| format!("invalid client intake assessment projection: {error}"))?;
+    let canonical = assess_client_intake(&SccmClientIntakeBundle {
+        artifacts,
+        capture_gaps: assessment.capture_gaps.clone(),
+    })
+    .map_err(|error| format!("invalid client intake assessment projection: {error}"))?;
     if canonical != *assessment {
         return Err(
             "client intake assessment is not the canonical projection of its artifacts".to_owned(),
@@ -896,7 +1021,12 @@ fn unsupported_as_intake_artifact(
 }
 
 fn validate_bundle(bundle: &SccmClientIntakeBundle) -> Result<(), SccmClientIntakeError> {
-    if bundle.artifacts.len() > MAX_SCCM_CLIENT_INTAKE_ARTIFACTS {
+    if bundle
+        .artifacts
+        .len()
+        .saturating_add(bundle.capture_gaps.len())
+        > MAX_SCCM_CLIENT_INTAKE_ARTIFACTS
+    {
         return Err(SccmClientIntakeError::ArtifactLimitExceeded);
     }
 
@@ -1086,6 +1216,65 @@ fn validate_bundle(bundle: &SccmClientIntakeBundle) -> Result<(), SccmClientInta
         }
     }
 
+    for capture_gap in &bundle.capture_gaps {
+        if !is_safe_artifact_id(&capture_gap.artifact_id)
+            || serde_json::to_value(&capture_gap.rotation).is_err()
+            || !is_safe_unknown_rotation(&capture_gap.rotation)
+            || !is_safe_basename(&capture_gap.basename, &capture_gap.rotation)
+            || !matches!(
+                capture_gap.coverage,
+                SccmCoverageState::Capped | SccmCoverageState::ParseFailed
+            )
+            || !is_safe_path_identity(&capture_gap.path_fingerprint)
+            || !is_safe_rotation_lineage(&capture_gap.rotation_lineage)
+            || matching_groups(&capture_gap.basename, &capture_gap.rotation).is_empty()
+        {
+            return Err(SccmClientIntakeError::InvalidCaptureGap);
+        }
+        if !artifact_ids.insert(capture_gap.artifact_id.to_ascii_lowercase()) {
+            return Err(SccmClientIntakeError::DuplicateArtifactId);
+        }
+
+        let path_fingerprint = capture_gap.path_fingerprint.to_ascii_lowercase();
+        let lineage = capture_gap.rotation_lineage.clone();
+        let basename = source_basename_identity(&capture_gap.basename, &capture_gap.rotation);
+        if let Some((bound_basename, bound_fingerprint)) = rotation_lineage_bindings.get(&lineage) {
+            if bound_basename != &basename
+                || bound_fingerprint.as_deref() != Some(&path_fingerprint)
+            {
+                return Err(SccmClientIntakeError::CollidingPhysicalIdentity);
+            }
+        } else {
+            rotation_lineage_bindings.insert(
+                lineage.clone(),
+                (basename.clone(), Some(path_fingerprint.clone())),
+            );
+        }
+        if !lineage_rotation_identities
+            .insert((lineage.clone(), rotation_identity(&capture_gap.rotation)))
+        {
+            return Err(SccmClientIntakeError::CollidingPhysicalIdentity);
+        }
+        if let Some((bound_lineage, bound_basename)) =
+            path_fingerprint_bindings.get(&path_fingerprint)
+        {
+            if bound_lineage.as_deref() != Some(lineage.as_str()) || bound_basename != &basename {
+                return Err(SccmClientIntakeError::CollidingPhysicalIdentity);
+            }
+        } else {
+            path_fingerprint_bindings.insert(path_fingerprint, (Some(lineage), basename));
+        }
+
+        let source_identity = (
+            capture_gap.basename.to_ascii_lowercase(),
+            rotation_identity(&capture_gap.rotation),
+        );
+        if unpinned_marker_identities.contains(&source_identity) {
+            return Err(SccmClientIntakeError::DuplicateArtifactId);
+        }
+        pinned_marker_identities.insert(source_identity);
+    }
+
     Ok(())
 }
 
@@ -1168,10 +1357,18 @@ fn normalized_collected_at(value: Option<&str>) -> Option<String> {
     })
 }
 
-fn group_coverage(fragments: &[SccmClientIntakeFragment]) -> SccmCoverageState {
+fn group_coverage(
+    fragments: &[SccmClientIntakeFragment],
+    capture_gaps: &[SccmClientIntakeCaptureGap],
+) -> SccmCoverageState {
     fragments
         .iter()
         .map(|fragment| fragment.coverage.clone())
+        .chain(
+            capture_gaps
+                .iter()
+                .map(|capture_gap| capture_gap.coverage.clone()),
+        )
         .max_by_key(coverage_rank)
         .unwrap_or(SccmCoverageState::Absent)
 }
@@ -1246,6 +1443,20 @@ fn source_coverage_reason(fragment: &SccmClientIntakeFragment) -> Option<String>
     }
 }
 
+fn capture_gap_coverage_reason(capture_gap: &SccmClientIntakeCaptureGap) -> String {
+    match capture_gap.coverage {
+        SccmCoverageState::Capped => format!(
+            "Client source rotation {} was omitted because its capture limit was reached.",
+            capture_gap.basename
+        ),
+        SccmCoverageState::ParseFailed => format!(
+            "Client source rotation {} was omitted because capture could not be completed.",
+            capture_gap.basename
+        ),
+        _ => unreachable!("capture gaps are validated as Capped or ParseFailed"),
+    }
+}
+
 /// Stable rotation discriminator for the canonical source identity shared
 /// by every declaration, physical or marker, so collisions intersect across
 /// all declaration shapes for a source.
@@ -1281,6 +1492,18 @@ fn compare_fragments(
                 .unwrap_or_default()
                 .cmp(right.rotation_lineage.as_deref().unwrap_or_default())
         })
+        .then_with(|| compare_rotation(&left.rotation, &right.rotation))
+        .then_with(|| left.basename.cmp(&right.basename))
+        .then_with(|| left.artifact_id.cmp(&right.artifact_id))
+}
+
+fn compare_capture_gaps(
+    left: &SccmClientIntakeCaptureGap,
+    right: &SccmClientIntakeCaptureGap,
+) -> Ordering {
+    left.path_fingerprint
+        .cmp(&right.path_fingerprint)
+        .then_with(|| left.rotation_lineage.cmp(&right.rotation_lineage))
         .then_with(|| compare_rotation(&left.rotation, &right.rotation))
         .then_with(|| left.basename.cmp(&right.basename))
         .then_with(|| left.artifact_id.cmp(&right.artifact_id))

--- a/crates/cmtraceopen-parser/tests/sccm_client_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_intake.rs
@@ -5,9 +5,9 @@ use std::path::{Path, PathBuf};
 use cmtraceopen_parser::sccm::{
     assess_client_intake, classify_artifact_name, declared_client_source_groups, SccmArtifact,
     SccmClientIntakeArtifact, SccmClientIntakeAssessment, SccmClientIntakeBundle,
-    SccmClientIntakeCoverageGap, SccmClientIntakeError, SccmClientIntakeFragment,
-    SccmClientUnsupportedArtifact, SccmCoverageState, SccmRole, SccmRotation, SccmUnknownRotation,
-    MAX_SCCM_CLIENT_INTAKE_ARTIFACTS,
+    SccmClientIntakeCaptureGap, SccmClientIntakeCoverageGap, SccmClientIntakeError,
+    SccmClientIntakeFragment, SccmClientUnsupportedArtifact, SccmCoverageState, SccmRole,
+    SccmRotation, SccmUnknownRotation, MAX_SCCM_CLIENT_INTAKE_ARTIFACTS,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -227,6 +227,7 @@ fn load_bundle(scenario: &str) -> SccmClientIntakeBundle {
                 }
             })
             .collect(),
+        capture_gaps: Vec::new(),
     }
 }
 
@@ -434,8 +435,11 @@ fn intake_rejects_more_than_the_v1_artifact_limit_before_validation_indexes() {
     let duplicate = synthetic_artifact("limit", "PolicyAgent.log");
     let artifacts = vec![duplicate; MAX_SCCM_CLIENT_INTAKE_ARTIFACTS + 1];
 
-    let error = assess_client_intake(&SccmClientIntakeBundle { artifacts })
-        .expect_err("the v1 client intake artifact ceiling must fail closed");
+    let error = assess_client_intake(&SccmClientIntakeBundle {
+        artifacts,
+        capture_gaps: Vec::new(),
+    })
+    .expect_err("the v1 client intake artifact ceiling must fail closed");
 
     assert_eq!(
         error.to_string(),
@@ -479,6 +483,265 @@ fn intake_wire_rejects_more_than_the_v1_artifact_limit_from_json_text() {
         error.to_string().contains("artifact count exceeds"),
         "the streaming fallback must report the bounded-contract violation: {error}"
     );
+}
+
+#[test]
+fn capped_omitted_rotation_degrades_group_coverage_without_relabeling_current_capture() {
+    let current = synthetic_artifact("current", "PolicyAgent.log");
+    let omitted_rotation = SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: "synthetic-capped-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    };
+
+    let assessment = assess_client_intake(&SccmClientIntakeBundle {
+        artifacts: vec![current],
+        capture_gaps: vec![omitted_rotation],
+    })
+    .expect("a coverage-only omitted rotation is a valid client intake declaration");
+
+    let group = assessment
+        .group("client-policy-agent")
+        .expect("policy agent group");
+    assert_eq!(group.coverage, SccmCoverageState::Capped);
+    assert_eq!(group.fragments.len(), 1);
+    assert_eq!(group.fragments[0].coverage, SccmCoverageState::Captured);
+    assert_eq!(assessment.physical_artifacts.len(), 1);
+    assert_eq!(
+        assessment.physical_artifacts[0].coverage,
+        SccmCoverageState::Captured
+    );
+    assert_eq!(assessment.capture_gaps.len(), 1);
+    assert_eq!(
+        assessment.capture_gaps[0].artifact_id,
+        "fixture-capped-rotation"
+    );
+    assert!(assessment.coverage_gaps.iter().any(|gap| {
+        gap.logical_artifact_id == "client-policy-agent"
+            && gap.artifact_id.as_deref() == Some("fixture-capped-rotation")
+            && gap.coverage == SccmCoverageState::Capped
+    }));
+
+    let serialized = serde_json::to_value(&assessment).expect("assessment serializes");
+    let gap = &serialized["captureGaps"][0];
+    assert!(gap.get("relativePath").is_none());
+    assert!(gap.get("bytesCopied").is_none());
+    assert!(gap.get("bytesRetained").is_none());
+}
+
+#[test]
+fn intake_wire_rejects_a_combined_artifact_and_capture_gap_count_above_the_v1_limit() {
+    let artifact = serde_json::to_value(synthetic_artifact("wire-current", "PolicyAgent.log"))
+        .expect("synthetic intake artifact serializes");
+    let capture_gap = serde_json::to_value(SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: "synthetic-capped-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    })
+    .expect("synthetic capture gap serializes");
+    let oversized = serde_json::json!({
+        "artifacts": [artifact],
+        "captureGaps": vec![capture_gap; MAX_SCCM_CLIENT_INTAKE_ARTIFACTS],
+    });
+
+    let error = serde_json::from_value::<SccmClientIntakeBundle>(oversized)
+        .expect_err("the shared v1 declaration ceiling must reject a combined oversized wire");
+    assert!(
+        error.to_string().contains("artifact count exceeds"),
+        "the wire must report the shared declaration bound: {error}"
+    );
+}
+
+#[test]
+fn intake_accepts_the_shared_v1_boundary_across_physical_and_coverage_only_declarations() {
+    let artifacts = (1..MAX_SCCM_CLIENT_INTAKE_ARTIFACTS)
+        .map(|number| SccmClientIntakeArtifact {
+            artifact: SccmArtifact {
+                artifact_id: format!("sccm-artifact:v1:sha256:{number:064x}"),
+                display_name: format!("PolicyAgent.log.{number}"),
+                original_path: None,
+                host: None,
+                role: SccmRole::Client,
+                configmgr_version: Some("5.00.TEST.0000".to_owned()),
+                collected_at_utc: Some("2026-07-30T00:00:00Z".to_owned()),
+                rotation: SccmRotation::Numbered(number as u32),
+                coverage: SccmCoverageState::Captured,
+                encoding: Some("utf-8".to_owned()),
+            },
+            path_fingerprint: Some(format!("sha256:{number:064x}")),
+            rotation_lineage: None,
+            relative_path: Some(format!(
+                "evidence/client-policy-agent/numbered-{number}/PolicyAgent.log.{number}"
+            )),
+            fragment_complete: Some(true),
+        })
+        .collect();
+    let capture_gap = SccmClientIntakeCaptureGap {
+        artifact_id: format!("sccm-artifact:v1:sha256:{MAX_SCCM_CLIENT_INTAKE_ARTIFACTS:064x}"),
+        basename: format!("PolicyAgent.log.{MAX_SCCM_CLIENT_INTAKE_ARTIFACTS}"),
+        rotation: SccmRotation::Numbered(MAX_SCCM_CLIENT_INTAKE_ARTIFACTS as u32),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: format!("sha256:{MAX_SCCM_CLIENT_INTAKE_ARTIFACTS:064x}"),
+        rotation_lineage: format!(
+            "cmtraceopen.lineage.sha256.v1:{MAX_SCCM_CLIENT_INTAKE_ARTIFACTS:064x}"
+        ),
+    };
+
+    let assessment = assess_client_intake(&SccmClientIntakeBundle {
+        artifacts,
+        capture_gaps: vec![capture_gap],
+    })
+    .expect("the shared v1 declaration boundary is accepted exactly");
+    assert_eq!(
+        assessment.physical_artifacts.len(),
+        MAX_SCCM_CLIENT_INTAKE_ARTIFACTS - 1
+    );
+    assert_eq!(assessment.capture_gaps.len(), 1);
+}
+
+#[test]
+fn legacy_bundle_wire_omits_the_additive_empty_capture_gap_field() {
+    let artifact = serde_json::to_value(synthetic_artifact("legacy-wire", "PolicyAgent.log"))
+        .expect("synthetic intake artifact serializes");
+    let legacy_wire = serde_json::json!({ "artifacts": [artifact] });
+
+    let decoded: SccmClientIntakeBundle =
+        serde_json::from_value(legacy_wire).expect("pre-gap bundle wire remains accepted");
+    assert!(decoded.capture_gaps.is_empty());
+    let reserialized = serde_json::to_value(decoded).expect("bundle reserializes");
+    assert!(
+        reserialized.get("captureGaps").is_none(),
+        "an empty additive field must preserve the existing wire shape"
+    );
+}
+
+#[test]
+fn intake_rejects_malformed_coverage_only_capture_gap() {
+    let malformed = SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-captured-rotation".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::Captured,
+        path_fingerprint: "synthetic-captured-rotation".to_owned(),
+        rotation_lineage: "synthetic:captured-rotation".to_owned(),
+    };
+
+    assert_eq!(
+        assess_client_intake(&SccmClientIntakeBundle {
+            artifacts: Vec::new(),
+            capture_gaps: vec![malformed],
+        }),
+        Err(SccmClientIntakeError::InvalidCaptureGap),
+        "coverage-only gaps must not be able to claim captured physical evidence"
+    );
+}
+
+#[test]
+fn capture_gap_wire_rejects_physical_path_or_byte_claims() {
+    let capture_gap = serde_json::to_value(SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: "synthetic-capped-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    })
+    .expect("synthetic capture gap serializes");
+    let mut with_path = capture_gap.clone();
+    with_path["relativePath"] =
+        serde_json::json!("evidence/client-policy-agent/numbered-1/PolicyAgent.log.1");
+    let mut with_bytes = capture_gap;
+    with_bytes["bytesCopied"] = serde_json::json!(1);
+
+    for malformed_gap in [with_path, with_bytes] {
+        assert!(
+            serde_json::from_value::<SccmClientIntakeBundle>(serde_json::json!({
+                "artifacts": [],
+                "captureGaps": [malformed_gap],
+            }))
+            .is_err(),
+            "a coverage-only gap must reject physical evidence fields"
+        );
+    }
+}
+
+#[test]
+fn intake_rejects_capture_gap_that_conflicts_with_physical_lineage() {
+    let mut current = synthetic_artifact("current", "PolicyAgent.log");
+    current.path_fingerprint = Some("synthetic-current-rotation".to_owned());
+    current.rotation_lineage = Some("synthetic:current-rotation".to_owned());
+    let colliding_gap = SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: "synthetic-current-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    };
+
+    assert_eq!(
+        assess_client_intake(&SccmClientIntakeBundle {
+            artifacts: vec![current],
+            capture_gaps: vec![colliding_gap],
+        }),
+        Err(SccmClientIntakeError::CollidingPhysicalIdentity),
+        "a coverage-only rotation must remain bound to the same collision and lineage rules"
+    );
+}
+
+#[test]
+fn capture_gap_projection_is_deterministic_and_round_trips() {
+    let current = synthetic_artifact("current", "PolicyAgent.log");
+    let first = SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation-numbered-1".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: "synthetic-capped-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    };
+    let second = SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation-numbered-2".to_owned(),
+        basename: "PolicyAgent.log.2".to_owned(),
+        rotation: SccmRotation::Numbered(2),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: "synthetic-capped-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    };
+
+    let ordered = assess_client_intake(&SccmClientIntakeBundle {
+        artifacts: vec![current.clone()],
+        capture_gaps: vec![first.clone(), second.clone()],
+    })
+    .expect("ordered capture gaps are valid");
+    let reversed = assess_client_intake(&SccmClientIntakeBundle {
+        artifacts: vec![current],
+        capture_gaps: vec![second, first],
+    })
+    .expect("reversed capture gaps are equally valid");
+
+    assert_eq!(ordered, reversed);
+    assert_eq!(
+        ordered
+            .capture_gaps
+            .iter()
+            .map(|gap| gap.artifact_id.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "fixture-capped-rotation-numbered-1",
+            "fixture-capped-rotation-numbered-2",
+        ]
+    );
+    let serialized = serde_json::to_value(&ordered).expect("assessment serializes");
+    let decoded: SccmClientIntakeAssessment =
+        serde_json::from_value(serialized).expect("canonical capture gaps round trip");
+    assert_eq!(decoded, ordered);
 }
 
 /// Every assertion that a serialized projection did not leak an identity must
@@ -603,6 +866,7 @@ fn collection_timestamp_is_projected_as_canonical_utc() {
 
     let intake = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![artifact],
+        capture_gaps: Vec::new(),
     })
     .expect("a valid RFC 3339 collection instant remains representable");
     assert_eq!(
@@ -1085,6 +1349,7 @@ fn fragment_order_is_source_identity_then_rotation_rank() {
 
     let bundle = SccmClientIntakeBundle {
         artifacts: vec![root_b_lo, root_a_current, root_b_current, root_a_lo],
+        capture_gaps: Vec::new(),
     };
     let assessment = assess_client_intake(&bundle).expect("two source lineages are valid");
     let ordered_ids = assessment
@@ -1196,6 +1461,7 @@ fn capped_cas_fragment_cannot_claim_complete() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![contradictory],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::InvalidFragmentCompleteness),
         "a capped physical fragment cannot claim complete public provenance"
@@ -1210,6 +1476,7 @@ fn captured_incomplete_fragment_retains_a_boundary_without_becoming_capped() {
 
     let intake = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![boundary],
+        capture_gaps: Vec::new(),
     })
     .expect("a fully copied rotation may still end on an incomplete logical record");
     let content = intake.group("client-content").expect("content group");
@@ -1240,6 +1507,7 @@ fn parse_failed_fragment_completeness_is_intentionally_two_valued() {
 
         let intake = assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![unparseable],
+            capture_gaps: Vec::new(),
         })
         .unwrap_or_else(|error| {
             panic!("parse-failed completeness {fragment_complete} was rejected: {error}")
@@ -1279,6 +1547,7 @@ fn mixed_captured_and_absent_group_preserves_partial_coverage_and_names_the_abse
 
     let intake = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![captured, absent],
+        capture_gaps: Vec::new(),
     })
     .expect("a mixed captured and absent client-content group is representable");
 
@@ -1331,6 +1600,7 @@ fn mixed_captured_and_access_denied_group_preserves_partial_coverage_and_names_t
 
     let intake = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![captured, denied],
+        capture_gaps: Vec::new(),
     })
     .expect("a mixed captured and access-denied client-content group is representable");
 
@@ -1372,6 +1642,7 @@ fn mixed_capped_and_absent_group_keeps_the_capped_capture_and_names_the_absent_s
 
     let intake = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![capped, absent],
+        capture_gaps: Vec::new(),
     })
     .expect("a mixed capped and absent client-content group is representable");
 
@@ -1425,6 +1696,7 @@ fn duplicate_nonphysical_markers_for_the_same_source_fail_closed() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![first, second],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::DuplicateArtifactId),
         "the same missing source must not be double-declared under differing caller labels"
@@ -1439,6 +1711,7 @@ fn duplicate_nonphysical_markers_for_the_same_source_fail_closed() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![absent, denied],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::DuplicateArtifactId),
         "contradictory marker states for the same source must not both project as fragments"
@@ -1462,6 +1735,7 @@ fn absent_markers_with_distinct_path_fingerprints_remain_distinct_sources() {
 
     let intake = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![root_a, root_b],
+        capture_gaps: Vec::new(),
     })
     .expect("markers distinguished by explicit path fingerprints stay representable");
 
@@ -1499,6 +1773,7 @@ fn unpinned_marker_for_a_physically_declared_source_fails_closed() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![captured.clone(), absent.clone()],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::CollidingPhysicalIdentity),
         "an unpinned absent marker for a captured source is a self-contradiction"
@@ -1506,6 +1781,7 @@ fn unpinned_marker_for_a_physically_declared_source_fails_closed() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![absent, captured],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::CollidingPhysicalIdentity),
         "declaration order must not reopen the marker-versus-physical collision"
@@ -1528,6 +1804,7 @@ fn pinned_markers_for_distinct_roots_coexist_with_physical_evidence() {
 
         let intake = assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![captured.clone(), pinned.clone()],
+            capture_gaps: Vec::new(),
         })
         .expect("distinct configured roots remain distinct sources");
         assert_eq!(intake.physical_artifacts.len(), 1);
@@ -1541,6 +1818,7 @@ fn pinned_markers_for_distinct_roots_coexist_with_physical_evidence() {
 
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![pinned, captured],
+            capture_gaps: Vec::new(),
         })
         .expect("declaration order must not collapse distinct roots");
     }
@@ -1552,6 +1830,7 @@ fn pinned_markers_for_distinct_roots_coexist_with_physical_evidence() {
     pinned.path_fingerprint = Some("synthetic:policy-root-b".to_owned());
     let intake = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![capped, pinned],
+        capture_gaps: Vec::new(),
     })
     .expect("a capped root and absent sibling root are both preserved");
     assert_eq!(
@@ -1572,6 +1851,7 @@ fn a_marker_cannot_reuse_the_physical_source_fingerprint() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![captured, marker],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::CollidingPhysicalIdentity)
     );
@@ -1596,6 +1876,7 @@ fn unpinned_and_pinned_markers_for_the_same_source_fail_closed() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![unpinned.clone(), pinned.clone()],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::DuplicateArtifactId),
         "an unpinned and a pinned marker must not double-declare one source"
@@ -1603,6 +1884,7 @@ fn unpinned_and_pinned_markers_for_the_same_source_fail_closed() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![pinned, unpinned],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::DuplicateArtifactId),
         "declaration order must not reopen the marker double-declaration"
@@ -1625,6 +1907,7 @@ fn markers_for_distinct_rotations_of_a_captured_source_remain_representable() {
 
     let intake = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![captured, rotated_absent],
+        capture_gaps: Vec::new(),
     })
     .expect("a marker for a distinct rotation of a captured source stays representable");
 
@@ -1681,6 +1964,7 @@ fn unknown_and_lookalike_names_are_retained_as_unsupported_not_reclassified() {
             synthetic_artifact("lookalike", "PolicyAgent.log.backup"),
             synthetic_artifact("unknown-lo", "CustomVendorHook.lo_"),
         ],
+        capture_gaps: Vec::new(),
     };
     let intake = assess_client_intake(&bundle).expect("unknown intake");
 
@@ -1707,6 +1991,7 @@ fn malformed_rotation_and_public_provenance_values_fail_closed() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![invalid_rotation],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::InvalidRotation),
         "a malformed rotation timestamp must fail on the rotation contract"
@@ -1719,6 +2004,7 @@ fn malformed_rotation_and_public_provenance_values_fail_closed() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![unsafe_basename],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::InvalidBasename),
         "a path-bearing basename must fail on the basename contract"
@@ -1730,6 +2016,7 @@ fn malformed_rotation_and_public_provenance_values_fail_closed() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![invalid_time],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::InvalidCollectedAt),
         "a non-RFC-3339 collection timestamp must fail on the timestamp contract"
@@ -1741,6 +2028,7 @@ fn malformed_rotation_and_public_provenance_values_fail_closed() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![invalid_version],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::InvalidConfigMgrVersion),
         "an unsafe ConfigMgr version must fail on the version contract"
@@ -1755,6 +2043,7 @@ fn configmgr_version_and_encoding_use_bounded_public_grammars() {
         assert!(
             assess_client_intake(&SccmClientIntakeBundle {
                 artifacts: vec![artifact],
+                capture_gaps: Vec::new(),
             })
             .is_ok(),
             "documented ConfigMgr version {version} should remain representable"
@@ -1773,6 +2062,7 @@ fn configmgr_version_and_encoding_use_bounded_public_grammars() {
         assert_eq!(
             assess_client_intake(&SccmClientIntakeBundle {
                 artifacts: vec![artifact],
+                capture_gaps: Vec::new(),
             }),
             Err(SccmClientIntakeError::InvalidConfigMgrVersion),
             "unsafe ConfigMgr version {version:?} must fail closed"
@@ -1785,6 +2075,7 @@ fn configmgr_version_and_encoding_use_bounded_public_grammars() {
         assert!(
             assess_client_intake(&SccmClientIntakeBundle {
                 artifacts: vec![artifact],
+                capture_gaps: Vec::new(),
             })
             .is_ok(),
             "supported encoding {encoding} should remain representable"
@@ -1803,6 +2094,7 @@ fn configmgr_version_and_encoding_use_bounded_public_grammars() {
         assert_eq!(
             assess_client_intake(&SccmClientIntakeBundle {
                 artifacts: vec![artifact],
+                capture_gaps: Vec::new(),
             }),
             Err(SccmClientIntakeError::InvalidEncoding),
             "unsafe encoding {encoding:?} must fail closed"
@@ -1830,6 +2122,7 @@ fn unknown_rotation_public_metadata_is_versioned_and_opaque() {
         assert_eq!(
             assess_client_intake(&SccmClientIntakeBundle {
                 artifacts: vec![artifact],
+                capture_gaps: Vec::new(),
             }),
             Err(SccmClientIntakeError::InvalidRotation)
         );
@@ -1854,6 +2147,7 @@ fn unknown_rotation_public_metadata_is_versioned_and_opaque() {
         assert_eq!(
             assess_client_intake(&SccmClientIntakeBundle {
                 artifacts: vec![artifact],
+                capture_gaps: Vec::new(),
             }),
             Err(SccmClientIntakeError::InvalidRotation)
         );
@@ -1867,6 +2161,7 @@ fn unknown_rotation_public_metadata_is_versioned_and_opaque() {
     future.relative_path = Some("evidence/unknown/PolicyAgent.log".to_owned());
     let assessed = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![future],
+        capture_gaps: Vec::new(),
     })
     .expect("versioned opaque future rotation remains representable");
     assert_eq!(assessed.unsupported_artifacts.len(), 1);
@@ -1893,6 +2188,7 @@ fn distinct_opaque_unknown_rotations_do_not_collapse_to_one_source_identity() {
 
     let intake = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![captured, unavailable],
+        capture_gaps: Vec::new(),
     })
     .expect("distinct opaque rotations remain distinct declarations");
 
@@ -1917,6 +2213,7 @@ fn caller_controlled_public_identity_channels_fail_closed() {
         assert_eq!(
             assess_client_intake(&SccmClientIntakeBundle {
                 artifacts: vec![artifact],
+                capture_gaps: Vec::new(),
             }),
             Err(SccmClientIntakeError::InvalidArtifactId),
             "identity-bearing artifact ID {artifact_id:?} reached public output"
@@ -1933,6 +2230,7 @@ fn caller_controlled_public_identity_channels_fail_closed() {
         assert_eq!(
             assess_client_intake(&SccmClientIntakeBundle {
                 artifacts: vec![artifact],
+                capture_gaps: Vec::new(),
             }),
             Err(SccmClientIntakeError::InvalidBasename),
             "identity-bearing unsupported basename {basename:?} reached public output"
@@ -1950,6 +2248,7 @@ fn caller_controlled_public_identity_channels_fail_closed() {
         assert_eq!(
             assess_client_intake(&SccmClientIntakeBundle {
                 artifacts: vec![artifact],
+                capture_gaps: Vec::new(),
             }),
             Err(SccmClientIntakeError::InvalidRelativePath),
             "relative path was not bound to its canonical source: {relative_path:?}"
@@ -1962,6 +2261,7 @@ fn caller_controlled_public_identity_channels_fail_closed() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![mixed_case],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::InvalidBasename),
         "supported source names must use their exact canonical spelling"
@@ -1974,6 +2274,7 @@ fn public_identity_contract_retains_only_reviewed_synthetic_and_opaque_forms() {
     native.artifact.artifact_id = format!("sccm-artifact:v1:sha256:{}", "a".repeat(64));
     assert!(assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![native],
+        capture_gaps: Vec::new(),
     })
     .is_ok());
 
@@ -1982,6 +2283,7 @@ fn public_identity_contract_retains_only_reviewed_synthetic_and_opaque_forms() {
     unknown.relative_path = Some(format!("evidence/unknown/current/{opaque_basename}"));
     let unknown = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![unknown],
+        capture_gaps: Vec::new(),
     })
     .expect("opaque unsupported source remains representable");
     assert_eq!(unknown.unsupported_artifacts.len(), 1);
@@ -1992,6 +2294,7 @@ fn public_identity_contract_retains_only_reviewed_synthetic_and_opaque_forms() {
     let serialized = serde_json::to_string(
         &assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![raw_context],
+            capture_gaps: Vec::new(),
         })
         .expect("raw native context is intentionally not projected"),
     )
@@ -2009,6 +2312,7 @@ fn public_identity_contract_retains_only_reviewed_synthetic_and_opaque_forms() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![oversized_timestamp],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::InvalidCollectedAt)
     );
@@ -2023,6 +2327,7 @@ fn fragment_completeness_and_every_path_fingerprint_are_explicit_and_unambiguous
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![missing_completeness],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::MissingFragmentCompleteness),
         "fragment completeness must be an explicit declaration"
@@ -2037,6 +2342,7 @@ fn fragment_completeness_and_every_path_fingerprint_are_explicit_and_unambiguous
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![invented_physical_state],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::InvalidFragmentCompleteness),
         "a marker claiming a complete fragment invents a physical capture"
@@ -2049,6 +2355,7 @@ fn fragment_completeness_and_every_path_fingerprint_are_explicit_and_unambiguous
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![missing_provenance],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::MissingPhysicalProvenance),
         "a physical capture without its bundle path lacks required provenance"
@@ -2066,6 +2373,7 @@ fn fragment_completeness_and_every_path_fingerprint_are_explicit_and_unambiguous
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![first, second],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::CollidingPhysicalIdentity),
         "two markers must not share one path fingerprint"
@@ -2079,6 +2387,7 @@ fn unsupported_physical_artifacts_retain_safe_provenance_without_raw_host_or_pat
     artifact.artifact.host = Some("real-user-host.example".to_owned());
     let intake = assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![artifact],
+        capture_gaps: Vec::new(),
     })
     .expect("unknown physical artifact remains representable");
     let serialized = serde_json::to_string(&intake).expect("intake JSON");
@@ -2236,6 +2545,7 @@ fn identity_bearing_relative_paths_fail_before_public_projection() {
 
         let result = assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![artifact],
+            capture_gaps: Vec::new(),
         });
         assert!(
             matches!(result, Err(SccmClientIntakeError::InvalidRelativePath)),
@@ -2254,6 +2564,7 @@ fn identity_bearing_relative_paths_fail_before_public_projection() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![malformed_timestamp],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::InvalidRotation),
         "malformed timestamp rotation must fail on its own metadata contract"
@@ -2267,6 +2578,7 @@ fn rotation_lineage_is_versioned_privacy_safe_and_bound_to_one_source() {
     opaque.rotation_lineage = Some(format!("cmtraceopen.lineage.sha256.v1:{digest}"));
     assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![opaque],
+        capture_gaps: Vec::new(),
     })
     .expect("the versioned opaque lineage form is accepted");
 
@@ -2283,6 +2595,7 @@ fn rotation_lineage_is_versioned_privacy_safe_and_bound_to_one_source() {
         assert_eq!(
             assess_client_intake(&SccmClientIntakeBundle {
                 artifacts: vec![artifact],
+                capture_gaps: Vec::new(),
             }),
             Err(SccmClientIntakeError::InvalidRotationLineage),
             "unsafe lineage reached the public projection: {lineage:?}"
@@ -2296,6 +2609,7 @@ fn rotation_lineage_is_versioned_privacy_safe_and_bound_to_one_source() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![policy, state],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::CollidingPhysicalIdentity),
         "one immutable lineage cannot be rebound to a different catalog source"
@@ -2329,6 +2643,7 @@ fn shared_location_services_path_binding_preserves_every_canonical_rotation() {
 
         let assessment = assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![artifact],
+            capture_gaps: Vec::new(),
         })
         .unwrap_or_else(|error| {
             panic!(
@@ -2389,6 +2704,7 @@ fn unsafe_path_fingerprints_fail_before_public_projection() {
 
         let result = assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![artifact],
+            capture_gaps: Vec::new(),
         });
         assert!(
             matches!(result, Err(SccmClientIntakeError::InvalidPathFingerprint)),
@@ -2412,6 +2728,7 @@ fn sha256_path_fingerprints_require_exactly_64_lowercase_hex_characters() {
         assert_eq!(
             assess_client_intake(&SccmClientIntakeBundle {
                 artifacts: vec![artifact],
+                capture_gaps: Vec::new(),
             }),
             Err(SccmClientIntakeError::InvalidPathFingerprint),
             "invalid SHA-256 digest was accepted: {digest:?}"
@@ -2422,6 +2739,7 @@ fn sha256_path_fingerprints_require_exactly_64_lowercase_hex_characters() {
     artifact.path_fingerprint = Some(format!("sha256:{}", "a".repeat(64)));
     assert!(assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![artifact],
+        capture_gaps: Vec::new(),
     })
     .is_ok());
 }
@@ -2435,6 +2753,7 @@ fn numbered_synthetic_path_fingerprints_accept_only_a_short_numeric_suffix() {
         Some("evidence/client-app-enforce/numbered-3/AppEnforce.log.3".to_owned());
     assert!(assess_client_intake(&SccmClientIntakeBundle {
         artifacts: vec![numbered],
+        capture_gaps: Vec::new(),
     })
     .is_ok());
 
@@ -2443,6 +2762,7 @@ fn numbered_synthetic_path_fingerprints_accept_only_a_short_numeric_suffix() {
     assert_eq!(
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![oversized],
+            capture_gaps: Vec::new(),
         }),
         Err(SccmClientIntakeError::InvalidPathFingerprint)
     );
@@ -2465,6 +2785,7 @@ fn approved_namespaced_path_fingerprints_remain_accepted() {
 
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![artifact],
+            capture_gaps: Vec::new(),
         })
         .unwrap_or_else(|error| panic!("approved fingerprint {fingerprint:?} failed: {error}"));
     }
@@ -2528,6 +2849,7 @@ fn approved_collision_safe_relative_layouts_remain_accepted() {
 
         assess_client_intake(&SccmClientIntakeBundle {
             artifacts: vec![artifact],
+            capture_gaps: Vec::new(),
         })
         .unwrap_or_else(|error| panic!("approved path {relative_path:?} failed: {error}"));
     }

--- a/crates/cmtraceopen-parser/tests/sccm_client_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_intake.rs
@@ -545,17 +545,25 @@ fn intake_wire_rejects_a_combined_artifact_and_capture_gap_count_above_the_v1_li
         rotation_lineage: "synthetic:capped-rotation".to_owned(),
     })
     .expect("synthetic capture gap serializes");
-    let oversized = serde_json::json!({
-        "artifacts": [artifact],
-        "captureGaps": vec![capture_gap; MAX_SCCM_CLIENT_INTAKE_ARTIFACTS],
-    });
+    let oversized_values = [
+        serde_json::json!({
+            "artifacts": [artifact.clone()],
+            "captureGaps": vec![capture_gap.clone(); MAX_SCCM_CLIENT_INTAKE_ARTIFACTS],
+        }),
+        serde_json::json!({
+            "artifacts": vec![artifact; MAX_SCCM_CLIENT_INTAKE_ARTIFACTS],
+            "captureGaps": [capture_gap],
+        }),
+    ];
 
-    let error = serde_json::from_value::<SccmClientIntakeBundle>(oversized)
-        .expect_err("the shared v1 declaration ceiling must reject a combined oversized wire");
-    assert!(
-        error.to_string().contains("artifact count exceeds"),
-        "the wire must report the shared declaration bound: {error}"
-    );
+    for oversized in oversized_values {
+        let error = serde_json::from_value::<SccmClientIntakeBundle>(oversized)
+            .expect_err("the shared v1 declaration ceiling must reject a combined oversized wire");
+        assert!(
+            error.to_string().contains("artifact count exceeds"),
+            "the wire must report the shared declaration bound: {error}"
+        );
+    }
 }
 
 #[test]
@@ -607,7 +615,7 @@ fn intake_accepts_the_shared_v1_boundary_across_physical_and_coverage_only_decla
 
 #[test]
 fn legacy_bundle_wire_omits_the_additive_empty_capture_gap_field() {
-    let artifact = serde_json::to_value(synthetic_artifact("legacy-wire", "PolicyAgent.log"))
+    let artifact = serde_json::to_value(synthetic_artifact("policy-current", "PolicyAgent.log"))
         .expect("synthetic intake artifact serializes");
     let legacy_wire = serde_json::json!({ "artifacts": [artifact] });
 
@@ -667,6 +675,149 @@ fn capture_gap_wire_rejects_physical_path_or_byte_claims() {
             }))
             .is_err(),
             "a coverage-only gap must reject physical evidence fields"
+        );
+    }
+}
+
+fn capture_gap_wire_value(gap: &SccmClientIntakeCaptureGap) -> Value {
+    serde_json::json!({
+        "artifactId": gap.artifact_id,
+        "basename": gap.basename,
+        "rotation": gap.rotation,
+        "coverage": gap.coverage,
+        "pathFingerprint": gap.path_fingerprint,
+        "rotationLineage": gap.rotation_lineage,
+    })
+}
+
+#[test]
+fn standalone_capture_gap_serde_and_direct_assessment_reject_unsafe_public_state() {
+    let valid = SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: "synthetic-capped-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    };
+    let mut captured = valid.clone();
+    captured.coverage = SccmCoverageState::Captured;
+    let mut unsafe_id = valid.clone();
+    unsafe_id.artifact_id = r"C:\Users\RealUser\PolicyAgent.log.1".to_owned();
+    let mut raw_fingerprint = valid.clone();
+    raw_fingerprint.path_fingerprint = r"C:\Users\RealUser".to_owned();
+    let mut unversioned_lineage = valid.clone();
+    unversioned_lineage.rotation_lineage = "lineage-1".to_owned();
+
+    for invalid in [captured, unsafe_id, raw_fingerprint, unversioned_lineage] {
+        assert_eq!(
+            assess_client_intake(&SccmClientIntakeBundle {
+                artifacts: Vec::new(),
+                capture_gaps: vec![invalid.clone()],
+            }),
+            Err(SccmClientIntakeError::InvalidCaptureGap),
+            "direct assessment must reject the unsafe capture-gap shape"
+        );
+        assert!(
+            serde_json::to_value(&invalid).is_err(),
+            "standalone serialization must validate post-construction mutation"
+        );
+
+        let wire = capture_gap_wire_value(&invalid);
+        assert!(
+            serde_json::from_value::<SccmClientIntakeCaptureGap>(wire.clone()).is_err(),
+            "from_value must validate standalone capture-gap input"
+        );
+        assert!(
+            serde_json::from_str::<SccmClientIntakeCaptureGap>(&wire.to_string()).is_err(),
+            "from_str must validate standalone capture-gap input"
+        );
+    }
+}
+
+#[test]
+fn standalone_capture_gap_serde_preserves_parse_failed_as_coverage_only() {
+    let gap = SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::ParseFailed,
+        path_fingerprint: "synthetic-capped-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    };
+
+    let wire = serde_json::to_value(&gap).expect("ParseFailed remains a valid unretained gap");
+    assert_eq!(
+        serde_json::from_value::<SccmClientIntakeCaptureGap>(wire.clone())
+            .expect("from_value accepts the reviewed ParseFailed state"),
+        gap
+    );
+    assert_eq!(
+        serde_json::from_str::<SccmClientIntakeCaptureGap>(&wire.to_string())
+            .expect("from_str accepts the reviewed ParseFailed state"),
+        gap
+    );
+}
+
+#[test]
+fn bundle_serialization_rejects_colliding_standalone_valid_capture_gaps() {
+    let first = SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation-numbered-1".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: "synthetic-capped-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    };
+    let mut second = first.clone();
+    second.artifact_id = "fixture-capped-rotation-numbered-2".to_owned();
+    assert!(serde_json::to_value(&first).is_ok());
+    assert!(serde_json::to_value(&second).is_ok());
+    let bundle = SccmClientIntakeBundle {
+        artifacts: Vec::new(),
+        capture_gaps: vec![first, second],
+    };
+
+    assert_eq!(
+        assess_client_intake(&bundle),
+        Err(SccmClientIntakeError::CollidingPhysicalIdentity)
+    );
+    assert!(
+        serde_json::to_value(&bundle).is_err(),
+        "bundle serialization must validate cross-declaration collisions"
+    );
+}
+
+#[test]
+fn shared_decode_quota_wins_before_malformed_second_field_in_both_wire_orders() {
+    let artifact =
+        serde_json::to_value(synthetic_artifact("boundary-candidate", "PolicyAgent.log"))
+            .expect("synthetic intake artifact serializes");
+    let capture_gap = capture_gap_wire_value(&SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: "synthetic-capped-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    });
+    let artifacts = serde_json::to_string(&vec![artifact; MAX_SCCM_CLIENT_INTAKE_ARTIFACTS])
+        .expect("artifact boundary wire serializes");
+    let capture_gaps = serde_json::to_string(&vec![capture_gap; MAX_SCCM_CLIENT_INTAKE_ARTIFACTS])
+        .expect("capture-gap boundary wire serializes");
+    let artifacts_first =
+        format!(r#"{{"artifacts":{artifacts},"captureGaps":[{{"coverage":"captured"}}]}}"#);
+    let capture_gaps_first =
+        format!(r#"{{"captureGaps":{capture_gaps},"artifacts":[{{"artifact":null}}]}}"#);
+
+    for wire in [artifacts_first, capture_gaps_first] {
+        let error = serde_json::from_str::<SccmClientIntakeBundle>(&wire)
+            .expect_err("the first field exhausts the shared declaration quota");
+        assert!(
+            error
+                .to_string()
+                .starts_with(&SccmClientIntakeError::ArtifactLimitExceeded.to_string()),
+            "an element beyond the shared quota must not be semantically decoded: {error}"
         );
     }
 }

--- a/crates/cmtraceopen-parser/tests/sccm_client_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_intake.rs
@@ -428,6 +428,30 @@ fn synthetic_marker(
     artifact
 }
 
+fn opaque_numbered_artifact(number: usize) -> SccmClientIntakeArtifact {
+    let rotation_number = u32::try_from(number).expect("test artifact number fits u32");
+    SccmClientIntakeArtifact {
+        artifact: SccmArtifact {
+            artifact_id: format!("sccm-artifact:v1:sha256:{number:064x}"),
+            display_name: format!("PolicyAgent.log.{number}"),
+            original_path: None,
+            host: None,
+            role: SccmRole::Client,
+            configmgr_version: Some("5.00.TEST.0000".to_owned()),
+            collected_at_utc: Some("2026-07-30T00:00:00Z".to_owned()),
+            rotation: SccmRotation::Numbered(rotation_number),
+            coverage: SccmCoverageState::Captured,
+            encoding: Some("utf-8".to_owned()),
+        },
+        path_fingerprint: Some(format!("sha256:{number:064x}")),
+        rotation_lineage: None,
+        relative_path: Some(format!(
+            "evidence/client-policy-agent/numbered-{number}/PolicyAgent.log.{number}"
+        )),
+        fragment_complete: Some(true),
+    }
+}
+
 #[test]
 fn intake_rejects_more_than_the_v1_artifact_limit_before_validation_indexes() {
     // Keep the input otherwise invalid (all declarations collide) so this
@@ -449,15 +473,18 @@ fn intake_rejects_more_than_the_v1_artifact_limit_before_validation_indexes() {
 
 #[test]
 fn intake_wire_rejects_more_than_the_v1_artifact_limit_while_deserializing() {
-    let artifact = serde_json::to_value(synthetic_artifact("wire-limit", "PolicyAgent.log"))
-        .expect("synthetic intake artifact serializes");
+    let boundary_artifacts = (1..=MAX_SCCM_CLIENT_INTAKE_ARTIFACTS)
+        .map(opaque_numbered_artifact)
+        .collect::<Vec<_>>();
     let boundary = serde_json::json!({
-        "artifacts": vec![artifact.clone(); MAX_SCCM_CLIENT_INTAKE_ARTIFACTS],
+        "artifacts": boundary_artifacts,
     });
     let decoded: SccmClientIntakeBundle =
         serde_json::from_value(boundary).expect("the declared v1 boundary is accepted");
     assert_eq!(decoded.artifacts.len(), MAX_SCCM_CLIENT_INTAKE_ARTIFACTS);
 
+    let artifact = serde_json::to_value(synthetic_artifact("wire-limit", "PolicyAgent.log"))
+        .expect("synthetic intake artifact serializes");
     let oversized = serde_json::json!({
         "artifacts": vec![artifact; MAX_SCCM_CLIENT_INTAKE_ARTIFACTS + 1],
     });
@@ -569,26 +596,7 @@ fn intake_wire_rejects_a_combined_artifact_and_capture_gap_count_above_the_v1_li
 #[test]
 fn intake_accepts_the_shared_v1_boundary_across_physical_and_coverage_only_declarations() {
     let artifacts = (1..MAX_SCCM_CLIENT_INTAKE_ARTIFACTS)
-        .map(|number| SccmClientIntakeArtifact {
-            artifact: SccmArtifact {
-                artifact_id: format!("sccm-artifact:v1:sha256:{number:064x}"),
-                display_name: format!("PolicyAgent.log.{number}"),
-                original_path: None,
-                host: None,
-                role: SccmRole::Client,
-                configmgr_version: Some("5.00.TEST.0000".to_owned()),
-                collected_at_utc: Some("2026-07-30T00:00:00Z".to_owned()),
-                rotation: SccmRotation::Numbered(number as u32),
-                coverage: SccmCoverageState::Captured,
-                encoding: Some("utf-8".to_owned()),
-            },
-            path_fingerprint: Some(format!("sha256:{number:064x}")),
-            rotation_lineage: None,
-            relative_path: Some(format!(
-                "evidence/client-policy-agent/numbered-{number}/PolicyAgent.log.{number}"
-            )),
-            fragment_complete: Some(true),
-        })
+        .map(opaque_numbered_artifact)
         .collect();
     let capture_gap = SccmClientIntakeCaptureGap {
         artifact_id: format!("sccm-artifact:v1:sha256:{MAX_SCCM_CLIENT_INTAKE_ARTIFACTS:064x}"),
@@ -611,6 +619,12 @@ fn intake_accepts_the_shared_v1_boundary_across_physical_and_coverage_only_decla
         MAX_SCCM_CLIENT_INTAKE_ARTIFACTS - 1
     );
     assert_eq!(assessment.capture_gaps.len(), 1);
+
+    let wire = serde_json::to_value(&assessment)
+        .expect("the canonical shared boundary assessment serializes");
+    let decoded = serde_json::from_value::<SccmClientIntakeAssessment>(wire)
+        .expect("the canonical shared boundary assessment deserializes");
+    assert_eq!(decoded, assessment);
 }
 
 #[test]
@@ -786,6 +800,75 @@ fn bundle_serialization_rejects_colliding_standalone_valid_capture_gaps() {
         serde_json::to_value(&bundle).is_err(),
         "bundle serialization must validate cross-declaration collisions"
     );
+}
+
+fn assert_bundle_wire_rejected_at_both_json_boundaries(label: &str, wire: Value) {
+    let value_rejected = serde_json::from_value::<SccmClientIntakeBundle>(wire.clone()).is_err();
+    let text_rejected = serde_json::from_str::<SccmClientIntakeBundle>(&wire.to_string()).is_err();
+    assert!(
+        value_rejected && text_rejected,
+        "invalid bundle declaration was accepted: {label}; \
+         from_value rejected={value_rejected}, from_str rejected={text_rejected}"
+    );
+}
+
+#[test]
+fn bundle_deserialization_revalidates_unsafe_collision_and_capture_gap_inputs() {
+    let artifact = serde_json::to_value(synthetic_artifact("policy-current", "PolicyAgent.log"))
+        .expect("valid artifact serializes");
+
+    let mut unsafe_identity = serde_json::json!({ "artifacts": [artifact.clone()] });
+    unsafe_identity["artifacts"][0]["artifact"]["artifactId"] =
+        serde_json::json!(r"C:\Users\RealUser\PolicyAgent.log");
+
+    let duplicate_artifact = serde_json::json!({
+        "artifacts": [artifact.clone(), artifact.clone()],
+    });
+
+    let first_gap = SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation-numbered-1".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: "synthetic-capped-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    };
+    let mut second_gap = first_gap.clone();
+    second_gap.artifact_id = "fixture-capped-rotation-numbered-2".to_owned();
+    let colliding_gaps = serde_json::json!({
+        "artifacts": [],
+        "captureGaps": [
+            capture_gap_wire_value(&first_gap),
+            capture_gap_wire_value(&second_gap),
+        ],
+    });
+
+    let mut invalid_gap = first_gap.clone();
+    invalid_gap.coverage = SccmCoverageState::Captured;
+    let invalid_gap_shape = serde_json::json!({
+        "artifacts": [],
+        "captureGaps": [capture_gap_wire_value(&invalid_gap)],
+    });
+
+    let mut duplicate_across_declaration_kinds = first_gap;
+    duplicate_across_declaration_kinds.artifact_id = "fixture-policy-current".to_owned();
+    let duplicate_artifact_and_gap = serde_json::json!({
+        "artifacts": [artifact],
+        "captureGaps": [capture_gap_wire_value(&duplicate_across_declaration_kinds)],
+    });
+
+    for (label, wire) in [
+        ("unsafe artifact identity", unsafe_identity),
+        ("duplicate artifact identity", duplicate_artifact),
+        ("colliding capture gaps", colliding_gaps),
+        ("invalid capture-gap shape", invalid_gap_shape),
+        (
+            "duplicate artifact and capture-gap identity",
+            duplicate_artifact_and_gap,
+        ),
+    ] {
+        assert_bundle_wire_rejected_at_both_json_boundaries(label, wire);
+    }
 }
 
 #[test]
@@ -976,6 +1059,36 @@ fn public_assessment_deserialization_rejects_forged_coverage_and_identity() {
     assert!(
         serde_json::from_value::<SccmClientIntakeAssessment>(leaked_identity).is_err(),
         "a standalone assessment must not deserialize raw identity-bearing provenance"
+    );
+}
+
+#[test]
+fn public_assessment_capture_gaps_are_bounded_before_projection_validation() {
+    let mut wire =
+        serde_json::to_value(assessment("missing-root")).expect("canonical assessment serializes");
+    let gap = capture_gap_wire_value(&SccmClientIntakeCaptureGap {
+        artifact_id: "fixture-capped-rotation".to_owned(),
+        basename: "PolicyAgent.log.1".to_owned(),
+        rotation: SccmRotation::Numbered(1),
+        coverage: SccmCoverageState::Capped,
+        path_fingerprint: "synthetic-capped-rotation".to_owned(),
+        rotation_lineage: "synthetic:capped-rotation".to_owned(),
+    });
+    wire["captureGaps"] = serde_json::json!(vec![gap; MAX_SCCM_CLIENT_INTAKE_ARTIFACTS + 1]);
+
+    let value_error = serde_json::from_value::<SccmClientIntakeAssessment>(wire.clone())
+        .expect_err("from_value must reject capture gap 4097 before projection validation");
+    let text = wire.to_string();
+    let text_error = serde_json::from_str::<SccmClientIntakeAssessment>(&text)
+        .expect_err("from_str must reject capture gap 4097 before projection validation");
+    let limit_error = SccmClientIntakeError::ArtifactLimitExceeded.to_string();
+    let value_stopped_early = value_error.to_string().starts_with(&limit_error);
+    let text_stopped_early = text_error.to_string().starts_with(&limit_error);
+    assert!(
+        value_stopped_early && text_stopped_early,
+        "oversized assessment capture gaps reached canonical projection validation; \
+         from_value early={value_stopped_early} ({value_error}); \
+         from_str early={text_stopped_early} ({text_error})"
     );
 }
 


### PR DESCRIPTION
## Scope

Advances #319 with the additive pure-Rust SCCM client capture-gap contract required before the native adapter can represent omitted rotations without relabeling retained evidence.

- adds a coverage-only `SccmClientIntakeCaptureGap` projection for `Capped` and `ParseFailed` omissions;
- keeps physical artifacts and public `LogEntry` behavior unchanged;
- preserves empty-field wire compatibility;
- validates standalone, bundle, and assessment serialization/deserialization;
- enforces one order-independent 4,096 declaration quota across bundle artifacts and gaps before unbounded typed allocation;
- preserves deterministic coverage, source identity, rotation lineage, and collision behavior.

No Windows I/O, registry, WMI, Tauri, network, database, workflow reducer, native capture, or live-Windows claim is included. Raw CCM remains the shared grammar; no parser kind was added.

## Test-first review history

RED cases reproduced during review/correction:

- standalone unsafe gap state serialized successfully;
- malformed declaration 4,097 won over the shared quota error;
- bundle deserialization accepted a raw Windows artifact ID through JSON Value and text;
- assessment deserialization materialized 4,097 gaps before late projection rejection.

The final exact head `fd52c4ceb6bde211f26d3647eda010e8fe81d8c0` passed a separate detached-worktree adversarial review across standalone/bundle/assessment serde, field order, malformed-over-quota precedence, collision matrices, deterministic projection, and compatibility behavior.

## Verification

- client intake: 65 passed;
- SCCM spine: 161 passed;
- full locked parser suite: passed;
- strict parser Clippy with all targets/features: passed;
- Rust 1.88 wasm32 check: passed;
- changed-file Rust 1.88 rustfmt, `git diff --check`, and `git show --check`: passed;
- independent exact-head verdict: GO;
- local CodeRabbit runs: no completed actionable finding payload.

Advisory retained for follow-up: malformed unknown capture-gap field/enum names can appear in Serde error strings. The top-level bundle behavior is inherited and no current non-test deserializer/IPC exporter was found, so this is not represented as evidence output or a live privacy failure. Re-evaluate before any caller exposes raw parser errors through IPC/UI.

## Dependency and next merge order

Target is `codex/parser-family-skeleton` at `ce774fd60c2d6e209a4bf69ea968865bf0d205f7`. Native client work remains local/NO-GO and must restack on the resulting merge commit, map native gaps explicitly, enforce the same global quota, sanitize legacy errors, and pass fresh review plus Windows acceptance. Keep #319 open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added capture-gap reporting for missing, capped, or failed-to-parse artifacts.
  - Capture gaps now appear in coverage assessments, summaries, grouping, sorting, and validation.
  - Added provenance details to help distinguish related capture gaps safely.
  - Added coverage reasons and ordering specifically for capture gaps.

- **Bug Fixes**
  - Improved artifact and capture-gap limit handling.
  - Preserved compatibility with existing intake data and validated boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->