### PR TITLE
feat(sccm): add native client manifest reader

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ esp-diagnostics = ["intune-diagnostics", "dep:cab", "dep:tempfile", "dep:zip"]
 intune-diagnostics = ["dep:evtx", "dep:quick-xml"]
 macos-diag = ["dep:plist"]
 secureboot = ["dep:tempfile"]
+sccm-diagnostics = []
 
 [dependencies]
 cmtraceopen-parser = { path = "../crates/cmtraceopen-parser", version = "0.1" }
@@ -126,6 +127,10 @@ required-features = ["esp-diagnostics"]
 [[test]]
 name = "sysmon_parser"
 required-features = ["sysmon"]
+
+[[test]]
+name = "sccm_client_manifest"
+required-features = ["sccm-diagnostics"]
 
 [[bench]]
 name = "intune_pipeline"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -89,6 +89,7 @@ windows = { version = "=0.62.2", features = [
     "Win32_Security_Cryptography",
     "Win32_Security_Authorization",
     "Win32_System_EventLog",
+    "Win32_System_IO",
     "Win32_Storage_FileSystem",
     "Win32_Security",
     "Win32_System_Com",
@@ -105,6 +106,8 @@ windows = { version = "=0.62.2", features = [
     "Foundation",
     "Foundation_Collections",
     "Win32_System_WinRT",
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
 ] }
 windows-future = "=0.3.2"
 # ureq 3.3 uses Cargo's 2024 edition and requires Rust 1.85, which the old

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,8 @@ mod menu;
 pub use cmtraceopen_parser::models;
 pub mod parser;
 pub mod process_util;
+#[cfg(feature = "sccm-diagnostics")]
+pub mod sccm;
 #[cfg(feature = "secureboot")]
 pub mod secureboot;
 mod state;

--- a/src-tauri/src/sccm/contract.rs
+++ b/src-tauri/src/sccm/contract.rs
@@ -1,0 +1,572 @@
+use std::cell::Cell;
+use std::cmp::Ordering;
+use std::fmt;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use cmtraceopen_parser::sccm::{
+    classify_artifact_name, declared_client_source_groups, SccmCoverageState, SccmRole,
+    SccmRotation,
+};
+use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const SCCM_MANIFEST_FILE_NAME: &str = "sccm-manifest.json";
+pub const SCCM_MANIFEST_VERSION: u32 = 1;
+pub const SCCM_CLIENT_SOURCE_CATALOG_VERSION: u32 = 1;
+pub const MAX_SCCM_MANIFEST_BYTES: u64 = 4 * 1024 * 1024;
+pub use cmtraceopen_parser::sccm::MAX_SCCM_CLIENT_INTAKE_ARTIFACTS as MAX_SCCM_MANIFEST_ARTIFACTS;
+
+pub(crate) const SHA256_HEX_CHARS: usize = 64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmManifestProvenance {
+    NativeClientCapture,
+    LegacyGenericUnscoped,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmManifestProvenanceProfile {
+    HmacSha256V1,
+    #[default]
+    LegacyGenericUnscoped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmManifestSourceState {
+    Captured,
+    Absent,
+    AccessDenied,
+    Capped,
+    Skipped,
+    Unsupported,
+    UnsafePath,
+    ParseFailed,
+    FailedUnknownDetail,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmManifestCoverageScope {
+    #[default]
+    Source,
+    RootEnumeration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmCaptureLimitKind {
+    FileCount,
+    Bytes,
+    SourceDeclared,
+}
+
+impl SccmManifestSourceState {
+    pub(crate) fn pure_coverage(self) -> SccmCoverageState {
+        match self {
+            Self::Captured => SccmCoverageState::Captured,
+            Self::Absent => SccmCoverageState::Absent,
+            Self::AccessDenied => SccmCoverageState::AccessDenied,
+            Self::Capped => SccmCoverageState::Capped,
+            Self::Skipped => SccmCoverageState::Skipped,
+            Self::Unsupported | Self::UnsafePath | Self::FailedUnknownDetail => {
+                SccmCoverageState::Unsupported
+            }
+            Self::ParseFailed => SccmCoverageState::ParseFailed,
+        }
+    }
+
+    pub(crate) fn is_physical(self) -> bool {
+        matches!(self, Self::Captured | Self::Capped | Self::ParseFailed)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SccmManifestArtifact {
+    pub catalog_entry_id: String,
+    pub logical_artifact_ids: Vec<String>,
+    pub artifact_id: String,
+    pub role: SccmRole,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_handle: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_handle: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_fingerprint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rotation_lineage: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relative_path: Option<String>,
+    pub basename: String,
+    pub rotation: SccmRotation,
+    pub state: SccmManifestSourceState,
+    #[serde(default)]
+    pub coverage_scope: SccmManifestCoverageScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_limit_kind: Option<SccmCaptureLimitKind>,
+    pub bytes_copied: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit_applied: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_sha256: Option<String>,
+    pub fragment_complete: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub configmgr_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collected_at_utc: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SccmManifestCaptureGap {
+    pub artifact_id: String,
+    pub catalog_entry_id: String,
+    pub logical_artifact_ids: Vec<String>,
+    pub source_handle: String,
+    pub root_handle: String,
+    pub path_fingerprint: String,
+    pub rotation_lineage: String,
+    pub basename: String,
+    pub rotation: SccmRotation,
+    pub state: SccmManifestSourceState,
+    pub capture_limit_kind: SccmCaptureLimitKind,
+    pub source_bytes: u64,
+    pub bytes_retained: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmBundleManifestV1 {
+    pub sccm_manifest_version: u32,
+    pub diagnostics_schema_version: u32,
+    pub source_catalog_version: u32,
+    pub provenance: SccmManifestProvenance,
+    #[serde(default)]
+    pub provenance_profile: SccmManifestProvenanceProfile,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_handle: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collected_at_utc: Option<String>,
+    pub max_files_per_source: usize,
+    pub max_bytes_per_source: u64,
+    pub artifacts: Vec<SccmManifestArtifact>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capture_gaps: Vec<SccmManifestCaptureGap>,
+}
+
+struct SharedBoundedVecSeed<T> {
+    total: Rc<Cell<usize>>,
+    marker: PhantomData<T>,
+}
+
+impl<'de, T> DeserializeSeed<'de> for SharedBoundedVecSeed<T>
+where
+    T: Deserialize<'de>,
+{
+    type Value = Vec<T>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct BoundedVisitor<T> {
+            total: Rc<Cell<usize>>,
+            marker: PhantomData<T>,
+        }
+
+        impl<'de, T> Visitor<'de> for BoundedVisitor<T>
+        where
+            T: Deserialize<'de>,
+        {
+            type Value = Vec<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a bounded SCCM manifest entry array")
+            }
+
+            fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let remaining = MAX_SCCM_MANIFEST_ARTIFACTS.saturating_sub(self.total.get());
+                if sequence.size_hint().is_some_and(|size| size > remaining) {
+                    return Err(de::Error::custom(
+                        "SCCM manifest has too many artifacts or capture gaps",
+                    ));
+                }
+                let mut values =
+                    Vec::with_capacity(sequence.size_hint().unwrap_or_default().min(remaining));
+                while self.total.get() < MAX_SCCM_MANIFEST_ARTIFACTS {
+                    let Some(value) = sequence.next_element()? else {
+                        return Ok(values);
+                    };
+                    self.total.set(self.total.get() + 1);
+                    values.push(value);
+                }
+                if sequence.next_element::<de::IgnoredAny>()?.is_some() {
+                    return Err(de::Error::custom(
+                        "SCCM manifest has too many artifacts or capture gaps",
+                    ));
+                }
+                Ok(values)
+            }
+        }
+
+        deserializer.deserialize_seq(BoundedVisitor {
+            total: self.total,
+            marker: self.marker,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for SccmBundleManifestV1 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "camelCase")]
+        enum Field {
+            SccmManifestVersion,
+            DiagnosticsSchemaVersion,
+            SourceCatalogVersion,
+            Provenance,
+            ProvenanceProfile,
+            HostHandle,
+            CollectedAtUtc,
+            MaxFilesPerSource,
+            MaxBytesPerSource,
+            Artifacts,
+            CaptureGaps,
+        }
+
+        const FIELDS: &[&str] = &[
+            "sccmManifestVersion",
+            "diagnosticsSchemaVersion",
+            "sourceCatalogVersion",
+            "provenance",
+            "provenanceProfile",
+            "hostHandle",
+            "collectedAtUtc",
+            "maxFilesPerSource",
+            "maxBytesPerSource",
+            "artifacts",
+            "captureGaps",
+        ];
+
+        struct ManifestVisitor;
+        impl<'de> Visitor<'de> for ManifestVisitor {
+            type Value = SccmBundleManifestV1;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an SCCM v1 manifest")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let total = Rc::new(Cell::new(0));
+                let mut sccm_manifest_version = None;
+                let mut diagnostics_schema_version = None;
+                let mut source_catalog_version = None;
+                let mut provenance = None;
+                let mut provenance_profile = None;
+                let mut host_handle = None;
+                let mut collected_at_utc = None;
+                let mut max_files_per_source = None;
+                let mut max_bytes_per_source = None;
+                let mut artifacts = None;
+                let mut capture_gaps = None;
+
+                while let Some(field) = map.next_key()? {
+                    match field {
+                        Field::SccmManifestVersion => set_once(
+                            &mut sccm_manifest_version,
+                            map.next_value()?,
+                            "sccmManifestVersion",
+                        )?,
+                        Field::DiagnosticsSchemaVersion => set_once(
+                            &mut diagnostics_schema_version,
+                            map.next_value()?,
+                            "diagnosticsSchemaVersion",
+                        )?,
+                        Field::SourceCatalogVersion => set_once(
+                            &mut source_catalog_version,
+                            map.next_value()?,
+                            "sourceCatalogVersion",
+                        )?,
+                        Field::Provenance => {
+                            set_once(&mut provenance, map.next_value()?, "provenance")?
+                        }
+                        Field::ProvenanceProfile => set_once(
+                            &mut provenance_profile,
+                            map.next_value()?,
+                            "provenanceProfile",
+                        )?,
+                        Field::HostHandle => {
+                            set_once(&mut host_handle, map.next_value()?, "hostHandle")?
+                        }
+                        Field::CollectedAtUtc => {
+                            set_once(&mut collected_at_utc, map.next_value()?, "collectedAtUtc")?
+                        }
+                        Field::MaxFilesPerSource => set_once(
+                            &mut max_files_per_source,
+                            map.next_value()?,
+                            "maxFilesPerSource",
+                        )?,
+                        Field::MaxBytesPerSource => set_once(
+                            &mut max_bytes_per_source,
+                            map.next_value()?,
+                            "maxBytesPerSource",
+                        )?,
+                        Field::Artifacts => {
+                            if artifacts.is_some() {
+                                return Err(de::Error::duplicate_field("artifacts"));
+                            }
+                            artifacts = Some(map.next_value_seed(SharedBoundedVecSeed {
+                                total: Rc::clone(&total),
+                                marker: PhantomData,
+                            })?);
+                        }
+                        Field::CaptureGaps => {
+                            if capture_gaps.is_some() {
+                                return Err(de::Error::duplicate_field("captureGaps"));
+                            }
+                            capture_gaps = Some(map.next_value_seed(SharedBoundedVecSeed {
+                                total: Rc::clone(&total),
+                                marker: PhantomData,
+                            })?);
+                        }
+                    }
+                }
+
+                Ok(SccmBundleManifestV1 {
+                    sccm_manifest_version: required(sccm_manifest_version, "sccmManifestVersion")?,
+                    diagnostics_schema_version: required(
+                        diagnostics_schema_version,
+                        "diagnosticsSchemaVersion",
+                    )?,
+                    source_catalog_version: required(
+                        source_catalog_version,
+                        "sourceCatalogVersion",
+                    )?,
+                    provenance: required(provenance, "provenance")?,
+                    provenance_profile: provenance_profile.unwrap_or_default(),
+                    host_handle: host_handle.unwrap_or(None),
+                    collected_at_utc: collected_at_utc.unwrap_or(None),
+                    max_files_per_source: required(max_files_per_source, "maxFilesPerSource")?,
+                    max_bytes_per_source: required(max_bytes_per_source, "maxBytesPerSource")?,
+                    artifacts: required(artifacts, "artifacts")?,
+                    capture_gaps: capture_gaps.unwrap_or_default(),
+                })
+            }
+        }
+
+        fn set_once<E, T>(slot: &mut Option<T>, value: T, field: &'static str) -> Result<(), E>
+        where
+            E: de::Error,
+        {
+            if slot.replace(value).is_some() {
+                return Err(E::duplicate_field(field));
+            }
+            Ok(())
+        }
+
+        fn required<E, T>(value: Option<T>, field: &'static str) -> Result<T, E>
+        where
+            E: de::Error,
+        {
+            value.ok_or_else(|| E::missing_field(field))
+        }
+
+        deserializer.deserialize_struct("SccmBundleManifestV1", FIELDS, ManifestVisitor)
+    }
+}
+
+pub(crate) fn sha256_bytes(value: &[u8]) -> String {
+    Sha256::digest(value)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+pub(crate) fn is_sha256_digest(value: &str) -> bool {
+    value.len() == SHA256_HEX_CHARS
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+pub(crate) fn is_versioned_handle(value: &str, prefix: &str) -> bool {
+    value.strip_prefix(prefix).is_some_and(is_sha256_digest)
+}
+
+pub(crate) fn catalog_entry_id(basename: &str) -> String {
+    format!(
+        "sccm-client-source:v1:sha256:{}",
+        sha256_bytes(basename.as_bytes())
+    )
+}
+
+pub(crate) fn logical_artifact_ids_for_basename(basename: &str) -> Vec<String> {
+    let mut values = declared_client_source_groups()
+        .into_iter()
+        .filter(|group| {
+            group
+                .accepted_basenames
+                .iter()
+                .any(|value| value == basename)
+        })
+        .map(|group| group.logical_artifact_id)
+        .collect::<Vec<_>>();
+    values.sort();
+    values
+}
+
+pub(crate) fn root_handle_digest(root_handle: &str) -> Option<&str> {
+    let digest = root_handle.strip_prefix("root-")?;
+    is_sha256_digest(digest).then_some(digest)
+}
+
+pub(crate) fn source_identity_digest(root_handle: &str, basename: &str) -> Option<String> {
+    let root_digest = root_handle_digest(root_handle)?;
+    Some(sha256_bytes(
+        format!("cmtraceopen.sccm.source.v1\0{root_digest}\0{basename}").as_bytes(),
+    ))
+}
+
+pub(crate) fn rotation_segment(rotation: &SccmRotation) -> String {
+    match rotation {
+        SccmRotation::Current => "current".to_owned(),
+        SccmRotation::LoUnderscore => "lo".to_owned(),
+        SccmRotation::Numbered(number) => format!("numbered-{number}"),
+        SccmRotation::Timestamped(timestamp) => format!("timestamped-{timestamp}"),
+        SccmRotation::Unknown(_) => "unknown".to_owned(),
+    }
+}
+
+pub(crate) fn expected_bundle_group(logical_artifact_ids: &[String]) -> &str {
+    if logical_artifact_ids == ["client-content", "client-location"] {
+        "client-location-services-shared"
+    } else {
+        logical_artifact_ids
+            .first()
+            .map(String::as_str)
+            .unwrap_or("unknown")
+    }
+}
+
+pub(crate) fn expected_physical_artifact_id(
+    fingerprint: &str,
+    rotation: &SccmRotation,
+    basename: &str,
+) -> String {
+    format!(
+        "sccm-artifact:v1:sha256:{}",
+        sha256_bytes(
+            format!(
+                "artifact:v1:{fingerprint}:{}:{basename}",
+                rotation_segment(rotation)
+            )
+            .as_bytes()
+        )
+    )
+}
+
+pub(crate) fn expected_marker_artifact_id(
+    catalog_entry_id: &str,
+    state: SccmManifestSourceState,
+    rotation: &SccmRotation,
+    basename: &str,
+    path_fingerprint: Option<&str>,
+) -> String {
+    format!(
+        "sccm-artifact:v1:sha256:{}",
+        sha256_bytes(
+            format!(
+                "marker:v1:{catalog_entry_id}:{}:{}:{basename}:{}",
+                manifest_state_segment(state),
+                rotation_segment(rotation),
+                path_fingerprint.unwrap_or("unscoped")
+            )
+            .as_bytes()
+        )
+    )
+}
+
+fn manifest_state_segment(state: SccmManifestSourceState) -> &'static str {
+    match state {
+        SccmManifestSourceState::Captured => "captured",
+        SccmManifestSourceState::Absent => "absent",
+        SccmManifestSourceState::AccessDenied => "accessDenied",
+        SccmManifestSourceState::Capped => "capped",
+        SccmManifestSourceState::Skipped => "skipped",
+        SccmManifestSourceState::Unsupported => "unsupported",
+        SccmManifestSourceState::UnsafePath => "unsafePath",
+        SccmManifestSourceState::ParseFailed => "parseFailed",
+        SccmManifestSourceState::FailedUnknownDetail => "failedUnknownDetail",
+    }
+}
+
+pub(crate) fn rotation_order(left: &SccmRotation, right: &SccmRotation) -> Ordering {
+    rotation_rank(left)
+        .cmp(&rotation_rank(right))
+        .then_with(|| match (left, right) {
+            (SccmRotation::Numbered(left), SccmRotation::Numbered(right)) => left.cmp(right),
+            (SccmRotation::Timestamped(left), SccmRotation::Timestamped(right)) => left.cmp(right),
+            _ => Ordering::Equal,
+        })
+}
+
+fn rotation_rank(rotation: &SccmRotation) -> u8 {
+    match rotation {
+        SccmRotation::Current => 0,
+        SccmRotation::LoUnderscore => 1,
+        SccmRotation::Numbered(_) => 2,
+        SccmRotation::Timestamped(_) => 3,
+        SccmRotation::Unknown(_) => 4,
+    }
+}
+
+pub(crate) fn compare_manifest_artifacts(
+    left: &SccmManifestArtifact,
+    right: &SccmManifestArtifact,
+) -> Ordering {
+    left.logical_artifact_ids
+        .cmp(&right.logical_artifact_ids)
+        .then_with(|| {
+            left.path_fingerprint
+                .as_deref()
+                .unwrap_or_default()
+                .cmp(right.path_fingerprint.as_deref().unwrap_or_default())
+        })
+        .then_with(|| rotation_order(&left.rotation, &right.rotation))
+        .then_with(|| left.basename.cmp(&right.basename))
+        .then_with(|| left.artifact_id.cmp(&right.artifact_id))
+}
+
+pub(crate) fn compare_manifest_capture_gaps(
+    left: &SccmManifestCaptureGap,
+    right: &SccmManifestCaptureGap,
+) -> Ordering {
+    left.logical_artifact_ids
+        .cmp(&right.logical_artifact_ids)
+        .then_with(|| left.path_fingerprint.cmp(&right.path_fingerprint))
+        .then_with(|| rotation_order(&left.rotation, &right.rotation))
+        .then_with(|| left.basename.cmp(&right.basename))
+        .then_with(|| left.artifact_id.cmp(&right.artifact_id))
+}
+
+pub(crate) fn canonical_client_source(basename: &str, rotation: &SccmRotation) -> Option<String> {
+    let classified = classify_artifact_name(basename, SccmRole::Client);
+    (classified.supported_for_diagnosis && classified.rotation == *rotation)
+        .then_some(classified.basename)
+}

--- a/src-tauri/src/sccm/manifest.rs
+++ b/src-tauri/src/sccm/manifest.rs
@@ -30,9 +30,10 @@ const LEGACY_GENERIC_PROFILE_NAME: &str = "cmtrace-full-diagnostics-v1";
 const LEGACY_GENERIC_PROFILE_VERSION: &str = "1.1.0";
 const LEGACY_CONFIGMGR_CCM_LOGS_ID: &str = "configmgr-ccm-logs";
 const LEGACY_CONFIGMGR_LOG_CATEGORY: &str = "logs";
-const LEGACY_CCMSETUP_GROUP: &str = "client-ccmsetup";
 const LEGACY_CCMSETUP_BASENAME: &str = "ccmsetup.log";
 const MAX_SAFE_TEXT_CHARS: usize = 160;
+const MAX_SCCM_CLIENT_PHYSICAL_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_SCCM_CLIENT_TOTAL_PHYSICAL_BYTES: u64 = 1024 * 1024 * 1024;
 
 pub fn read_sccm_manifest_or_legacy(bundle_root: &Path) -> Result<SccmBundleManifestV1, AppError> {
     let verified_root = verify_bundle_root(bundle_root)?;
@@ -123,7 +124,6 @@ fn validate_native_manifest(
     bundle_root: &VerifiedBundleRoot,
     manifest: &SccmBundleManifestV1,
 ) -> Result<(), AppError> {
-    validate_native_manifest_structure(manifest)?;
     manifest_to_client_intake_bundle(manifest)?;
     validate_physical_source_limits(manifest)?;
     for artifact in &manifest.artifacts {
@@ -136,11 +136,13 @@ fn validate_native_manifest(
 
 fn validate_physical_source_limits(manifest: &SccmBundleManifestV1) -> Result<(), AppError> {
     let mut totals = BTreeMap::<String, (u64, u64)>::new();
+    let mut total_physical_bytes = 0_u64;
     for artifact in manifest
         .artifacts
         .iter()
         .filter(|artifact| artifact.state.is_physical())
     {
+        add_to_client_physical_byte_budget(artifact.bytes_copied, &mut total_physical_bytes)?;
         let canonical_basename = canonical_client_source(&artifact.basename, &artifact.rotation)
             .expect("physical artifacts were catalog-validated before source limits");
         let source = source_identity_digest(
@@ -170,6 +172,28 @@ fn validate_physical_source_limits(manifest: &SccmBundleManifestV1) -> Result<()
                 "SCCM source byte cap is exceeded".to_owned(),
             ));
         }
+    }
+    Ok(())
+}
+
+fn add_to_client_physical_byte_budget(
+    artifact_bytes: u64,
+    total_physical_bytes: &mut u64,
+) -> Result<(), AppError> {
+    if artifact_bytes > MAX_SCCM_CLIENT_PHYSICAL_ARTIFACT_BYTES {
+        return Err(AppError::InvalidInput(
+            "SCCM physical artifact byte cap is exceeded".to_owned(),
+        ));
+    }
+    *total_physical_bytes = total_physical_bytes
+        .checked_add(artifact_bytes)
+        .ok_or_else(|| {
+            AppError::InvalidInput("SCCM aggregate physical byte cap is exceeded".to_owned())
+        })?;
+    if *total_physical_bytes > MAX_SCCM_CLIENT_TOTAL_PHYSICAL_BYTES {
+        return Err(AppError::InvalidInput(
+            "SCCM aggregate physical byte cap is exceeded".to_owned(),
+        ));
     }
     Ok(())
 }
@@ -780,7 +804,7 @@ fn read_legacy_client_intake_bundle(
             ));
         }
         known_gap_seen = true;
-        let catalog_id = catalog_entry_id(LEGACY_CCMSETUP_GROUP);
+        let catalog_id = catalog_entry_id(LEGACY_CCMSETUP_BASENAME);
         artifacts.push(SccmClientIntakeArtifact {
             artifact: SccmArtifact {
                 artifact_id: expected_marker_artifact_id(
@@ -822,7 +846,7 @@ fn legacy_gap(index: usize, gap: &Value) -> Result<SccmManifestArtifact, AppErro
     let legacy_id = legacy_identity(gap, "gap")?;
     let state = match gap.get("status").and_then(Value::as_str) {
         Some("Missing") => SccmManifestSourceState::Absent,
-        Some("Failed") | Some(_) | None => SccmManifestSourceState::FailedUnknownDetail,
+        _ => SccmManifestSourceState::FailedUnknownDetail,
     };
     Ok(legacy_unscoped_artifact("gap", index, legacy_id, state))
 }
@@ -834,9 +858,9 @@ fn legacy_artifact(index: usize, artifact: &Value) -> Result<SccmManifestArtifac
     }
     let state = match artifact.get("status").and_then(Value::as_str) {
         Some("missing") => SccmManifestSourceState::Absent,
-        Some("collected") | Some("failed") | Some(_) | None => {
-            SccmManifestSourceState::FailedUnknownDetail
-        }
+        // Legacy manifests provide no verifiable evidence binding, so even a
+        // collected status remains a conservative unknown-detail failure.
+        _ => SccmManifestSourceState::FailedUnknownDetail,
     };
     Ok(legacy_unscoped_artifact(
         "artifact", index, legacy_id, state,
@@ -936,4 +960,23 @@ fn is_safe_configmgr_version(value: &str) -> bool {
 
 fn is_four_ascii_digits(value: &str) -> bool {
     value.len() == 4 && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_owned_physical_byte_budget_accepts_exact_ceilings_without_opening_evidence() {
+        let mut total = 0;
+        for _ in 0..4 {
+            add_to_client_physical_byte_budget(MAX_SCCM_CLIENT_PHYSICAL_ARTIFACT_BYTES, &mut total)
+                .expect("the exact reader-owned ceilings are admitted before any file is opened");
+        }
+        assert_eq!(total, MAX_SCCM_CLIENT_TOTAL_PHYSICAL_BYTES);
+
+        let error = add_to_client_physical_byte_budget(1, &mut total)
+            .expect_err("one byte beyond the aggregate ceiling is rejected before a file open");
+        assert!(error.to_string().contains("aggregate physical byte cap"));
+    }
 }

--- a/src-tauri/src/sccm/manifest.rs
+++ b/src-tauri/src/sccm/manifest.rs
@@ -987,12 +987,41 @@ fn is_four_ascii_digits(value: &str) -> bool {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     #[test]
-    fn native_validation_returns_its_reusable_intake_projection() {
-        let _validate: fn(
-            &VerifiedBundleRoot,
-            &SccmBundleManifestV1,
-        ) -> Result<SccmClientIntakeBundle, AppError> = validate_native_manifest;
+    fn native_intake_reader_assesses_the_projection_once() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temporary root");
+        let bundle_root = temp.path().join("bundle");
+        fs::create_dir(&bundle_root).expect("create bundle root");
+        fs::set_permissions(&bundle_root, fs::Permissions::from_mode(0o700))
+            .expect("make bundle root private");
+        let manifest = serde_json::json!({
+            "sccmManifestVersion": 1,
+            "diagnosticsSchemaVersion": 1,
+            "sourceCatalogVersion": 1,
+            "provenance": "nativeClientCapture",
+            "provenanceProfile": "hmacSha256V1",
+            "collectedAtUtc": "2026-07-30T15:00:00Z",
+            "maxFilesPerSource": 8,
+            "maxBytesPerSource": 4096,
+            "artifacts": [],
+            "captureGaps": []
+        });
+        fs::write(
+            bundle_root.join(SCCM_MANIFEST_FILE_NAME),
+            serde_json::to_vec(&manifest).expect("serialize native manifest"),
+        )
+        .expect("write native manifest");
+
+        reset_intake_projection_count();
+        let bundle = read_sccm_client_intake_bundle(&bundle_root).expect("read native intake");
+
+        assert!(bundle.artifacts.is_empty());
+        assert!(bundle.capture_gaps.is_empty());
+        assert_eq!(intake_projection_count(), 1);
     }
 
     #[test]

--- a/src-tauri/src/sccm/manifest.rs
+++ b/src-tauri/src/sccm/manifest.rs
@@ -35,7 +35,17 @@ const MAX_SAFE_TEXT_CHARS: usize = 160;
 const MAX_SCCM_CLIENT_PHYSICAL_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_SCCM_CLIENT_TOTAL_PHYSICAL_BYTES: u64 = 1024 * 1024 * 1024;
 
-pub fn read_sccm_manifest_or_legacy(bundle_root: &Path) -> Result<SccmBundleManifestV1, AppError> {
+enum ValidatedManifestRead {
+    Native {
+        manifest: SccmBundleManifestV1,
+        intake_bundle: SccmClientIntakeBundle,
+    },
+    Legacy(SccmBundleManifestV1),
+}
+
+fn read_validated_manifest_or_legacy(
+    bundle_root: &Path,
+) -> Result<ValidatedManifestRead, AppError> {
     let verified_root = verify_bundle_root(bundle_root)?;
     match verified_root.open_relative_file(Path::new(SCCM_MANIFEST_FILE_NAME)) {
         Ok(input) => {
@@ -47,15 +57,25 @@ pub fn read_sccm_manifest_or_legacy(bundle_root: &Path) -> Result<SccmBundleMani
                         reason: error.to_string(),
                     }
                 })?;
-            validate_native_manifest(&verified_root, &manifest)?;
-            Ok(manifest)
+            let intake_bundle = validate_native_manifest(&verified_root, &manifest)?;
+            Ok(ValidatedManifestRead::Native {
+                manifest,
+                intake_bundle,
+            })
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            read_legacy_manifest(&verified_root)
+            read_legacy_manifest(&verified_root).map(ValidatedManifestRead::Legacy)
         }
         Err(_) => Err(AppError::InvalidInput(
             "SCCM manifest cannot be opened safely".to_owned(),
         )),
+    }
+}
+
+pub fn read_sccm_manifest_or_legacy(bundle_root: &Path) -> Result<SccmBundleManifestV1, AppError> {
+    match read_validated_manifest_or_legacy(bundle_root)? {
+        ValidatedManifestRead::Native { manifest, .. }
+        | ValidatedManifestRead::Legacy(manifest) => Ok(manifest),
     }
 }
 
@@ -112,26 +132,27 @@ fn manifest_to_client_intake_bundle(
 pub fn read_sccm_client_intake_bundle(
     bundle_root: &Path,
 ) -> Result<SccmClientIntakeBundle, AppError> {
-    let manifest = read_sccm_manifest_or_legacy(bundle_root)?;
-    if manifest.provenance == SccmManifestProvenance::LegacyGenericUnscoped {
-        let verified_root = verify_bundle_root(bundle_root)?;
-        return read_legacy_client_intake_bundle(&verified_root);
+    match read_validated_manifest_or_legacy(bundle_root)? {
+        ValidatedManifestRead::Native { intake_bundle, .. } => Ok(intake_bundle),
+        ValidatedManifestRead::Legacy(_) => {
+            let verified_root = verify_bundle_root(bundle_root)?;
+            read_legacy_client_intake_bundle(&verified_root)
+        }
     }
-    manifest_to_client_intake_bundle(&manifest)
 }
 
 fn validate_native_manifest(
     bundle_root: &VerifiedBundleRoot,
     manifest: &SccmBundleManifestV1,
-) -> Result<(), AppError> {
-    manifest_to_client_intake_bundle(manifest)?;
+) -> Result<SccmClientIntakeBundle, AppError> {
+    let intake_bundle = manifest_to_client_intake_bundle(manifest)?;
     validate_physical_source_limits(manifest)?;
     for artifact in &manifest.artifacts {
         if artifact.state.is_physical() {
             validate_evidence_file(bundle_root, artifact)?;
         }
     }
-    Ok(())
+    Ok(intake_bundle)
 }
 
 fn validate_physical_source_limits(manifest: &SccmBundleManifestV1) -> Result<(), AppError> {

--- a/src-tauri/src/sccm/manifest.rs
+++ b/src-tauri/src/sccm/manifest.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::Read;
 use std::path::{Component, Path};
 
@@ -23,7 +23,7 @@ use super::contract::{
     SccmManifestSourceState, MAX_SCCM_MANIFEST_ARTIFACTS, MAX_SCCM_MANIFEST_BYTES,
     SCCM_CLIENT_SOURCE_CATALOG_VERSION, SCCM_MANIFEST_FILE_NAME, SCCM_MANIFEST_VERSION,
 };
-use super::private_fs::{is_reparse_point, open_file_no_follow, verify_bundle_root};
+use super::private_fs::{is_reparse_point, verify_bundle_root, VerifiedBundleRoot};
 
 const LEGACY_MANIFEST_FILE_NAME: &str = "manifest.json";
 const LEGACY_GENERIC_PROFILE_NAME: &str = "cmtrace-full-diagnostics-v1";
@@ -35,9 +35,8 @@ const LEGACY_CCMSETUP_BASENAME: &str = "ccmsetup.log";
 const MAX_SAFE_TEXT_CHARS: usize = 160;
 
 pub fn read_sccm_manifest_or_legacy(bundle_root: &Path) -> Result<SccmBundleManifestV1, AppError> {
-    let canonical_root = verify_bundle_root(bundle_root)?;
-    let manifest_path = canonical_root.join(SCCM_MANIFEST_FILE_NAME);
-    match open_file_no_follow(&manifest_path) {
+    let verified_root = verify_bundle_root(bundle_root)?;
+    match verified_root.open_relative_file(Path::new(SCCM_MANIFEST_FILE_NAME)) {
         Ok(input) => {
             let bytes = read_bounded_file(input, MAX_SCCM_MANIFEST_BYTES, "SCCM manifest")?;
             let manifest =
@@ -47,11 +46,11 @@ pub fn read_sccm_manifest_or_legacy(bundle_root: &Path) -> Result<SccmBundleMani
                         reason: error.to_string(),
                     }
                 })?;
-            validate_native_manifest(&canonical_root, &manifest)?;
+            validate_native_manifest(&verified_root, &manifest)?;
             Ok(manifest)
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            read_legacy_manifest(&canonical_root)
+            read_legacy_manifest(&verified_root)
         }
         Err(_) => Err(AppError::InvalidInput(
             "SCCM manifest cannot be opened safely".to_owned(),
@@ -59,7 +58,7 @@ pub fn read_sccm_manifest_or_legacy(bundle_root: &Path) -> Result<SccmBundleMani
     }
 }
 
-pub fn manifest_to_client_intake_bundle(
+fn manifest_to_client_intake_bundle(
     manifest: &SccmBundleManifestV1,
 ) -> Result<SccmClientIntakeBundle, AppError> {
     validate_native_manifest_structure(manifest)?;
@@ -114,21 +113,62 @@ pub fn read_sccm_client_intake_bundle(
 ) -> Result<SccmClientIntakeBundle, AppError> {
     let manifest = read_sccm_manifest_or_legacy(bundle_root)?;
     if manifest.provenance == SccmManifestProvenance::LegacyGenericUnscoped {
-        let canonical_root = verify_bundle_root(bundle_root)?;
-        return read_legacy_client_intake_bundle(&canonical_root);
+        let verified_root = verify_bundle_root(bundle_root)?;
+        return read_legacy_client_intake_bundle(&verified_root);
     }
     manifest_to_client_intake_bundle(&manifest)
 }
 
 fn validate_native_manifest(
-    bundle_root: &Path,
+    bundle_root: &VerifiedBundleRoot,
     manifest: &SccmBundleManifestV1,
 ) -> Result<(), AppError> {
     validate_native_manifest_structure(manifest)?;
     manifest_to_client_intake_bundle(manifest)?;
+    validate_physical_source_limits(manifest)?;
     for artifact in &manifest.artifacts {
         if artifact.state.is_physical() {
             validate_evidence_file(bundle_root, artifact)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_physical_source_limits(manifest: &SccmBundleManifestV1) -> Result<(), AppError> {
+    let mut totals = BTreeMap::<String, (u64, u64)>::new();
+    for artifact in manifest
+        .artifacts
+        .iter()
+        .filter(|artifact| artifact.state.is_physical())
+    {
+        let canonical_basename = canonical_client_source(&artifact.basename, &artifact.rotation)
+            .expect("physical artifacts were catalog-validated before source limits");
+        let source = source_identity_digest(
+            artifact
+                .root_handle
+                .as_deref()
+                .expect("physical artifacts have validated root provenance"),
+            &canonical_basename,
+        )
+        .expect("physical artifacts have a validated root handle");
+        let entry = totals.entry(source).or_insert((0, 0));
+        entry.0 = entry
+            .0
+            .checked_add(1)
+            .ok_or_else(|| AppError::InvalidInput("SCCM source file cap is exceeded".to_owned()))?;
+        entry.1 = entry
+            .1
+            .checked_add(artifact.bytes_copied)
+            .ok_or_else(|| AppError::InvalidInput("SCCM source byte cap is exceeded".to_owned()))?;
+        if entry.0 > manifest.max_files_per_source as u64 {
+            return Err(AppError::InvalidInput(
+                "SCCM source file cap is exceeded".to_owned(),
+            ));
+        }
+        if entry.1 > manifest.max_bytes_per_source {
+            return Err(AppError::InvalidInput(
+                "SCCM source byte cap is exceeded".to_owned(),
+            ));
         }
     }
     Ok(())
@@ -534,30 +574,15 @@ fn validate_relative_path(
 }
 
 fn validate_evidence_file(
-    bundle_root: &Path,
+    bundle_root: &VerifiedBundleRoot,
     artifact: &SccmManifestArtifact,
 ) -> Result<(), AppError> {
     let relative_path = artifact
         .relative_path
         .as_deref()
         .ok_or_else(|| AppError::InvalidInput("physical SCCM artifact has no path".to_owned()))?;
-    let candidate = bundle_root.join(relative_path);
-    let metadata = fs::symlink_metadata(&candidate)
-        .map_err(|_| AppError::InvalidInput("SCCM evidence file is unavailable".to_owned()))?;
-    if is_reparse_point(&metadata) || !metadata.is_file() {
-        return Err(AppError::InvalidInput(
-            "SCCM evidence must be a real file".to_owned(),
-        ));
-    }
-    let canonical = candidate.canonicalize().map_err(|_| {
-        AppError::InvalidInput("SCCM evidence cannot be resolved safely".to_owned())
-    })?;
-    if !canonical.starts_with(bundle_root) || metadata.len() != artifact.bytes_copied {
-        return Err(AppError::InvalidInput(
-            "SCCM evidence violates path or size coherence".to_owned(),
-        ));
-    }
-    let mut input = open_file_no_follow(&candidate)
+    let mut input = bundle_root
+        .open_relative_file(Path::new(relative_path))
         .map_err(|_| AppError::InvalidInput("SCCM evidence cannot be opened safely".to_owned()))?;
     let opened_metadata = input.metadata().map_err(|_| {
         AppError::InvalidInput("SCCM evidence metadata cannot be verified".to_owned())
@@ -640,7 +665,9 @@ fn sha256_exact_file(input: &mut File, expected_bytes: u64) -> Result<String, Ap
         .collect())
 }
 
-fn read_legacy_manifest(bundle_root: &Path) -> Result<SccmBundleManifestV1, AppError> {
+fn read_legacy_manifest(
+    bundle_root: &VerifiedBundleRoot,
+) -> Result<SccmBundleManifestV1, AppError> {
     let legacy = read_legacy_value(bundle_root)?;
     let values = legacy
         .get("artifacts")
@@ -680,17 +707,18 @@ fn read_legacy_manifest(bundle_root: &Path) -> Result<SccmBundleManifestV1, AppE
     })
 }
 
-fn read_legacy_value(bundle_root: &Path) -> Result<Value, AppError> {
-    let legacy_path = bundle_root.join(LEGACY_MANIFEST_FILE_NAME);
-    let input = open_file_no_follow(&legacy_path).map_err(|error| {
-        if error.kind() == std::io::ErrorKind::NotFound {
-            AppError::InvalidInput(format!(
+fn read_legacy_value(bundle_root: &VerifiedBundleRoot) -> Result<Value, AppError> {
+    let input = bundle_root
+        .open_relative_file(Path::new(LEGACY_MANIFEST_FILE_NAME))
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                AppError::InvalidInput(format!(
                 "bundle contains neither {SCCM_MANIFEST_FILE_NAME} nor {LEGACY_MANIFEST_FILE_NAME}"
             ))
-        } else {
-            AppError::InvalidInput("legacy manifest cannot be opened safely".to_owned())
-        }
-    })?;
+            } else {
+                AppError::InvalidInput("legacy manifest cannot be opened safely".to_owned())
+            }
+        })?;
     let bytes = read_bounded_file(input, MAX_SCCM_MANIFEST_BYTES, "legacy manifest")?;
     serde_json::from_slice(&bytes).map_err(|error| AppError::Parse {
         file: LEGACY_MANIFEST_FILE_NAME.to_owned(),
@@ -709,7 +737,7 @@ fn legacy_gaps(legacy: &Value) -> Result<&[Value], AppError> {
 }
 
 fn read_legacy_client_intake_bundle(
-    bundle_root: &Path,
+    bundle_root: &VerifiedBundleRoot,
 ) -> Result<SccmClientIntakeBundle, AppError> {
     let legacy = read_legacy_value(bundle_root)?;
     let supported_profile = legacy

--- a/src-tauri/src/sccm/manifest.rs
+++ b/src-tauri/src/sccm/manifest.rs
@@ -1055,4 +1055,19 @@ mod tests {
             .expect_err("one byte beyond the aggregate ceiling is rejected before a file open");
         assert!(error.to_string().contains("aggregate physical byte cap"));
     }
+
+    #[test]
+    fn client_owned_physical_byte_budget_rejects_accumulator_overflow() {
+        let mut total = u64::MAX;
+
+        let error = add_to_client_physical_byte_budget(1, &mut total)
+            .expect_err("metadata summation cannot wrap the aggregate byte counter");
+
+        assert!(error.to_string().contains("aggregate physical byte cap"));
+        assert_eq!(
+            total,
+            u64::MAX,
+            "a rejected addition leaves the counter intact"
+        );
+    }
 }

--- a/src-tauri/src/sccm/manifest.rs
+++ b/src-tauri/src/sccm/manifest.rs
@@ -1,0 +1,911 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Component, Path};
+
+use chrono::DateTime;
+use cmtraceopen_parser::sccm::{
+    assess_client_intake, SccmArtifact, SccmClientIntakeArtifact, SccmClientIntakeBundle,
+    SccmClientIntakeCaptureGap, SccmRole, SccmRotation, SCCM_DIAGNOSTICS_SCHEMA_VERSION,
+};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::error::AppError;
+
+use super::contract::{
+    canonical_client_source, catalog_entry_id, compare_manifest_artifacts,
+    compare_manifest_capture_gaps, expected_bundle_group, expected_marker_artifact_id,
+    expected_physical_artifact_id, is_sha256_digest, is_versioned_handle,
+    logical_artifact_ids_for_basename, root_handle_digest, rotation_segment, sha256_bytes,
+    source_identity_digest, SccmBundleManifestV1, SccmManifestArtifact, SccmManifestCaptureGap,
+    SccmManifestCoverageScope, SccmManifestProvenance, SccmManifestProvenanceProfile,
+    SccmManifestSourceState, MAX_SCCM_MANIFEST_ARTIFACTS, MAX_SCCM_MANIFEST_BYTES,
+    SCCM_CLIENT_SOURCE_CATALOG_VERSION, SCCM_MANIFEST_FILE_NAME, SCCM_MANIFEST_VERSION,
+};
+use super::private_fs::{is_reparse_point, open_file_no_follow, verify_bundle_root};
+
+const LEGACY_MANIFEST_FILE_NAME: &str = "manifest.json";
+const LEGACY_GENERIC_PROFILE_NAME: &str = "cmtrace-full-diagnostics-v1";
+const LEGACY_GENERIC_PROFILE_VERSION: &str = "1.1.0";
+const LEGACY_CONFIGMGR_CCM_LOGS_ID: &str = "configmgr-ccm-logs";
+const LEGACY_CONFIGMGR_LOG_CATEGORY: &str = "logs";
+const LEGACY_CCMSETUP_GROUP: &str = "client-ccmsetup";
+const LEGACY_CCMSETUP_BASENAME: &str = "ccmsetup.log";
+const MAX_SAFE_TEXT_CHARS: usize = 160;
+
+pub fn read_sccm_manifest_or_legacy(bundle_root: &Path) -> Result<SccmBundleManifestV1, AppError> {
+    let canonical_root = verify_bundle_root(bundle_root)?;
+    let manifest_path = canonical_root.join(SCCM_MANIFEST_FILE_NAME);
+    match open_file_no_follow(&manifest_path) {
+        Ok(input) => {
+            let bytes = read_bounded_file(input, MAX_SCCM_MANIFEST_BYTES, "SCCM manifest")?;
+            let manifest =
+                serde_json::from_slice::<SccmBundleManifestV1>(&bytes).map_err(|error| {
+                    AppError::Parse {
+                        file: SCCM_MANIFEST_FILE_NAME.to_owned(),
+                        reason: error.to_string(),
+                    }
+                })?;
+            validate_native_manifest(&canonical_root, &manifest)?;
+            Ok(manifest)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            read_legacy_manifest(&canonical_root)
+        }
+        Err(_) => Err(AppError::InvalidInput(
+            "SCCM manifest cannot be opened safely".to_owned(),
+        )),
+    }
+}
+
+pub fn manifest_to_client_intake_bundle(
+    manifest: &SccmBundleManifestV1,
+) -> Result<SccmClientIntakeBundle, AppError> {
+    validate_native_manifest_structure(manifest)?;
+    let artifacts = manifest
+        .artifacts
+        .iter()
+        .map(|source| SccmClientIntakeArtifact {
+            artifact: SccmArtifact {
+                artifact_id: source.artifact_id.clone(),
+                display_name: source.basename.clone(),
+                original_path: None,
+                host: None,
+                role: SccmRole::Client,
+                configmgr_version: source.configmgr_version.clone(),
+                collected_at_utc: source.collected_at_utc.clone(),
+                rotation: source.rotation.clone(),
+                coverage: source.state.pure_coverage(),
+                encoding: source.encoding.clone(),
+            },
+            path_fingerprint: source.path_fingerprint.clone(),
+            rotation_lineage: source.rotation_lineage.clone(),
+            relative_path: source.relative_path.clone(),
+            fragment_complete: Some(source.fragment_complete),
+        })
+        .collect();
+    let capture_gaps = manifest
+        .capture_gaps
+        .iter()
+        .map(|gap| SccmClientIntakeCaptureGap {
+            artifact_id: gap.artifact_id.clone(),
+            basename: gap.basename.clone(),
+            rotation: gap.rotation.clone(),
+            coverage: gap.state.pure_coverage(),
+            path_fingerprint: gap.path_fingerprint.clone(),
+            rotation_lineage: gap.rotation_lineage.clone(),
+        })
+        .collect();
+    let bundle = SccmClientIntakeBundle {
+        artifacts,
+        capture_gaps,
+    };
+    assess_client_intake(&bundle).map_err(|error| {
+        AppError::InvalidInput(format!(
+            "SCCM manifest cannot be converted to the pure client intake contract: {error}"
+        ))
+    })?;
+    Ok(bundle)
+}
+
+pub fn read_sccm_client_intake_bundle(
+    bundle_root: &Path,
+) -> Result<SccmClientIntakeBundle, AppError> {
+    let manifest = read_sccm_manifest_or_legacy(bundle_root)?;
+    if manifest.provenance == SccmManifestProvenance::LegacyGenericUnscoped {
+        let canonical_root = verify_bundle_root(bundle_root)?;
+        return read_legacy_client_intake_bundle(&canonical_root);
+    }
+    manifest_to_client_intake_bundle(&manifest)
+}
+
+fn validate_native_manifest(
+    bundle_root: &Path,
+    manifest: &SccmBundleManifestV1,
+) -> Result<(), AppError> {
+    validate_native_manifest_structure(manifest)?;
+    manifest_to_client_intake_bundle(manifest)?;
+    for artifact in &manifest.artifacts {
+        if artifact.state.is_physical() {
+            validate_evidence_file(bundle_root, artifact)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_native_manifest_structure(manifest: &SccmBundleManifestV1) -> Result<(), AppError> {
+    if manifest.sccm_manifest_version != SCCM_MANIFEST_VERSION
+        || manifest.diagnostics_schema_version != SCCM_DIAGNOSTICS_SCHEMA_VERSION
+        || manifest.source_catalog_version != SCCM_CLIENT_SOURCE_CATALOG_VERSION
+        || manifest.provenance != SccmManifestProvenance::NativeClientCapture
+        || manifest.provenance_profile != SccmManifestProvenanceProfile::HmacSha256V1
+    {
+        return Err(AppError::InvalidInput(
+            "unsupported or non-native SCCM client manifest contract".to_owned(),
+        ));
+    }
+    if manifest
+        .artifacts
+        .len()
+        .saturating_add(manifest.capture_gaps.len())
+        > MAX_SCCM_MANIFEST_ARTIFACTS
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM manifest has too many artifacts or capture gaps".to_owned(),
+        ));
+    }
+    if manifest.max_files_per_source == 0
+        || manifest.max_bytes_per_source == 0
+        || manifest
+            .collected_at_utc
+            .as_deref()
+            .is_none_or(|value| !is_utc_rfc3339(value))
+        || manifest
+            .host_handle
+            .as_deref()
+            .is_some_and(|value| !is_versioned_handle(value, "cmtraceopen.host.hmac-sha256.v1:"))
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM manifest context is malformed or privacy-unsafe".to_owned(),
+        ));
+    }
+
+    let mut artifact_ids = BTreeSet::new();
+    let mut relative_paths = BTreeSet::new();
+    let mut lineage_bindings = BTreeMap::<String, (String, String)>::new();
+    for artifact in &manifest.artifacts {
+        validate_native_artifact(manifest, artifact)?;
+        if !artifact_ids.insert(artifact.artifact_id.to_ascii_lowercase()) {
+            return Err(AppError::InvalidInput(
+                "SCCM manifest contains duplicate artifact IDs".to_owned(),
+            ));
+        }
+        if let Some(relative_path) = &artifact.relative_path {
+            if !relative_paths.insert(relative_path.to_ascii_lowercase()) {
+                return Err(AppError::InvalidInput(
+                    "SCCM manifest contains duplicate relative paths".to_owned(),
+                ));
+            }
+        }
+        if let (Some(lineage), Some(fingerprint)) =
+            (&artifact.rotation_lineage, &artifact.path_fingerprint)
+        {
+            bind_lineage(
+                &mut lineage_bindings,
+                lineage,
+                &canonical_basename(&artifact.basename),
+                fingerprint,
+                "SCCM rotation lineage crosses physical sources",
+            )?;
+        }
+    }
+    for gap in &manifest.capture_gaps {
+        validate_capture_gap(gap)?;
+        if !artifact_ids.insert(gap.artifact_id.to_ascii_lowercase()) {
+            return Err(AppError::InvalidInput(
+                "SCCM manifest contains duplicate artifact IDs".to_owned(),
+            ));
+        }
+        bind_lineage(
+            &mut lineage_bindings,
+            &gap.rotation_lineage,
+            &canonical_basename(&gap.basename),
+            &gap.path_fingerprint,
+            "SCCM capture gap lineage crosses physical sources",
+        )?;
+    }
+    if !manifest
+        .artifacts
+        .windows(2)
+        .all(|pair| compare_manifest_artifacts(&pair[0], &pair[1]).is_le())
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM manifest artifacts are not in deterministic order".to_owned(),
+        ));
+    }
+    if !manifest
+        .capture_gaps
+        .windows(2)
+        .all(|pair| compare_manifest_capture_gaps(&pair[0], &pair[1]).is_le())
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM manifest capture gaps are not in deterministic order".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn bind_lineage(
+    bindings: &mut BTreeMap<String, (String, String)>,
+    lineage: &str,
+    basename: &str,
+    fingerprint: &str,
+    error_message: &str,
+) -> Result<(), AppError> {
+    let binding = (basename.to_owned(), fingerprint.to_owned());
+    if bindings
+        .insert(lineage.to_owned(), binding.clone())
+        .is_some_and(|existing| existing != binding)
+    {
+        return Err(AppError::InvalidInput(error_message.to_owned()));
+    }
+    Ok(())
+}
+
+fn validate_native_artifact(
+    manifest: &SccmBundleManifestV1,
+    artifact: &SccmManifestArtifact,
+) -> Result<(), AppError> {
+    if artifact.role != SccmRole::Client
+        || !is_versioned_handle(&artifact.artifact_id, "sccm-artifact:v1:sha256:")
+        || artifact.collected_at_utc != manifest.collected_at_utc
+        || artifact
+            .configmgr_version
+            .as_deref()
+            .is_some_and(|value| !is_safe_configmgr_version(value))
+        || artifact
+            .encoding
+            .as_deref()
+            .is_some_and(|value| !is_supported_encoding(value))
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM manifest artifact identity, role, time, or encoding is invalid".to_owned(),
+        ));
+    }
+    let canonical_basename = canonical_client_source(&artifact.basename, &artifact.rotation)
+        .ok_or_else(|| {
+            AppError::InvalidInput(
+                "SCCM manifest artifact is not bound to the authoritative catalog".to_owned(),
+            )
+        })?;
+    if artifact.catalog_entry_id != catalog_entry_id(&canonical_basename)
+        || artifact.logical_artifact_ids != logical_artifact_ids_for_basename(&canonical_basename)
+        || artifact.logical_artifact_ids.is_empty()
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM manifest artifact memberships are incomplete or unordered".to_owned(),
+        ));
+    }
+
+    if artifact.state.is_physical() {
+        if artifact.coverage_scope != SccmManifestCoverageScope::Source {
+            return Err(AppError::InvalidInput(
+                "physical SCCM evidence cannot claim a root-enumeration scope".to_owned(),
+            ));
+        }
+        validate_bound_provenance(artifact, &canonical_basename)?;
+        let fingerprint = artifact
+            .path_fingerprint
+            .as_deref()
+            .expect("validated physical provenance includes a fingerprint");
+        if artifact.artifact_id
+            != expected_physical_artifact_id(fingerprint, &artifact.rotation, &artifact.basename)
+        {
+            return Err(AppError::InvalidInput(
+                "physical SCCM artifact provenance is malformed".to_owned(),
+            ));
+        }
+        validate_relative_path(artifact, &canonical_basename)?;
+        if artifact
+            .content_sha256
+            .as_deref()
+            .is_none_or(|digest| !is_sha256_digest(digest))
+        {
+            return Err(AppError::InvalidInput(
+                "physical SCCM artifact has no valid content digest".to_owned(),
+            ));
+        }
+        if artifact.state == SccmManifestSourceState::Capped
+            || (artifact.state == SccmManifestSourceState::ParseFailed
+                && artifact.limit_applied.is_some())
+        {
+            if artifact.fragment_complete
+                || artifact.capture_limit_kind.is_none()
+                || artifact.limit_applied != Some(artifact.bytes_copied)
+            {
+                return Err(AppError::InvalidInput(
+                    "bounded SCCM artifact has incoherent limit or completeness".to_owned(),
+                ));
+            }
+        } else if artifact.limit_applied.is_some() || artifact.capture_limit_kind.is_some() {
+            return Err(AppError::InvalidInput(
+                "uncapped SCCM artifact declares a capture limit".to_owned(),
+            ));
+        }
+    } else {
+        if artifact.relative_path.is_some()
+            || artifact.bytes_copied != 0
+            || artifact.limit_applied.is_some()
+            || artifact.capture_limit_kind.is_some()
+            || artifact.content_sha256.is_some()
+            || artifact.fragment_complete
+        {
+            return Err(AppError::InvalidInput(
+                "nonphysical SCCM coverage marker claims physical evidence".to_owned(),
+            ));
+        }
+        validate_nonphysical_provenance(artifact, &canonical_basename)?;
+        if artifact.artifact_id
+            != expected_marker_artifact_id(
+                &artifact.catalog_entry_id,
+                artifact.state,
+                &artifact.rotation,
+                &artifact.basename,
+                artifact.path_fingerprint.as_deref(),
+            )
+        {
+            return Err(AppError::InvalidInput(
+                "SCCM coverage marker identity is not canonical".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_nonphysical_provenance(
+    artifact: &SccmManifestArtifact,
+    canonical_basename: &str,
+) -> Result<(), AppError> {
+    if artifact.coverage_scope == SccmManifestCoverageScope::RootEnumeration {
+        if !matches!(
+            artifact.state,
+            SccmManifestSourceState::AccessDenied | SccmManifestSourceState::FailedUnknownDetail
+        ) || artifact.rotation != SccmRotation::Current
+        {
+            return Err(AppError::InvalidInput(
+                "SCCM root-enumeration coverage scope is incoherent".to_owned(),
+            ));
+        }
+        return validate_enumeration_provenance(artifact, canonical_basename);
+    }
+    let has_any_provenance = artifact.source_handle.is_some()
+        || artifact.root_handle.is_some()
+        || artifact.path_fingerprint.is_some()
+        || artifact.rotation_lineage.is_some();
+    if has_any_provenance {
+        validate_bound_provenance(artifact, canonical_basename)?;
+    }
+    Ok(())
+}
+
+fn validate_capture_gap(gap: &SccmManifestCaptureGap) -> Result<(), AppError> {
+    if !matches!(
+        gap.state,
+        SccmManifestSourceState::Capped | SccmManifestSourceState::ParseFailed
+    ) || gap.bytes_retained != 0
+        || !is_versioned_handle(&gap.artifact_id, "sccm-artifact:v1:sha256:")
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM capture gap state or payload claim is incoherent".to_owned(),
+        ));
+    }
+    let canonical_basename =
+        canonical_client_source(&gap.basename, &gap.rotation).ok_or_else(|| {
+            AppError::InvalidInput(
+                "SCCM capture gap is not bound to the authoritative catalog".to_owned(),
+            )
+        })?;
+    if gap.catalog_entry_id != catalog_entry_id(&canonical_basename)
+        || gap.logical_artifact_ids != logical_artifact_ids_for_basename(&canonical_basename)
+        || gap.logical_artifact_ids.is_empty()
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM capture gap is not bound to the authoritative catalog".to_owned(),
+        ));
+    }
+    let expected_source_digest = source_identity_digest(&gap.root_handle, &canonical_basename)
+        .ok_or_else(|| AppError::InvalidInput("SCCM root handle is malformed".to_owned()))?;
+    let expected_lineage = sha256_bytes(format!("lineage:v1:{expected_source_digest}").as_bytes());
+    if gap
+        .source_handle
+        .strip_prefix("cmtraceopen.source.sha256.v1:")
+        != Some(expected_source_digest.as_str())
+        || gap.path_fingerprint.strip_prefix("sha256:") != Some(expected_source_digest.as_str())
+        || gap
+            .rotation_lineage
+            .strip_prefix("cmtraceopen.lineage.sha256.v1:")
+            != Some(expected_lineage.as_str())
+        || gap.artifact_id
+            != expected_marker_artifact_id(
+                &gap.catalog_entry_id,
+                gap.state,
+                &gap.rotation,
+                &gap.basename,
+                Some(&gap.path_fingerprint),
+            )
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM capture gap provenance is malformed".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_bound_provenance(
+    artifact: &SccmManifestArtifact,
+    canonical_basename: &str,
+) -> Result<(), AppError> {
+    let source_handle = required_provenance(&artifact.source_handle)?;
+    let root_handle = required_provenance(&artifact.root_handle)?;
+    let fingerprint = required_provenance(&artifact.path_fingerprint)?;
+    let lineage = required_provenance(&artifact.rotation_lineage)?;
+    let expected_source_digest = source_identity_digest(root_handle, canonical_basename)
+        .ok_or_else(|| AppError::InvalidInput("SCCM root handle is malformed".to_owned()))?;
+    let expected_lineage = sha256_bytes(format!("lineage:v1:{expected_source_digest}").as_bytes());
+    if source_handle.strip_prefix("cmtraceopen.source.sha256.v1:")
+        != Some(expected_source_digest.as_str())
+        || fingerprint.strip_prefix("sha256:") != Some(expected_source_digest.as_str())
+        || lineage.strip_prefix("cmtraceopen.lineage.sha256.v1:") != Some(expected_lineage.as_str())
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM source provenance is malformed".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn required_provenance(value: &Option<String>) -> Result<&str, AppError> {
+    value
+        .as_deref()
+        .ok_or_else(|| AppError::InvalidInput("SCCM source provenance is incomplete".to_owned()))
+}
+
+fn validate_enumeration_provenance(
+    artifact: &SccmManifestArtifact,
+    canonical_basename: &str,
+) -> Result<(), AppError> {
+    let source_handle = required_provenance(&artifact.source_handle)?;
+    let root_handle = required_provenance(&artifact.root_handle)?;
+    let fingerprint = required_provenance(&artifact.path_fingerprint)?;
+    let lineage = required_provenance(&artifact.rotation_lineage)?;
+    let root_digest = root_handle_digest(root_handle)
+        .ok_or_else(|| AppError::InvalidInput("SCCM root handle is malformed".to_owned()))?;
+    let expected_source_digest = sha256_bytes(
+        format!("cmtraceopen.sccm.root-enumeration.v1\0{root_digest}\0{canonical_basename}")
+            .as_bytes(),
+    );
+    let expected_lineage = sha256_bytes(format!("lineage:v1:{expected_source_digest}").as_bytes());
+    if source_handle.strip_prefix("cmtraceopen.source.sha256.v1:")
+        != Some(expected_source_digest.as_str())
+        || fingerprint.strip_prefix("sha256:") != Some(expected_source_digest.as_str())
+        || lineage.strip_prefix("cmtraceopen.lineage.sha256.v1:") != Some(expected_lineage.as_str())
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM enumeration provenance is malformed".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_relative_path(
+    artifact: &SccmManifestArtifact,
+    canonical_basename: &str,
+) -> Result<(), AppError> {
+    let relative = artifact.relative_path.as_deref().ok_or_else(|| {
+        AppError::InvalidInput("physical SCCM artifact has no relative path".to_owned())
+    })?;
+    if relative.len() > 1024
+        || relative.contains('\\')
+        || Path::new(relative).is_absolute()
+        || Path::new(relative)
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM artifact relative path is unsafe".to_owned(),
+        ));
+    }
+    let segments = relative.split('/').collect::<Vec<_>>();
+    if segments.len() != 7
+        || segments[0..3] != ["evidence", "sccm", "client"]
+        || segments[3] != expected_bundle_group(&artifact.logical_artifact_ids)
+        || artifact.root_handle.as_deref() != Some(segments[4])
+        || segments[5] != rotation_segment(&artifact.rotation)
+        || segments[6] != artifact.basename
+        || canonical_client_source(segments[6], &artifact.rotation).as_deref()
+            != Some(canonical_basename)
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM artifact relative path does not match catalog provenance".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_evidence_file(
+    bundle_root: &Path,
+    artifact: &SccmManifestArtifact,
+) -> Result<(), AppError> {
+    let relative_path = artifact
+        .relative_path
+        .as_deref()
+        .ok_or_else(|| AppError::InvalidInput("physical SCCM artifact has no path".to_owned()))?;
+    let candidate = bundle_root.join(relative_path);
+    let metadata = fs::symlink_metadata(&candidate)
+        .map_err(|_| AppError::InvalidInput("SCCM evidence file is unavailable".to_owned()))?;
+    if is_reparse_point(&metadata) || !metadata.is_file() {
+        return Err(AppError::InvalidInput(
+            "SCCM evidence must be a real file".to_owned(),
+        ));
+    }
+    let canonical = candidate.canonicalize().map_err(|_| {
+        AppError::InvalidInput("SCCM evidence cannot be resolved safely".to_owned())
+    })?;
+    if !canonical.starts_with(bundle_root) || metadata.len() != artifact.bytes_copied {
+        return Err(AppError::InvalidInput(
+            "SCCM evidence violates path or size coherence".to_owned(),
+        ));
+    }
+    let mut input = open_file_no_follow(&candidate)
+        .map_err(|_| AppError::InvalidInput("SCCM evidence cannot be opened safely".to_owned()))?;
+    let opened_metadata = input.metadata().map_err(|_| {
+        AppError::InvalidInput("SCCM evidence metadata cannot be verified".to_owned())
+    })?;
+    if is_reparse_point(&opened_metadata)
+        || !opened_metadata.is_file()
+        || opened_metadata.len() != artifact.bytes_copied
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM evidence violates opened-file coherence".to_owned(),
+        ));
+    }
+    let digest = sha256_exact_file(&mut input, artifact.bytes_copied)?;
+    if artifact.content_sha256.as_deref() != Some(digest.as_str()) {
+        return Err(AppError::InvalidInput(
+            "SCCM evidence violates content digest coherence".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn read_bounded_file(mut input: File, maximum: u64, label: &str) -> Result<Vec<u8>, AppError> {
+    let metadata = input
+        .metadata()
+        .map_err(|_| AppError::InvalidInput(format!("{label} metadata cannot be verified")))?;
+    if is_reparse_point(&metadata) || !metadata.is_file() {
+        return Err(AppError::InvalidInput(format!(
+            "{label} must be a real file inside the bundle"
+        )));
+    }
+    if metadata.len() > maximum {
+        return Err(AppError::InvalidInput(format!(
+            "{label} exceeds its size limit"
+        )));
+    }
+    let mut bytes = Vec::new();
+    Read::by_ref(&mut input)
+        .take(maximum.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| AppError::InvalidInput(format!("{label} cannot be read safely")))?;
+    if bytes.len() as u64 > maximum {
+        return Err(AppError::InvalidInput(format!(
+            "{label} exceeds its size limit"
+        )));
+    }
+    Ok(bytes)
+}
+
+fn sha256_exact_file(input: &mut File, expected_bytes: u64) -> Result<String, AppError> {
+    let mut digest = Sha256::new();
+    let mut remaining = expected_bytes;
+    let mut buffer = [0_u8; 64 * 1024];
+    while remaining > 0 {
+        let requested = usize::try_from(remaining.min(buffer.len() as u64))
+            .expect("bounded digest buffer length fits usize");
+        let read = input.read(&mut buffer[..requested]).map_err(|_| {
+            AppError::InvalidInput("SCCM evidence content cannot be verified".to_owned())
+        })?;
+        if read == 0 {
+            return Err(AppError::InvalidInput(
+                "SCCM evidence shrank during content verification".to_owned(),
+            ));
+        }
+        digest.update(&buffer[..read]);
+        remaining -= read as u64;
+    }
+    let mut probe = [0_u8; 1];
+    if input.read(&mut probe).map_err(|_| {
+        AppError::InvalidInput("SCCM evidence content cannot be verified".to_owned())
+    })? != 0
+    {
+        return Err(AppError::InvalidInput(
+            "SCCM evidence grew during content verification".to_owned(),
+        ));
+    }
+    Ok(digest
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
+}
+
+fn read_legacy_manifest(bundle_root: &Path) -> Result<SccmBundleManifestV1, AppError> {
+    let legacy = read_legacy_value(bundle_root)?;
+    let values = legacy
+        .get("artifacts")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            AppError::InvalidInput("legacy manifest does not contain artifacts".to_owned())
+        })?;
+    let gaps = legacy_gaps(&legacy)?;
+    if values.len().saturating_add(gaps.len()) > MAX_SCCM_MANIFEST_ARTIFACTS {
+        return Err(AppError::InvalidInput(
+            "legacy manifest has too many artifacts or gaps".to_owned(),
+        ));
+    }
+    let mut artifacts = values
+        .iter()
+        .enumerate()
+        .map(|(index, artifact)| legacy_artifact(index, artifact))
+        .collect::<Result<Vec<_>, _>>()?;
+    artifacts.extend(
+        gaps.iter()
+            .enumerate()
+            .map(|(index, gap)| legacy_gap(index, gap))
+            .collect::<Result<Vec<_>, _>>()?,
+    );
+    Ok(SccmBundleManifestV1 {
+        sccm_manifest_version: SCCM_MANIFEST_VERSION,
+        diagnostics_schema_version: SCCM_DIAGNOSTICS_SCHEMA_VERSION,
+        source_catalog_version: 0,
+        provenance: SccmManifestProvenance::LegacyGenericUnscoped,
+        provenance_profile: SccmManifestProvenanceProfile::LegacyGenericUnscoped,
+        host_handle: None,
+        collected_at_utc: None,
+        max_files_per_source: 0,
+        max_bytes_per_source: 0,
+        artifacts,
+        capture_gaps: Vec::new(),
+    })
+}
+
+fn read_legacy_value(bundle_root: &Path) -> Result<Value, AppError> {
+    let legacy_path = bundle_root.join(LEGACY_MANIFEST_FILE_NAME);
+    let input = open_file_no_follow(&legacy_path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            AppError::InvalidInput(format!(
+                "bundle contains neither {SCCM_MANIFEST_FILE_NAME} nor {LEGACY_MANIFEST_FILE_NAME}"
+            ))
+        } else {
+            AppError::InvalidInput("legacy manifest cannot be opened safely".to_owned())
+        }
+    })?;
+    let bytes = read_bounded_file(input, MAX_SCCM_MANIFEST_BYTES, "legacy manifest")?;
+    serde_json::from_slice(&bytes).map_err(|error| AppError::Parse {
+        file: LEGACY_MANIFEST_FILE_NAME.to_owned(),
+        reason: error.to_string(),
+    })
+}
+
+fn legacy_gaps(legacy: &Value) -> Result<&[Value], AppError> {
+    match legacy.pointer("/collection/results/gaps") {
+        Some(Value::Array(gaps)) => Ok(gaps),
+        Some(_) => Err(AppError::InvalidInput(
+            "legacy manifest collection gaps are malformed".to_owned(),
+        )),
+        None => Ok(&[]),
+    }
+}
+
+fn read_legacy_client_intake_bundle(
+    bundle_root: &Path,
+) -> Result<SccmClientIntakeBundle, AppError> {
+    let legacy = read_legacy_value(bundle_root)?;
+    let supported_profile = legacy
+        .pointer("/collection/collectorProfile")
+        .and_then(Value::as_str)
+        == Some(LEGACY_GENERIC_PROFILE_NAME)
+        && legacy
+            .pointer("/collection/collectorVersion")
+            .and_then(Value::as_str)
+            == Some(LEGACY_GENERIC_PROFILE_VERSION);
+    if !supported_profile {
+        return Ok(SccmClientIntakeBundle {
+            artifacts: Vec::new(),
+            capture_gaps: Vec::new(),
+        });
+    }
+    let gaps = legacy_gaps(&legacy)?;
+    if gaps.len() > MAX_SCCM_MANIFEST_ARTIFACTS {
+        return Err(AppError::InvalidInput(
+            "legacy manifest has too many collection gaps".to_owned(),
+        ));
+    }
+
+    let mut artifacts = Vec::new();
+    let mut known_gap_seen = false;
+    for gap in gaps {
+        if gap.get("artifactId").and_then(Value::as_str) != Some(LEGACY_CONFIGMGR_CCM_LOGS_ID)
+            || gap.get("category").and_then(Value::as_str) != Some(LEGACY_CONFIGMGR_LOG_CATEGORY)
+        {
+            continue;
+        }
+        let state = match gap.get("status").and_then(Value::as_str) {
+            Some("Missing") => SccmManifestSourceState::Absent,
+            Some("Failed") => SccmManifestSourceState::FailedUnknownDetail,
+            _ => continue,
+        };
+        if known_gap_seen {
+            return Err(AppError::InvalidInput(
+                "legacy manifest duplicates a known SCCM collection gap".to_owned(),
+            ));
+        }
+        known_gap_seen = true;
+        let catalog_id = catalog_entry_id(LEGACY_CCMSETUP_GROUP);
+        artifacts.push(SccmClientIntakeArtifact {
+            artifact: SccmArtifact {
+                artifact_id: expected_marker_artifact_id(
+                    &catalog_id,
+                    state,
+                    &SccmRotation::Current,
+                    LEGACY_CCMSETUP_BASENAME,
+                    None,
+                ),
+                display_name: LEGACY_CCMSETUP_BASENAME.to_owned(),
+                original_path: None,
+                host: None,
+                role: SccmRole::Client,
+                configmgr_version: None,
+                collected_at_utc: None,
+                rotation: SccmRotation::Current,
+                coverage: state.pure_coverage(),
+                encoding: None,
+            },
+            path_fingerprint: None,
+            rotation_lineage: None,
+            relative_path: None,
+            fragment_complete: Some(false),
+        });
+    }
+    let bundle = SccmClientIntakeBundle {
+        artifacts,
+        capture_gaps: Vec::new(),
+    };
+    assess_client_intake(&bundle).map_err(|error| {
+        AppError::InvalidInput(format!(
+            "legacy manifest cannot be converted to the pure client intake contract: {error}"
+        ))
+    })?;
+    Ok(bundle)
+}
+
+fn legacy_gap(index: usize, gap: &Value) -> Result<SccmManifestArtifact, AppError> {
+    let legacy_id = legacy_identity(gap, "gap")?;
+    let state = match gap.get("status").and_then(Value::as_str) {
+        Some("Missing") => SccmManifestSourceState::Absent,
+        Some("Failed") | Some(_) | None => SccmManifestSourceState::FailedUnknownDetail,
+    };
+    Ok(legacy_unscoped_artifact("gap", index, legacy_id, state))
+}
+
+fn legacy_artifact(index: usize, artifact: &Value) -> Result<SccmManifestArtifact, AppError> {
+    let legacy_id = legacy_identity(artifact, "artifact")?;
+    if let Some(path) = artifact.get("relativePath").and_then(Value::as_str) {
+        validate_legacy_relative_path(path)?;
+    }
+    let state = match artifact.get("status").and_then(Value::as_str) {
+        Some("missing") => SccmManifestSourceState::Absent,
+        Some("collected") | Some("failed") | Some(_) | None => {
+            SccmManifestSourceState::FailedUnknownDetail
+        }
+    };
+    Ok(legacy_unscoped_artifact(
+        "artifact", index, legacy_id, state,
+    ))
+}
+
+fn legacy_identity<'a>(value: &'a Value, kind: &str) -> Result<&'a str, AppError> {
+    let identity = value
+        .get("artifactId")
+        .and_then(Value::as_str)
+        .ok_or_else(|| AppError::InvalidInput(format!("legacy {kind} is missing artifactId")))?;
+    if identity.is_empty() || identity.chars().count() > MAX_SAFE_TEXT_CHARS {
+        return Err(AppError::InvalidInput(format!(
+            "legacy {kind} identity is empty or too long"
+        )));
+    }
+    Ok(identity)
+}
+
+fn legacy_unscoped_artifact(
+    domain: &str,
+    index: usize,
+    legacy_id: &str,
+    state: SccmManifestSourceState,
+) -> SccmManifestArtifact {
+    let digest = sha256_bytes(format!("legacy:v1:{domain}:{index}:{legacy_id}").as_bytes());
+    SccmManifestArtifact {
+        catalog_entry_id: "legacy-generic-unscoped:v1".to_owned(),
+        logical_artifact_ids: Vec::new(),
+        artifact_id: format!("sccm-artifact:v1:sha256:{digest}"),
+        role: SccmRole::Unknown("legacyGenericUnscoped".to_owned()),
+        source_handle: None,
+        root_handle: None,
+        path_fingerprint: None,
+        rotation_lineage: None,
+        relative_path: None,
+        basename: format!("sccm-unknown-v1-sha256-{digest}.log"),
+        rotation: SccmRotation::Current,
+        state,
+        coverage_scope: SccmManifestCoverageScope::Source,
+        capture_limit_kind: None,
+        bytes_copied: 0,
+        limit_applied: None,
+        content_sha256: None,
+        fragment_complete: false,
+        configmgr_version: None,
+        collected_at_utc: None,
+        encoding: None,
+    }
+}
+
+fn validate_legacy_relative_path(value: &str) -> Result<(), AppError> {
+    if value.is_empty()
+        || value.len() > 512
+        || value.contains('\\')
+        || Path::new(value).is_absolute()
+        || !value.starts_with("evidence/")
+        || Path::new(value)
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(AppError::InvalidInput(
+            "legacy artifact relative path is unsafe".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn canonical_basename(value: &str) -> String {
+    cmtraceopen_parser::sccm::classify_artifact_name(value, SccmRole::Client)
+        .basename
+        .to_ascii_lowercase()
+}
+
+fn is_utc_rfc3339(value: &str) -> bool {
+    value.len() <= 64
+        && value.is_ascii()
+        && DateTime::parse_from_rfc3339(value)
+            .is_ok_and(|timestamp| timestamp.offset().local_minus_utc() == 0)
+}
+
+fn is_supported_encoding(value: &str) -> bool {
+    matches!(value, "utf-8" | "utf-16le" | "utf-16be" | "windows-1252")
+}
+
+fn is_safe_configmgr_version(value: &str) -> bool {
+    if matches!(value, "5.00.TEST.0000" | "5.00.UNKNOWN.0000") {
+        return true;
+    }
+    let mut components = value.split('.');
+    matches!(components.next(), Some("5"))
+        && matches!(components.next(), Some("00"))
+        && components.next().is_some_and(is_four_ascii_digits)
+        && components.next().is_some_and(is_four_ascii_digits)
+        && components.next().is_none()
+}
+
+fn is_four_ascii_digits(value: &str) -> bool {
+    value.len() == 4 && value.bytes().all(|byte| byte.is_ascii_digit())
+}

--- a/src-tauri/src/sccm/manifest.rs
+++ b/src-tauri/src/sccm/manifest.rs
@@ -35,17 +35,17 @@ const MAX_SAFE_TEXT_CHARS: usize = 160;
 const MAX_SCCM_CLIENT_PHYSICAL_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_SCCM_CLIENT_TOTAL_PHYSICAL_BYTES: u64 = 1024 * 1024 * 1024;
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 thread_local! {
     static INTAKE_PROJECTION_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 fn reset_intake_projection_count() {
     INTAKE_PROJECTION_COUNT.with(|count| count.set(0));
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 fn intake_projection_count() -> usize {
     INTAKE_PROJECTION_COUNT.with(std::cell::Cell::get)
 }
@@ -97,7 +97,7 @@ pub fn read_sccm_manifest_or_legacy(bundle_root: &Path) -> Result<SccmBundleMani
 fn manifest_to_client_intake_bundle(
     manifest: &SccmBundleManifestV1,
 ) -> Result<SccmClientIntakeBundle, AppError> {
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     INTAKE_PROJECTION_COUNT.with(|count| count.set(count.get().saturating_add(1)));
 
     validate_native_manifest_structure(manifest)?;

--- a/src-tauri/src/sccm/manifest.rs
+++ b/src-tauri/src/sccm/manifest.rs
@@ -967,6 +967,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn native_validation_returns_its_reusable_intake_projection() {
+        let _validate: fn(
+            &VerifiedBundleRoot,
+            &SccmBundleManifestV1,
+        ) -> Result<SccmClientIntakeBundle, AppError> = validate_native_manifest;
+    }
+
+    #[test]
     fn client_owned_physical_byte_budget_accepts_exact_ceilings_without_opening_evidence() {
         let mut total = 0;
         for _ in 0..4 {

--- a/src-tauri/src/sccm/manifest.rs
+++ b/src-tauri/src/sccm/manifest.rs
@@ -35,6 +35,21 @@ const MAX_SAFE_TEXT_CHARS: usize = 160;
 const MAX_SCCM_CLIENT_PHYSICAL_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_SCCM_CLIENT_TOTAL_PHYSICAL_BYTES: u64 = 1024 * 1024 * 1024;
 
+#[cfg(test)]
+thread_local! {
+    static INTAKE_PROJECTION_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn reset_intake_projection_count() {
+    INTAKE_PROJECTION_COUNT.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+fn intake_projection_count() -> usize {
+    INTAKE_PROJECTION_COUNT.with(std::cell::Cell::get)
+}
+
 enum ValidatedManifestRead {
     Native {
         manifest: SccmBundleManifestV1,
@@ -82,6 +97,9 @@ pub fn read_sccm_manifest_or_legacy(bundle_root: &Path) -> Result<SccmBundleMani
 fn manifest_to_client_intake_bundle(
     manifest: &SccmBundleManifestV1,
 ) -> Result<SccmClientIntakeBundle, AppError> {
+    #[cfg(test)]
+    INTAKE_PROJECTION_COUNT.with(|count| count.set(count.get().saturating_add(1)));
+
     validate_native_manifest_structure(manifest)?;
     let artifacts = manifest
         .artifacts

--- a/src-tauri/src/sccm/mod.rs
+++ b/src-tauri/src/sccm/mod.rs
@@ -1,0 +1,13 @@
+//! Reader-only native SCCM diagnostic manifest boundary.
+//!
+//! The pure diagnostic models and reducers remain in `cmtraceopen-parser`.
+//! This module validates native bundle provenance and projects it into those
+//! pure contracts without changing the generic collection manifest.
+
+mod contract;
+mod manifest;
+mod private_fs;
+
+pub use cmtraceopen_parser::sccm::{SccmCoverageState, SccmRole, SccmRotation};
+pub use contract::*;
+pub use manifest::*;

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -815,6 +815,35 @@ mod windows_tests {
     use super::*;
 
     #[test]
+    fn missing_final_component_preserves_not_found_for_legacy_fallback() {
+        let temp = tempdir().expect("temporary root");
+        let root = temp.path().join("bundle");
+        fs::create_dir_all(&root).expect("create bundle");
+
+        let verified = verify_bundle_root(&root).expect("open private root");
+        let error = verified
+            .open_relative_file(Path::new("sccm-manifest.json"))
+            .expect_err("missing native manifest is reported to the legacy fallback");
+
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn relative_component_rejects_alternate_data_streams() {
+        let temp = tempdir().expect("temporary root");
+        let root = temp.path().join("bundle");
+        fs::create_dir_all(&root).expect("create bundle");
+        fs::write(root.join("manifest.json"), b"{}\n").expect("create manifest");
+
+        let verified = verify_bundle_root(&root).expect("open private root");
+        let error = verified
+            .open_relative_file(Path::new("manifest.json:alternate"))
+            .expect_err("alternate data streams cannot be opened as bundle entries");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
     fn verified_root_keeps_reading_the_original_directory_after_root_replacement() {
         let temp = tempdir().expect("temporary root");
         let root = temp.path().join("bundle");

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -1,0 +1,349 @@
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::error::AppError;
+
+pub(super) fn verify_bundle_root(bundle_root: &Path) -> Result<PathBuf, AppError> {
+    let metadata = fs::symlink_metadata(bundle_root).map_err(|_| {
+        AppError::InvalidInput("SCCM bundle root is unavailable or unsafe".to_owned())
+    })?;
+    if is_reparse_point(&metadata) || !metadata.is_dir() {
+        return Err(AppError::InvalidInput(
+            "SCCM bundle root must be a real directory".to_owned(),
+        ));
+    }
+    verify_private_directory(bundle_root, &metadata)?;
+    bundle_root.canonicalize().map_err(|_| {
+        AppError::InvalidInput("SCCM bundle root cannot be resolved safely".to_owned())
+    })
+}
+
+#[cfg(unix)]
+fn verify_private_directory(_path: &Path, metadata: &fs::Metadata) -> Result<(), AppError> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    // SAFETY: `geteuid` has no preconditions and reads process identity only.
+    let effective_user = unsafe { libc::geteuid() };
+    if metadata.uid() != 0 && metadata.uid() != effective_user {
+        return Err(AppError::InvalidInput(
+            "SCCM bundle directory is not owned by the capture user".to_owned(),
+        ));
+    }
+    if metadata.permissions().mode() & 0o077 != 0 {
+        return Err(AppError::InvalidInput(
+            "SCCM bundle directory is not private".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WindowsAclTrustee {
+    Owner,
+    LocalSystem,
+    BuiltinAdministrators,
+    CreatorOwner,
+    Other,
+}
+
+#[cfg(windows)]
+fn windows_allow_ace_is_restricted(trustee: WindowsAclTrustee, inherit_only: bool) -> bool {
+    matches!(
+        trustee,
+        WindowsAclTrustee::Owner
+            | WindowsAclTrustee::LocalSystem
+            | WindowsAclTrustee::BuiltinAdministrators
+    ) || (trustee == WindowsAclTrustee::CreatorOwner && inherit_only)
+}
+
+#[cfg(windows)]
+fn verify_private_directory(path: &Path, _metadata: &fs::Metadata) -> Result<(), AppError> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::{CloseHandle, LocalFree, ERROR_SUCCESS, HANDLE, HLOCAL};
+    use windows::Win32::Security::Authorization::{
+        GetExplicitEntriesFromAclW, GetNamedSecurityInfoW, GRANT_ACCESS, SET_ACCESS,
+        SE_FILE_OBJECT, TRUSTEE_IS_SID,
+    };
+    use windows::Win32::Security::{
+        EqualSid, GetTokenInformation, IsValidSid, IsWellKnownSid, TokenUser,
+        WinBuiltinAdministratorsSid, WinCreatorOwnerSid, WinLocalSystemSid, ACL,
+        DACL_SECURITY_INFORMATION, INHERIT_ONLY_ACE, OWNER_SECURITY_INFORMATION,
+        PSECURITY_DESCRIPTOR, PSID, TOKEN_QUERY, TOKEN_USER,
+    };
+    use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    const MAX_ACL_ENTRIES: u32 = 4096;
+
+    struct LocalAllocation(*mut core::ffi::c_void);
+
+    impl Drop for LocalAllocation {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                unsafe {
+                    let _ = LocalFree(Some(HLOCAL(self.0)));
+                }
+            }
+        }
+    }
+
+    struct OwnedHandle(HANDLE);
+
+    impl Drop for OwnedHandle {
+        fn drop(&mut self) {
+            if !self.0.is_invalid() {
+                unsafe {
+                    let _ = CloseHandle(self.0);
+                }
+            }
+        }
+    }
+
+    fn owner_is_current_process_user(owner: PSID) -> Result<bool, AppError> {
+        let mut token = HANDLE::default();
+        unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) }.map_err(
+            |_| {
+                AppError::InvalidInput(
+                    "SCCM bundle root ACL owner could not be verified".to_owned(),
+                )
+            },
+        )?;
+        let _token = OwnedHandle(token);
+        let mut required = 0_u32;
+        let _ = unsafe { GetTokenInformation(token, TokenUser, None, 0, &mut required) };
+        if required < std::mem::size_of::<TOKEN_USER>() as u32 {
+            return Err(AppError::InvalidInput(
+                "SCCM bundle root ACL owner token information is unavailable".to_owned(),
+            ));
+        }
+        let word_bytes = std::mem::size_of::<usize>();
+        let word_count = (required as usize).div_ceil(word_bytes);
+        let mut buffer = vec![0_usize; word_count];
+        let mut returned = required;
+        unsafe {
+            GetTokenInformation(
+                token,
+                TokenUser,
+                Some(buffer.as_mut_ptr().cast()),
+                required,
+                &mut returned,
+            )
+        }
+        .map_err(|_| {
+            AppError::InvalidInput(
+                "SCCM bundle root ACL owner token information could not be read".to_owned(),
+            )
+        })?;
+        if returned > required {
+            return Err(AppError::InvalidInput(
+                "SCCM bundle root ACL owner token information changed during validation".to_owned(),
+            ));
+        }
+        let token_user = unsafe { &*buffer.as_ptr().cast::<TOKEN_USER>() };
+        let token_sid = token_user.User.Sid;
+        if token_sid.is_invalid() || !unsafe { IsValidSid(token_sid).as_bool() } {
+            return Err(AppError::InvalidInput(
+                "SCCM bundle root ACL owner token contains an invalid SID".to_owned(),
+            ));
+        }
+        Ok(unsafe { EqualSid(owner, token_sid).is_ok() })
+    }
+
+    let path_wide = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let mut owner = PSID::default();
+    let mut dacl: *mut ACL = std::ptr::null_mut();
+    let mut descriptor = PSECURITY_DESCRIPTOR::default();
+    let status = unsafe {
+        GetNamedSecurityInfoW(
+            PCWSTR(path_wide.as_ptr()),
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+            Some(&mut owner),
+            None,
+            Some(&mut dacl),
+            None,
+            &mut descriptor,
+        )
+    };
+    let _descriptor = LocalAllocation(descriptor.0);
+    if status != ERROR_SUCCESS {
+        return Err(AppError::InvalidInput(format!(
+            "SCCM bundle root ACL could not be verified (Win32 error {})",
+            status.0
+        )));
+    }
+    if owner.is_invalid() || !unsafe { IsValidSid(owner).as_bool() } || dacl.is_null() {
+        return Err(AppError::InvalidInput(
+            "SCCM bundle root ACL has no valid owner or has a null DACL".to_owned(),
+        ));
+    }
+    let owner_is_current_user = owner_is_current_process_user(owner)?;
+    let owner_is_local_system = unsafe { IsWellKnownSid(owner, WinLocalSystemSid).as_bool() };
+    let owner_is_builtin_administrator =
+        unsafe { IsWellKnownSid(owner, WinBuiltinAdministratorsSid).as_bool() };
+    if !(owner_is_current_user || owner_is_local_system || owner_is_builtin_administrator) {
+        return Err(AppError::InvalidInput(
+            "SCCM bundle root ACL owner is not the capture user, LocalSystem, or Administrators"
+                .to_owned(),
+        ));
+    }
+
+    let mut entry_count = 0_u32;
+    let mut entries = std::ptr::null_mut();
+    let status = unsafe { GetExplicitEntriesFromAclW(dacl, &mut entry_count, &mut entries) };
+    let _entries = LocalAllocation(entries.cast());
+    if status != ERROR_SUCCESS {
+        return Err(AppError::InvalidInput(format!(
+            "SCCM bundle root ACL entries could not be verified (Win32 error {})",
+            status.0
+        )));
+    }
+    if entry_count > MAX_ACL_ENTRIES || (entry_count != 0 && entries.is_null()) {
+        return Err(AppError::InvalidInput(
+            "SCCM bundle root ACL has an unsafe entry count".to_owned(),
+        ));
+    }
+    let entries = if entry_count == 0 {
+        &[][..]
+    } else {
+        unsafe { std::slice::from_raw_parts(entries, entry_count as usize) }
+    };
+    for entry in entries {
+        if entry.grfAccessPermissions == 0
+            || !matches!(entry.grfAccessMode, GRANT_ACCESS | SET_ACCESS)
+        {
+            continue;
+        }
+        if entry.Trustee.TrusteeForm != TRUSTEE_IS_SID || entry.Trustee.ptstrName.is_null() {
+            return Err(AppError::InvalidInput(
+                "SCCM bundle root ACL contains an unverifiable allow trustee".to_owned(),
+            ));
+        }
+        let sid = PSID(entry.Trustee.ptstrName.0.cast());
+        if !unsafe { IsValidSid(sid).as_bool() } {
+            return Err(AppError::InvalidInput(
+                "SCCM bundle root ACL contains an invalid allow trustee".to_owned(),
+            ));
+        }
+        let trustee = if unsafe { EqualSid(sid, owner).is_ok() } {
+            WindowsAclTrustee::Owner
+        } else if unsafe { IsWellKnownSid(sid, WinLocalSystemSid).as_bool() } {
+            WindowsAclTrustee::LocalSystem
+        } else if unsafe { IsWellKnownSid(sid, WinBuiltinAdministratorsSid).as_bool() } {
+            WindowsAclTrustee::BuiltinAdministrators
+        } else if unsafe { IsWellKnownSid(sid, WinCreatorOwnerSid).as_bool() } {
+            WindowsAclTrustee::CreatorOwner
+        } else {
+            WindowsAclTrustee::Other
+        };
+        let inherit_only = entry.grfInheritance.0 & INHERIT_ONLY_ACE.0 != 0;
+        if !windows_allow_ace_is_restricted(trustee, inherit_only) {
+            return Err(AppError::InvalidInput(
+                "SCCM bundle root ACL grants access to a non-privileged trustee".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn verify_private_directory(_path: &Path, _metadata: &fs::Metadata) -> Result<(), AppError> {
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)?;
+    let file = require_regular_file(file)?;
+    let descriptor = file.as_raw_fd();
+    // SAFETY: `descriptor` is borrowed from the live `File`; both fcntl calls
+    // operate only on its status flags and preserve every flag except NONBLOCK.
+    let flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(descriptor, libc::F_SETFL, flags & !libc::O_NONBLOCK) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    require_regular_file(file)
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
+    let file = OpenOptions::new().read(true).open(path)?;
+    require_regular_file(file)
+}
+
+fn require_regular_file(file: File) -> io::Result<File> {
+    let metadata = file.metadata()?;
+    if is_reparse_point(&metadata) || !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM bundle entry is not a regular file",
+        ));
+    }
+    Ok(file)
+}
+
+pub(super) fn is_reparse_point(metadata: &fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::fd::AsRawFd;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn safe_open_returns_only_regular_blocking_files() {
+        let root = tempdir().expect("temporary root");
+        let path = root.path().join("manifest.json");
+        fs::write(&path, b"{}").expect("synthetic manifest");
+
+        let file = open_file_no_follow(&path).expect("regular file");
+        let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+        assert!(flags >= 0, "opened descriptor flags are readable");
+        assert_eq!(flags & libc::O_NONBLOCK, 0);
+
+        open_file_no_follow(root.path()).expect_err("directories are rejected after opening");
+    }
+}

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -604,3 +604,76 @@ mod tests {
         assert_eq!(contents, "original");
     }
 }
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use std::io::Read;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn verified_root_keeps_reading_the_original_directory_after_root_replacement() {
+        let temp = tempdir().expect("temporary root");
+        let root = temp.path().join("bundle");
+        let replacement = temp.path().join("replacement");
+        fs::create_dir_all(root.join("nested")).expect("create original bundle");
+        fs::create_dir_all(replacement.join("nested")).expect("create replacement bundle");
+        fs::write(root.join("nested/evidence.log"), b"original").expect("original evidence");
+        fs::write(replacement.join("nested/evidence.log"), b"replacement")
+            .expect("replacement evidence");
+
+        let verified = verify_bundle_root(&root).expect("open original root");
+        fs::rename(&root, temp.path().join("retired")).expect("move original root");
+        fs::rename(&replacement, &root).expect("install replacement root");
+
+        let mut opened = verified
+            .open_relative_file(Path::new("nested/evidence.log"))
+            .expect("bound root remains readable");
+        let mut contents = String::new();
+        opened
+            .read_to_string(&mut contents)
+            .expect("read bound evidence");
+        assert_eq!(contents, "original");
+    }
+
+    #[test]
+    fn verified_root_rejects_a_hard_linked_final_entry() {
+        let temp = tempdir().expect("temporary root");
+        let root = temp.path().join("bundle");
+        fs::create_dir_all(&root).expect("create bundle");
+        let manifest = root.join("manifest.json");
+        let second_link = root.join("manifest-copy.json");
+        fs::write(&manifest, b"{}\n").expect("manifest");
+        fs::hard_link(&manifest, &second_link).expect("create hard link");
+
+        let verified = verify_bundle_root(&root).expect("open private root");
+        let error = verified
+            .open_relative_file(Path::new("manifest.json"))
+            .expect_err("hard-linked entries are unsafe");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn verified_root_rejects_a_reparse_final_entry_when_symlinks_are_available() {
+        use std::os::windows::fs::symlink_file;
+
+        let temp = tempdir().expect("temporary root");
+        let root = temp.path().join("bundle");
+        fs::create_dir_all(&root).expect("create bundle");
+        let target = temp.path().join("outside-manifest.json");
+        fs::write(&target, b"outside").expect("outside manifest");
+        if symlink_file(&target, root.join("manifest.json")).is_err() {
+            // Windows systems without Developer Mode or SeCreateSymbolicLinkPrivilege
+            // cannot create this fixture. The hosted Windows job covers the real path.
+            return;
+        }
+
+        let verified = verify_bundle_root(&root).expect("open private root");
+        let error = verified
+            .open_relative_file(Path::new("manifest.json"))
+            .expect_err("reparse entries are unsafe");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+}

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -546,12 +546,6 @@ fn open_relative_file_no_follow(root: &File, relative: &Path) -> io::Result<File
     unreachable!("non-empty relative paths always return from their final component")
 }
 
-#[cfg(not(any(unix, windows)))]
-pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
-    let file = OpenOptions::new().read(true).open(path)?;
-    require_regular_file(file)
-}
-
 fn require_regular_file(file: File) -> io::Result<File> {
     #[cfg(windows)]
     {

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -870,9 +870,7 @@ mod windows_tests {
         use std::os::windows::{fs::OpenOptionsExt, io::AsRawHandle};
 
         use windows::core::PWSTR;
-        use windows::Win32::Foundation::{
-            LocalFree, ERROR_SUCCESS, HANDLE, HLOCAL, READ_CONTROL, WRITE_DAC,
-        };
+        use windows::Win32::Foundation::{LocalFree, ERROR_SUCCESS, HANDLE, HLOCAL};
         use windows::Win32::Security::Authorization::{
             GetSecurityInfo, SetEntriesInAclW, SetSecurityInfo, EXPLICIT_ACCESS_W, GRANT_ACCESS,
             NO_MULTIPLE_TRUSTEE, SE_FILE_OBJECT, TRUSTEE_IS_SID, TRUSTEE_IS_USER, TRUSTEE_W,
@@ -881,7 +879,9 @@ mod windows_tests {
             ACL, DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION,
             PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID,
         };
-        use windows::Win32::Storage::FileSystem::{FILE_ALL_ACCESS, FILE_FLAG_BACKUP_SEMANTICS};
+        use windows::Win32::Storage::FileSystem::{
+            FILE_ALL_ACCESS, FILE_FLAG_BACKUP_SEMANTICS, READ_CONTROL, WRITE_DAC,
+        };
 
         fs::create_dir_all(path).expect("create bundle directory");
         // READ_CONTROL is required for GetSecurityInfo (owner query).

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -1,22 +1,71 @@
 use std::fs::{self, File, OpenOptions};
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path};
 
 use crate::error::AppError;
 
-pub(super) fn verify_bundle_root(bundle_root: &Path) -> Result<PathBuf, AppError> {
-    let metadata = fs::symlink_metadata(bundle_root).map_err(|_| {
-        AppError::InvalidInput("SCCM bundle root is unavailable or unsafe".to_owned())
-    })?;
-    if is_reparse_point(&metadata) || !metadata.is_dir() {
-        return Err(AppError::InvalidInput(
-            "SCCM bundle root must be a real directory".to_owned(),
-        ));
+/// A bundle root whose identity remains bound for the lifetime of a native read.
+///
+/// Unix keeps an open directory descriptor and never re-resolves descendants by
+/// pathname. Windows rejects the native boundary rather than making a weaker
+/// pathname-based safety claim until it has equivalent handle-relative traversal.
+pub(super) struct VerifiedBundleRoot {
+    #[cfg(unix)]
+    directory: File,
+}
+
+pub(super) fn verify_bundle_root(bundle_root: &Path) -> Result<VerifiedBundleRoot, AppError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let directory = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+            .open(bundle_root)
+            .map_err(|_| {
+                AppError::InvalidInput("SCCM bundle root is unavailable or unsafe".to_owned())
+            })?;
+        let metadata = directory.metadata().map_err(|_| {
+            AppError::InvalidInput("SCCM bundle root metadata cannot be verified".to_owned())
+        })?;
+        if is_reparse_point(&metadata) || !metadata.is_dir() {
+            return Err(AppError::InvalidInput(
+                "SCCM bundle root must be a real directory".to_owned(),
+            ));
+        }
+        verify_private_directory(bundle_root, &metadata)?;
+        Ok(VerifiedBundleRoot { directory })
     }
-    verify_private_directory(bundle_root, &metadata)?;
-    bundle_root.canonicalize().map_err(|_| {
-        AppError::InvalidInput("SCCM bundle root cannot be resolved safely".to_owned())
-    })
+
+    #[cfg(not(unix))]
+    {
+        let _ = bundle_root;
+        Err(AppError::InvalidInput(
+            "native SCCM manifest reading requires handle-bound directory traversal on this platform"
+                .to_owned(),
+        ))
+    }
+}
+
+impl VerifiedBundleRoot {
+    pub(super) fn open_relative_file(&self, relative: &Path) -> io::Result<File> {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            open_relative_file_no_follow(self.directory.as_raw_fd(), relative)
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = relative;
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "handle-bound directory traversal is unavailable",
+            ))
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -258,7 +307,7 @@ fn verify_private_directory(_path: &Path, _metadata: &fs::Metadata) -> Result<()
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, test))]
 pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
     use std::os::fd::AsRawFd;
     use std::os::unix::fs::OpenOptionsExt;
@@ -279,6 +328,73 @@ pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
         return Err(io::Error::last_os_error());
     }
     Ok(file)
+}
+
+#[cfg(unix)]
+fn open_relative_file_no_follow(root_fd: std::os::fd::RawFd, relative: &Path) -> io::Result<File> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    let components = relative.components().collect::<Vec<_>>();
+    if components.is_empty()
+        || components
+            .iter()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM bundle relative path is unsafe",
+        ));
+    }
+
+    // Duplicate the root so every descriptor remains owned locally while each
+    // `openat` call is bound to the directory identity opened above.
+    let duplicate = unsafe { libc::fcntl(root_fd, libc::F_DUPFD_CLOEXEC, 0) };
+    if duplicate < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut directory = unsafe { File::from_raw_fd(duplicate) };
+    for (index, component) in components.iter().enumerate() {
+        let Component::Normal(name) = component else {
+            unreachable!("unsafe components were rejected above");
+        };
+        let name = CString::new(name.as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "SCCM bundle path contains an interior NUL",
+            )
+        })?;
+        let final_component = index + 1 == components.len();
+        let flags = if final_component {
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC
+        } else {
+            libc::O_RDONLY
+                | libc::O_DIRECTORY
+                | libc::O_NOFOLLOW
+                | libc::O_NONBLOCK
+                | libc::O_CLOEXEC
+        };
+        let descriptor = unsafe { libc::openat(directory.as_raw_fd(), name.as_ptr(), flags) };
+        if descriptor < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let opened = unsafe { File::from_raw_fd(descriptor) };
+        if final_component {
+            return require_regular_file(opened);
+        }
+        let metadata = opened.metadata()?;
+        if is_reparse_point(&metadata) || !metadata.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "SCCM bundle ancestor is not a real directory",
+            ));
+        }
+        #[cfg(test)]
+        invoke_open_component_hook(name.as_c_str());
+        directory = opened;
+    }
+    unreachable!("non-empty relative paths always return from their final component")
 }
 
 #[cfg(windows)]
@@ -307,7 +423,53 @@ fn require_regular_file(file: File) -> io::Result<File> {
             "SCCM bundle entry is not a regular file",
         ));
     }
+    require_single_link(&file)?;
     Ok(file)
+}
+
+#[cfg(unix)]
+fn require_single_link(file: &File) -> io::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    if file.metadata()?.nlink() != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM bundle entry must be a single-link file",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn require_single_link(file: &File) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+    };
+
+    let mut information = BY_HANDLE_FILE_INFORMATION::default();
+    unsafe {
+        GetFileInformationByHandle(
+            windows::Win32::Foundation::HANDLE(file.as_raw_handle()),
+            &mut information,
+        )
+    }
+    .map_err(|error| io::Error::new(io::ErrorKind::Other, error.to_string()))?;
+    if information.nNumberOfLinks != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM bundle entry must be a single-link file",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn require_single_link(_file: &File) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "SCCM bundle link count cannot be verified",
+    ))
 }
 
 pub(super) fn is_reparse_point(metadata: &fs::Metadata) -> bool {
@@ -326,8 +488,34 @@ pub(super) fn is_reparse_point(metadata: &fs::Metadata) -> bool {
 }
 
 #[cfg(all(test, unix))]
+type OpenComponentHook = Box<dyn FnMut(&std::ffi::CStr)>;
+
+#[cfg(all(test, unix))]
+thread_local! {
+    static OPEN_COMPONENT_HOOK: std::cell::RefCell<Option<OpenComponentHook>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(all(test, unix))]
+fn set_open_component_hook(hook: Option<OpenComponentHook>) {
+    OPEN_COMPONENT_HOOK.with(|slot| *slot.borrow_mut() = hook);
+}
+
+#[cfg(all(test, unix))]
+fn invoke_open_component_hook(component: &std::ffi::CStr) {
+    OPEN_COMPONENT_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().as_mut() {
+            hook(component);
+        }
+    });
+}
+
+#[cfg(all(test, unix))]
 mod tests {
+    use std::cell::RefCell;
+    use std::io::Read;
     use std::os::fd::AsRawFd;
+    use std::rc::Rc;
 
     use tempfile::tempdir;
 
@@ -345,5 +533,74 @@ mod tests {
         assert_eq!(flags & libc::O_NONBLOCK, 0);
 
         open_file_no_follow(root.path()).expect_err("directories are rejected after opening");
+    }
+
+    #[test]
+    fn verified_root_keeps_reading_the_original_directory_after_root_replacement() {
+        let temp = tempdir().expect("temporary root");
+        let root = temp.path().join("bundle");
+        let replacement = temp.path().join("replacement");
+        fs::create_dir_all(root.join("nested")).expect("create original bundle");
+        fs::create_dir_all(replacement.join("nested")).expect("create replacement bundle");
+        fs::write(root.join("nested/evidence.log"), b"original").expect("original evidence");
+        fs::write(replacement.join("nested/evidence.log"), b"replacement")
+            .expect("replacement evidence");
+        for directory in [&root, &replacement] {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(directory, fs::Permissions::from_mode(0o700))
+                .expect("private root");
+        }
+
+        let verified = verify_bundle_root(&root).expect("open original root");
+        fs::rename(&root, temp.path().join("retired")).expect("move original root");
+        fs::rename(&replacement, &root).expect("install replacement root");
+
+        let mut opened = verified
+            .open_relative_file(Path::new("nested/evidence.log"))
+            .expect("bound root remains readable");
+        let mut contents = String::new();
+        opened
+            .read_to_string(&mut contents)
+            .expect("read bound evidence");
+        assert_eq!(contents, "original");
+    }
+
+    #[test]
+    fn verified_root_keeps_an_opened_ancestor_after_a_deterministic_swap() {
+        let temp = tempdir().expect("temporary root");
+        let root = temp.path().join("bundle");
+        let replacement = temp.path().join("replacement-evidence");
+        fs::create_dir_all(root.join("evidence/nested")).expect("create original evidence");
+        fs::create_dir_all(replacement.join("nested")).expect("create replacement evidence");
+        fs::write(root.join("evidence/nested/evidence.log"), b"original")
+            .expect("original evidence");
+        fs::write(replacement.join("nested/evidence.log"), b"replacement")
+            .expect("replacement evidence");
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).expect("private root");
+
+        let verified = verify_bundle_root(&root).expect("open original root");
+        let retired = temp.path().join("retired-evidence");
+        let fired = Rc::new(RefCell::new(false));
+        let fired_in_hook = Rc::clone(&fired);
+        set_open_component_hook(Some(Box::new(move |component| {
+            if component.to_bytes() == b"evidence" && !*fired_in_hook.borrow() {
+                *fired_in_hook.borrow_mut() = true;
+                fs::rename(root.join("evidence"), &retired).expect("retire opened ancestor");
+                fs::rename(&replacement, root.join("evidence"))
+                    .expect("install replacement ancestor");
+            }
+        })));
+
+        let mut opened = verified
+            .open_relative_file(Path::new("evidence/nested/evidence.log"))
+            .expect("opened ancestor remains bound");
+        set_open_component_hook(None);
+        let mut contents = String::new();
+        opened
+            .read_to_string(&mut contents)
+            .expect("read bound evidence");
+        assert!(*fired.borrow(), "test hook ran after ancestor open");
+        assert_eq!(contents, "original");
     }
 }

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -438,7 +438,9 @@ fn open_relative_file_no_follow(root: &File, relative: &Path) -> io::Result<File
         NtCreateFile, FILE_DIRECTORY_FILE, FILE_NON_DIRECTORY_FILE, FILE_OPEN,
         FILE_OPEN_REPARSE_POINT, FILE_SYNCHRONOUS_IO_NONALERT,
     };
-    use windows::Win32::Foundation::{HANDLE, OBJ_CASE_INSENSITIVE, UNICODE_STRING};
+    use windows::Win32::Foundation::{
+        RtlNtStatusToDosError, HANDLE, OBJ_CASE_INSENSITIVE, UNICODE_STRING,
+    };
     use windows::Win32::Storage::FileSystem::{
         FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_READ, FILE_SHARE_DELETE, FILE_SHARE_READ,
         FILE_SHARE_WRITE,
@@ -472,7 +474,11 @@ fn open_relative_file_no_follow(root: &File, relative: &Path) -> io::Result<File
                     "SCCM bundle path component is too long",
                 )
             })?;
-        if wide_name.is_empty() || wide_name.contains(&0) || wide_bytes > u16::MAX as usize {
+        if wide_name.is_empty()
+            || wide_name.contains(&0)
+            || wide_name.contains(&(b':' as u16))
+            || wide_bytes > u16::MAX as usize
+        {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "SCCM bundle path contains an invalid component",
@@ -518,6 +524,13 @@ fn open_relative_file_no_follow(root: &File, relative: &Path) -> io::Result<File
             )
         };
         if status.0 < 0 || handle.0.is_null() || handle.is_invalid() {
+            if status.0 < 0 {
+                // SAFETY: RtlNtStatusToDosError converts the NTSTATUS returned
+                // by NtCreateFile without dereferencing caller-owned memory.
+                return Err(io::Error::from_raw_os_error(unsafe {
+                    RtlNtStatusToDosError(status) as i32
+                }));
+            }
             return Err(io::Error::new(
                 io::ErrorKind::Other,
                 "SCCM bundle entry could not be opened safely",

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -748,6 +748,25 @@ mod tests {
     }
 
     #[test]
+    fn handle_relative_open_returns_a_blocking_final_descriptor() {
+        let root = tempdir().expect("temporary root");
+        let bundle = root.path().join("bundle");
+        fs::create_dir_all(bundle.join("evidence")).expect("private bundle");
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&bundle, fs::Permissions::from_mode(0o700))
+            .expect("private root");
+        fs::write(bundle.join("evidence/manifest.json"), b"{}").expect("synthetic manifest");
+
+        let verified = verify_bundle_root(&bundle).expect("verified root");
+        let file = verified
+            .open_relative_file(Path::new("evidence/manifest.json"))
+            .expect("regular nested file");
+        let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+        assert!(flags >= 0, "opened descriptor flags are readable");
+        assert_eq!(flags & libc::O_NONBLOCK, 0);
+    }
+
+    #[test]
     fn verified_root_keeps_reading_the_original_directory_after_root_replacement() {
         let temp = tempdir().expect("temporary root");
         let root = temp.path().join("bundle");

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -7,10 +7,12 @@ use crate::error::AppError;
 /// A bundle root whose identity remains bound for the lifetime of a native read.
 ///
 /// Unix keeps an open directory descriptor and never re-resolves descendants by
-/// pathname. Windows rejects the native boundary rather than making a weaker
-/// pathname-based safety claim until it has equivalent handle-relative traversal.
+/// pathname. Windows keeps a non-followed directory handle and opens each
+/// component relative to that handle.
 pub(super) struct VerifiedBundleRoot {
     #[cfg(unix)]
+    directory: File,
+    #[cfg(windows)]
     directory: File,
 }
 
@@ -38,7 +40,30 @@ pub(super) fn verify_bundle_root(bundle_root: &Path) -> Result<VerifiedBundleRoo
         Ok(VerifiedBundleRoot { directory })
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows::Win32::Storage::FileSystem::{
+            FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE,
+            FILE_SHARE_READ, FILE_SHARE_WRITE,
+        };
+
+        let directory = OpenOptions::new()
+            .read(true)
+            .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0)
+            .custom_flags((FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT).0)
+            .open(bundle_root)
+            .map_err(|_| {
+                AppError::InvalidInput("SCCM bundle root is unavailable or unsafe".to_owned())
+            })?;
+        require_real_windows_directory(&directory).map_err(|_| {
+            AppError::InvalidInput("SCCM bundle root must be a real directory".to_owned())
+        })?;
+        verify_private_directory(&directory)?;
+        Ok(VerifiedBundleRoot { directory })
+    }
+
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = bundle_root;
         Err(AppError::InvalidInput(
@@ -57,7 +82,12 @@ impl VerifiedBundleRoot {
             open_relative_file_no_follow(self.directory.as_raw_fd(), relative)
         }
 
-        #[cfg(not(unix))]
+        #[cfg(windows)]
+        {
+            open_relative_file_no_follow(&self.directory, relative)
+        }
+
+        #[cfg(not(any(unix, windows)))]
         {
             let _ = relative;
             Err(io::Error::new(
@@ -108,14 +138,13 @@ fn windows_allow_ace_is_restricted(trustee: WindowsAclTrustee, inherit_only: boo
 }
 
 #[cfg(windows)]
-fn verify_private_directory(path: &Path, _metadata: &fs::Metadata) -> Result<(), AppError> {
-    use std::os::windows::ffi::OsStrExt;
+fn verify_private_directory(directory: &File) -> Result<(), AppError> {
+    use std::os::windows::io::AsRawHandle;
 
-    use windows::core::PCWSTR;
     use windows::Win32::Foundation::{CloseHandle, LocalFree, ERROR_SUCCESS, HANDLE, HLOCAL};
     use windows::Win32::Security::Authorization::{
-        GetExplicitEntriesFromAclW, GetNamedSecurityInfoW, GRANT_ACCESS, SET_ACCESS,
-        SE_FILE_OBJECT, TRUSTEE_IS_SID,
+        GetExplicitEntriesFromAclW, GetSecurityInfo, GRANT_ACCESS, SET_ACCESS, SE_FILE_OBJECT,
+        TRUSTEE_IS_SID,
     };
     use windows::Win32::Security::{
         EqualSid, GetTokenInformation, IsValidSid, IsWellKnownSid, TokenUser,
@@ -201,24 +230,19 @@ fn verify_private_directory(path: &Path, _metadata: &fs::Metadata) -> Result<(),
         Ok(unsafe { EqualSid(owner, token_sid).is_ok() })
     }
 
-    let path_wide = path
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect::<Vec<_>>();
     let mut owner = PSID::default();
     let mut dacl: *mut ACL = std::ptr::null_mut();
     let mut descriptor = PSECURITY_DESCRIPTOR::default();
     let status = unsafe {
-        GetNamedSecurityInfoW(
-            PCWSTR(path_wide.as_ptr()),
+        GetSecurityInfo(
+            HANDLE(directory.as_raw_handle()),
             SE_FILE_OBJECT,
             OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
             Some(&mut owner),
             None,
             Some(&mut dacl),
             None,
-            &mut descriptor,
+            Some(&mut descriptor),
         )
     };
     let _descriptor = LocalAllocation(descriptor.0);
@@ -299,11 +323,6 @@ fn verify_private_directory(path: &Path, _metadata: &fs::Metadata) -> Result<(),
             ));
         }
     }
-    Ok(())
-}
-
-#[cfg(not(any(unix, windows)))]
-fn verify_private_directory(_path: &Path, _metadata: &fs::Metadata) -> Result<(), AppError> {
     Ok(())
 }
 
@@ -409,6 +428,115 @@ pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
     require_regular_file(file)
 }
 
+#[cfg(windows)]
+fn open_relative_file_no_follow(root: &File, relative: &Path) -> io::Result<File> {
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::{AsRawHandle, FromRawHandle};
+    use windows::core::PWSTR;
+    use windows::Wdk::Foundation::OBJECT_ATTRIBUTES;
+    use windows::Wdk::Storage::FileSystem::{
+        NtCreateFile, FILE_DIRECTORY_FILE, FILE_NON_DIRECTORY_FILE, FILE_OPEN,
+        FILE_OPEN_REPARSE_POINT, FILE_SYNCHRONOUS_IO_NONALERT,
+    };
+    use windows::Win32::Foundation::{HANDLE, OBJ_CASE_INSENSITIVE, UNICODE_STRING};
+    use windows::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_READ, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE,
+    };
+    use windows::Win32::System::IO::IO_STATUS_BLOCK;
+
+    let components = relative.components().collect::<Vec<_>>();
+    if components.is_empty()
+        || components
+            .iter()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM bundle relative path is unsafe",
+        ));
+    }
+
+    let mut held_directories = Vec::new();
+    for (index, component) in components.iter().enumerate() {
+        let Component::Normal(name) = component else {
+            unreachable!("unsafe components were rejected above");
+        };
+        let mut wide_name = name.encode_wide().collect::<Vec<_>>();
+        let wide_bytes = wide_name
+            .len()
+            .checked_mul(std::mem::size_of::<u16>())
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "SCCM bundle path component is too long",
+                )
+            })?;
+        if wide_name.is_empty() || wide_name.contains(&0) || wide_bytes > u16::MAX as usize {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "SCCM bundle path contains an invalid component",
+            ));
+        }
+        let mut object_name = UNICODE_STRING {
+            Length: wide_bytes as u16,
+            MaximumLength: wide_bytes as u16,
+            Buffer: PWSTR(wide_name.as_mut_ptr()),
+        };
+        let object_attributes = OBJECT_ATTRIBUTES {
+            Length: std::mem::size_of::<OBJECT_ATTRIBUTES>() as u32,
+            RootDirectory: held_directories.last().map_or_else(
+                || HANDLE(root.as_raw_handle()),
+                |directory: &File| HANDLE(directory.as_raw_handle()),
+            ),
+            ObjectName: &mut object_name,
+            Attributes: OBJ_CASE_INSENSITIVE,
+            SecurityDescriptor: std::ptr::null(),
+            SecurityQualityOfService: std::ptr::null(),
+        };
+        let final_component = index + 1 == components.len();
+        let options = if final_component {
+            FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT
+        } else {
+            FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT
+        };
+        let mut handle = HANDLE::default();
+        let mut io_status = IO_STATUS_BLOCK::default();
+        let status = unsafe {
+            NtCreateFile(
+                &mut handle,
+                FILE_GENERIC_READ,
+                &object_attributes,
+                &mut io_status,
+                None,
+                FILE_ATTRIBUTE_NORMAL,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                FILE_OPEN,
+                options,
+                None,
+                0,
+            )
+        };
+        if status.0 < 0 || handle.0.is_null() || handle.is_invalid() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "SCCM bundle entry could not be opened safely",
+            ));
+        }
+        // SAFETY: a successful NtCreateFile returns an owned handle. This File
+        // owns it until it is returned or replaced by the next live ancestor.
+        let opened = unsafe { File::from_raw_handle(handle.0) };
+        if final_component {
+            return require_regular_file(opened);
+        }
+        require_real_windows_directory(&opened)?;
+        held_directories.push(opened);
+        #[cfg(test)]
+        invoke_open_component_hook(name);
+    }
+    unreachable!("non-empty relative paths always return from their final component")
+}
+
 #[cfg(not(any(unix, windows)))]
 pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
     let file = OpenOptions::new().read(true).open(path)?;
@@ -416,15 +544,24 @@ pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
 }
 
 fn require_regular_file(file: File) -> io::Result<File> {
-    let metadata = file.metadata()?;
-    if is_reparse_point(&metadata) || !metadata.is_file() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "SCCM bundle entry is not a regular file",
-        ));
+    #[cfg(windows)]
+    {
+        require_real_windows_file(&file)?;
+        return Ok(file);
     }
-    require_single_link(&file)?;
-    Ok(file)
+
+    #[cfg(not(windows))]
+    {
+        let metadata = file.metadata()?;
+        if is_reparse_point(&metadata) || !metadata.is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "SCCM bundle entry is not a regular file",
+            ));
+        }
+        require_single_link(&file)?;
+        Ok(file)
+    }
 }
 
 #[cfg(unix)]
@@ -441,7 +578,9 @@ fn require_single_link(file: &File) -> io::Result<()> {
 }
 
 #[cfg(windows)]
-fn require_single_link(file: &File) -> io::Result<()> {
+fn windows_file_information(
+    file: &File,
+) -> io::Result<windows::Win32::Storage::FileSystem::BY_HANDLE_FILE_INFORMATION> {
     use std::os::windows::io::AsRawHandle;
     use windows::Win32::Storage::FileSystem::{
         GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
@@ -455,6 +594,43 @@ fn require_single_link(file: &File) -> io::Result<()> {
         )
     }
     .map_err(|error| io::Error::new(io::ErrorKind::Other, error.to_string()))?;
+    Ok(information)
+}
+
+#[cfg(windows)]
+fn require_real_windows_directory(file: &File) -> io::Result<()> {
+    use windows::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+    };
+
+    let information = windows_file_information(file)?;
+    let attributes = information.dwFileAttributes;
+    if attributes & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0
+        || attributes & FILE_ATTRIBUTE_DIRECTORY.0 == 0
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM bundle ancestor is not a real directory",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn require_real_windows_file(file: &File) -> io::Result<()> {
+    use windows::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+    };
+
+    let information = windows_file_information(file)?;
+    if information.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0
+        || information.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY.0 != 0
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM bundle entry is not a regular file",
+        ));
+    }
     if information.nNumberOfLinks != 1 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -503,6 +679,29 @@ fn set_open_component_hook(hook: Option<OpenComponentHook>) {
 
 #[cfg(all(test, unix))]
 fn invoke_open_component_hook(component: &std::ffi::CStr) {
+    OPEN_COMPONENT_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().as_mut() {
+            hook(component);
+        }
+    });
+}
+
+#[cfg(all(test, windows))]
+type OpenComponentHook = Box<dyn FnMut(&std::ffi::OsStr)>;
+
+#[cfg(all(test, windows))]
+thread_local! {
+    static OPEN_COMPONENT_HOOK: std::cell::RefCell<Option<OpenComponentHook>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(all(test, windows))]
+fn set_open_component_hook(hook: Option<OpenComponentHook>) {
+    OPEN_COMPONENT_HOOK.with(|slot| *slot.borrow_mut() = hook);
+}
+
+#[cfg(all(test, windows))]
+fn invoke_open_component_hook(component: &std::ffi::OsStr) {
     OPEN_COMPONENT_HOOK.with(|slot| {
         if let Some(hook) = slot.borrow_mut().as_mut() {
             hook(component);
@@ -607,7 +806,9 @@ mod tests {
 
 #[cfg(all(test, windows))]
 mod windows_tests {
+    use std::cell::RefCell;
     use std::io::Read;
+    use std::rc::Rc;
 
     use tempfile::tempdir;
 
@@ -635,6 +836,43 @@ mod windows_tests {
         opened
             .read_to_string(&mut contents)
             .expect("read bound evidence");
+        assert_eq!(contents, "original");
+    }
+
+    #[test]
+    fn verified_root_keeps_an_opened_ancestor_after_a_deterministic_swap() {
+        let temp = tempdir().expect("temporary root");
+        let root = temp.path().join("bundle");
+        let replacement = temp.path().join("replacement-evidence");
+        fs::create_dir_all(root.join("evidence/nested")).expect("create original evidence");
+        fs::create_dir_all(replacement.join("nested")).expect("create replacement evidence");
+        fs::write(root.join("evidence/nested/evidence.log"), b"original")
+            .expect("original evidence");
+        fs::write(replacement.join("nested/evidence.log"), b"replacement")
+            .expect("replacement evidence");
+
+        let verified = verify_bundle_root(&root).expect("open original root");
+        let retired = temp.path().join("retired-evidence");
+        let fired = Rc::new(RefCell::new(false));
+        let fired_in_hook = Rc::clone(&fired);
+        set_open_component_hook(Some(Box::new(move |component| {
+            if component.eq_ignore_ascii_case("evidence") && !*fired_in_hook.borrow() {
+                *fired_in_hook.borrow_mut() = true;
+                fs::rename(root.join("evidence"), &retired).expect("retire opened ancestor");
+                fs::rename(&replacement, root.join("evidence"))
+                    .expect("install replacement ancestor");
+            }
+        })));
+
+        let mut opened = verified
+            .open_relative_file(Path::new("evidence/nested/evidence.log"))
+            .expect("opened ancestor remains bound");
+        set_open_component_hook(None);
+        let mut contents = String::new();
+        opened
+            .read_to_string(&mut contents)
+            .expect("read bound evidence");
+        assert!(*fired.borrow(), "test hook ran after ancestor open");
         assert_eq!(contents, "original");
     }
 

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -1038,7 +1038,7 @@ mod windows_tests {
     fn verified_root_rejects_a_hard_linked_final_entry() {
         let temp = tempdir().expect("temporary root");
         let root = temp.path().join("bundle");
-        fs::create_dir_all(&root).expect("create bundle");
+        make_private_directory(&root);
         let manifest = root.join("manifest.json");
         let second_link = root.join("manifest-copy.json");
         fs::write(&manifest, b"{}\n").expect("manifest");
@@ -1057,7 +1057,7 @@ mod windows_tests {
 
         let temp = tempdir().expect("temporary root");
         let root = temp.path().join("bundle");
-        fs::create_dir_all(&root).expect("create bundle");
+        make_private_directory(&root);
         let target = temp.path().join("outside-manifest.json");
         fs::write(&target, b"outside").expect("outside manifest");
         if symlink_file(&target, root.join("manifest.json")).is_err() {

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -870,7 +870,9 @@ mod windows_tests {
         use std::os::windows::{fs::OpenOptionsExt, io::AsRawHandle};
 
         use windows::core::PWSTR;
-        use windows::Win32::Foundation::{LocalFree, ERROR_SUCCESS, HANDLE, HLOCAL};
+        use windows::Win32::Foundation::{
+            LocalFree, ERROR_SUCCESS, HANDLE, HLOCAL, READ_CONTROL, WRITE_DAC,
+        };
         use windows::Win32::Security::Authorization::{
             GetSecurityInfo, SetEntriesInAclW, SetSecurityInfo, EXPLICIT_ACCESS_W, GRANT_ACCESS,
             NO_MULTIPLE_TRUSTEE, SE_FILE_OBJECT, TRUSTEE_IS_SID, TRUSTEE_IS_USER, TRUSTEE_W,
@@ -882,8 +884,11 @@ mod windows_tests {
         use windows::Win32::Storage::FileSystem::{FILE_ALL_ACCESS, FILE_FLAG_BACKUP_SEMANTICS};
 
         fs::create_dir_all(path).expect("create bundle directory");
+        // READ_CONTROL is required for GetSecurityInfo (owner query).
+        // WRITE_DAC is required for SetSecurityInfo (DACL write); it is NOT included
+        // in GENERIC_READ, so using .read(true) alone produces ERROR_ACCESS_DENIED.
         let directory = OpenOptions::new()
-            .read(true)
+            .access_mode(READ_CONTROL.0 | WRITE_DAC.0)
             .custom_flags(FILE_FLAG_BACKUP_SEMANTICS.0)
             .open(path)
             .expect("open bundle directory for DACL fixture");

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -328,7 +328,6 @@ fn verify_private_directory(directory: &File) -> Result<(), AppError> {
 
 #[cfg(all(unix, test))]
 pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
-    use std::os::fd::AsRawFd;
     use std::os::unix::fs::OpenOptionsExt;
 
     let file = OpenOptions::new()
@@ -336,6 +335,14 @@ pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
         .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
         .open(path)?;
     let file = require_regular_file(file)?;
+    clear_nonblock(&file)?;
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn clear_nonblock(file: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
     let descriptor = file.as_raw_fd();
     // SAFETY: `descriptor` is borrowed from the live `File`; both fcntl calls
     // operate only on its status flags and preserve every flag except NONBLOCK.
@@ -346,7 +353,7 @@ pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
     if unsafe { libc::fcntl(descriptor, libc::F_SETFL, flags & !libc::O_NONBLOCK) } < 0 {
         return Err(io::Error::last_os_error());
     }
-    Ok(file)
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -400,7 +407,9 @@ fn open_relative_file_no_follow(root_fd: std::os::fd::RawFd, relative: &Path) ->
         }
         let opened = unsafe { File::from_raw_fd(descriptor) };
         if final_component {
-            return require_regular_file(opened);
+            let opened = require_regular_file(opened)?;
+            clear_nonblock(&opened)?;
+            return Ok(opened);
         }
         let metadata = opened.metadata()?;
         if is_reparse_point(&metadata) || !metadata.is_dir() {
@@ -414,18 +423,6 @@ fn open_relative_file_no_follow(root_fd: std::os::fd::RawFd, relative: &Path) ->
         directory = opened;
     }
     unreachable!("non-empty relative paths always return from their final component")
-}
-
-#[cfg(windows)]
-pub(super) fn open_file_no_follow(path: &Path) -> io::Result<File> {
-    use std::os::windows::fs::OpenOptionsExt;
-
-    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-    let file = OpenOptions::new()
-        .read(true)
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)?;
-    require_regular_file(file)
 }
 
 #[cfg(windows)]
@@ -531,8 +528,7 @@ fn open_relative_file_no_follow(root: &File, relative: &Path) -> io::Result<File
                     RtlNtStatusToDosError(status) as i32
                 }));
             }
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(io::Error::other(
                 "SCCM bundle entry could not be opened safely",
             ));
         }
@@ -560,7 +556,7 @@ fn require_regular_file(file: File) -> io::Result<File> {
     #[cfg(windows)]
     {
         require_real_windows_file(&file)?;
-        return Ok(file);
+        Ok(file)
     }
 
     #[cfg(not(windows))]
@@ -606,7 +602,7 @@ fn windows_file_information(
             &mut information,
         )
     }
-    .map_err(|error| io::Error::new(io::ErrorKind::Other, error.to_string()))?;
+    .map_err(|error| io::Error::other(error.to_string()))?;
     Ok(information)
 }
 
@@ -690,6 +686,24 @@ fn set_open_component_hook(hook: Option<OpenComponentHook>) {
     OPEN_COMPONENT_HOOK.with(|slot| *slot.borrow_mut() = hook);
 }
 
+#[cfg(all(test, any(unix, windows)))]
+struct OpenComponentHookGuard;
+
+#[cfg(all(test, any(unix, windows)))]
+impl OpenComponentHookGuard {
+    fn install(hook: OpenComponentHook) -> Self {
+        set_open_component_hook(Some(hook));
+        Self
+    }
+}
+
+#[cfg(all(test, any(unix, windows)))]
+impl Drop for OpenComponentHookGuard {
+    fn drop(&mut self) {
+        set_open_component_hook(None);
+    }
+}
+
 #[cfg(all(test, unix))]
 fn invoke_open_component_hook(component: &std::ffi::CStr) {
     OPEN_COMPONENT_HOOK.with(|slot| {
@@ -753,8 +767,7 @@ mod tests {
         let bundle = root.path().join("bundle");
         fs::create_dir_all(bundle.join("evidence")).expect("private bundle");
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&bundle, fs::Permissions::from_mode(0o700))
-            .expect("private root");
+        fs::set_permissions(&bundle, fs::Permissions::from_mode(0o700)).expect("private root");
         fs::write(bundle.join("evidence/manifest.json"), b"{}").expect("synthetic manifest");
 
         let verified = verify_bundle_root(&bundle).expect("verified root");
@@ -764,6 +777,20 @@ mod tests {
         let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
         assert!(flags >= 0, "opened descriptor flags are readable");
         assert_eq!(flags & libc::O_NONBLOCK, 0);
+    }
+
+    #[test]
+    fn open_component_hook_guard_clears_the_hook_after_unwinding() {
+        let unwind = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _hook = OpenComponentHookGuard::install(Box::new(|_| {
+                panic!("stale hook must not survive this scope")
+            }));
+            panic!("test unwind");
+        }));
+        assert!(unwind.is_err());
+
+        let component = std::ffi::CString::new("evidence").expect("test component");
+        invoke_open_component_hook(component.as_c_str());
     }
 
     #[test]
@@ -814,19 +841,18 @@ mod tests {
         let retired = temp.path().join("retired-evidence");
         let fired = Rc::new(RefCell::new(false));
         let fired_in_hook = Rc::clone(&fired);
-        set_open_component_hook(Some(Box::new(move |component| {
+        let _hook = OpenComponentHookGuard::install(Box::new(move |component| {
             if component.to_bytes() == b"evidence" && !*fired_in_hook.borrow() {
                 *fired_in_hook.borrow_mut() = true;
                 fs::rename(root.join("evidence"), &retired).expect("retire opened ancestor");
                 fs::rename(&replacement, root.join("evidence"))
                     .expect("install replacement ancestor");
             }
-        })));
+        }));
 
         let mut opened = verified
             .open_relative_file(Path::new("evidence/nested/evidence.log"))
             .expect("opened ancestor remains bound");
-        set_open_component_hook(None);
         let mut contents = String::new();
         opened
             .read_to_string(&mut contents)
@@ -846,11 +872,80 @@ mod windows_tests {
 
     use super::*;
 
+    fn make_private_directory(path: &Path) {
+        use std::os::windows::{fs::OpenOptionsExt, io::AsRawHandle};
+
+        use windows::core::PWSTR;
+        use windows::Win32::Foundation::{LocalFree, ERROR_SUCCESS, HANDLE, HLOCAL};
+        use windows::Win32::Security::Authorization::{
+            GetSecurityInfo, SetEntriesInAclW, SetSecurityInfo, EXPLICIT_ACCESS_W, GRANT_ACCESS,
+            NO_MULTIPLE_TRUSTEE, SE_FILE_OBJECT, TRUSTEE_IS_SID, TRUSTEE_IS_USER, TRUSTEE_W,
+        };
+        use windows::Win32::Security::{
+            ACL, DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION,
+            PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID,
+        };
+        use windows::Win32::Storage::FileSystem::{FILE_ALL_ACCESS, FILE_FLAG_BACKUP_SEMANTICS};
+
+        fs::create_dir_all(path).expect("create bundle directory");
+        let directory = OpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS.0)
+            .open(path)
+            .expect("open bundle directory for DACL fixture");
+        let mut owner = PSID::default();
+        let mut descriptor = PSECURITY_DESCRIPTOR::default();
+        let status = unsafe {
+            GetSecurityInfo(
+                HANDLE(directory.as_raw_handle()),
+                SE_FILE_OBJECT,
+                OWNER_SECURITY_INFORMATION,
+                Some(&mut owner),
+                None,
+                None,
+                None,
+                Some(&mut descriptor),
+            )
+        };
+        assert_eq!(status, ERROR_SUCCESS, "read fixture owner");
+        let fixture_access = EXPLICIT_ACCESS_W {
+            grfAccessPermissions: FILE_ALL_ACCESS.0,
+            grfAccessMode: GRANT_ACCESS,
+            grfInheritance: windows::Win32::Security::SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+            Trustee: TRUSTEE_W {
+                pMultipleTrustee: std::ptr::null_mut(),
+                MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+                TrusteeForm: TRUSTEE_IS_SID,
+                TrusteeType: TRUSTEE_IS_USER,
+                ptstrName: PWSTR(owner.0.cast()),
+            },
+        };
+        let mut dacl: *mut ACL = std::ptr::null_mut();
+        let status = unsafe { SetEntriesInAclW(Some(&[fixture_access]), None, &mut dacl) };
+        assert_eq!(status, ERROR_SUCCESS, "build restrictive fixture DACL");
+        let status = unsafe {
+            SetSecurityInfo(
+                HANDLE(directory.as_raw_handle()),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                None,
+                None,
+                Some(dacl),
+                None,
+            )
+        };
+        unsafe {
+            let _ = LocalFree(Some(HLOCAL(descriptor.0)));
+            let _ = LocalFree(Some(HLOCAL(dacl.cast())));
+        }
+        assert_eq!(status, ERROR_SUCCESS, "install restrictive fixture DACL");
+    }
+
     #[test]
     fn missing_final_component_preserves_not_found_for_legacy_fallback() {
         let temp = tempdir().expect("temporary root");
         let root = temp.path().join("bundle");
-        fs::create_dir_all(&root).expect("create bundle");
+        make_private_directory(&root);
 
         let verified = verify_bundle_root(&root).expect("open private root");
         let error = verified
@@ -864,7 +959,7 @@ mod windows_tests {
     fn relative_component_rejects_alternate_data_streams() {
         let temp = tempdir().expect("temporary root");
         let root = temp.path().join("bundle");
-        fs::create_dir_all(&root).expect("create bundle");
+        make_private_directory(&root);
         fs::write(root.join("manifest.json"), b"{}\n").expect("create manifest");
 
         let verified = verify_bundle_root(&root).expect("open private root");
@@ -880,6 +975,8 @@ mod windows_tests {
         let temp = tempdir().expect("temporary root");
         let root = temp.path().join("bundle");
         let replacement = temp.path().join("replacement");
+        make_private_directory(&root);
+        make_private_directory(&replacement);
         fs::create_dir_all(root.join("nested")).expect("create original bundle");
         fs::create_dir_all(replacement.join("nested")).expect("create replacement bundle");
         fs::write(root.join("nested/evidence.log"), b"original").expect("original evidence");
@@ -905,6 +1002,8 @@ mod windows_tests {
         let temp = tempdir().expect("temporary root");
         let root = temp.path().join("bundle");
         let replacement = temp.path().join("replacement-evidence");
+        make_private_directory(&root);
+        make_private_directory(&replacement);
         fs::create_dir_all(root.join("evidence/nested")).expect("create original evidence");
         fs::create_dir_all(replacement.join("nested")).expect("create replacement evidence");
         fs::write(root.join("evidence/nested/evidence.log"), b"original")
@@ -916,19 +1015,18 @@ mod windows_tests {
         let retired = temp.path().join("retired-evidence");
         let fired = Rc::new(RefCell::new(false));
         let fired_in_hook = Rc::clone(&fired);
-        set_open_component_hook(Some(Box::new(move |component| {
+        let _hook = OpenComponentHookGuard::install(Box::new(move |component| {
             if component.eq_ignore_ascii_case("evidence") && !*fired_in_hook.borrow() {
                 *fired_in_hook.borrow_mut() = true;
                 fs::rename(root.join("evidence"), &retired).expect("retire opened ancestor");
                 fs::rename(&replacement, root.join("evidence"))
                     .expect("install replacement ancestor");
             }
-        })));
+        }));
 
         let mut opened = verified
             .open_relative_file(Path::new("evidence/nested/evidence.log"))
             .expect("opened ancestor remains bound");
-        set_open_component_hook(None);
         let mut contents = String::new();
         opened
             .read_to_string(&mut contents)

--- a/src-tauri/tests/sccm_client_manifest.rs
+++ b/src-tauri/tests/sccm_client_manifest.rs
@@ -220,6 +220,13 @@ fn write_native_bundle(
     .expect("write fixture manifest");
 }
 
+fn remove_written_evidence(root: &Path, artifact: &PhysicalArtifactFixture) {
+    let relative_path = artifact.value["relativePath"]
+        .as_str()
+        .expect("physical fixture path");
+    fs::remove_file(root.join(relative_path)).expect("remove evidence after writing manifest");
+}
+
 fn set_native_limits(root: &Path, max_files: u64, max_bytes: u64) {
     let manifest_path = root.join(SCCM_MANIFEST_FILE_NAME);
     let mut manifest: Value = serde_json::from_slice(
@@ -605,6 +612,7 @@ fn reader_rejects_a_client_owned_per_artifact_ceiling_before_evidence_reads() {
     current.value["bytesCopied"] = json!(256_u64 * 1024 * 1024 + 1);
     write_native_bundle(&bundle_root, &[&current], &[]);
     set_native_limits(&bundle_root, 8, u64::MAX);
+    remove_written_evidence(&bundle_root, &current);
 
     let error = read_sccm_manifest_or_legacy(&bundle_root)
         .expect_err("a manifest cannot raise the reader-owned artifact ceiling");
@@ -628,6 +636,9 @@ fn reader_rejects_a_client_owned_aggregate_ceiling_before_evidence_reads() {
     let references = artifacts.iter().collect::<Vec<_>>();
     write_native_bundle(&bundle_root, &references, &[]);
     set_native_limits(&bundle_root, 8, u64::MAX);
+    for artifact in &artifacts {
+        remove_written_evidence(&bundle_root, artifact);
+    }
 
     let error = read_sccm_manifest_or_legacy(&bundle_root)
         .expect_err("a manifest cannot raise the reader-owned aggregate ceiling");

--- a/src-tauri/tests/sccm_client_manifest.rs
+++ b/src-tauri/tests/sccm_client_manifest.rs
@@ -1,0 +1,476 @@
+use std::fs;
+use std::path::Path;
+
+use app_lib::sccm::{
+    manifest_to_client_intake_bundle, read_sccm_client_intake_bundle, read_sccm_manifest_or_legacy,
+    SccmBundleManifestV1, SccmManifestProvenance, SccmManifestSourceState,
+    MAX_SCCM_MANIFEST_ARTIFACTS, SCCM_MANIFEST_FILE_NAME,
+};
+use cmtraceopen_parser::sccm::{assess_client_intake, SccmCoverageState, SccmRotation};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use tempfile::tempdir;
+
+const COLLECTED_AT_UTC: &str = "2026-07-30T15:00:00Z";
+const CONFIGMGR_VERSION: &str = "5.00.TEST.0000";
+const POLICY_BASENAME: &str = "PolicyAgent.log";
+const POLICY_GROUP: &str = "client-policy-agent";
+const ROOT_HANDLE: &str = "root-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const HOST_HANDLE: &str = concat!(
+    "cmtraceopen.host.hmac-sha256.v1:",
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+);
+
+fn sha256(value: &[u8]) -> String {
+    Sha256::digest(value)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn catalog_entry_id() -> String {
+    format!(
+        "sccm-client-source:v1:sha256:{}",
+        sha256(POLICY_BASENAME.as_bytes())
+    )
+}
+
+fn source_digest() -> String {
+    let root_digest = ROOT_HANDLE
+        .strip_prefix("root-")
+        .expect("fixture root handle is versioned");
+    sha256(format!("cmtraceopen.sccm.source.v1\0{root_digest}\0{POLICY_BASENAME}").as_bytes())
+}
+
+fn source_handle() -> String {
+    format!("cmtraceopen.source.sha256.v1:{}", source_digest())
+}
+
+fn path_fingerprint() -> String {
+    format!("sha256:{}", source_digest())
+}
+
+fn rotation_lineage() -> String {
+    format!(
+        "cmtraceopen.lineage.sha256.v1:{}",
+        sha256(format!("lineage:v1:{}", source_digest()).as_bytes())
+    )
+}
+
+fn rotation_basename(rotation: &SccmRotation) -> String {
+    match rotation {
+        SccmRotation::Current => POLICY_BASENAME.to_owned(),
+        SccmRotation::LoUnderscore => "PolicyAgent.lo_".to_owned(),
+        SccmRotation::Numbered(number) => format!("{POLICY_BASENAME}.{number}"),
+        SccmRotation::Timestamped(timestamp) => format!("{POLICY_BASENAME}.{timestamp}"),
+        SccmRotation::Unknown(_) => panic!("fixture never uses unknown rotations"),
+    }
+}
+
+fn rotation_segment(rotation: &SccmRotation) -> String {
+    match rotation {
+        SccmRotation::Current => "current".to_owned(),
+        SccmRotation::LoUnderscore => "lo".to_owned(),
+        SccmRotation::Numbered(number) => format!("numbered-{number}"),
+        SccmRotation::Timestamped(timestamp) => format!("timestamped-{timestamp}"),
+        SccmRotation::Unknown(_) => panic!("fixture never uses unknown rotations"),
+    }
+}
+
+fn relative_path(rotation: &SccmRotation) -> String {
+    format!(
+        "evidence/sccm/client/{POLICY_GROUP}/{ROOT_HANDLE}/{}/{}",
+        rotation_segment(rotation),
+        rotation_basename(rotation)
+    )
+}
+
+fn physical_artifact(rotation: SccmRotation, content: &[u8]) -> Value {
+    let basename = rotation_basename(&rotation);
+    let fingerprint = path_fingerprint();
+    let artifact_id = format!(
+        "sccm-artifact:v1:sha256:{}",
+        sha256(
+            format!(
+                "artifact:v1:{fingerprint}:{}:{basename}",
+                rotation_segment(&rotation)
+            )
+            .as_bytes()
+        )
+    );
+    json!({
+        "catalogEntryId": catalog_entry_id(),
+        "logicalArtifactIds": [POLICY_GROUP],
+        "artifactId": artifact_id,
+        "role": "client",
+        "sourceHandle": source_handle(),
+        "rootHandle": ROOT_HANDLE,
+        "pathFingerprint": fingerprint,
+        "rotationLineage": rotation_lineage(),
+        "relativePath": relative_path(&rotation),
+        "basename": basename,
+        "rotation": rotation,
+        "state": "captured",
+        "coverageScope": "source",
+        "bytesCopied": content.len(),
+        "contentSha256": sha256(content),
+        "fragmentComplete": false,
+        "configmgrVersion": CONFIGMGR_VERSION,
+        "collectedAtUtc": COLLECTED_AT_UTC,
+        "encoding": "utf-8"
+    })
+}
+
+fn capture_gap(rotation: SccmRotation, state: &str) -> Value {
+    let basename = rotation_basename(&rotation);
+    let fingerprint = path_fingerprint();
+    let artifact_id = format!(
+        "sccm-artifact:v1:sha256:{}",
+        sha256(
+            format!(
+                "marker:v1:{}:{state}:{}:{basename}:{fingerprint}",
+                catalog_entry_id(),
+                rotation_segment(&rotation)
+            )
+            .as_bytes()
+        )
+    );
+    json!({
+        "artifactId": artifact_id,
+        "catalogEntryId": catalog_entry_id(),
+        "logicalArtifactIds": [POLICY_GROUP],
+        "sourceHandle": source_handle(),
+        "rootHandle": ROOT_HANDLE,
+        "pathFingerprint": fingerprint,
+        "rotationLineage": rotation_lineage(),
+        "basename": basename,
+        "rotation": rotation,
+        "state": state,
+        "captureLimitKind": "fileCount",
+        "sourceBytes": 2048,
+        "bytesRetained": 0
+    })
+}
+
+fn native_manifest(artifacts: Vec<Value>, capture_gaps: Vec<Value>) -> Value {
+    json!({
+        "sccmManifestVersion": 1,
+        "diagnosticsSchemaVersion": 1,
+        "sourceCatalogVersion": 1,
+        "provenance": "nativeClientCapture",
+        "provenanceProfile": "hmacSha256V1",
+        "hostHandle": HOST_HANDLE,
+        "collectedAtUtc": COLLECTED_AT_UTC,
+        "maxFilesPerSource": 8,
+        "maxBytesPerSource": 4096,
+        "artifacts": artifacts,
+        "captureGaps": capture_gaps
+    })
+}
+
+fn make_private_directory(path: &Path) {
+    fs::create_dir_all(path).expect("create fixture directory");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .expect("make fixture directory private");
+    }
+}
+
+fn write_native_bundle(root: &Path, artifacts: &[Value], capture_gaps: &[Value]) {
+    make_private_directory(root);
+    for artifact in artifacts {
+        let relative_path = artifact["relativePath"]
+            .as_str()
+            .expect("physical fixture path");
+        let basename = artifact["basename"]
+            .as_str()
+            .expect("physical fixture basename");
+        let content = match basename {
+            POLICY_BASENAME => b"policy-current".as_slice(),
+            "PolicyAgent.log.1" => b"policy-rotation-one".as_slice(),
+            "PolicyAgent.log.2" => b"policy-rotation-two".as_slice(),
+            _ => panic!("unexpected physical fixture basename"),
+        };
+        let destination = root.join(relative_path);
+        fs::create_dir_all(destination.parent().expect("evidence parent"))
+            .expect("create evidence tree");
+        fs::write(destination, content).expect("write synthetic evidence");
+    }
+    let manifest = native_manifest(artifacts.to_vec(), capture_gaps.to_vec());
+    fs::write(
+        root.join(SCCM_MANIFEST_FILE_NAME),
+        serde_json::to_vec_pretty(&manifest).expect("serialize fixture manifest"),
+    )
+    .expect("write fixture manifest");
+}
+
+#[test]
+fn validated_v1_reader_projects_one_physical_client_artifact() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let current = physical_artifact(SccmRotation::Current, b"policy-current");
+    write_native_bundle(&bundle_root, std::slice::from_ref(&current), &[]);
+
+    let manifest = read_sccm_manifest_or_legacy(&bundle_root).expect("validated manifest");
+    let bundle = manifest_to_client_intake_bundle(&manifest).expect("pure projection");
+
+    assert_eq!(manifest.sccm_manifest_version, 1);
+    assert_eq!(
+        manifest.provenance,
+        SccmManifestProvenance::NativeClientCapture
+    );
+    assert_eq!(bundle.artifacts.len(), 1);
+    assert!(bundle.capture_gaps.is_empty());
+    let physical = &bundle.artifacts[0];
+    assert_eq!(physical.artifact.display_name, POLICY_BASENAME);
+    assert_eq!(physical.artifact.coverage, SccmCoverageState::Captured);
+    assert_eq!(physical.artifact.original_path, None);
+    assert_eq!(physical.artifact.host, None);
+    assert_eq!(
+        physical.relative_path.as_deref(),
+        Some(relative_path(&SccmRotation::Current).as_str())
+    );
+    assert_eq!(physical.fragment_complete, Some(false));
+}
+
+#[test]
+fn omitted_capped_rotation_projects_as_a_gap_without_a_fake_fragment() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let current = physical_artifact(SccmRotation::Current, b"policy-current");
+    let omitted = capture_gap(SccmRotation::Numbered(1), "capped");
+    write_native_bundle(
+        &bundle_root,
+        std::slice::from_ref(&current),
+        std::slice::from_ref(&omitted),
+    );
+
+    let bundle = read_sccm_client_intake_bundle(&bundle_root).expect("projected bundle");
+    assert_eq!(
+        bundle.artifacts.len(),
+        1,
+        "a gap is not a zero-byte artifact"
+    );
+    assert_eq!(bundle.capture_gaps.len(), 1);
+    assert_eq!(bundle.capture_gaps[0].basename, "PolicyAgent.log.1");
+    assert_eq!(bundle.capture_gaps[0].rotation, SccmRotation::Numbered(1));
+    assert_eq!(bundle.capture_gaps[0].coverage, SccmCoverageState::Capped);
+
+    let assessment = assess_client_intake(&bundle).expect("assessment accepts native gap");
+    let group = assessment
+        .groups
+        .iter()
+        .find(|group| group.logical_artifact_id == POLICY_GROUP)
+        .expect("policy group");
+    assert_eq!(group.fragments.len(), 1);
+    assert_eq!(group.coverage, SccmCoverageState::Capped);
+    assert_eq!(assessment.capture_gaps, bundle.capture_gaps);
+}
+
+#[test]
+fn parse_failed_omitted_rotation_remains_coverage_only() {
+    let manifest_value = native_manifest(
+        vec![physical_artifact(SccmRotation::Current, b"policy-current")],
+        vec![capture_gap(SccmRotation::Numbered(2), "parseFailed")],
+    );
+    let manifest: SccmBundleManifestV1 =
+        serde_json::from_value(manifest_value).expect("manifest shape");
+    let bundle = manifest_to_client_intake_bundle(&manifest).expect("pure projection");
+
+    assert_eq!(bundle.artifacts.len(), 1);
+    assert_eq!(bundle.capture_gaps.len(), 1);
+    assert_eq!(
+        bundle.capture_gaps[0].coverage,
+        SccmCoverageState::ParseFailed
+    );
+    assert_eq!(bundle.capture_gaps[0].rotation, SccmRotation::Numbered(2));
+}
+
+#[test]
+fn native_manifest_uses_one_shared_4096_entry_decode_ceiling() {
+    let gap = capture_gap(SccmRotation::Numbered(1), "capped");
+    let boundary = native_manifest(
+        vec![physical_artifact(SccmRotation::Current, b"policy-current")],
+        vec![gap.clone(); MAX_SCCM_MANIFEST_ARTIFACTS - 1],
+    );
+    serde_json::from_value::<SccmBundleManifestV1>(boundary)
+        .expect("combined 4096-entry boundary decodes");
+
+    let overflow = native_manifest(
+        vec![physical_artifact(SccmRotation::Current, b"policy-current")],
+        vec![gap; MAX_SCCM_MANIFEST_ARTIFACTS],
+    );
+    let error = serde_json::from_value::<SccmBundleManifestV1>(overflow)
+        .expect_err("combined 4097-entry manifest is rejected during decoding");
+    assert!(error
+        .to_string()
+        .contains("too many artifacts or capture gaps"));
+}
+
+#[test]
+fn reader_rejects_artifacts_outside_canonical_rotation_order() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let current = physical_artifact(SccmRotation::Current, b"policy-current");
+    let numbered = physical_artifact(SccmRotation::Numbered(1), b"policy-rotation-one");
+    write_native_bundle(&bundle_root, &[numbered, current], &[]);
+
+    let error = read_sccm_manifest_or_legacy(&bundle_root)
+        .expect_err("manifest order is part of deterministic intake");
+    assert!(error.to_string().contains("deterministic order"));
+}
+
+#[test]
+fn reader_rejects_duplicate_artifact_ids_and_relative_paths() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let current = physical_artifact(SccmRotation::Current, b"policy-current");
+    write_native_bundle(&bundle_root, &[current.clone(), current], &[]);
+
+    let error =
+        read_sccm_manifest_or_legacy(&bundle_root).expect_err("colliding artifacts fail closed");
+    assert!(error.to_string().contains("duplicate artifact IDs"));
+}
+
+#[test]
+fn legacy_projection_never_invents_native_capture_gaps() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("legacy-bundle");
+    make_private_directory(&bundle_root);
+    fs::write(
+        bundle_root.join("manifest.json"),
+        serde_json::to_vec_pretty(&json!({
+            "collection": {
+                "collectorProfile": "cmtrace-full-diagnostics-v1",
+                "collectorVersion": "1.1.0",
+                "results": { "gaps": [] }
+            },
+            "artifacts": []
+        }))
+        .expect("legacy JSON"),
+    )
+    .expect("legacy manifest");
+
+    let manifest = read_sccm_manifest_or_legacy(&bundle_root).expect("legacy manifest view");
+    let bundle = read_sccm_client_intake_bundle(&bundle_root).expect("legacy pure view");
+    assert_eq!(
+        manifest.provenance,
+        SccmManifestProvenance::LegacyGenericUnscoped
+    );
+    assert!(manifest.capture_gaps.is_empty());
+    assert!(bundle.capture_gaps.is_empty());
+}
+
+#[test]
+fn missing_and_malformed_legacy_errors_do_not_disclose_the_bundle_path() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("secret-bundle-root");
+    make_private_directory(&bundle_root);
+    let sensitive_root = bundle_root.display().to_string();
+
+    let missing = read_sccm_manifest_or_legacy(&bundle_root)
+        .expect_err("an existing empty bundle has no supported manifest");
+    assert!(!missing.to_string().contains(&sensitive_root));
+
+    fs::write(bundle_root.join("manifest.json"), b"{malformed").expect("malformed legacy manifest");
+    let malformed =
+        read_sccm_manifest_or_legacy(&bundle_root).expect_err("malformed legacy JSON fails closed");
+    assert!(!malformed.to_string().contains(&sensitive_root));
+    assert!(malformed.to_string().contains("manifest.json"));
+}
+
+#[cfg(unix)]
+#[test]
+fn reader_rejects_a_symlinked_bundle_root_without_following_it() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir().expect("temporary root");
+    let real_root = temp.path().join("real-private-root");
+    let alias = temp.path().join("secret-root-alias");
+    make_private_directory(&real_root);
+    symlink(&real_root, &alias).expect("bundle root symlink");
+
+    let error = read_sccm_manifest_or_legacy(&alias).expect_err("root symlink is rejected");
+    assert!(!error.to_string().contains(&alias.display().to_string()));
+}
+
+#[cfg(unix)]
+#[test]
+fn reader_opens_manifest_without_following_a_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("private-bundle");
+    let outside = temp.path().join("outside-manifest.json");
+    make_private_directory(&bundle_root);
+    fs::write(&outside, b"{}").expect("outside file");
+    symlink(&outside, bundle_root.join(SCCM_MANIFEST_FILE_NAME)).expect("manifest symlink");
+
+    let error = read_sccm_manifest_or_legacy(&bundle_root)
+        .expect_err("reader must not follow the manifest symlink");
+    assert!(!error
+        .to_string()
+        .contains(&bundle_root.display().to_string()));
+    assert!(!error.to_string().contains(&outside.display().to_string()));
+}
+
+#[cfg(unix)]
+#[test]
+fn reader_rejects_a_nonprivate_bundle_directory() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("public-bundle");
+    make_private_directory(&bundle_root);
+    fs::set_permissions(&bundle_root, fs::Permissions::from_mode(0o755))
+        .expect("make bundle public");
+
+    let error = read_sccm_manifest_or_legacy(&bundle_root)
+        .expect_err("public bundle directory fails closed");
+    assert!(error.to_string().contains("not private"));
+    assert!(!error
+        .to_string()
+        .contains(&bundle_root.display().to_string()));
+}
+
+#[test]
+fn manifest_wire_and_debug_never_gain_raw_host_or_native_path_fields() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("RealUser-secret-bundle");
+    let current = physical_artifact(SccmRotation::Current, b"policy-current");
+    write_native_bundle(&bundle_root, std::slice::from_ref(&current), &[]);
+
+    let manifest = read_sccm_manifest_or_legacy(&bundle_root).expect("validated manifest");
+    let serialized = serde_json::to_string(&manifest).expect("manifest JSON");
+    let debug = format!("{manifest:?}");
+    let native_path = bundle_root.display().to_string();
+    for public in [&serialized, &debug] {
+        assert!(!public.contains("LAB-CLIENT-SECRET"));
+        assert!(!public.contains(&native_path));
+        assert!(!public.contains("RealUser"));
+    }
+
+    let mut raw_host = native_manifest(vec![current], vec![]);
+    raw_host["host"] = json!("LAB-CLIENT-SECRET");
+    assert!(serde_json::from_value::<SccmBundleManifestV1>(raw_host).is_err());
+}
+
+#[test]
+fn malformed_native_state_is_rejected_before_pure_projection() {
+    let mut value = native_manifest(
+        vec![physical_artifact(SccmRotation::Current, b"policy-current")],
+        vec![],
+    );
+    value["artifacts"][0]["state"] = json!("absent");
+    let manifest: SccmBundleManifestV1 = serde_json::from_value(value).expect("wire shape");
+
+    let error = manifest_to_client_intake_bundle(&manifest)
+        .expect_err("nonphysical state cannot claim a file");
+    assert!(error.to_string().contains("nonphysical"));
+    assert_ne!(
+        manifest.artifacts[0].state,
+        SccmManifestSourceState::Captured
+    );
+}

--- a/src-tauri/tests/sccm_client_manifest.rs
+++ b/src-tauri/tests/sccm_client_manifest.rs
@@ -556,6 +556,7 @@ fn reader_enforces_the_physical_file_cap_per_canonical_source_before_evidence_re
     let rotated = physical_artifact(SccmRotation::Numbered(1), b"policy-rotation-one");
     write_native_bundle(&bundle_root, &[&current, &rotated], &[]);
     set_native_limits(&bundle_root, 1, 4096);
+    remove_written_evidence(&bundle_root, &rotated);
 
     let error = read_sccm_manifest_or_legacy(&bundle_root)
         .expect_err("two rotations cannot bypass one-file source cap");

--- a/src-tauri/tests/sccm_client_manifest.rs
+++ b/src-tauri/tests/sccm_client_manifest.rs
@@ -469,6 +469,9 @@ fn reader_opens_manifest_without_following_a_symlink() {
         .to_string()
         .contains(&bundle_root.display().to_string()));
     assert!(!error.to_string().contains(&outside.display().to_string()));
+    assert!(error
+        .to_string()
+        .contains("manifest cannot be opened safely"));
 }
 
 #[cfg(unix)]

--- a/src-tauri/tests/sccm_client_manifest.rs
+++ b/src-tauri/tests/sccm_client_manifest.rs
@@ -282,11 +282,7 @@ fn omitted_capped_rotation_projects_as_a_gap_without_a_fake_fragment() {
     let bundle_root = temp.path().join("bundle");
     let current = physical_artifact(SccmRotation::Current, b"policy-current");
     let omitted = capture_gap(SccmRotation::Numbered(1), "capped");
-    write_native_bundle(
-        &bundle_root,
-        &[&current],
-        std::slice::from_ref(&omitted),
-    );
+    write_native_bundle(&bundle_root, &[&current], std::slice::from_ref(&omitted));
 
     let bundle = read_sccm_client_intake_bundle(&bundle_root).expect("projected bundle");
     assert_eq!(
@@ -316,11 +312,7 @@ fn parse_failed_omitted_rotation_remains_coverage_only() {
     let bundle_root = temp.path().join("bundle");
     let current = physical_artifact(SccmRotation::Current, b"policy-current");
     let failed = capture_gap(SccmRotation::Numbered(2), "parseFailed");
-    write_native_bundle(
-        &bundle_root,
-        &[&current],
-        std::slice::from_ref(&failed),
-    );
+    write_native_bundle(&bundle_root, &[&current], std::slice::from_ref(&failed));
     let bundle = read_sccm_client_intake_bundle(&bundle_root).expect("verified pure projection");
 
     assert_eq!(bundle.artifacts.len(), 1);
@@ -416,13 +408,14 @@ fn legacy_projection_never_invents_native_capture_gaps() {
     let expected_artifact_id = format!(
         "sccm-artifact:v1:sha256:{}",
         sha256(
-            format!(
-                "marker:v1:{expected_catalog_id}:absent:current:ccmsetup.log:unscoped"
-            )
-            .as_bytes()
+            format!("marker:v1:{expected_catalog_id}:absent:current:ccmsetup.log:unscoped")
+                .as_bytes()
         )
     );
-    assert_eq!(bundle.artifacts[0].artifact.artifact_id, expected_artifact_id);
+    assert_eq!(
+        bundle.artifacts[0].artifact.artifact_id,
+        expected_artifact_id
+    );
 }
 
 #[test]
@@ -598,7 +591,7 @@ fn reader_rejects_physical_byte_metadata_overflow_before_evidence_reads() {
 
     let error = read_sccm_manifest_or_legacy(&bundle_root)
         .expect_err("overflowing source bytes fail before unbounded evidence verification");
-    assert!(error.to_string().contains("source byte cap"));
+    assert!(error.to_string().contains("physical artifact byte cap"));
 }
 
 #[test]

--- a/src-tauri/tests/sccm_client_manifest.rs
+++ b/src-tauri/tests/sccm_client_manifest.rs
@@ -591,17 +591,17 @@ fn reader_rejects_multi_rotation_physical_bytes_over_the_source_cap() {
 }
 
 #[test]
-fn reader_rejects_physical_byte_metadata_overflow_before_evidence_reads() {
+fn reader_rejects_u64_max_physical_byte_metadata_before_evidence_reads() {
     let temp = tempdir().expect("temporary root");
     let bundle_root = temp.path().join("bundle");
     let mut current = physical_artifact(SccmRotation::Current, b"policy-current");
     current.value["bytesCopied"] = json!(u64::MAX);
-    let rotated = physical_artifact(SccmRotation::Numbered(1), b"policy-rotation-one");
-    write_native_bundle(&bundle_root, &[&current, &rotated], &[]);
-    set_native_limits(&bundle_root, 2, u64::MAX);
+    write_native_bundle(&bundle_root, &[&current], &[]);
+    set_native_limits(&bundle_root, 1, u64::MAX);
+    remove_written_evidence(&bundle_root, &current);
 
     let error = read_sccm_manifest_or_legacy(&bundle_root)
-        .expect_err("overflowing source bytes fail before unbounded evidence verification");
+        .expect_err("extreme metadata fails before unbounded evidence verification");
     assert!(error.to_string().contains("physical artifact byte cap"));
 }
 

--- a/src-tauri/tests/sccm_client_manifest.rs
+++ b/src-tauri/tests/sccm_client_manifest.rs
@@ -206,6 +206,21 @@ fn write_native_bundle(root: &Path, artifacts: &[Value], capture_gaps: &[Value])
     .expect("write fixture manifest");
 }
 
+fn set_native_limits(root: &Path, max_files: u64, max_bytes: u64) {
+    let manifest_path = root.join(SCCM_MANIFEST_FILE_NAME);
+    let mut manifest: Value = serde_json::from_slice(
+        &fs::read(&manifest_path).expect("read synthetic manifest for limit mutation"),
+    )
+    .expect("synthetic manifest is JSON");
+    manifest["maxFilesPerSource"] = json!(max_files);
+    manifest["maxBytesPerSource"] = json!(max_bytes);
+    fs::write(
+        manifest_path,
+        serde_json::to_vec_pretty(&manifest).expect("serialize limit-mutated manifest"),
+    )
+    .expect("write limit-mutated manifest");
+}
+
 #[test]
 fn validated_v1_reader_projects_one_physical_client_artifact() {
     let temp = tempdir().expect("temporary root");
@@ -473,4 +488,76 @@ fn malformed_native_state_is_rejected_before_pure_projection() {
         manifest.artifacts[0].state,
         SccmManifestSourceState::Captured
     );
+}
+
+#[test]
+fn reader_enforces_the_physical_file_cap_per_canonical_source_before_evidence_reads() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let current = physical_artifact(SccmRotation::Current, b"policy-current");
+    let rotated = physical_artifact(SccmRotation::Numbered(1), b"policy-rotation-one");
+    write_native_bundle(&bundle_root, &[current, rotated], &[]);
+    set_native_limits(&bundle_root, 1, 4096);
+
+    let error = read_sccm_manifest_or_legacy(&bundle_root)
+        .expect_err("two rotations cannot bypass one-file source cap");
+    assert!(error.to_string().contains("source file cap"));
+}
+
+#[test]
+fn reader_accepts_the_exact_physical_byte_cap_boundary() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let content = b"policy-current";
+    let current = physical_artifact(SccmRotation::Current, content);
+    write_native_bundle(&bundle_root, std::slice::from_ref(&current), &[]);
+    set_native_limits(&bundle_root, 1, content.len() as u64);
+
+    read_sccm_manifest_or_legacy(&bundle_root)
+        .expect("an artifact exactly at the source byte cap remains valid");
+}
+
+#[test]
+fn reader_rejects_multi_rotation_physical_bytes_over_the_source_cap() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let current = physical_artifact(SccmRotation::Current, b"policy-current");
+    let rotated = physical_artifact(SccmRotation::Numbered(1), b"policy-rotation-one");
+    write_native_bundle(&bundle_root, &[current, rotated], &[]);
+    set_native_limits(&bundle_root, 2, b"policy-current".len() as u64);
+
+    let error = read_sccm_manifest_or_legacy(&bundle_root)
+        .expect_err("rotations cannot collectively exceed their source byte cap");
+    assert!(error.to_string().contains("source byte cap"));
+}
+
+#[test]
+fn reader_rejects_overflowing_physical_byte_totals_before_hashing_evidence() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let mut current = physical_artifact(SccmRotation::Current, b"policy-current");
+    current["bytesCopied"] = json!(u64::MAX);
+    let rotated = physical_artifact(SccmRotation::Numbered(1), b"policy-rotation-one");
+    write_native_bundle(&bundle_root, &[current, rotated], &[]);
+    set_native_limits(&bundle_root, 2, u64::MAX);
+
+    let error = read_sccm_manifest_or_legacy(&bundle_root)
+        .expect_err("overflowing source bytes fail before unbounded evidence verification");
+    assert!(error.to_string().contains("source byte cap"));
+}
+
+#[cfg(unix)]
+#[test]
+fn reader_rejects_hard_linked_physical_evidence() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let current = physical_artifact(SccmRotation::Current, b"policy-current");
+    write_native_bundle(&bundle_root, std::slice::from_ref(&current), &[]);
+    let evidence = bundle_root.join(relative_path(&SccmRotation::Current));
+    fs::hard_link(&evidence, bundle_root.join("duplicate-evidence-link"))
+        .expect("create a second name for the evidence inode");
+
+    let error = read_sccm_manifest_or_legacy(&bundle_root)
+        .expect_err("hard-linked physical evidence is not a private capture artifact");
+    assert!(error.to_string().contains("single-link"));
 }

--- a/src-tauri/tests/sccm_client_manifest.rs
+++ b/src-tauri/tests/sccm_client_manifest.rs
@@ -29,9 +29,13 @@ fn sha256(value: &[u8]) -> String {
 }
 
 fn catalog_entry_id() -> String {
+    catalog_entry_id_for(POLICY_BASENAME)
+}
+
+fn catalog_entry_id_for(basename: &str) -> String {
     format!(
         "sccm-client-source:v1:sha256:{}",
-        sha256(POLICY_BASENAME.as_bytes())
+        sha256(basename.as_bytes())
     )
 }
 
@@ -85,7 +89,13 @@ fn relative_path(rotation: &SccmRotation) -> String {
     )
 }
 
-fn physical_artifact(rotation: SccmRotation, content: &[u8]) -> Value {
+#[derive(Clone)]
+struct PhysicalArtifactFixture {
+    value: Value,
+    content: Vec<u8>,
+}
+
+fn physical_artifact(rotation: SccmRotation, content: &[u8]) -> PhysicalArtifactFixture {
     let basename = rotation_basename(&rotation);
     let fingerprint = path_fingerprint();
     let artifact_id = format!(
@@ -98,7 +108,8 @@ fn physical_artifact(rotation: SccmRotation, content: &[u8]) -> Value {
             .as_bytes()
         )
     );
-    json!({
+    PhysicalArtifactFixture {
+        value: json!({
         "catalogEntryId": catalog_entry_id(),
         "logicalArtifactIds": [POLICY_GROUP],
         "artifactId": artifact_id,
@@ -118,7 +129,9 @@ fn physical_artifact(rotation: SccmRotation, content: &[u8]) -> Value {
         "configmgrVersion": CONFIGMGR_VERSION,
         "collectedAtUtc": COLLECTED_AT_UTC,
         "encoding": "utf-8"
-    })
+        }),
+        content: content.to_vec(),
+    }
 }
 
 fn capture_gap(rotation: SccmRotation, state: &str) -> Value {
@@ -178,27 +191,28 @@ fn make_private_directory(path: &Path) {
     }
 }
 
-fn write_native_bundle(root: &Path, artifacts: &[Value], capture_gaps: &[Value]) {
+fn write_native_bundle(
+    root: &Path,
+    artifacts: &[&PhysicalArtifactFixture],
+    capture_gaps: &[Value],
+) {
     make_private_directory(root);
     for artifact in artifacts {
-        let relative_path = artifact["relativePath"]
+        let relative_path = artifact.value["relativePath"]
             .as_str()
             .expect("physical fixture path");
-        let basename = artifact["basename"]
-            .as_str()
-            .expect("physical fixture basename");
-        let content = match basename {
-            POLICY_BASENAME => b"policy-current".as_slice(),
-            "PolicyAgent.log.1" => b"policy-rotation-one".as_slice(),
-            "PolicyAgent.log.2" => b"policy-rotation-two".as_slice(),
-            _ => panic!("unexpected physical fixture basename"),
-        };
         let destination = root.join(relative_path);
         fs::create_dir_all(destination.parent().expect("evidence parent"))
             .expect("create evidence tree");
-        fs::write(destination, content).expect("write synthetic evidence");
+        fs::write(destination, &artifact.content).expect("write synthetic evidence");
     }
-    let manifest = native_manifest(artifacts.to_vec(), capture_gaps.to_vec());
+    let manifest = native_manifest(
+        artifacts
+            .iter()
+            .map(|artifact| artifact.value.clone())
+            .collect(),
+        capture_gaps.to_vec(),
+    );
     fs::write(
         root.join(SCCM_MANIFEST_FILE_NAME),
         serde_json::to_vec_pretty(&manifest).expect("serialize fixture manifest"),
@@ -226,7 +240,7 @@ fn validated_v1_reader_projects_one_physical_client_artifact() {
     let temp = tempdir().expect("temporary root");
     let bundle_root = temp.path().join("bundle");
     let current = physical_artifact(SccmRotation::Current, b"policy-current");
-    write_native_bundle(&bundle_root, std::slice::from_ref(&current), &[]);
+    write_native_bundle(&bundle_root, &[&current], &[]);
 
     let manifest = read_sccm_manifest_or_legacy(&bundle_root).expect("validated manifest");
     let bundle = read_sccm_client_intake_bundle(&bundle_root).expect("verified pure projection");
@@ -251,6 +265,18 @@ fn validated_v1_reader_projects_one_physical_client_artifact() {
 }
 
 #[test]
+fn validated_v1_reader_preserves_a_complete_fragment() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let mut current = physical_artifact(SccmRotation::Current, b"complete-policy-current");
+    current.value["fragmentComplete"] = json!(true);
+    write_native_bundle(&bundle_root, &[&current], &[]);
+
+    let bundle = read_sccm_client_intake_bundle(&bundle_root).expect("verified pure projection");
+    assert_eq!(bundle.artifacts[0].fragment_complete, Some(true));
+}
+
+#[test]
 fn omitted_capped_rotation_projects_as_a_gap_without_a_fake_fragment() {
     let temp = tempdir().expect("temporary root");
     let bundle_root = temp.path().join("bundle");
@@ -258,7 +284,7 @@ fn omitted_capped_rotation_projects_as_a_gap_without_a_fake_fragment() {
     let omitted = capture_gap(SccmRotation::Numbered(1), "capped");
     write_native_bundle(
         &bundle_root,
-        std::slice::from_ref(&current),
+        &[&current],
         std::slice::from_ref(&omitted),
     );
 
@@ -292,7 +318,7 @@ fn parse_failed_omitted_rotation_remains_coverage_only() {
     let failed = capture_gap(SccmRotation::Numbered(2), "parseFailed");
     write_native_bundle(
         &bundle_root,
-        std::slice::from_ref(&current),
+        &[&current],
         std::slice::from_ref(&failed),
     );
     let bundle = read_sccm_client_intake_bundle(&bundle_root).expect("verified pure projection");
@@ -310,14 +336,14 @@ fn parse_failed_omitted_rotation_remains_coverage_only() {
 fn native_manifest_uses_one_shared_4096_entry_decode_ceiling() {
     let gap = capture_gap(SccmRotation::Numbered(1), "capped");
     let boundary = native_manifest(
-        vec![physical_artifact(SccmRotation::Current, b"policy-current")],
+        vec![physical_artifact(SccmRotation::Current, b"policy-current").value],
         vec![gap.clone(); MAX_SCCM_MANIFEST_ARTIFACTS - 1],
     );
     serde_json::from_value::<SccmBundleManifestV1>(boundary)
         .expect("combined 4096-entry boundary decodes");
 
     let overflow = native_manifest(
-        vec![physical_artifact(SccmRotation::Current, b"policy-current")],
+        vec![physical_artifact(SccmRotation::Current, b"policy-current").value],
         vec![gap; MAX_SCCM_MANIFEST_ARTIFACTS],
     );
     let error = serde_json::from_value::<SccmBundleManifestV1>(overflow)
@@ -333,7 +359,7 @@ fn reader_rejects_artifacts_outside_canonical_rotation_order() {
     let bundle_root = temp.path().join("bundle");
     let current = physical_artifact(SccmRotation::Current, b"policy-current");
     let numbered = physical_artifact(SccmRotation::Numbered(1), b"policy-rotation-one");
-    write_native_bundle(&bundle_root, &[numbered, current], &[]);
+    write_native_bundle(&bundle_root, &[&numbered, &current], &[]);
 
     let error = read_sccm_manifest_or_legacy(&bundle_root)
         .expect_err("manifest order is part of deterministic intake");
@@ -341,11 +367,11 @@ fn reader_rejects_artifacts_outside_canonical_rotation_order() {
 }
 
 #[test]
-fn reader_rejects_duplicate_artifact_ids_and_relative_paths() {
+fn reader_rejects_duplicate_artifact_ids() {
     let temp = tempdir().expect("temporary root");
     let bundle_root = temp.path().join("bundle");
     let current = physical_artifact(SccmRotation::Current, b"policy-current");
-    write_native_bundle(&bundle_root, &[current.clone(), current], &[]);
+    write_native_bundle(&bundle_root, &[&current, &current], &[]);
 
     let error =
         read_sccm_manifest_or_legacy(&bundle_root).expect_err("colliding artifacts fail closed");
@@ -363,7 +389,13 @@ fn legacy_projection_never_invents_native_capture_gaps() {
             "collection": {
                 "collectorProfile": "cmtrace-full-diagnostics-v1",
                 "collectorVersion": "1.1.0",
-                "results": { "gaps": [] }
+                "results": {
+                    "gaps": [{
+                        "artifactId": "configmgr-ccm-logs",
+                        "category": "logs",
+                        "status": "Missing"
+                    }]
+                }
             },
             "artifacts": []
         }))
@@ -379,6 +411,18 @@ fn legacy_projection_never_invents_native_capture_gaps() {
     );
     assert!(manifest.capture_gaps.is_empty());
     assert!(bundle.capture_gaps.is_empty());
+    assert_eq!(bundle.artifacts.len(), 1);
+    let expected_catalog_id = catalog_entry_id_for("ccmsetup.log");
+    let expected_artifact_id = format!(
+        "sccm-artifact:v1:sha256:{}",
+        sha256(
+            format!(
+                "marker:v1:{expected_catalog_id}:absent:current:ccmsetup.log:unscoped"
+            )
+            .as_bytes()
+        )
+    );
+    assert_eq!(bundle.artifacts[0].artifact.artifact_id, expected_artifact_id);
 }
 
 #[test]
@@ -458,7 +502,7 @@ fn manifest_wire_and_debug_never_gain_raw_host_or_native_path_fields() {
     let temp = tempdir().expect("temporary root");
     let bundle_root = temp.path().join("RealUser-secret-bundle");
     let current = physical_artifact(SccmRotation::Current, b"policy-current");
-    write_native_bundle(&bundle_root, std::slice::from_ref(&current), &[]);
+    write_native_bundle(&bundle_root, &[&current], &[]);
 
     let manifest = read_sccm_manifest_or_legacy(&bundle_root).expect("validated manifest");
     let serialized = serde_json::to_string(&manifest).expect("manifest JSON");
@@ -470,7 +514,7 @@ fn manifest_wire_and_debug_never_gain_raw_host_or_native_path_fields() {
         assert!(!public.contains("RealUser"));
     }
 
-    let mut raw_host = native_manifest(vec![current], vec![]);
+    let mut raw_host = native_manifest(vec![current.value], vec![]);
     raw_host["host"] = json!("LAB-CLIENT-SECRET");
     assert!(serde_json::from_value::<SccmBundleManifestV1>(raw_host).is_err());
 }
@@ -480,7 +524,7 @@ fn malformed_native_state_is_rejected_before_pure_projection() {
     let temp = tempdir().expect("temporary root");
     let bundle_root = temp.path().join("bundle");
     let mut value = native_manifest(
-        vec![physical_artifact(SccmRotation::Current, b"policy-current")],
+        vec![physical_artifact(SccmRotation::Current, b"policy-current").value],
         vec![],
     );
     value["artifacts"][0]["state"] = json!("absent");
@@ -507,7 +551,7 @@ fn reader_enforces_the_physical_file_cap_per_canonical_source_before_evidence_re
     let bundle_root = temp.path().join("bundle");
     let current = physical_artifact(SccmRotation::Current, b"policy-current");
     let rotated = physical_artifact(SccmRotation::Numbered(1), b"policy-rotation-one");
-    write_native_bundle(&bundle_root, &[current, rotated], &[]);
+    write_native_bundle(&bundle_root, &[&current, &rotated], &[]);
     set_native_limits(&bundle_root, 1, 4096);
 
     let error = read_sccm_manifest_or_legacy(&bundle_root)
@@ -521,7 +565,7 @@ fn reader_accepts_the_exact_physical_byte_cap_boundary() {
     let bundle_root = temp.path().join("bundle");
     let content = b"policy-current";
     let current = physical_artifact(SccmRotation::Current, content);
-    write_native_bundle(&bundle_root, std::slice::from_ref(&current), &[]);
+    write_native_bundle(&bundle_root, &[&current], &[]);
     set_native_limits(&bundle_root, 1, content.len() as u64);
 
     read_sccm_manifest_or_legacy(&bundle_root)
@@ -534,7 +578,7 @@ fn reader_rejects_multi_rotation_physical_bytes_over_the_source_cap() {
     let bundle_root = temp.path().join("bundle");
     let current = physical_artifact(SccmRotation::Current, b"policy-current");
     let rotated = physical_artifact(SccmRotation::Numbered(1), b"policy-rotation-one");
-    write_native_bundle(&bundle_root, &[current, rotated], &[]);
+    write_native_bundle(&bundle_root, &[&current, &rotated], &[]);
     set_native_limits(&bundle_root, 2, b"policy-current".len() as u64);
 
     let error = read_sccm_manifest_or_legacy(&bundle_root)
@@ -543,18 +587,55 @@ fn reader_rejects_multi_rotation_physical_bytes_over_the_source_cap() {
 }
 
 #[test]
-fn reader_rejects_overflowing_physical_byte_totals_before_hashing_evidence() {
+fn reader_rejects_physical_byte_metadata_overflow_before_evidence_reads() {
     let temp = tempdir().expect("temporary root");
     let bundle_root = temp.path().join("bundle");
     let mut current = physical_artifact(SccmRotation::Current, b"policy-current");
-    current["bytesCopied"] = json!(u64::MAX);
+    current.value["bytesCopied"] = json!(u64::MAX);
     let rotated = physical_artifact(SccmRotation::Numbered(1), b"policy-rotation-one");
-    write_native_bundle(&bundle_root, &[current, rotated], &[]);
+    write_native_bundle(&bundle_root, &[&current, &rotated], &[]);
     set_native_limits(&bundle_root, 2, u64::MAX);
 
     let error = read_sccm_manifest_or_legacy(&bundle_root)
         .expect_err("overflowing source bytes fail before unbounded evidence verification");
     assert!(error.to_string().contains("source byte cap"));
+}
+
+#[test]
+fn reader_rejects_a_client_owned_per_artifact_ceiling_before_evidence_reads() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let mut current = physical_artifact(SccmRotation::Current, b"policy-current");
+    current.value["bytesCopied"] = json!(256_u64 * 1024 * 1024 + 1);
+    write_native_bundle(&bundle_root, &[&current], &[]);
+    set_native_limits(&bundle_root, 8, u64::MAX);
+
+    let error = read_sccm_manifest_or_legacy(&bundle_root)
+        .expect_err("a manifest cannot raise the reader-owned artifact ceiling");
+    assert!(error.to_string().contains("physical artifact byte cap"));
+}
+
+#[test]
+fn reader_rejects_a_client_owned_aggregate_ceiling_before_evidence_reads() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let mut artifacts = vec![
+        physical_artifact(SccmRotation::Current, b"policy-current"),
+        physical_artifact(SccmRotation::LoUnderscore, b"policy-lo"),
+        physical_artifact(SccmRotation::Numbered(1), b"policy-one"),
+        physical_artifact(SccmRotation::Numbered(2), b"policy-two"),
+        physical_artifact(SccmRotation::Numbered(3), b"policy-three"),
+    ];
+    for artifact in &mut artifacts {
+        artifact.value["bytesCopied"] = json!(205_u64 * 1024 * 1024);
+    }
+    let references = artifacts.iter().collect::<Vec<_>>();
+    write_native_bundle(&bundle_root, &references, &[]);
+    set_native_limits(&bundle_root, 8, u64::MAX);
+
+    let error = read_sccm_manifest_or_legacy(&bundle_root)
+        .expect_err("a manifest cannot raise the reader-owned aggregate ceiling");
+    assert!(error.to_string().contains("aggregate physical byte cap"));
 }
 
 #[cfg(unix)]
@@ -563,7 +644,7 @@ fn reader_rejects_hard_linked_physical_evidence() {
     let temp = tempdir().expect("temporary root");
     let bundle_root = temp.path().join("bundle");
     let current = physical_artifact(SccmRotation::Current, b"policy-current");
-    write_native_bundle(&bundle_root, std::slice::from_ref(&current), &[]);
+    write_native_bundle(&bundle_root, &[&current], &[]);
     let evidence = bundle_root.join(relative_path(&SccmRotation::Current));
     fs::hard_link(&evidence, bundle_root.join("duplicate-evidence-link"))
         .expect("create a second name for the evidence inode");

--- a/src-tauri/tests/sccm_client_manifest.rs
+++ b/src-tauri/tests/sccm_client_manifest.rs
@@ -2,9 +2,9 @@ use std::fs;
 use std::path::Path;
 
 use app_lib::sccm::{
-    manifest_to_client_intake_bundle, read_sccm_client_intake_bundle, read_sccm_manifest_or_legacy,
-    SccmBundleManifestV1, SccmManifestProvenance, SccmManifestSourceState,
-    MAX_SCCM_MANIFEST_ARTIFACTS, SCCM_MANIFEST_FILE_NAME,
+    read_sccm_client_intake_bundle, read_sccm_manifest_or_legacy, SccmBundleManifestV1,
+    SccmManifestProvenance, SccmManifestSourceState, MAX_SCCM_MANIFEST_ARTIFACTS,
+    SCCM_MANIFEST_FILE_NAME,
 };
 use cmtraceopen_parser::sccm::{assess_client_intake, SccmCoverageState, SccmRotation};
 use serde_json::{json, Value};
@@ -229,7 +229,7 @@ fn validated_v1_reader_projects_one_physical_client_artifact() {
     write_native_bundle(&bundle_root, std::slice::from_ref(&current), &[]);
 
     let manifest = read_sccm_manifest_or_legacy(&bundle_root).expect("validated manifest");
-    let bundle = manifest_to_client_intake_bundle(&manifest).expect("pure projection");
+    let bundle = read_sccm_client_intake_bundle(&bundle_root).expect("verified pure projection");
 
     assert_eq!(manifest.sccm_manifest_version, 1);
     assert_eq!(
@@ -286,13 +286,16 @@ fn omitted_capped_rotation_projects_as_a_gap_without_a_fake_fragment() {
 
 #[test]
 fn parse_failed_omitted_rotation_remains_coverage_only() {
-    let manifest_value = native_manifest(
-        vec![physical_artifact(SccmRotation::Current, b"policy-current")],
-        vec![capture_gap(SccmRotation::Numbered(2), "parseFailed")],
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
+    let current = physical_artifact(SccmRotation::Current, b"policy-current");
+    let failed = capture_gap(SccmRotation::Numbered(2), "parseFailed");
+    write_native_bundle(
+        &bundle_root,
+        std::slice::from_ref(&current),
+        std::slice::from_ref(&failed),
     );
-    let manifest: SccmBundleManifestV1 =
-        serde_json::from_value(manifest_value).expect("manifest shape");
-    let bundle = manifest_to_client_intake_bundle(&manifest).expect("pure projection");
+    let bundle = read_sccm_client_intake_bundle(&bundle_root).expect("verified pure projection");
 
     assert_eq!(bundle.artifacts.len(), 1);
     assert_eq!(bundle.capture_gaps.len(), 1);
@@ -474,16 +477,24 @@ fn manifest_wire_and_debug_never_gain_raw_host_or_native_path_fields() {
 
 #[test]
 fn malformed_native_state_is_rejected_before_pure_projection() {
+    let temp = tempdir().expect("temporary root");
+    let bundle_root = temp.path().join("bundle");
     let mut value = native_manifest(
         vec![physical_artifact(SccmRotation::Current, b"policy-current")],
         vec![],
     );
     value["artifacts"][0]["state"] = json!("absent");
-    let manifest: SccmBundleManifestV1 = serde_json::from_value(value).expect("wire shape");
+    make_private_directory(&bundle_root);
+    fs::write(
+        bundle_root.join(SCCM_MANIFEST_FILE_NAME),
+        serde_json::to_vec(&value).expect("serialize malformed native manifest"),
+    )
+    .expect("write malformed native manifest");
 
-    let error = manifest_to_client_intake_bundle(&manifest)
+    let error = read_sccm_client_intake_bundle(&bundle_root)
         .expect_err("nonphysical state cannot claim a file");
     assert!(error.to_string().contains("nonphysical"));
+    let manifest: SccmBundleManifestV1 = serde_json::from_value(value).expect("wire shape");
     assert_ne!(
         manifest.artifacts[0].state,
         SccmManifestSourceState::Captured
@@ -559,5 +570,5 @@ fn reader_rejects_hard_linked_physical_evidence() {
 
     let error = read_sccm_manifest_or_legacy(&bundle_root)
         .expect_err("hard-linked physical evidence is not a private capture artifact");
-    assert!(error.to_string().contains("single-link"));
+    assert!(error.to_string().contains("cannot be opened safely"));
 }


### PR DESCRIPTION
## Scope

Advances #319 under epic #317 with the first native client-intake stack only:

- internal native manifest contract and validated projection into the public pure-Rust intake model;
- bounded, digest-checked physical evidence admission with explicit capture-gap projection;
- handle-bound, no-follow filesystem traversal on Unix and Windows, including hard-link and reparse rejection;
- legacy `manifest.json` fallback without public path disclosure;
- Windows NTSTATUS-to-Win32 error preservation so a missing native manifest still reaches legacy fallback;
- alternate-data-stream component rejection.

This stack does **not** add source discovery, collection, writing, publication, or a public capture command. It does not change the pure parser's platform boundaries.

## Dependency and acceptance state

- Base: exact `codex/parser-family-skeleton` integration commit `26a9a5ee6397696475b3ea709d044f16aa8104fd`.
- Exact head: `84079b8c30bd1ab52d3c7711ea50ee58a92276b2`.
- Independent full-lineage review rejected the first Windows reader because missing files were flattened to `ErrorKind::Other`; the RED/GREEN correction is `c3f1c949` / `84079b8c`.
- Independent exact-delta review is GO and local CodeRabbit reports no findings for the full integration-to-head range.
- Windows 11 executed the pre-correction handle tests 4/4 and reproduced the legacy fallback failure 12/14. Exact-head Windows CI is required here before acceptance.
- No live SCCM lab acceptance is claimed. Issue #319 stays open for discovery, capture/publication, and actual lab validation.

## Verification

- `cargo +1.88.0 test --locked -p cmtrace-open --test sccm_client_manifest --features sccm-diagnostics` — 18/18 pass.
- `cargo +1.88.0 test --locked -p cmtrace-open --features sccm-diagnostics sccm::private_fs` — 3/3 non-Windows tests pass; Windows-gated tests await hosted execution.
- `cargo +1.88.0 test --locked -p cmtraceopen-parser` — pass.
- `cargo +1.88.0 check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown` — pass.
- `cargo +1.88.0 check --locked -p cmtrace-open --all-features` — pass.
- `cargo clippy --locked -p cmtrace-open --all-targets --all-features -- -D warnings` — pass on the repository stable toolchain.
- `cargo clippy --locked -p cmtraceopen-parser --all-targets --all-features -- -D warnings` — pass on the repository stable toolchain.
- Changed-file `rustfmt --check` and `git diff --check` — pass.
- The prescribed repository-wide `cargo fmt --all -- --check` remains red only on inherited files outside this seven-file range; no formatting debt is hidden in this slice.

## Review focus

- Windows `NtCreateFile` relative-handle semantics, NTSTATUS mapping, owner/DACL checks, reparse/hard-link handling, and legacy fallback.
- Manifest cardinality/byte limits, digest binding, capture-gap projection, and path/privacy boundaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reader-only SCCM diagnostic bundle support for native and legacy manifest formats.
  - Added validation for evidence integrity, ordering, timestamps, paths, and capture limits.
  - Added secure bundle traversal to block unsafe links, path replacement, and hard-linked evidence.
  - Added diagnostic coverage, role, and rotation information.

- **Bug Fixes**
  - Rejects malformed, incomplete, duplicate, oversized, or unsafe manifest data.
  - Prevents sensitive filesystem paths from appearing in serialized output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->