### PR TITLE
fix(intune): preserve scoped names across retries and events

### DIFF
--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -1160,6 +1160,24 @@ mod tests {
     }
 
     #[test]
+    fn named_guid_fallback_is_shared_by_identity_and_download_extraction() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let message = format!(
+            r#"Download completed successfully correlation {app_guid} {{"Name":"Local Fallback Name"}}"#
+        );
+        assert_eq!(extract_content_id(&message).as_deref(), Some(app_guid));
+
+        let lines = vec![test_line(1, message)];
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&lines);
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &registry);
+
+        assert_eq!(downloads.len(), 1);
+        assert_eq!(downloads[0].content_id, app_guid);
+        assert_eq!(downloads[0].name, "Local Fallback Name");
+    }
+
+    #[test]
     fn explicit_same_scope_name_remains_valid_with_ingested_registry() {
         let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
         let lines = vec![test_line(

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -3,9 +3,11 @@ use std::path::Path;
 
 use regex::Regex;
 
+#[cfg(test)]
+use super::guid_registry::explicit_app_identity_context;
 use super::guid_registry::{
-    explicit_app_identity_context, extract_app_name, is_fallback_name, ExplicitAppIdentity,
-    GuidRegistry,
+    explicit_app_identity_context_with_named_guid_fallback, extract_app_name, is_fallback_name,
+    ExplicitAppIdentity, GuidRegistry,
 };
 use super::ime_parser::ImeLine;
 use super::models::DownloadStat;
@@ -385,7 +387,7 @@ struct DownloadIdentityAnalysis {
 }
 
 fn extract_download_identity(msg: &str) -> DownloadIdentityAnalysis {
-    let context = explicit_app_identity_context(msg);
+    let context = explicit_app_identity_context_with_named_guid_fallback(msg);
     match context.identity {
         ExplicitAppIdentity::Valid(guid) => {
             let display_name = context.local_name;

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -550,6 +550,18 @@ mod tests {
         downloads.remove(0)
     }
 
+    fn test_line(line_number: u32, message: impl Into<String>) -> ImeLine {
+        ImeLine {
+            line_number,
+            timestamp: Some("01-15-2024 10:00:05.000".to_string()),
+            timestamp_utc: None,
+            message: message.into(),
+            component: None,
+            thread: None,
+            timezone_offset: None,
+        }
+    }
+
     #[test]
     fn completed_download_is_recorded() {
         let lines = vec![
@@ -1024,5 +1036,101 @@ mod tests {
         for payload in payloads {
             assert_eq!(completed_json_download(&payload).name, "Preferred");
         }
+    }
+
+    #[test]
+    fn ingested_descendant_name_does_not_enrich_outer_selected_download() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let lines = vec![test_line(
+            1,
+            format!(
+                r#"Download completed successfully {{"AppId":"{app_guid}","Metadata":{{"AppId":"{app_guid}","Name":"Descendant Name"}}}}"#
+            ),
+        )];
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&lines);
+        assert_eq!(registry.resolve(app_guid), Some("Descendant Name"));
+
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &registry);
+
+        assert_eq!(downloads.len(), 1);
+        assert_eq!(downloads[0].content_id, app_guid);
+        assert_eq!(downloads[0].name, format!("Download ({app_guid})"));
+    }
+
+    #[test]
+    fn explicit_name_ambiguity_suppresses_existing_registry_enrichment() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payloads = [
+            format!(r#"{{"AppId":"{app_guid}","Name":"First Name","Name":"Second Name"}}"#),
+            format!(r#"[{{"AppId":"{app_guid}"}},{{"Name":"Sibling Name"}}]"#),
+        ];
+
+        for payload in payloads {
+            let lines = vec![
+                test_line(
+                    1,
+                    format!(
+                        r#"Observed identity {{"AppId":"{app_guid}","ApplicationName":"Trusted Registry Name"}}"#
+                    ),
+                ),
+                test_line(2, format!("Download completed successfully {payload}")),
+            ];
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&lines);
+            assert_eq!(registry.resolve(app_guid), Some("Trusted Registry Name"));
+
+            let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &registry);
+
+            assert_eq!(downloads.len(), 1, "missing download for {payload}");
+            assert_eq!(downloads[0].content_id, app_guid);
+            assert_eq!(
+                downloads[0].name,
+                format!("Download ({app_guid})"),
+                "enriched explicit ambiguous name for {payload}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_explicit_download_keeps_registry_fallback() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let lines = vec![
+            test_line(
+                1,
+                format!(
+                    r#"Observed identity {app_guid} {{"ApplicationName":"Trusted Registry Name"}}"#
+                ),
+            ),
+            test_line(
+                2,
+                format!("Download completed successfully for app id: {app_guid}"),
+            ),
+        ];
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&lines);
+
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &registry);
+
+        assert_eq!(downloads.len(), 1);
+        assert_eq!(downloads[0].name, "Trusted Registry Name");
+    }
+
+    #[test]
+    fn explicit_same_scope_name_remains_valid_with_ingested_registry() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let lines = vec![test_line(
+            1,
+            format!(
+                r#"Download completed successfully {{"AppId":"{app_guid}","Name":"Local Name"}}"#
+            ),
+        )];
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&lines);
+
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &registry);
+
+        assert_eq!(downloads.len(), 1);
+        assert_eq!(downloads[0].name, "Local Name");
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -910,4 +910,37 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn downloads_do_not_take_names_outside_the_selected_identity_object() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payloads = [
+            format!(r#"[{{"AppId":"{app_guid}"}},{{"Name":"Sibling Name"}}]"#),
+            format!(r#"{{"AppId":"{app_guid}","Metadata":{{"Name":"Nested Name"}}}}"#),
+        ];
+
+        for payload in payloads {
+            let downloads = extract_downloads(
+                &[ImeLine {
+                    line_number: 1,
+                    timestamp: Some("01-15-2024 10:00:05.000".to_string()),
+                    timestamp_utc: None,
+                    message: format!("Download completed successfully {payload}"),
+                    component: None,
+                    thread: None,
+                    timezone_offset: None,
+                }],
+                "C:/Logs/AppWorkload.log",
+                &empty_registry(),
+            );
+
+            assert_eq!(downloads.len(), 1, "missing coverage record for {payload}");
+            assert_eq!(downloads[0].content_id, app_guid);
+            assert_eq!(
+                downloads[0].name,
+                format!("Download ({app_guid})"),
+                "accepted out-of-scope name for {payload}"
+            );
+        }
+    }
 }

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use regex::Regex;
 
 use super::guid_registry::{
-    explicit_app_identity, extract_app_id, extract_app_name, extract_explicit_identity_name_pair,
-    is_fallback_name, ExplicitAppIdentity, GuidRegistry,
+    explicit_app_identity_context, extract_app_id, extract_app_name, is_fallback_name,
+    ExplicitAppIdentity, GuidRegistry,
 };
 use super::ime_parser::ImeLine;
 use super::models::DownloadStat;
@@ -139,8 +139,12 @@ pub fn extract_downloads(
         let display_name = analysis.display_name.clone();
 
         if analysis.is_retry {
+            let previous = active.remove(&content_id);
+            let inherited_suppression = previous
+                .as_ref()
+                .is_some_and(|download| download.suppress_registry_enrichment);
             if let Some(stat) = finalize_download(
-                active.remove(&content_id),
+                previous,
                 Some(content_id.clone()),
                 display_name.clone(),
                 &analysis,
@@ -157,7 +161,7 @@ pub fn extract_downloads(
                     Some(content_id),
                     display_name,
                     timestamp_owned.clone(),
-                    analysis.suppress_registry_enrichment,
+                    inherited_suppression || analysis.suppress_registry_enrichment,
                 ),
             );
             continue;
@@ -381,9 +385,10 @@ struct DownloadIdentityAnalysis {
 }
 
 fn extract_download_identity(msg: &str) -> DownloadIdentityAnalysis {
-    match explicit_app_identity(msg) {
+    let context = explicit_app_identity_context(msg);
+    match context.identity {
         ExplicitAppIdentity::Valid(guid) => {
-            let display_name = extract_explicit_identity_name_pair(msg).map(|(_, name)| name);
+            let display_name = context.local_name;
             let suppress_registry_enrichment = display_name.is_none();
             DownloadIdentityAnalysis {
                 content_id: Some(guid),
@@ -1028,7 +1033,7 @@ mod tests {
 
         assert_eq!(download.content_id, app_guid);
         assert_eq!(download.name, format!("Download ({app_guid})"));
-        assert_eq!(extract_explicit_identity_name_pair(&payload), None);
+        assert_eq!(explicit_app_identity_context(&payload).local_name, None);
     }
 
     #[test]
@@ -1048,7 +1053,7 @@ mod tests {
                 format!("Download ({app_guid})"),
                 "accepted conflicting name from {payload}"
             );
-            assert_eq!(extract_explicit_identity_name_pair(&payload), None);
+            assert_eq!(explicit_app_identity_context(&payload).local_name, None);
         }
     }
 
@@ -1184,7 +1189,7 @@ mod tests {
             test_line(
                 2,
                 format!(
-                    r#"Download started {{"AppId":"{app_guid}","Metadata":{{"AppId":"{app_guid}","Name":"Unsafe Descendant"}}}}"#
+                    r#"Starting content download {{"AppId":"{app_guid}","Metadata":{{"AppId":"{app_guid}","Name":"Unsafe Descendant"}}}}"#
                 ),
             ),
             test_line(
@@ -1203,8 +1208,71 @@ mod tests {
         let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &registry);
 
         assert_eq!(downloads.len(), 2);
-        assert!(downloads.iter().all(|download| {
-            download.content_id == app_guid && download.name == format!("Download ({app_guid})")
-        }));
+        assert!(
+            downloads.iter().all(|download| {
+                download.content_id == app_guid && download.name == format!("Download ({app_guid})")
+            }),
+            "retry outputs were not safely attributed: {downloads:#?}"
+        );
+    }
+
+    #[test]
+    fn retry_suppression_is_isolated_between_concurrent_content_ids() {
+        let unsafe_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let safe_guid = "11111111-2222-3333-4444-555555555555";
+        let lines = vec![
+            test_line(
+                1,
+                format!(
+                    r#"Observed identity {{"AppId":"{unsafe_guid}","ApplicationName":"Unsafe Registry Name"}}"#
+                ),
+            ),
+            test_line(
+                2,
+                format!(
+                    r#"Starting content download {{"AppId":"{unsafe_guid}","Metadata":{{"AppId":"{unsafe_guid}","Name":"Unsafe Descendant"}}}}"#
+                ),
+            ),
+            test_line(
+                3,
+                format!(
+                    r#"Starting content download {{"AppId":"{safe_guid}","Name":"Safe Local Name"}}"#
+                ),
+            ),
+            test_line(
+                4,
+                format!("Download failed, retrying content download for app id: {unsafe_guid}"),
+            ),
+            test_line(
+                5,
+                format!("Download completed successfully for app id: {safe_guid}"),
+            ),
+            test_line(
+                6,
+                format!("Download completed successfully for app id: {unsafe_guid}"),
+            ),
+        ];
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&lines);
+
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &registry);
+
+        assert_eq!(downloads.len(), 3);
+        let unsafe_fallback = format!("Download ({unsafe_guid})");
+        assert_eq!(
+            downloads
+                .iter()
+                .filter(|download| download.content_id == unsafe_guid)
+                .map(|download| download.name.as_str())
+                .collect::<Vec<_>>(),
+            vec![unsafe_fallback.as_str(), unsafe_fallback.as_str()]
+        );
+        assert_eq!(
+            downloads
+                .iter()
+                .find(|download| download.content_id == safe_guid)
+                .map(|download| download.name.as_str()),
+            Some("Safe Local Name")
+        );
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use regex::Regex;
 
 use super::guid_registry::{
-    explicit_app_identity_context, extract_app_id, extract_app_name, is_fallback_name,
-    ExplicitAppIdentity, GuidRegistry,
+    explicit_app_identity_context, extract_app_name, is_fallback_name, ExplicitAppIdentity,
+    GuidRegistry,
 };
 use super::ime_parser::ImeLine;
 use super::models::DownloadStat;
@@ -404,7 +404,7 @@ fn extract_download_identity(msg: &str) -> DownloadIdentityAnalysis {
         ExplicitAppIdentity::Absent => {
             // Preserve named-context and download-specific heuristics only
             // when the line has no explicit JSON identity field.
-            let content_id = extract_app_id(msg).or_else(|| {
+            let content_id = context.fallback_app_id.or_else(|| {
                 content_id_re()
                     .captures(msg)
                     .and_then(|captures| captures.get(1))
@@ -809,7 +809,8 @@ mod tests {
     fn escaped_json_fields_are_extracted_without_normalization() {
         let message = r#"Download completed successfully RequestPayload: {\"AppId\":\"a1b2c3d4-e5f6-7890-abcd-ef1234567890\",\"ApplicationName\":\"Contoso App\",\"SetUpFilePath\":\"C:\\Cache\\setup.exe\"}"#;
 
-        // extract_content_id delegates to guid_registry::extract_app_id + content_id_re() fallback
+        // extract_content_id reuses the shared explicit-identity context before
+        // the download-specific content-ID fallback.
         assert_eq!(
             extract_content_id(message).as_deref(),
             Some("a1b2c3d4-e5f6-7890-abcd-ef1234567890")

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -1170,4 +1170,41 @@ mod tests {
         assert_eq!(downloads.len(), 1);
         assert_eq!(downloads[0].name, "Local Name");
     }
+
+    #[test]
+    fn retry_keeps_explicit_name_suppression_across_attempts() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let lines = vec![
+            test_line(
+                1,
+                format!(
+                    r#"Observed identity {{"AppId":"{app_guid}","ApplicationName":"Trusted Registry Name"}}"#
+                ),
+            ),
+            test_line(
+                2,
+                format!(
+                    r#"Download started {{"AppId":"{app_guid}","Metadata":{{"AppId":"{app_guid}","Name":"Unsafe Descendant"}}}}"#
+                ),
+            ),
+            test_line(
+                3,
+                format!("Download failed, retrying content download for app id: {app_guid}"),
+            ),
+            test_line(
+                4,
+                format!("Download completed successfully for app id: {app_guid}"),
+            ),
+        ];
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&lines);
+        assert_eq!(registry.resolve(app_guid), Some("Trusted Registry Name"));
+
+        let downloads = extract_downloads(&lines, "C:/Logs/AppWorkload.log", &registry);
+
+        assert_eq!(downloads.len(), 2);
+        assert!(downloads.iter().all(|download| {
+            download.content_id == app_guid && download.name == format!("Download ({app_guid})")
+        }));
+    }
 }

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -153,7 +153,12 @@ pub fn extract_downloads(
 
             active.insert(
                 content_id.clone(),
-                PartialDownload::new(Some(content_id), display_name, timestamp_owned.clone()),
+                PartialDownload::new(
+                    Some(content_id),
+                    display_name,
+                    timestamp_owned.clone(),
+                    analysis.suppress_registry_enrichment,
+                ),
             );
             continue;
         }
@@ -164,6 +169,7 @@ pub fn extract_downloads(
                     Some(content_id.clone()),
                     display_name.clone(),
                     timestamp_owned.clone(),
+                    analysis.suppress_registry_enrichment,
                 )
             });
             apply_download_analysis(entry, &analysis, timestamp);
@@ -209,7 +215,7 @@ pub fn extract_downloads(
                 .display_name
                 .clone()
                 .unwrap_or_else(|| short_id(&cid));
-            let name = if is_fallback_name(&raw_name) {
+            let name = if is_fallback_name(&raw_name) && !partial.suppress_registry_enrichment {
                 registry
                     .resolve(&cid)
                     .map(|n| n.to_string())
@@ -246,6 +252,7 @@ struct DownloadLineAnalysis {
     speed_bps: Option<f64>,
     do_percentage: Option<f64>,
     duration_secs: Option<f64>,
+    suppress_registry_enrichment: bool,
     is_retry: bool,
     is_start: bool,
     is_progress: bool,
@@ -276,13 +283,16 @@ impl DownloadLineAnalysis {
             }
         });
 
+        let identity = extract_download_identity(msg);
+
         Some(Self {
-            content_id: extract_content_id(msg),
-            display_name: extract_display_name(msg),
+            content_id: identity.content_id,
+            display_name: identity.display_name,
             size_bytes,
             speed_bps,
             do_percentage,
             duration_secs,
+            suppress_registry_enrichment: identity.suppress_registry_enrichment,
             is_retry: appworkload_retry_re().is_match(msg),
             is_start: download_start_re().is_match(msg),
             is_progress: download_progress_re().is_match(msg),
@@ -302,6 +312,7 @@ struct PartialDownload {
     speed_bps: Option<f64>,
     do_percentage: Option<f64>,
     duration_secs: Option<f64>,
+    suppress_registry_enrichment: bool,
     saw_progress: bool,
     saw_failure_signal: bool,
     saw_retry_signal: bool,
@@ -312,6 +323,7 @@ impl PartialDownload {
         content_id: Option<String>,
         display_name: Option<String>,
         start_time: Option<String>,
+        suppress_registry_enrichment: bool,
     ) -> Self {
         Self {
             content_id,
@@ -322,6 +334,7 @@ impl PartialDownload {
             speed_bps: None,
             do_percentage: None,
             duration_secs: None,
+            suppress_registry_enrichment,
             saw_progress: false,
             saw_failure_signal: false,
             saw_retry_signal: false,
@@ -351,31 +364,53 @@ fn classify_download_source(source_file: &str) -> DownloadSourceKind {
     }
 }
 
+#[cfg(test)]
 fn extract_content_id(msg: &str) -> Option<String> {
+    extract_download_identity(msg).content_id
+}
+
+#[cfg(test)]
+fn extract_display_name(msg: &str) -> Option<String> {
+    extract_download_identity(msg).display_name
+}
+
+struct DownloadIdentityAnalysis {
+    content_id: Option<String>,
+    display_name: Option<String>,
+    suppress_registry_enrichment: bool,
+}
+
+fn extract_download_identity(msg: &str) -> DownloadIdentityAnalysis {
     match explicit_app_identity(msg) {
-        ExplicitAppIdentity::Valid(guid) => Some(guid),
-        ExplicitAppIdentity::Invalid => None,
+        ExplicitAppIdentity::Valid(guid) => {
+            let display_name = extract_explicit_identity_name_pair(msg).map(|(_, name)| name);
+            let suppress_registry_enrichment = display_name.is_none();
+            DownloadIdentityAnalysis {
+                content_id: Some(guid),
+                display_name,
+                suppress_registry_enrichment,
+            }
+        }
+        ExplicitAppIdentity::Invalid => DownloadIdentityAnalysis {
+            content_id: None,
+            display_name: None,
+            suppress_registry_enrichment: true,
+        },
         ExplicitAppIdentity::Absent => {
             // Preserve named-context and download-specific heuristics only
             // when the line has no explicit JSON identity field.
-            extract_app_id(msg).or_else(|| {
+            let content_id = extract_app_id(msg).or_else(|| {
                 content_id_re()
                     .captures(msg)
                     .and_then(|captures| captures.get(1))
                     .map(|value| value.as_str().to_string())
-            })
+            });
+            DownloadIdentityAnalysis {
+                content_id,
+                display_name: extract_app_name(msg),
+                suppress_registry_enrichment: false,
+            }
         }
-    }
-}
-
-fn extract_display_name(msg: &str) -> Option<String> {
-    match explicit_app_identity(msg) {
-        ExplicitAppIdentity::Valid(_) => {
-            extract_explicit_identity_name_pair(msg).map(|(_, name)| name)
-        }
-        ExplicitAppIdentity::Invalid => None,
-        // Preserve line-wide extraction for the established named-context fallback.
-        ExplicitAppIdentity::Absent => extract_app_name(msg),
     }
 }
 
@@ -397,6 +432,7 @@ fn apply_download_analysis(
     if download.display_name.is_none() {
         download.display_name = analysis.display_name.clone();
     }
+    download.suppress_registry_enrichment |= analysis.suppress_registry_enrichment;
 
     if analysis.is_progress {
         download.saw_progress = true;
@@ -468,6 +504,7 @@ fn finalize_download(
             content_id.clone(),
             display_name.clone(),
             timestamp.map(|value| value.to_string()),
+            analysis.suppress_registry_enrichment,
         )
     });
     apply_download_analysis(&mut partial, analysis, timestamp);
@@ -490,7 +527,7 @@ fn finalize_download(
         .display_name
         .clone()
         .unwrap_or_else(|| short_id(&resolved_content_id));
-    let name = if is_fallback_name(&raw_name) {
+    let name = if is_fallback_name(&raw_name) && !partial.suppress_registry_enrichment {
         registry
             .resolve(&resolved_content_id)
             .map(|n| n.to_string())

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -532,6 +532,24 @@ mod tests {
         GuidRegistry::new()
     }
 
+    fn completed_json_download(payload: &str) -> DownloadStat {
+        let mut downloads = extract_downloads(
+            &[ImeLine {
+                line_number: 1,
+                timestamp: Some("01-15-2024 10:00:05.000".to_string()),
+                timestamp_utc: None,
+                message: format!("Download completed successfully {payload}"),
+                component: None,
+                thread: None,
+                timezone_offset: None,
+            }],
+            "C:/Logs/AppWorkload.log",
+            &empty_registry(),
+        );
+        assert_eq!(downloads.len(), 1, "missing coverage record for {payload}");
+        downloads.remove(0)
+    }
+
     #[test]
     fn completed_download_is_recorded() {
         let lines = vec![
@@ -947,6 +965,64 @@ mod tests {
                 format!("Download ({app_guid})"),
                 "accepted out-of-scope name for {payload}"
             );
+        }
+    }
+
+    #[test]
+    fn selected_ancestor_does_not_take_a_repeated_descendant_identity_name() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payload = format!(
+            r#"{{"AppId":"{app_guid}","Metadata":{{"AppId":"{app_guid}","Name":"Descendant Name"}}}}"#
+        );
+
+        let download = completed_json_download(&payload);
+
+        assert_eq!(download.content_id, app_guid);
+        assert_eq!(download.name, format!("Download ({app_guid})"));
+        assert_eq!(extract_explicit_identity_name_pair(&payload), None);
+    }
+
+    #[test]
+    fn conflicting_duplicate_names_in_the_selected_object_fail_closed() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payloads = [
+            format!(r#"{{"AppId":"{app_guid}","Name":"First Name","Name":"Second Name"}}"#),
+            format!(r#"{{"AppId":"{app_guid}","Name":"Second Name","Name":"First Name"}}"#),
+        ];
+
+        for payload in payloads {
+            let download = completed_json_download(&payload);
+
+            assert_eq!(download.content_id, app_guid);
+            assert_eq!(
+                download.name,
+                format!("Download ({app_guid})"),
+                "accepted conflicting name from {payload}"
+            );
+            assert_eq!(extract_explicit_identity_name_pair(&payload), None);
+        }
+    }
+
+    #[test]
+    fn identical_duplicate_names_are_deterministic() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payload = format!(r#"{{"AppId":"{app_guid}","Name":"Same Name","Name":"Same Name"}}"#);
+
+        let download = completed_json_download(&payload);
+
+        assert_eq!(download.name, "Same Name");
+    }
+
+    #[test]
+    fn application_name_precedes_name_in_either_field_order() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let payloads = [
+            format!(r#"{{"AppId":"{app_guid}","ApplicationName":"Preferred","Name":"Fallback"}}"#),
+            format!(r#"{{"AppId":"{app_guid}","Name":"Fallback","ApplicationName":"Preferred"}}"#),
+        ];
+
+        for payload in payloads {
+            assert_eq!(completed_json_download(&payload).name, "Preferred");
         }
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/download_stats.rs
+++ b/crates/cmtraceopen-parser/src/intune/download_stats.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use regex::Regex;
 
 use super::guid_registry::{
-    explicit_app_identity, extract_app_id, extract_app_name, is_fallback_name, ExplicitAppIdentity,
-    GuidRegistry,
+    explicit_app_identity, extract_app_id, extract_app_name, extract_explicit_identity_name_pair,
+    is_fallback_name, ExplicitAppIdentity, GuidRegistry,
 };
 use super::ime_parser::ImeLine;
 use super::models::DownloadStat;
@@ -369,8 +369,14 @@ fn extract_content_id(msg: &str) -> Option<String> {
 }
 
 fn extract_display_name(msg: &str) -> Option<String> {
-    // Delegates to shared extraction in guid_registry (handles ApplicationName, Name, SetUpFilePath)
-    extract_app_name(msg)
+    match explicit_app_identity(msg) {
+        ExplicitAppIdentity::Valid(_) => {
+            extract_explicit_identity_name_pair(msg).map(|(_, name)| name)
+        }
+        ExplicitAppIdentity::Invalid => None,
+        // Preserve line-wide extraction for the established named-context fallback.
+        ExplicitAppIdentity::Absent => extract_app_name(msg),
+    }
 }
 
 fn apply_download_analysis(

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -492,9 +492,13 @@ pub fn extract_events(
             continue;
         };
 
-        // Try primary extract_guid, fall back to guid_registry::extract_app_id
-        let guid =
-            extract_guid(&line.message).or_else(|| guid_registry::extract_app_id(&line.message));
+        let guid = match guid_registry::explicit_app_identity(&line.message) {
+            guid_registry::ExplicitAppIdentity::Valid(guid) => Some(guid),
+            guid_registry::ExplicitAppIdentity::Invalid => None,
+            guid_registry::ExplicitAppIdentity::Absent => {
+                extract_guid(&line.message).or_else(|| guid_registry::extract_app_id(&line.message))
+            }
+        };
         let status = determine_status(&line.message, source_kind);
         let raw_name = build_event_name(&event_type, &guid, &line.message, source_kind);
 
@@ -2269,7 +2273,10 @@ mod tests {
                 format!(r#"ESP status for tenant {unrelated_guid} {{"Id":"not-an-app-guid"}}"#),
                 None,
             ),
-            (format!("ESP status for tenant {unrelated_guid}"), Some(unrelated_guid)),
+            (
+                format!("ESP status for tenant {unrelated_guid}"),
+                Some(unrelated_guid),
+            ),
             (
                 format!(r#"ESP status for tenant {unrelated_guid} {{"AppId":"{app_guid}"}}"#),
                 Some(app_guid),

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -2154,6 +2154,7 @@ mod tests {
         let mut registry = GuidRegistry::new();
         registry.ingest_lines(&[line(&message, "01-15-2024 10:00:04.000", 1)]);
         assert_eq!(registry.resolve(app_guid), Some("Contoso"));
+        guid_registry::reset_named_guid_fallback_extraction_count();
         let events = extract_events(
             &[line(&message, "01-15-2024 10:00:05.000", 2)],
             "C:/Logs/AppWorkload.log",
@@ -2164,6 +2165,7 @@ mod tests {
         assert_eq!(events[0].event_type, IntuneEventType::ContentDownload);
         assert_eq!(events[0].guid.as_deref(), Some(app_guid));
         assert!(events[0].name.contains("Contoso"));
+        assert_eq!(guid_registry::named_guid_fallback_extraction_count(), 0);
     }
 
     #[test]
@@ -2413,6 +2415,7 @@ mod tests {
             "C:/Logs/AppWorkload.log",
             &explicit_registry,
         );
+        guid_registry::reset_named_guid_fallback_extraction_count();
         let fallback_events = extract_events(
             &[line(&fallback, "01-15-2024 10:00:05.000", 4)],
             "C:/Logs/IntuneManagementExtension.log",
@@ -2424,5 +2427,6 @@ mod tests {
         assert_eq!(fallback_events.len(), 1);
         assert_eq!(fallback_events[0].guid.as_deref(), Some(app_guid));
         assert!(fallback_events[0].name.contains("Fallback Name"));
+        assert_eq!(guid_registry::named_guid_fallback_extraction_count(), 0);
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -2255,4 +2255,40 @@ mod tests {
             assert_eq!(events[0].parent_app_guid, None);
         }
     }
+
+    #[test]
+    fn non_appworkload_events_respect_explicit_identity_boundaries() {
+        let unrelated_guid = "11111111-2222-3333-4444-555555555555";
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let cases = [
+            (
+                format!(r#"ESP status for tenant {unrelated_guid} {{"AppId":"not-an-app-guid"}}"#),
+                None,
+            ),
+            (
+                format!(r#"ESP status for tenant {unrelated_guid} {{"Id":"not-an-app-guid"}}"#),
+                None,
+            ),
+            (format!("ESP status for tenant {unrelated_guid}"), Some(unrelated_guid)),
+            (
+                format!(r#"ESP status for tenant {unrelated_guid} {{"AppId":"{app_guid}"}}"#),
+                Some(app_guid),
+            ),
+        ];
+
+        for (message, expected_guid) in cases {
+            let events = extract_events(
+                &[line(&message, "01-15-2024 10:00:05.000", 1)],
+                "C:/Logs/IntuneManagementExtension.log",
+                &empty_registry(),
+            );
+
+            assert_eq!(events.len(), 1, "missing event for {message}");
+            assert_eq!(
+                events[0].guid.as_deref(),
+                expected_guid,
+                "wrong GUID attribution for {message}"
+            );
+        }
+    }
 }

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -497,7 +497,7 @@ pub fn extract_events(
             guid_registry::ExplicitAppIdentity::Valid(guid) => Some(guid.clone()),
             guid_registry::ExplicitAppIdentity::Invalid => None,
             guid_registry::ExplicitAppIdentity::Absent => {
-                extract_guid(&line.message).or_else(|| guid_registry::extract_app_id(&line.message))
+                extract_guid(&line.message).or_else(|| identity_context.fallback_app_id.clone())
             }
         };
         let status = determine_status(&line.message, source_kind);
@@ -612,7 +612,7 @@ fn extract_appworkload_event(
         guid_registry::ExplicitAppIdentity::Absent => {
             // Preserve the established AppWorkload heuristics only when the
             // line does not claim an explicit JSON identity field.
-            extract_guid(msg).or_else(|| guid_registry::extract_app_id(msg))
+            extract_guid(msg).or_else(|| identity_context.fallback_app_id.clone())
         }
     };
 

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -492,8 +492,9 @@ pub fn extract_events(
             continue;
         };
 
-        let guid = match guid_registry::explicit_app_identity(&line.message) {
-            guid_registry::ExplicitAppIdentity::Valid(guid) => Some(guid),
+        let identity_context = guid_registry::explicit_app_identity_context(&line.message);
+        let guid = match &identity_context.identity {
+            guid_registry::ExplicitAppIdentity::Valid(guid) => Some(guid.clone()),
             guid_registry::ExplicitAppIdentity::Invalid => None,
             guid_registry::ExplicitAppIdentity::Absent => {
                 extract_guid(&line.message).or_else(|| guid_registry::extract_app_id(&line.message))
@@ -503,10 +504,8 @@ pub fn extract_events(
         let raw_name = build_event_name(&event_type, &guid, &line.message, source_kind);
 
         // Inline enrichment: resolve GUID suffix immediately if possible
-        let name = match guid.as_deref() {
-            Some(g) => registry.enrich_event_name(&raw_name, g).unwrap_or(raw_name),
-            None => raw_name,
-        };
+        let name =
+            enrich_event_name_for_identity(raw_name, guid.as_deref(), &identity_context, registry);
 
         let detail = line.message.clone();
 
@@ -536,6 +535,28 @@ pub fn extract_events(
 
     pair_events(&mut events);
     events
+}
+
+fn enrich_event_name_for_identity(
+    current_name: String,
+    guid: Option<&str>,
+    identity_context: &guid_registry::ExplicitAppIdentityContext,
+    registry: &GuidRegistry,
+) -> String {
+    let Some(guid) = guid else {
+        return current_name;
+    };
+    let enriched = match &identity_context.identity {
+        guid_registry::ExplicitAppIdentity::Valid(_) => identity_context
+            .local_name
+            .as_deref()
+            .and_then(|name| guid_registry::enrich_event_name_with_name(&current_name, name)),
+        guid_registry::ExplicitAppIdentity::Absent => {
+            registry.enrich_event_name(&current_name, guid)
+        }
+        guid_registry::ExplicitAppIdentity::Invalid => None,
+    };
+    enriched.unwrap_or(current_name)
 }
 
 fn extract_appworkload_event(
@@ -584,8 +605,9 @@ fn extract_appworkload_event(
         return None;
     };
 
-    let guid = match guid_registry::explicit_app_identity(msg) {
-        guid_registry::ExplicitAppIdentity::Valid(guid) => Some(guid),
+    let identity_context = guid_registry::explicit_app_identity_context(msg);
+    let guid = match &identity_context.identity {
+        guid_registry::ExplicitAppIdentity::Valid(guid) => Some(guid.clone()),
         guid_registry::ExplicitAppIdentity::Invalid => None,
         guid_registry::ExplicitAppIdentity::Absent => {
             // Preserve the established AppWorkload heuristics only when the
@@ -613,10 +635,8 @@ fn extract_appworkload_event(
         };
         let raw_name = format!("Script Detection {phase} ({short})");
 
-        let name = match guid.as_deref() {
-            Some(g) => registry.enrich_event_name(&raw_name, g).unwrap_or(raw_name),
-            None => raw_name,
-        };
+        let name =
+            enrich_event_name_for_identity(raw_name, guid.as_deref(), &identity_context, registry);
 
         return Some(IntuneEvent {
             id: next_id,
@@ -645,10 +665,8 @@ fn extract_appworkload_event(
     let raw_name = build_appworkload_name(&event_type, &guid, msg, flags);
 
     // Inline enrichment: resolve GUID suffix immediately if possible
-    let name = match guid.as_deref() {
-        Some(g) => registry.enrich_event_name(&raw_name, g).unwrap_or(raw_name),
-        None => raw_name,
-    };
+    let name =
+        enrich_event_name_for_identity(raw_name, guid.as_deref(), &identity_context, registry);
     let detail = build_appworkload_detail(lines, index, guid.as_deref(), msg, status);
 
     Some(IntuneEvent {
@@ -2382,25 +2400,24 @@ mod tests {
             r#"AppWorkload download {{"AppId":"{app_guid}","ApplicationName":"Local Name"}}"#
         );
         let fallback = format!("ESP status for app {app_guid}");
-        let mut registry = GuidRegistry::new();
-        registry.ingest_lines(&[
-            line(&explicit, "01-15-2024 10:00:04.000", 1),
-            line(
-                &format!(r#"Observed identity {app_guid} {{"ApplicationName":"Fallback Name"}}"#),
-                "01-15-2024 10:00:04.000",
-                2,
-            ),
-        ]);
+        let mut explicit_registry = GuidRegistry::new();
+        explicit_registry.ingest_lines(&[line(&explicit, "01-15-2024 10:00:04.000", 1)]);
+        let mut fallback_registry = GuidRegistry::new();
+        fallback_registry.ingest_lines(&[line(
+            &format!(r#"Observed identity {app_guid} {{"ApplicationName":"Fallback Name"}}"#),
+            "01-15-2024 10:00:04.000",
+            2,
+        )]);
 
         let explicit_events = extract_events(
             &[line(&explicit, "01-15-2024 10:00:05.000", 3)],
             "C:/Logs/AppWorkload.log",
-            &registry,
+            &explicit_registry,
         );
         let fallback_events = extract_events(
             &[line(&fallback, "01-15-2024 10:00:05.000", 4)],
             "C:/Logs/IntuneManagementExtension.log",
-            &registry,
+            &fallback_registry,
         );
 
         assert_eq!(explicit_events.len(), 1);

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -496,9 +496,7 @@ pub fn extract_events(
         let guid = match &identity_context.identity {
             guid_registry::ExplicitAppIdentity::Valid(guid) => Some(guid.clone()),
             guid_registry::ExplicitAppIdentity::Invalid => None,
-            guid_registry::ExplicitAppIdentity::Absent => {
-                extract_guid(&line.message).or_else(|| identity_context.fallback_app_id.clone())
-            }
+            guid_registry::ExplicitAppIdentity::Absent => extract_guid(&line.message),
         };
         let status = determine_status(&line.message, source_kind);
         let raw_name = build_event_name(&event_type, &guid, &line.message, source_kind);
@@ -612,7 +610,7 @@ fn extract_appworkload_event(
         guid_registry::ExplicitAppIdentity::Absent => {
             // Preserve the established AppWorkload heuristics only when the
             // line does not claim an explicit JSON identity field.
-            extract_guid(msg).or_else(|| identity_context.fallback_app_id.clone())
+            extract_guid(msg)
         }
     };
 
@@ -2153,10 +2151,13 @@ mod tests {
         let message = format!(
             r#"SidecarScriptDetectionManager launch identity {app_guid} {{"ApplicationName":"Contoso"}}"#
         );
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&[line(&message, "01-15-2024 10:00:04.000", 1)]);
+        assert_eq!(registry.resolve(app_guid), Some("Contoso"));
         let events = extract_events(
-            &[line(&message, "01-15-2024 10:00:05.000", 1)],
+            &[line(&message, "01-15-2024 10:00:05.000", 2)],
             "C:/Logs/AppWorkload.log",
-            &empty_registry(),
+            &registry,
         );
 
         assert_eq!(events.len(), 1);
@@ -2399,15 +2400,12 @@ mod tests {
         let explicit = format!(
             r#"AppWorkload download {{"AppId":"{app_guid}","ApplicationName":"Local Name"}}"#
         );
-        let fallback = format!("ESP status for app {app_guid}");
+        let fallback =
+            format!(r#"ESP status correlation {app_guid} {{"ApplicationName":"Fallback Name"}}"#);
         let mut explicit_registry = GuidRegistry::new();
         explicit_registry.ingest_lines(&[line(&explicit, "01-15-2024 10:00:04.000", 1)]);
         let mut fallback_registry = GuidRegistry::new();
-        fallback_registry.ingest_lines(&[line(
-            &format!(r#"Observed identity {app_guid} {{"ApplicationName":"Fallback Name"}}"#),
-            "01-15-2024 10:00:04.000",
-            2,
-        )]);
+        fallback_registry.ingest_lines(&[line(&fallback, "01-15-2024 10:00:04.000", 2)]);
 
         let explicit_events = extract_events(
             &[line(&explicit, "01-15-2024 10:00:05.000", 3)],
@@ -2423,6 +2421,7 @@ mod tests {
         assert_eq!(explicit_events.len(), 1);
         assert!(explicit_events[0].name.contains("Local Name"));
         assert_eq!(fallback_events.len(), 1);
+        assert_eq!(fallback_events[0].guid.as_deref(), Some(app_guid));
         assert!(fallback_events[0].name.contains("Fallback Name"));
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -2298,4 +2298,114 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn appworkload_events_do_not_enrich_names_outside_selected_identity_scope() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let messages = [
+            format!(
+                r#"AppWorkload download {{"AppId":"{app_guid}","Metadata":{{"AppId":"{app_guid}","Name":"Descendant Name"}}}}"#
+            ),
+            format!(
+                r#"AppWorkload download {{"AppId":"{app_guid}","Name":"First Name","Name":"Second Name"}}"#
+            ),
+            format!(
+                r#"SidecarScriptDetectionManager launch {{"AppId":"{app_guid}","Metadata":{{"AppId":"{app_guid}","Name":"Descendant Name"}}}}"#
+            ),
+        ];
+
+        for message in messages {
+            let registry_lines = vec![
+                line(
+                    &format!(
+                        r#"Observed identity {{"AppId":"{app_guid}","ApplicationName":"Trusted Registry Name"}}"#
+                    ),
+                    "01-15-2024 10:00:04.000",
+                    1,
+                ),
+                line(&message, "01-15-2024 10:00:05.000", 2),
+            ];
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&registry_lines);
+
+            let events = extract_events(
+                &[line(&message, "01-15-2024 10:00:05.000", 2)],
+                "C:/Logs/AppWorkload.log",
+                &registry,
+            );
+
+            assert_eq!(events.len(), 1, "missing event for {message}");
+            assert_eq!(events[0].guid.as_deref(), Some(app_guid));
+            assert!(!events[0].name.contains("Trusted Registry Name"));
+            assert!(!events[0].name.contains("Descendant Name"));
+        }
+    }
+
+    #[test]
+    fn non_appworkload_events_do_not_enrich_ambiguous_explicit_names() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let messages = [
+            format!(
+                r#"ESP status {{"AppId":"{app_guid}","Metadata":{{"AppId":"{app_guid}","Name":"Descendant Name"}}}}"#
+            ),
+            format!(
+                r#"ESP status {{"AppId":"{app_guid}","Name":"First Name","Name":"Second Name"}}"#
+            ),
+        ];
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&[line(
+            &format!(
+                r#"Observed identity {{"AppId":"{app_guid}","ApplicationName":"Trusted Registry Name"}}"#
+            ),
+            "01-15-2024 10:00:04.000",
+            1,
+        )]);
+
+        for message in messages {
+            let events = extract_events(
+                &[line(&message, "01-15-2024 10:00:05.000", 2)],
+                "C:/Logs/IntuneManagementExtension.log",
+                &registry,
+            );
+
+            assert_eq!(events.len(), 1, "missing event for {message}");
+            assert_eq!(events[0].guid.as_deref(), Some(app_guid));
+            assert!(!events[0].name.contains("Trusted Registry Name"));
+            assert!(!events[0].name.contains("Descendant Name"));
+        }
+    }
+
+    #[test]
+    fn event_name_enrichment_remains_for_safe_identity_contexts() {
+        let app_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let explicit = format!(
+            r#"AppWorkload download {{"AppId":"{app_guid}","ApplicationName":"Local Name"}}"#
+        );
+        let fallback = format!("ESP status for app {app_guid}");
+        let mut registry = GuidRegistry::new();
+        registry.ingest_lines(&[
+            line(&explicit, "01-15-2024 10:00:04.000", 1),
+            line(
+                &format!(r#"Observed identity {app_guid} {{"ApplicationName":"Fallback Name"}}"#),
+                "01-15-2024 10:00:04.000",
+                2,
+            ),
+        ]);
+
+        let explicit_events = extract_events(
+            &[line(&explicit, "01-15-2024 10:00:05.000", 3)],
+            "C:/Logs/AppWorkload.log",
+            &registry,
+        );
+        let fallback_events = extract_events(
+            &[line(&fallback, "01-15-2024 10:00:05.000", 4)],
+            "C:/Logs/IntuneManagementExtension.log",
+            &registry,
+        );
+
+        assert_eq!(explicit_events.len(), 1);
+        assert!(explicit_events[0].name.contains("Local Name"));
+        assert_eq!(fallback_events.len(), 1);
+        assert!(fallback_events[0].name.contains("Fallback Name"));
+    }
 }

--- a/crates/cmtraceopen-parser/src/intune/event_tracker.rs
+++ b/crates/cmtraceopen-parser/src/intune/event_tracker.rs
@@ -2149,7 +2149,7 @@ mod tests {
     fn appworkload_named_context_fallback_remains_without_identity_field() {
         let app_guid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
         let message = format!(
-            r#"SidecarScriptDetectionManager launch identity {app_guid} {{"ApplicationName":"Contoso"}}"#
+            r#"AppWorkload download stalled with no progress correlation {app_guid} {{"ApplicationName":"Contoso"}}"#
         );
         let mut registry = GuidRegistry::new();
         registry.ingest_lines(&[line(&message, "01-15-2024 10:00:04.000", 1)]);
@@ -2161,8 +2161,9 @@ mod tests {
         );
 
         assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, IntuneEventType::ContentDownload);
         assert_eq!(events[0].guid.as_deref(), Some(app_guid));
-        assert_eq!(events[0].parent_app_guid.as_deref(), Some(app_guid));
+        assert!(events[0].name.contains("Contoso"));
     }
 
     #[test]

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -1254,6 +1254,18 @@ mod tests {
     }
 
     #[test]
+    fn strip_guid_suffix_rejects_malformed_full_length_shape() {
+        assert_eq!(
+            strip_short_guid_suffix("Some Name (------------------------------------)"),
+            None
+        );
+        assert_eq!(
+            strip_short_guid_suffix("Some Name (a1b2c3d4e5f6-7890-abcd-ef12-34567890)"),
+            None
+        );
+    }
+
+    #[test]
     fn to_serializable_preserves_entries_and_sources() {
         let mut reg = GuidRegistry::new();
         reg.ingest_lines(&[

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -43,6 +43,8 @@ pub(crate) enum ExplicitAppIdentity {
 pub(crate) struct ExplicitAppIdentityContext {
     pub identity: ExplicitAppIdentity,
     pub local_name: Option<String>,
+    /// Populated only for an absent explicit identity when the caller enables
+    /// the legacy named-GUID fallback; valid and invalid identities keep this `None`.
     pub fallback_app_id: Option<String>,
 }
 

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -272,6 +272,15 @@ struct JsonFieldScan<'a> {
     scopes: Vec<JsonObjectScope<'a>>,
 }
 
+enum ExplicitAppIdentitySelection<'scan, 'msg> {
+    Absent,
+    Valid {
+        guid: String,
+        scope: &'scan JsonObjectScope<'msg>,
+    },
+    Invalid,
+}
+
 impl JsonFieldScan<'_> {
     fn has_explicit_identity_fields(&self) -> bool {
         self.root
@@ -553,14 +562,19 @@ fn scope_name(scope: &JsonObjectScope<'_>) -> Option<(String, GuidNameSource)> {
         JsonFieldKind::Name,
         JsonFieldKind::SetUpFilePath,
     ] {
-        let Some(value) = scope
+        let mut values = scope
             .fields
             .iter()
             .filter(|field| field.kind == kind)
-            .find_map(|field| field.value)
-        else {
+            .filter_map(|field| field.value);
+        let Some(value) = values.next() else {
             continue;
         };
+        // Repeated identical values are deterministic. Conflicting values of
+        // the highest-priority available name kind make the scope ambiguous.
+        if values.any(|candidate| candidate != value) {
+            return None;
+        }
         return Some(match kind {
             JsonFieldKind::ApplicationName => (value.to_string(), GuidNameSource::ApplicationName),
             JsonFieldKind::Name => (value.to_string(), GuidNameSource::NameField),
@@ -597,15 +611,13 @@ pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
 /// Extract an explicit app identity together with a name from that identity's
 /// own JSON object. Names in a sibling or nested object are not associated.
 pub(crate) fn extract_explicit_identity_name_pair(msg: &str) -> Option<(String, String)> {
-    let guid = match explicit_app_identity(msg) {
-        ExplicitAppIdentity::Valid(guid) => guid,
-        ExplicitAppIdentity::Absent | ExplicitAppIdentity::Invalid => return None,
-    };
     let scan = scan_json_fields(msg).ok()?;
-    extract_all_identity_name_pairs(&scan)
-        .into_iter()
-        .find(|(candidate, _, _)| candidate == &guid)
-        .map(|(_, name, _)| (guid, name))
+    match select_explicit_app_identity(&scan) {
+        ExplicitAppIdentitySelection::Valid { guid, scope } => {
+            scope_name(scope).map(|(name, _)| (guid, name))
+        }
+        ExplicitAppIdentitySelection::Absent | ExplicitAppIdentitySelection::Invalid => None,
+    }
 }
 
 /// Classify explicit JSON `AppId`/`Id` fields without falling back to other
@@ -616,8 +628,19 @@ pub(crate) fn explicit_app_identity(msg: &str) -> ExplicitAppIdentity {
         return ExplicitAppIdentity::Invalid;
     };
 
+    match select_explicit_app_identity(&scan) {
+        ExplicitAppIdentitySelection::Absent => ExplicitAppIdentity::Absent,
+        ExplicitAppIdentitySelection::Valid { guid, .. } => ExplicitAppIdentity::Valid(guid),
+        ExplicitAppIdentitySelection::Invalid => ExplicitAppIdentity::Invalid,
+    }
+}
+
+fn select_explicit_app_identity<'scan, 'msg>(
+    scan: &'scan JsonFieldScan<'msg>,
+) -> ExplicitAppIdentitySelection<'scan, 'msg> {
     let root_identity = classify_scope_identity(&scan.root);
-    let mut selected = (root_identity != ExplicitAppIdentity::Absent).then_some(root_identity);
+    let mut selected =
+        (root_identity != ExplicitAppIdentity::Absent).then_some((&scan.root, root_identity));
     let mut start = 0;
     while start < scan.scopes.len() {
         let tree_start = scan.scopes[start].tree_start;
@@ -631,7 +654,7 @@ pub(crate) fn explicit_app_identity(msg: &str) -> ExplicitAppIdentity {
                 match identity_span {
                     None => {
                         identity_span = Some((scan.scopes[end].start, scan.scopes[end].end));
-                        tree_identity = Some(identity);
+                        tree_identity = Some((&scan.scopes[end], identity));
                     }
                     Some((outer_start, outer_end))
                         if scan.scopes[end].start >= outer_start
@@ -642,19 +665,26 @@ pub(crate) fn explicit_app_identity(msg: &str) -> ExplicitAppIdentity {
             end += 1;
         }
 
-        if let Some(mut identity) = tree_identity {
+        if let Some((scope, mut identity)) = tree_identity {
             if ambiguous {
                 identity = ExplicitAppIdentity::Invalid;
             }
             if selected.is_some() {
-                return ExplicitAppIdentity::Invalid;
+                return ExplicitAppIdentitySelection::Invalid;
             }
-            selected = Some(identity);
+            selected = Some((scope, identity));
         }
         start = end;
     }
 
-    selected.unwrap_or(ExplicitAppIdentity::Absent)
+    match selected {
+        None => ExplicitAppIdentitySelection::Absent,
+        Some((scope, ExplicitAppIdentity::Valid(guid))) => {
+            ExplicitAppIdentitySelection::Valid { guid, scope }
+        }
+        Some((_, ExplicitAppIdentity::Invalid)) => ExplicitAppIdentitySelection::Invalid,
+        Some((_, ExplicitAppIdentity::Absent)) => unreachable!(),
+    }
 }
 
 fn classify_scope_identity(scope: &JsonObjectScope<'_>) -> ExplicitAppIdentity {

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -40,6 +40,12 @@ pub(crate) enum ExplicitAppIdentity {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExplicitAppIdentityContext {
+    pub identity: ExplicitAppIdentity,
+    pub local_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum IdentityFieldState {
     Absent,
     Valid(String),
@@ -186,8 +192,7 @@ impl GuidRegistry {
     /// Returns `None` if the name doesn't match the pattern or the GUID is unknown.
     pub fn enrich_event_name(&self, current_name: &str, guid: &str) -> Option<String> {
         let resolved = self.resolve(guid)?;
-        // Strip the trailing "(shortguid...)" suffix and replace with the resolved name
-        strip_short_guid_suffix(current_name).map(|prefix| format!("{prefix}{resolved}"))
+        enrich_event_name_with_name(current_name, resolved)
     }
 
     /// Number of entries in the registry.
@@ -608,15 +613,30 @@ pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
     }
 }
 
-/// Extract an explicit app identity together with a name from that identity's
-/// own JSON object. Names in a sibling or nested object are not associated.
-pub(crate) fn extract_explicit_identity_name_pair(msg: &str) -> Option<(String, String)> {
-    let scan = scan_json_fields(msg).ok()?;
+/// Resolve one explicit identity selection and its object-local name in a
+/// single bounded scan. A valid identity without a local unambiguous name is
+/// an enrichment boundary; callers must not substitute a global registry name.
+pub(crate) fn explicit_app_identity_context(msg: &str) -> ExplicitAppIdentityContext {
+    let Ok(scan) = scan_json_fields(msg) else {
+        return ExplicitAppIdentityContext {
+            identity: ExplicitAppIdentity::Invalid,
+            local_name: None,
+        };
+    };
+
     match select_explicit_app_identity(&scan) {
-        ExplicitAppIdentitySelection::Valid { guid, scope } => {
-            scope_name(scope).map(|(name, _)| (guid, name))
-        }
-        ExplicitAppIdentitySelection::Absent | ExplicitAppIdentitySelection::Invalid => None,
+        ExplicitAppIdentitySelection::Absent => ExplicitAppIdentityContext {
+            identity: ExplicitAppIdentity::Absent,
+            local_name: None,
+        },
+        ExplicitAppIdentitySelection::Valid { guid, scope } => ExplicitAppIdentityContext {
+            identity: ExplicitAppIdentity::Valid(guid),
+            local_name: scope_name(scope).map(|(name, _)| name),
+        },
+        ExplicitAppIdentitySelection::Invalid => ExplicitAppIdentityContext {
+            identity: ExplicitAppIdentity::Invalid,
+            local_name: None,
+        },
     }
 }
 
@@ -624,15 +644,7 @@ pub(crate) fn extract_explicit_identity_name_pair(msg: &str) -> Option<(String, 
 /// GUIDs on the line. An invalid explicit field is an identity boundary: its
 /// presence suppresses line-wide GUID inference.
 pub(crate) fn explicit_app_identity(msg: &str) -> ExplicitAppIdentity {
-    let Ok(scan) = scan_json_fields(msg) else {
-        return ExplicitAppIdentity::Invalid;
-    };
-
-    match select_explicit_app_identity(&scan) {
-        ExplicitAppIdentitySelection::Absent => ExplicitAppIdentity::Absent,
-        ExplicitAppIdentitySelection::Valid { guid, .. } => ExplicitAppIdentity::Valid(guid),
-        ExplicitAppIdentitySelection::Invalid => ExplicitAppIdentity::Invalid,
-    }
+    explicit_app_identity_context(msg).identity
 }
 
 fn select_explicit_app_identity<'scan, 'msg>(
@@ -860,6 +872,13 @@ fn strip_short_guid_suffix(name: &str) -> Option<String> {
     }
     let prefix = trimmed[..paren_open].trim_end();
     Some(format!("{prefix} — "))
+}
+
+pub(crate) fn enrich_event_name_with_name(
+    current_name: &str,
+    resolved_name: &str,
+) -> Option<String> {
+    strip_short_guid_suffix(current_name).map(|prefix| format!("{prefix}{resolved_name}"))
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -1375,6 +1375,30 @@ mod tests {
     }
 
     #[test]
+    fn explicit_identity_context_carries_the_named_guid_fallback_from_its_scan() {
+        let upper = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
+        let lower = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let messages = [
+            format!(
+                r#"Processing identity {upper} for {{"ApplicationName":"Contoso"}}"#
+            ),
+            format!(
+                r#"Processing identity {upper} for {{\"Name\":\"Contoso\"}}"#
+            ),
+        ];
+
+        for message in messages {
+            let context = explicit_app_identity_context(&message);
+            assert_eq!(context.identity, ExplicitAppIdentity::Absent);
+            assert_eq!(context.fallback_app_id.as_deref(), Some(lower));
+        }
+
+        let context = explicit_app_identity_context(&format!("Processing identity {upper}"));
+        assert_eq!(context.identity, ExplicitAppIdentity::Absent);
+        assert_eq!(context.fallback_app_id, None);
+    }
+
+    #[test]
     fn decorated_identity_field_uses_its_field_local_guid() {
         let unrelated_guid = "11111111-2222-3333-4444-555555555555";
         let app_guid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -1667,6 +1667,50 @@ mod tests {
     }
 
     #[test]
+    fn registry_rejects_conflicting_duplicate_names() {
+        let app = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let messages = [
+            format!(r#"{{"AppId":"{app}","Name":"First Name","Name":"Second Name"}}"#),
+            format!(r#"{{"AppId":"{app}","Name":"Second Name","Name":"First Name"}}"#),
+        ];
+
+        for message in messages {
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&[line(&message)]);
+            assert_eq!(
+                registry.resolve(app),
+                None,
+                "accepted conflicting name from {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn registry_keeps_identical_names_and_application_name_precedence() {
+        let app = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let cases = [
+            (
+                format!(r#"{{"AppId":"{app}","Name":"Same Name","Name":"Same Name"}}"#),
+                "Same Name",
+            ),
+            (
+                format!(r#"{{"AppId":"{app}","ApplicationName":"Preferred","Name":"Fallback"}}"#),
+                "Preferred",
+            ),
+            (
+                format!(r#"{{"AppId":"{app}","Name":"Fallback","ApplicationName":"Preferred"}}"#),
+                "Preferred",
+            ),
+        ];
+
+        for (message, expected) in cases {
+            let mut registry = GuidRegistry::new();
+            registry.ingest_lines(&[line(&message)]);
+            assert_eq!(registry.resolve(app), Some(expected));
+        }
+    }
+
+    #[test]
     fn registry_keeps_independent_root_and_object_local_pairs() {
         let root = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
         let object = "11111111-2222-3333-4444-555555555555";

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -594,6 +594,20 @@ pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
     }
 }
 
+/// Extract an explicit app identity together with a name from that identity's
+/// own JSON object. Names in a sibling or nested object are not associated.
+pub(crate) fn extract_explicit_identity_name_pair(msg: &str) -> Option<(String, String)> {
+    let guid = match explicit_app_identity(msg) {
+        ExplicitAppIdentity::Valid(guid) => guid,
+        ExplicitAppIdentity::Absent | ExplicitAppIdentity::Invalid => return None,
+    };
+    let scan = scan_json_fields(msg).ok()?;
+    extract_all_identity_name_pairs(&scan)
+        .into_iter()
+        .find(|(candidate, _, _)| candidate == &guid)
+        .map(|(_, name, _)| (guid, name))
+}
+
 /// Classify explicit JSON `AppId`/`Id` fields without falling back to other
 /// GUIDs on the line. An invalid explicit field is an identity boundary: its
 /// presence suppresses line-wide GUID inference.

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -1397,6 +1397,21 @@ mod tests {
         let context = explicit_app_identity_context(&format!("Processing identity {upper}"));
         assert_eq!(context.identity, ExplicitAppIdentity::Absent);
         assert_eq!(context.fallback_app_id, None);
+
+        let valid = explicit_app_identity_context(&format!(
+            r#"Processing identity {upper} for {{"AppId":"{lower}","Name":"Contoso"}}"#
+        ));
+        assert_eq!(
+            valid.identity,
+            ExplicitAppIdentity::Valid(lower.to_string())
+        );
+        assert_eq!(valid.fallback_app_id, None);
+
+        let invalid = explicit_app_identity_context(&format!(
+            r#"Processing identity {upper} for {{"AppId":"invalid","Name":"Contoso"}}"#
+        ));
+        assert_eq!(invalid.identity, ExplicitAppIdentity::Invalid);
+        assert_eq!(invalid.fallback_app_id, None);
     }
 
     #[test]

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -46,6 +46,26 @@ pub(crate) struct ExplicitAppIdentityContext {
     pub fallback_app_id: Option<String>,
 }
 
+#[cfg(test)]
+std::thread_local! {
+    static NAMED_GUID_FALLBACK_EXTRACTIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_named_guid_fallback_extraction_count() {
+    NAMED_GUID_FALLBACK_EXTRACTIONS.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn named_guid_fallback_extraction_count() -> usize {
+    NAMED_GUID_FALLBACK_EXTRACTIONS.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
+fn record_named_guid_fallback_extraction() {
+    NAMED_GUID_FALLBACK_EXTRACTIONS.with(|count| count.set(count.get().saturating_add(1)));
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum IdentityFieldState {
     Absent,
@@ -596,7 +616,7 @@ fn scope_name(scope: &JsonObjectScope<'_>) -> Option<(String, GuidNameSource)> {
 /// Checks (in order): `"AppId"`, `"Id"`, then falls back to a generic
 /// GUID regex when a name field is also present on the same line.
 pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
-    let context = explicit_app_identity_context(msg);
+    let context = explicit_app_identity_context_with_named_guid_fallback(msg);
     match context.identity {
         ExplicitAppIdentity::Valid(guid) => Some(guid),
         ExplicitAppIdentity::Invalid => None,
@@ -608,6 +628,22 @@ pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
 /// single bounded scan. A valid identity without a local unambiguous name is
 /// an enrichment boundary; callers must not substitute a global registry name.
 pub(crate) fn explicit_app_identity_context(msg: &str) -> ExplicitAppIdentityContext {
+    explicit_app_identity_context_impl(msg, false)
+}
+
+/// Resolve explicit identity context and opt into the legacy named-GUID
+/// fallback. Callers that already apply their own GUID heuristics should use
+/// `explicit_app_identity_context` so this fallback is not computed twice.
+pub(crate) fn explicit_app_identity_context_with_named_guid_fallback(
+    msg: &str,
+) -> ExplicitAppIdentityContext {
+    explicit_app_identity_context_impl(msg, true)
+}
+
+fn explicit_app_identity_context_impl(
+    msg: &str,
+    include_named_guid_fallback: bool,
+) -> ExplicitAppIdentityContext {
     let Ok(scan) = scan_json_fields(msg) else {
         return ExplicitAppIdentityContext {
             identity: ExplicitAppIdentity::Invalid,
@@ -622,7 +658,9 @@ pub(crate) fn explicit_app_identity_context(msg: &str) -> ExplicitAppIdentityCon
             local_name: None,
             // Preserve the established named-context fallback without running
             // the structural scanner a second time.
-            fallback_app_id: if scan_has_name_field(&scan) {
+            fallback_app_id: if include_named_guid_fallback && scan_has_name_field(&scan) {
+                #[cfg(test)]
+                record_named_guid_fallback_extraction();
                 guid_re()
                     .captures(msg)
                     .and_then(|captures| captures.get(1))
@@ -1393,8 +1431,7 @@ mod tests {
             assert_eq!(context.identity, ExplicitAppIdentity::Absent);
             assert_eq!(context.fallback_app_id, None);
 
-            let context =
-                explicit_app_identity_context_with_named_guid_fallback(&message);
+            let context = explicit_app_identity_context_with_named_guid_fallback(&message);
             assert_eq!(context.identity, ExplicitAppIdentity::Absent);
             assert_eq!(context.fallback_app_id.as_deref(), Some(lower));
         }

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -1391,6 +1391,11 @@ mod tests {
         for message in messages {
             let context = explicit_app_identity_context(&message);
             assert_eq!(context.identity, ExplicitAppIdentity::Absent);
+            assert_eq!(context.fallback_app_id, None);
+
+            let context =
+                explicit_app_identity_context_with_named_guid_fallback(&message);
+            assert_eq!(context.identity, ExplicitAppIdentity::Absent);
             assert_eq!(context.fallback_app_id.as_deref(), Some(lower));
         }
 
@@ -1398,7 +1403,7 @@ mod tests {
         assert_eq!(context.identity, ExplicitAppIdentity::Absent);
         assert_eq!(context.fallback_app_id, None);
 
-        let valid = explicit_app_identity_context(&format!(
+        let valid = explicit_app_identity_context_with_named_guid_fallback(&format!(
             r#"Processing identity {upper} for {{"AppId":"{lower}","Name":"Contoso"}}"#
         ));
         assert_eq!(
@@ -1407,7 +1412,7 @@ mod tests {
         );
         assert_eq!(valid.fallback_app_id, None);
 
-        let invalid = explicit_app_identity_context(&format!(
+        let invalid = explicit_app_identity_context_with_named_guid_fallback(&format!(
             r#"Processing identity {upper} for {{"AppId":"invalid","Name":"Contoso"}}"#
         ));
         assert_eq!(invalid.identity, ExplicitAppIdentity::Invalid);

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -903,9 +903,8 @@ fn strip_short_guid_suffix(name: &str) -> Option<String> {
     if inner.is_empty() {
         return None;
     }
-    // Accept full GUID: hex + dashes, 36 chars
-    let is_full_guid =
-        inner.len() == 36 && inner.chars().all(|c| c.is_ascii_hexdigit() || c == '-');
+    // Accept only a complete 8-4-4-4-12 GUID shape.
+    let is_full_guid = exact_guid(inner).is_some();
     // Accept legacy short format: hex chars followed by "..."
     let is_short_guid = inner.ends_with("...")
         && inner[..inner.len() - 3]

--- a/crates/cmtraceopen-parser/src/intune/guid_registry.rs
+++ b/crates/cmtraceopen-parser/src/intune/guid_registry.rs
@@ -43,6 +43,7 @@ pub(crate) enum ExplicitAppIdentity {
 pub(crate) struct ExplicitAppIdentityContext {
     pub identity: ExplicitAppIdentity,
     pub local_name: Option<String>,
+    pub fallback_app_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -595,21 +596,11 @@ fn scope_name(scope: &JsonObjectScope<'_>) -> Option<(String, GuidNameSource)> {
 /// Checks (in order): `"AppId"`, `"Id"`, then falls back to a generic
 /// GUID regex when a name field is also present on the same line.
 pub(crate) fn extract_app_id(msg: &str) -> Option<String> {
-    match explicit_app_identity(msg) {
+    let context = explicit_app_identity_context(msg);
+    match context.identity {
         ExplicitAppIdentity::Valid(guid) => Some(guid),
         ExplicitAppIdentity::Invalid => None,
-        ExplicitAppIdentity::Absent => {
-            // Only fall back to generic GUID if a name field is present
-            // (avoids polluting registry with context-free GUIDs)
-            if scan_json_fields(msg).is_ok_and(|scan| scan_has_name_field(&scan)) {
-                guid_re()
-                    .captures(msg)
-                    .and_then(|c| c.get(1))
-                    .map(|m| m.as_str().to_ascii_lowercase())
-            } else {
-                None
-            }
-        }
+        ExplicitAppIdentity::Absent => context.fallback_app_id,
     }
 }
 
@@ -621,6 +612,7 @@ pub(crate) fn explicit_app_identity_context(msg: &str) -> ExplicitAppIdentityCon
         return ExplicitAppIdentityContext {
             identity: ExplicitAppIdentity::Invalid,
             local_name: None,
+            fallback_app_id: None,
         };
     };
 
@@ -628,14 +620,26 @@ pub(crate) fn explicit_app_identity_context(msg: &str) -> ExplicitAppIdentityCon
         ExplicitAppIdentitySelection::Absent => ExplicitAppIdentityContext {
             identity: ExplicitAppIdentity::Absent,
             local_name: None,
+            // Preserve the established named-context fallback without running
+            // the structural scanner a second time.
+            fallback_app_id: if scan_has_name_field(&scan) {
+                guid_re()
+                    .captures(msg)
+                    .and_then(|captures| captures.get(1))
+                    .map(|matched| matched.as_str().to_ascii_lowercase())
+            } else {
+                None
+            },
         },
         ExplicitAppIdentitySelection::Valid { guid, scope } => ExplicitAppIdentityContext {
             identity: ExplicitAppIdentity::Valid(guid),
             local_name: scope_name(scope).map(|(name, _)| name),
+            fallback_app_id: None,
         },
         ExplicitAppIdentitySelection::Invalid => ExplicitAppIdentityContext {
             identity: ExplicitAppIdentity::Invalid,
             local_name: None,
+            fallback_app_id: None,
         },
     }
 }
@@ -643,6 +647,7 @@ pub(crate) fn explicit_app_identity_context(msg: &str) -> ExplicitAppIdentityCon
 /// Classify explicit JSON `AppId`/`Id` fields without falling back to other
 /// GUIDs on the line. An invalid explicit field is an identity boundary: its
 /// presence suppresses line-wide GUID inference.
+#[cfg(test)]
 pub(crate) fn explicit_app_identity(msg: &str) -> ExplicitAppIdentity {
     explicit_app_identity_context(msg).identity
 }
@@ -1379,12 +1384,8 @@ mod tests {
         let upper = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
         let lower = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
         let messages = [
-            format!(
-                r#"Processing identity {upper} for {{"ApplicationName":"Contoso"}}"#
-            ),
-            format!(
-                r#"Processing identity {upper} for {{\"Name\":\"Contoso\"}}"#
-            ),
+            format!(r#"Processing identity {upper} for {{"ApplicationName":"Contoso"}}"#),
+            format!(r#"Processing identity {upper} for {{\"Name\":\"Contoso\"}}"#),
         ];
 
         for message in messages {


### PR DESCRIPTION
## Summary

- keep explicit-name suppression monotonic when a failed Intune download attempt is replaced by a retry
- keep retry state isolated by content ID when downloads overlap
- resolve an explicit app identity and its object-local name in one bounded scan
- prevent AppWorkload, sidecar, and non-AppWorkload event paths from reattaching stale global registry names to ambiguous explicit evidence
- preserve safe object-local enrichment and the established registry fallback when no explicit identity is present

This is a focused post-merge correction to the Intune batch-two work. It does not change public parser models.

## Test-first evidence

- RED `190a88e8`: retry and event name-laundering regressions
- GREEN `b2b16aad`: scoped identity/name context and inherited retry suppression

## Verification

- focused GUID registry, download, event, and Intune contract tests
- `cargo test --locked -p cmtraceopen-parser`
- `cargo clippy --locked -p cmtraceopen-parser --all-targets --all-features -- -D warnings`
- `cargo +1.88.0 check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown`
- Rust 1.88 scoped rustfmt and `git diff --check`
- independent full-range executable review — GO, no actionable findings

## Review gates

- [ ] Hosted CodeRabbit review at the final head
- [ ] GitHub Copilot review at the final head
- [ ] Required CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app identity detection and name enrichment for download and event information.
  * Prevented ambiguous, conflicting, or out-of-scope names from being incorrectly associated with applications.
  * Preserved accurate local names while retaining safe fallback enrichment when no explicit identity is available.
  * Improved consistency across retries, partial downloads, failed downloads, and concurrent content processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->