### PR TITLE
test(sccm): reject cyclic advanced-role supersession

### DIFF
--- a/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
@@ -601,6 +601,17 @@ fn validate_card_with_inventory(card: &SourceCard, inventory: &BTreeSet<String>)
     validation
 }
 
+fn validate_catalog(cards: &[SourceCard]) -> Vec<Validation> {
+    let inventory = cards
+        .iter()
+        .map(|card| card.card_id.clone())
+        .collect::<BTreeSet<_>>();
+    cards
+        .iter()
+        .map(|card| validate_card_with_inventory(card, &inventory))
+        .collect()
+}
+
 fn validate_path(path: &Path) -> Validation {
     match load_card(path) {
         Ok(card) => validate_card(&card),
@@ -650,9 +661,13 @@ fn candidate_catalog_is_typed_private_and_not_semantically_admitted() {
         cards.len(),
         "source-card IDs must be unique"
     );
+    let validations = validate_catalog(&cards);
     let mut card_ids = Vec::new();
-    for (filename, card) in SOURCE_CARDS.into_iter().zip(cards) {
-        let validation = validate_card_with_inventory(&card, &inventory);
+    for ((filename, card), validation) in SOURCE_CARDS
+        .into_iter()
+        .zip(cards)
+        .zip(validations)
+    {
         assert!(
             validation.valid,
             "{filename}: {}",
@@ -811,6 +826,34 @@ fn deprecation_requires_an_explicit_successor_and_never_panics() {
         resolved.valid,
         "a supersedes entry present in the catalog keeps the card valid"
     );
+}
+
+#[test]
+fn supersession_self_references_and_cycles_fail_closed() {
+    let path = corpus_root()
+        .join("catalog-fixtures/valid")
+        .join("source-card.json");
+    let mut self_referential = load_card(&path).expect("valid fixture loads");
+    self_referential.supersession.supersedes = vec![self_referential.card_id.clone()];
+    let self_validation = validate_catalog(&[self_referential]);
+    assert_eq!(self_validation[0].issues, ["supersessionCycleDetected"]);
+    assert!(!self_validation[0].admitted_to_semantic_catalog);
+
+    let mut alpha = load_card(&path).expect("valid fixture loads");
+    alpha.card_id = "alpha-card".to_owned();
+    alpha.supersession.supersedes = vec!["bravo-card".to_owned()];
+    let mut bravo = load_card(&path).expect("valid fixture loads");
+    bravo.card_id = "bravo-card".to_owned();
+    bravo.supersession.supersedes = vec!["charlie-card".to_owned()];
+    let mut charlie = load_card(&path).expect("valid fixture loads");
+    charlie.card_id = "charlie-card".to_owned();
+    charlie.supersession.supersedes = vec!["alpha-card".to_owned()];
+
+    let cycle_validations = validate_catalog(&[alpha, bravo, charlie]);
+    assert!(cycle_validations.iter().all(|validation| {
+        validation.issues == ["supersessionCycleDetected"]
+            && !validation.admitted_to_semantic_catalog
+    }));
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_advanced_roles_catalog.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -606,10 +606,74 @@ fn validate_catalog(cards: &[SourceCard]) -> Vec<Validation> {
         .iter()
         .map(|card| card.card_id.clone())
         .collect::<BTreeSet<_>>();
+    let cycle_members = supersession_cycle_members(cards);
     cards
         .iter()
-        .map(|card| validate_card_with_inventory(card, &inventory))
+        .map(|card| {
+            let mut validation = validate_card_with_inventory(card, &inventory);
+            if cycle_members.contains(&card.card_id) {
+                validation
+                    .issues
+                    .push("supersessionCycleDetected".to_owned());
+                validation.issues.sort();
+                validation.issues.dedup();
+                validation.valid = false;
+                validation.admitted_to_semantic_catalog = false;
+            }
+            validation
+        })
         .collect()
+}
+
+fn supersession_cycle_members(cards: &[SourceCard]) -> BTreeSet<String> {
+    let mut graph = cards
+        .iter()
+        .map(|card| (card.card_id.clone(), Vec::new()))
+        .collect::<BTreeMap<_, _>>();
+
+    for card in cards {
+        if let Some(successor) = &card.supersession.superseded_by {
+            graph
+                .entry(card.card_id.clone())
+                .or_default()
+                .push(successor.clone());
+        }
+        for predecessor in &card.supersession.supersedes {
+            graph
+                .entry(predecessor.clone())
+                .or_default()
+                .push(card.card_id.clone());
+        }
+    }
+
+    cards
+        .iter()
+        .filter(|card| {
+            supersession_cycle_reaches(&card.card_id, &card.card_id, &graph, &mut BTreeSet::new())
+        })
+        .map(|card| card.card_id.clone())
+        .collect()
+}
+
+fn supersession_cycle_reaches(
+    origin: &str,
+    current: &str,
+    graph: &BTreeMap<String, Vec<String>>,
+    visited: &mut BTreeSet<String>,
+) -> bool {
+    graph.get(current).is_some_and(|targets| {
+        targets.iter().any(|target| {
+            if target == origin {
+                return true;
+            }
+            if !visited.insert(target.clone()) {
+                return false;
+            }
+            let reaches_origin = supersession_cycle_reaches(origin, target, graph, visited);
+            visited.remove(target);
+            reaches_origin
+        })
+    })
 }
 
 fn validate_path(path: &Path) -> Validation {
@@ -663,11 +727,7 @@ fn candidate_catalog_is_typed_private_and_not_semantically_admitted() {
     );
     let validations = validate_catalog(&cards);
     let mut card_ids = Vec::new();
-    for ((filename, card), validation) in SOURCE_CARDS
-        .into_iter()
-        .zip(cards)
-        .zip(validations)
-    {
+    for ((filename, card), validation) in SOURCE_CARDS.into_iter().zip(cards).zip(validations) {
         assert!(
             validation.valid,
             "{filename}: {}",
@@ -854,6 +914,19 @@ fn supersession_self_references_and_cycles_fail_closed() {
         validation.issues == ["supersessionCycleDetected"]
             && !validation.admitted_to_semantic_catalog
     }));
+
+    let mut predecessor = load_card(&path).expect("valid fixture loads");
+    predecessor.card_id = "predecessor-card".to_owned();
+    predecessor.supersession.state = SupersessionState::Deprecated;
+    predecessor.supersession.superseded_by = Some("successor-card".to_owned());
+    let mut successor = load_card(&path).expect("valid fixture loads");
+    successor.card_id = "successor-card".to_owned();
+    successor.supersession.supersedes = vec!["predecessor-card".to_owned()];
+
+    let reciprocal_validations = validate_catalog(&[predecessor, successor]);
+    assert!(reciprocal_validations
+        .iter()
+        .all(|validation| validation.valid));
 }
 
 #[test]


### PR DESCRIPTION
## Scope

Closes one source-card admission gap in the advanced-role catalog contract: self-referential and multi-card supersession cycles now fail closed and every cycle member receives the deterministic `supersessionCycleDetected` violation.

This is deliberately a catalog/fixture-gate hardening slice. It does not add an advanced-role parser, reducer, native collector, live Windows validation, or broader role support.

## Test-first evidence

- RED `f62b5299`: self and three-card cycles were accepted by the existing inventory validator.
- GREEN `410af9d7`: graph validation rejects closed cycles while preserving legitimate reciprocal `supersededBy` / `supersedes` metadata as one predecessor-to-successor edge.
- Independent review reproduced RED, probed longer/disconnected cycles, unknown targets, asymmetric metadata, duplicate IDs, deterministic ordering, and returned no P0-P3 findings.

## Verification

- `cargo test --locked -p cmtraceopen-parser --test sccm_server_advanced_roles_catalog` — 7 passed
- `cargo test --locked -p cmtraceopen-parser` — passed
- `cargo clippy --locked -p cmtraceopen-parser --all-targets --all-features -- -D warnings` — passed
- `rustup run 1.88.0 cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown --all-features` — passed
- scoped Rust 1.88 `rustfmt --check` — passed
- `git diff --check` — passed
- local committed-range CodeRabbit — no findings

Repository-wide `cargo fmt --all -- --check` remains red only on inherited files outside this one-file slice; no formatter spill is included.

Tracks #334. The issue remains open after this slice because advanced roles remain source-card candidates rather than accepted production analyzers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog validation for supersession relationships.
  * Catalogs containing self-references or circular chains are now correctly identified as invalid.
  * Affected entries are prevented from being admitted, reducing the risk of inconsistent or unusable catalog data.
  * Added validation coverage for multi-entry cycles and valid reciprocal predecessor/successor relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->