### PR TITLE
chore(scoop): bump bucket manifests to 1.5.1

### DIFF
--- a/bucket/cmtrace-lite.json
+++ b/bucket/cmtrace-lite.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Lite edition of CMTrace Open: a free, open-source CMTrace replacement for Windows log files with format auto-detection, real-time tailing, find and filter, and Windows error-code lookup.",
     "homepage": "https://cmtraceopen.com",
     "license": "MIT",
@@ -11,12 +11,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.0/CMTrace-Open-Lite_1.5.0_x64.exe#/cmtrace-lite.exe",
-            "hash": "cdcd984bcc2c76688de0bcd587a12ed9047882e9bada9539234d650804797818"
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.1/CMTrace-Open-Lite_1.5.1_x64.exe#/cmtrace-lite.exe",
+            "hash": "e5ae9bf01b2194f19ae7a510b3292d58dbe84dd1eefca8d91beeaead7d42f35e"
         },
         "arm64": {
-            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.0/CMTrace-Open-Lite_1.5.0_arm64.exe#/cmtrace-lite.exe",
-            "hash": "84117a3e890b4a4605773b9f56be2951aab8a062ba65776f6235c9febe2ace30"
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.1/CMTrace-Open-Lite_1.5.1_arm64.exe#/cmtrace-lite.exe",
+            "hash": "8ab5887479cf79f07a7e0beff7aae6c7cacb045eae581ff08a6415cd5251bacc"
         }
     },
     "bin": "cmtrace-lite.exe",

--- a/bucket/cmtrace.json
+++ b/bucket/cmtrace.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Free, open-source CMTrace replacement for Windows log files: ConfigMgr/SCCM, Intune IME, and Autopilot ESP diagnostics, DSRegCmd triage, .evtx viewing, real-time tailing, and Windows error-code lookup.",
     "homepage": "https://cmtraceopen.com",
     "license": "MIT",
@@ -10,12 +10,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.0/CMTrace-Open_1.5.0_x64.exe#/cmtrace.exe",
-            "hash": "559fd27986088982885548a45821abcebf9f2667d092ba198fc6f34d8c68ab90"
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.1/CMTrace-Open_1.5.1_x64.exe#/cmtrace.exe",
+            "hash": "e87d6c70e4a673c259193439f1f65a84e903376f71bfb0d416c8a2d4aa2992dd"
         },
         "arm64": {
-            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.0/CMTrace-Open_1.5.0_arm64.exe#/cmtrace.exe",
-            "hash": "71a9ef5f606841dded7a0cbe742c7761eb7464b503c0cbc45ec76d733f5801c7"
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.1/CMTrace-Open_1.5.1_arm64.exe#/cmtrace.exe",
+            "hash": "d63d7cc0439794ecd845f2b71580d96c3787b41e105de60cb5c1d0c0d6ca6535"
         }
     },
     "bin": "cmtrace.exe",


### PR DESCRIPTION
## Summary
- update Scoop bucket manifests (cmtrace, cmtrace-lite) from 1.5.0 to 1.5.1
- point URLs at the v1.5.1 Windows x64/arm64 assets
- update SHA256 hashes to match the published v1.5.1 release assets

## Why
The CMTrace Open: Publish to Scoop bucket rerun validated successfully but cannot push directly to main because repository rules now require pull requests and signed/verified status checks.

This PR is the rule-compliant path to complete the Scoop publish step for v1.5.1.