### PR TITLE
fix(sccm): preserve bounded discovery coverage correctness

### DIFF
--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -37,7 +37,7 @@ pub enum SccmClientDiscoveryObservationState {
     Skipped,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SccmClientDiscoveryState {
     Discovered,
     AccessDenied,
@@ -50,6 +50,9 @@ pub enum SccmClientDiscoveryState {
 pub enum SccmClientDiscoveryCoverageIssueState {
     InvalidProvenance,
     Unsupported,
+    /// The bounded declaration output omitted one or more otherwise eligible
+    /// observations. This is a capacity fact, not a source-observation state.
+    DeclarationLimitExceeded,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -74,6 +77,10 @@ pub struct SccmClientDiscoveryCoverageIssue {
     pub logical_artifact_ids: Vec<String>,
     pub rotation_category: SccmClientDiscoveryRotationCategory,
     pub state: SccmClientDiscoveryCoverageIssueState,
+    /// Actual declaration state omitted only by the global output bound. This
+    /// preserves per-source `Capped` separately from raw input `Found`.
+    /// Other issue kinds leave this unset.
+    pub omitted_declaration_state: Option<SccmClientDiscoveryState>,
     /// Number of supplied observations represented by this privacy-safe issue
     /// category. The category identity intentionally remains count-independent.
     pub occurrence_count: NonZeroU16,
@@ -152,7 +159,7 @@ struct NormalizedObservation<'a> {
 
 struct NormalizedDiscovery<'a> {
     observations: Vec<NormalizedObservation<'a>>,
-    coverage_issues: Vec<SccmClientDiscoveryCoverageIssue>,
+    coverage_issue_counts: BTreeMap<CoverageIssueKey, u16>,
 }
 
 #[derive(Debug)]
@@ -188,6 +195,7 @@ struct CoverageIssueKey {
     logical_artifact_ids: Vec<String>,
     rotation_category: SccmClientDiscoveryRotationCategory,
     state: SccmClientDiscoveryCoverageIssueState,
+    omitted_declaration_state: Option<SccmClientDiscoveryState>,
 }
 
 #[cfg(test)]
@@ -208,17 +216,18 @@ pub fn discover_client_sources(
         return Err(SccmClientDiscoveryError::ObservationLimitExceeded);
     }
 
-    let normalized = normalize_observations(input)?;
-    let observations = normalized.observations;
+    let NormalizedDiscovery {
+        observations,
+        mut coverage_issue_counts,
+    } = normalize_observations(input)?;
     let mut found_per_source = BTreeMap::<(String, String), usize>::new();
     let mut capped_sources = BTreeSet::<(String, String)>::new();
-    let mut declarations = Vec::with_capacity(
+    let mut selected = Vec::with_capacity(
         input
             .observations
             .len()
-            .min(MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS),
+            .min(MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS),
     );
-    let mut first_omitted: Option<(NormalizedObservation<'_>, SccmClientDiscoveryState)> = None;
 
     for observation in observations {
         let Some(state) = selection_state(
@@ -229,36 +238,40 @@ pub fn discover_client_sources(
         ) else {
             continue;
         };
+        selected.push((observation, state));
+    }
 
-        if declarations.len() < MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS - 1 {
-            declarations.push(declaration_from_candidate(
+    if selected.len() > MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS {
+        let terminal = selected
+            .pop()
+            .expect("an over-cap selection has a terminal observation");
+        for (_, omitted_state) in &selected[MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS - 1..] {
+            add_coverage_issue_count(
+                &mut coverage_issue_counts,
+                declaration_limit_issue_key(*omitted_state),
+                1,
+            );
+        }
+        selected.truncate(MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS - 1);
+        selected.push(terminal);
+    }
+
+    let declarations = selected
+        .into_iter()
+        .map(|(observation, state)| {
+            declaration_from_candidate(
                 candidate_from_observation(&observation).expect("prevalidated observation"),
                 state,
-            ));
-        } else if let Some((first_omitted, _)) = first_omitted {
-            declarations.push(declaration_from_candidate(
-                candidate_from_observation(&first_omitted).expect("prevalidated observation"),
-                SccmClientDiscoveryState::Capped,
-            ));
-            return Ok(SccmClientDiscoveryResult {
-                declarations,
-                coverage_issues: normalized.coverage_issues,
-            });
-        } else {
-            first_omitted = Some((observation, state));
-        }
-    }
-
-    if let Some((last, state)) = first_omitted {
-        declarations.push(declaration_from_candidate(
-            candidate_from_observation(&last).expect("prevalidated observation"),
-            state,
-        ));
-    }
-
+            )
+        })
+        .collect();
+    debug_assert!(coverage_issue_counts.len() <= MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES);
     Ok(SccmClientDiscoveryResult {
         declarations,
-        coverage_issues: normalized.coverage_issues,
+        coverage_issues: coverage_issue_counts
+            .into_iter()
+            .map(|(issue, count)| coverage_issue_from_key(issue, count))
+            .collect(),
     })
 }
 
@@ -382,10 +395,7 @@ fn normalize_observations(
             }
             (root_is_valid, catalog_basename) => {
                 let coverage_issue = coverage_issue_key(root_is_valid, catalog_basename.as_deref());
-                let count = coverage_issue_counts.entry(coverage_issue).or_insert(0_u16);
-                *count = count
-                    .checked_add(1)
-                    .expect("admitted discovery issue count fits in u16");
+                add_coverage_issue_count(&mut coverage_issue_counts, coverage_issue, 1);
             }
         }
     }
@@ -394,10 +404,7 @@ fn normalize_observations(
     debug_assert!(coverage_issue_counts.len() <= MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES);
     Ok(NormalizedDiscovery {
         observations,
-        coverage_issues: coverage_issue_counts
-            .into_iter()
-            .map(|(issue, count)| coverage_issue_from_key(issue, count))
-            .collect(),
+        coverage_issue_counts,
     })
 }
 
@@ -415,7 +422,33 @@ fn coverage_issue_key(root_is_valid: bool, catalog_basename: Option<&str>) -> Co
         logical_artifact_ids: Vec::new(),
         rotation_category: SccmClientDiscoveryRotationCategory::Unknown,
         state,
+        omitted_declaration_state: None,
     }
+}
+
+fn declaration_limit_issue_key(
+    omitted_declaration_state: SccmClientDiscoveryState,
+) -> CoverageIssueKey {
+    CoverageIssueKey {
+        catalog_entry_id: "sccm-client-source:v1:none".to_owned(),
+        logical_artifact_ids: Vec::new(),
+        rotation_category: SccmClientDiscoveryRotationCategory::Unknown,
+        state: SccmClientDiscoveryCoverageIssueState::DeclarationLimitExceeded,
+        omitted_declaration_state: Some(omitted_declaration_state),
+    }
+}
+
+fn add_coverage_issue_count(
+    counts: &mut BTreeMap<CoverageIssueKey, u16>,
+    key: CoverageIssueKey,
+    additional_count: usize,
+) {
+    let additional_count =
+        u16::try_from(additional_count).expect("admitted discovery issue count fits in u16");
+    let count = counts.entry(key).or_insert(0_u16);
+    *count = count
+        .checked_add(additional_count)
+        .expect("aggregated discovery issue count fits in u16");
 }
 
 fn coverage_issue_from_key(
@@ -427,14 +460,21 @@ fn coverage_issue_from_key(
         logical_artifact_ids,
         rotation_category,
         state,
+        omitted_declaration_state,
     } = key;
-    let artifact_id = coverage_issue_id(&catalog_entry_id, rotation_category, state);
+    let artifact_id = coverage_issue_id(
+        &catalog_entry_id,
+        rotation_category,
+        state,
+        omitted_declaration_state,
+    );
     SccmClientDiscoveryCoverageIssue {
         artifact_id,
         catalog_entry_id,
         logical_artifact_ids,
         rotation_category,
         state,
+        omitted_declaration_state,
         occurrence_count: NonZeroU16::new(occurrence_count)
             .expect("every coverage issue represents an admitted observation"),
     }
@@ -450,6 +490,7 @@ fn coverage_issue_id(
     catalog_entry_id: &str,
     rotation_category: SccmClientDiscoveryRotationCategory,
     state: SccmClientDiscoveryCoverageIssueState,
+    omitted_declaration_state: Option<SccmClientDiscoveryState>,
 ) -> String {
     let rotation = match rotation_category {
         SccmClientDiscoveryRotationCategory::Current => "current",
@@ -461,10 +502,25 @@ fn coverage_issue_id(
     let state = match state {
         SccmClientDiscoveryCoverageIssueState::InvalidProvenance => "invalid-provenance",
         SccmClientDiscoveryCoverageIssueState::Unsupported => "unsupported",
+        SccmClientDiscoveryCoverageIssueState::DeclarationLimitExceeded => {
+            "declaration-limit-exceeded"
+        }
     };
-    let value = format!(
-        "cmtraceopen.sccm.discovery.coverage.v1\\0{catalog_entry_id}\\0{rotation}\\0{state}"
-    );
+    let omitted_state = omitted_declaration_state.map(|state| match state {
+        SccmClientDiscoveryState::Discovered => "discovered",
+        SccmClientDiscoveryState::AccessDenied => "access-denied",
+        SccmClientDiscoveryState::NotFound => "not-found",
+        SccmClientDiscoveryState::Capped => "capped",
+        SccmClientDiscoveryState::Skipped => "skipped",
+    });
+    let value = match omitted_state {
+        Some(omitted_state) => format!(
+            "cmtraceopen.sccm.discovery.coverage.v1\\0{catalog_entry_id}\\0{rotation}\\0{state}\\0{omitted_state}"
+        ),
+        None => format!(
+            "cmtraceopen.sccm.discovery.coverage.v1\\0{catalog_entry_id}\\0{rotation}\\0{state}"
+        ),
+    };
     format!(
         "sccm-discovery-coverage:v1:sha256:{}",
         sha256_bytes(value.as_bytes())

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -14,7 +14,7 @@ use super::contract::{
     rotation_order, rotation_segment, sha256_bytes, source_identity_digest,
     SccmManifestSourceState,
 };
-use cmtraceopen_parser::sccm::{classify_artifact_name, SccmRole, SccmRotation};
+use cmtraceopen_parser::sccm::SccmRotation;
 
 pub const MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS: usize = 4_096;
 /// Defensive bound for supplied observations. Native enumeration must report
@@ -61,7 +61,7 @@ pub enum SccmClientDiscoveryRotationCategory {
 
 /// Coverage-only metadata intentionally kept out of declarations. These
 /// issues cannot be captured or interpreted as workflow evidence.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SccmClientDiscoveryCoverageIssue {
     pub artifact_id: String,
     /// A validated catalog identity or the fixed `none` category. It never
@@ -158,12 +158,41 @@ struct NormalizedDiscovery<'a> {
     coverage_issues: Vec<SccmClientDiscoveryCoverageIssue>,
 }
 
+#[derive(Debug, PartialEq)]
+enum PhysicalConsistencyBasename<'a> {
+    Validated(String),
+    Rejected(&'a str),
+}
+
+#[derive(Debug, PartialEq)]
+struct PhysicalConsistencyKey<'a> {
+    /// Rejected raw metadata is borrowed only for this bounded consistency
+    /// pass. It is never cloned, hashed, or returned.
+    root_handle: &'a str,
+    basename: PhysicalConsistencyBasename<'a>,
+    rotation: &'a SccmRotation,
+}
+
+struct PhysicalConsistencyObservation<'a> {
+    key: PhysicalConsistencyKey<'a>,
+    state: SccmClientDiscoveryObservationState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct CoverageIssueKey {
+    catalog_entry_id: String,
+    logical_artifact_ids: Vec<String>,
+    rotation_category: SccmClientDiscoveryRotationCategory,
+    state: SccmClientDiscoveryCoverageIssueState,
+}
+
 #[cfg(test)]
 thread_local! {
     static CANDIDATE_CONSTRUCTIONS: Cell<usize> = const { Cell::new(0) };
     static DECLARATION_CONSTRUCTIONS: Cell<usize> = const { Cell::new(0) };
     static NORMALIZATION_OPERATIONS: Cell<usize> = const { Cell::new(0) };
     static LOGICAL_ARTIFACT_ID_LOOKUPS: Cell<usize> = const { Cell::new(0) };
+    static CONSISTENCY_KEY_CONSTRUCTIONS: Cell<usize> = const { Cell::new(0) };
 }
 
 pub fn discover_client_sources(
@@ -173,6 +202,7 @@ pub fn discover_client_sources(
         return Err(SccmClientDiscoveryError::ObservationLimitExceeded);
     }
 
+    validate_observation_consistency(&input.observations)?;
     let normalized = normalize_observations(input)?;
     let observations = normalized.observations;
     let mut found_per_source = BTreeMap::<(String, String), usize>::new();
@@ -227,15 +257,114 @@ pub fn discover_client_sources(
     })
 }
 
+fn validate_observation_consistency(
+    observations: &[SccmClientDiscoveryObservation],
+) -> Result<(), SccmClientDiscoveryError> {
+    let mut keyed = observations
+        .iter()
+        .map(|observation| PhysicalConsistencyObservation {
+            key: physical_consistency_key(observation),
+            state: observation.state,
+        })
+        .collect::<Vec<_>>();
+    debug_assert!(keyed.len() <= MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS);
+    keyed.sort_by(compare_physical_consistency_observations);
+
+    let mut group_start = 0;
+    while group_start < keyed.len() {
+        let mut group_end = group_start + 1;
+        while group_end < keyed.len()
+            && compare_physical_consistency_keys(&keyed[group_start].key, &keyed[group_end].key)
+                == Ordering::Equal
+        {
+            group_end += 1;
+        }
+
+        if matches!(keyed[group_start].key.rotation, SccmRotation::Unknown(_)) {
+            for current in group_start..group_end {
+                for previous in group_start..current {
+                    if keyed[previous].key.rotation == keyed[current].key.rotation
+                        && keyed[previous].state != keyed[current].state
+                    {
+                        return Err(SccmClientDiscoveryError::ConflictingObservation);
+                    }
+                }
+            }
+        } else if keyed[group_start + 1..group_end]
+            .iter()
+            .any(|observation| observation.state != keyed[group_start].state)
+        {
+            return Err(SccmClientDiscoveryError::ConflictingObservation);
+        }
+
+        group_start = group_end;
+    }
+    Ok(())
+}
+
+fn physical_consistency_key(
+    observation: &SccmClientDiscoveryObservation,
+) -> PhysicalConsistencyKey<'_> {
+    #[cfg(test)]
+    CONSISTENCY_KEY_CONSTRUCTIONS.with(|count| count.set(count.get() + 1));
+    let basename = canonical_client_source(&observation.basename, &observation.rotation)
+        .map(PhysicalConsistencyBasename::Validated)
+        .unwrap_or_else(|| PhysicalConsistencyBasename::Rejected(&observation.basename));
+    PhysicalConsistencyKey {
+        root_handle: &observation.root_handle,
+        basename,
+        rotation: &observation.rotation,
+    }
+}
+
+fn compare_physical_consistency_observations(
+    left: &PhysicalConsistencyObservation<'_>,
+    right: &PhysicalConsistencyObservation<'_>,
+) -> Ordering {
+    compare_physical_consistency_keys(&left.key, &right.key)
+}
+
+fn compare_physical_consistency_keys(
+    left: &PhysicalConsistencyKey<'_>,
+    right: &PhysicalConsistencyKey<'_>,
+) -> Ordering {
+    left.root_handle
+        .cmp(right.root_handle)
+        .then_with(|| compare_physical_consistency_basenames(&left.basename, &right.basename))
+        .then_with(|| rotation_order(left.rotation, right.rotation))
+}
+
+fn compare_physical_consistency_basenames(
+    left: &PhysicalConsistencyBasename<'_>,
+    right: &PhysicalConsistencyBasename<'_>,
+) -> Ordering {
+    match (left, right) {
+        (
+            PhysicalConsistencyBasename::Validated(left),
+            PhysicalConsistencyBasename::Validated(right),
+        ) => left.cmp(right),
+        (PhysicalConsistencyBasename::Validated(_), PhysicalConsistencyBasename::Rejected(_)) => {
+            Ordering::Less
+        }
+        (PhysicalConsistencyBasename::Rejected(_), PhysicalConsistencyBasename::Validated(_)) => {
+            Ordering::Greater
+        }
+        (
+            PhysicalConsistencyBasename::Rejected(left),
+            PhysicalConsistencyBasename::Rejected(right),
+        ) => left.cmp(right),
+    }
+}
+
 fn normalize_observations(
     input: &SccmClientDiscoveryInput,
 ) -> Result<NormalizedDiscovery<'_>, SccmClientDiscoveryError> {
     let mut observations = BTreeMap::<PhysicalObservationKey, NormalizedObservation<'_>>::new();
-    let mut coverage_issue_counts = BTreeMap::new();
+    let mut coverage_issue_counts = BTreeMap::<CoverageIssueKey, u16>::new();
     for observation in &input.observations {
         let Some(normalized) = normalize_observation(observation) else {
             let count = coverage_issue_counts
-                .entry(coverage_issue_from_observation(observation))
+                .entry(coverage_issue_key(observation))
                 .or_insert(0_u16);
             *count = count
                 .checked_add(1)
@@ -268,11 +397,7 @@ fn normalize_observations(
         observations,
         coverage_issues: coverage_issue_counts
             .into_iter()
-            .map(|(mut issue, count)| {
-                issue.occurrence_count = NonZeroU16::new(count)
-                    .expect("every coverage issue represents an admitted observation");
-                issue
-            })
+            .map(|(issue, count)| coverage_issue_from_key(issue, count))
             .collect(),
     })
 }
@@ -292,11 +417,9 @@ fn normalize_observation(
     })
 }
 
-fn coverage_issue_from_observation(
-    observation: &SccmClientDiscoveryObservation,
-) -> SccmClientDiscoveryCoverageIssue {
+fn coverage_issue_key(observation: &SccmClientDiscoveryObservation) -> CoverageIssueKey {
     let root_is_valid = root_handle_digest(&observation.root_handle).is_some();
-    let catalog_basename = catalogued_basename(&observation.basename);
+    let catalog_basename = canonical_client_source(&observation.basename, &observation.rotation);
     let state = if root_is_valid {
         SccmClientDiscoveryCoverageIssueState::Unsupported
     } else {
@@ -316,6 +439,24 @@ fn coverage_issue_from_observation(
         Vec::new()
     };
     let rotation_category = rotation_category(&observation.rotation);
+    CoverageIssueKey {
+        catalog_entry_id,
+        logical_artifact_ids,
+        rotation_category,
+        state,
+    }
+}
+
+fn coverage_issue_from_key(
+    key: CoverageIssueKey,
+    occurrence_count: u16,
+) -> SccmClientDiscoveryCoverageIssue {
+    let CoverageIssueKey {
+        catalog_entry_id,
+        logical_artifact_ids,
+        rotation_category,
+        state,
+    } = key;
     let artifact_id = coverage_issue_id(&catalog_entry_id, rotation_category, state);
     SccmClientDiscoveryCoverageIssue {
         artifact_id,
@@ -323,14 +464,9 @@ fn coverage_issue_from_observation(
         logical_artifact_ids,
         rotation_category,
         state,
-        occurrence_count: NonZeroU16::MIN,
+        occurrence_count: NonZeroU16::new(occurrence_count)
+            .expect("every coverage issue represents an admitted observation"),
     }
-}
-
-fn catalogued_basename(basename: &str) -> Option<String> {
-    let classified = classify_artifact_name(basename, SccmRole::Client);
-    (!logical_artifact_ids_for_basename(&classified.basename).is_empty())
-        .then_some(classified.basename)
 }
 
 fn rotation_category(rotation: &SccmRotation) -> SccmClientDiscoveryRotationCategory {

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -438,6 +438,8 @@ fn declaration_limit_issue_key(
     }
 }
 
+const _: () = assert!(MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS <= u16::MAX as usize);
+
 fn add_coverage_issue_count(
     counts: &mut BTreeMap<CoverageIssueKey, u16>,
     key: CoverageIssueKey,

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -515,10 +515,10 @@ fn coverage_issue_id(
     });
     let value = match omitted_state {
         Some(omitted_state) => format!(
-            "cmtraceopen.sccm.discovery.coverage.v1\\0{catalog_entry_id}\\0{rotation}\\0{state}\\0{omitted_state}"
+            "cmtraceopen.sccm.discovery.coverage.v1\0{catalog_entry_id}\0{rotation}\0{state}\0{omitted_state}"
         ),
         None => format!(
-            "cmtraceopen.sccm.discovery.coverage.v1\\0{catalog_entry_id}\\0{rotation}\\0{state}"
+            "cmtraceopen.sccm.discovery.coverage.v1\0{catalog_entry_id}\0{rotation}\0{state}"
         ),
     };
     format!(

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -601,6 +601,14 @@ mod tests {
         LOGICAL_ARTIFACT_ID_LOOKUPS.with(|count| count.set(0));
     }
 
+    fn consistency_key_count() -> usize {
+        CONSISTENCY_KEY_CONSTRUCTIONS.with(Cell::get)
+    }
+
+    fn reset_consistency_key_count() {
+        CONSISTENCY_KEY_CONSTRUCTIONS.with(|count| count.set(0));
+    }
+
     #[test]
     fn defensive_observation_limit_rejects_before_any_normalization_or_construction() {
         let observations = (1..=MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS + 1)
@@ -619,6 +627,7 @@ mod tests {
 
         reset_construction_counts();
         reset_normalization_count();
+        reset_consistency_key_count();
         assert_eq!(
             discover_client_sources(&input),
             Err(SccmClientDiscoveryError::ObservationLimitExceeded),
@@ -633,6 +642,11 @@ mod tests {
             construction_counts(),
             (0, 0),
             "the defensive limit rejects before candidates or declarations are built"
+        );
+        assert_eq!(
+            consistency_key_count(),
+            0,
+            "the defensive limit rejects before ephemeral consistency keys are built"
         );
     }
 
@@ -663,6 +677,7 @@ mod tests {
         for observations in [all_found, mixed_states] {
             reset_construction_counts();
             reset_normalization_count();
+            reset_consistency_key_count();
             let result = discover_client_sources(&SccmClientDiscoveryInput {
                 max_found_fragments_per_source: MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
                 observations,
@@ -673,6 +688,11 @@ mod tests {
                 normalization_count(),
                 MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
                 "each accepted observation is normalized exactly once"
+            );
+            assert_eq!(
+                consistency_key_count(),
+                MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
+                "the bounded consistency pass builds exactly one borrowed key per observation"
             );
             assert!(
                 result.declarations.len() <= MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -32,6 +32,8 @@ pub enum SccmClientDiscoveryObservationState {
     Found,
     AccessDenied,
     NotFound,
+    /// An additive caller-observed state; exhaustive matches must handle it.
+    /// Discovery never infers this state from a rejected observation.
     Skipped,
 }
 
@@ -109,6 +111,8 @@ pub struct SccmClientDiscoveryDeclaration {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct SccmClientDiscoveryResult {
     pub declarations: Vec<SccmClientDiscoveryDeclaration>,
+    /// Additive discovery-only diagnostics. Result struct literals must
+    /// initialize this field; coverage issues never become capture declarations.
     pub coverage_issues: Vec<SccmClientDiscoveryCoverageIssue>,
 }
 
@@ -140,13 +144,6 @@ struct Candidate {
     source_digest: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct PhysicalObservationKey {
-    root_handle: String,
-    canonical_basename: String,
-    rotation: String,
-}
-
 struct NormalizedObservation<'a> {
     observation: &'a SccmClientDiscoveryObservation,
     canonical_basename: String,
@@ -158,24 +155,24 @@ struct NormalizedDiscovery<'a> {
     coverage_issues: Vec<SccmClientDiscoveryCoverageIssue>,
 }
 
-#[derive(Debug, PartialEq)]
-enum PhysicalConsistencyBasename<'a> {
-    Validated(String),
-    Rejected(&'a str),
+#[derive(Debug)]
+enum PhysicalConsistencyKey<'a> {
+    Accepted {
+        root_handle: &'a str,
+        canonical_basename: String,
+        rotation: String,
+    },
+    /// Raw rejected metadata is borrowed only while this bounded map exists.
+    /// Caller-supplied rotation metadata is deliberately excluded.
+    Rejected {
+        root_handle: &'a str,
+        raw_basename: &'a str,
+    },
 }
 
-#[derive(Debug, PartialEq)]
-struct PhysicalConsistencyKey<'a> {
-    /// Rejected raw metadata is borrowed only for this bounded consistency
-    /// pass. It is never cloned, hashed, or returned.
-    root_handle: &'a str,
-    basename: PhysicalConsistencyBasename<'a>,
-    rotation: &'a SccmRotation,
-}
-
-struct PhysicalConsistencyObservation<'a> {
-    key: PhysicalConsistencyKey<'a>,
+struct ConsistentObservation<'a> {
     state: SccmClientDiscoveryObservationState,
+    normalized: Option<NormalizedObservation<'a>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -204,7 +201,6 @@ pub fn discover_client_sources(
         return Err(SccmClientDiscoveryError::ObservationLimitExceeded);
     }
 
-    validate_observation_consistency(&input.observations)?;
     let normalized = normalize_observations(input)?;
     let observations = normalized.observations;
     let mut found_per_source = BTreeMap::<(String, String), usize>::new();
@@ -259,148 +255,136 @@ pub fn discover_client_sources(
     })
 }
 
-fn validate_observation_consistency(
-    observations: &[SccmClientDiscoveryObservation],
-) -> Result<(), SccmClientDiscoveryError> {
-    let mut keyed = observations
-        .iter()
-        .map(|observation| PhysicalConsistencyObservation {
-            key: physical_consistency_key(observation),
-            state: observation.state,
-        })
-        .collect::<Vec<_>>();
-    debug_assert!(keyed.len() <= MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS);
-    keyed.sort_by(compare_physical_consistency_observations);
-
-    let mut group_start = 0;
-    while group_start < keyed.len() {
-        let mut group_end = group_start + 1;
-        while group_end < keyed.len()
-            && compare_physical_consistency_keys(&keyed[group_start].key, &keyed[group_end].key)
-                == Ordering::Equal
-        {
-            group_end += 1;
-        }
-
-        if matches!(keyed[group_start].key.rotation, SccmRotation::Unknown(_)) {
-            for current in group_start..group_end {
-                for previous in group_start..current {
-                    if exact_rotation_eq(keyed[previous].key.rotation, keyed[current].key.rotation)
-                        && keyed[previous].state != keyed[current].state
-                    {
-                        return Err(SccmClientDiscoveryError::ConflictingObservation);
-                    }
-                }
-            }
-        } else if keyed[group_start + 1..group_end]
-            .iter()
-            .any(|observation| observation.state != keyed[group_start].state)
-        {
-            return Err(SccmClientDiscoveryError::ConflictingObservation);
-        }
-
-        group_start = group_end;
-    }
-    Ok(())
-}
-
-fn physical_consistency_key(
-    observation: &SccmClientDiscoveryObservation,
-) -> PhysicalConsistencyKey<'_> {
-    #[cfg(test)]
-    CONSISTENCY_KEY_CONSTRUCTIONS.with(|count| count.set(count.get() + 1));
-    let basename = classify_observation_source(&observation.basename, &observation.rotation)
-        .map(PhysicalConsistencyBasename::Validated)
-        .unwrap_or_else(|| PhysicalConsistencyBasename::Rejected(&observation.basename));
-    PhysicalConsistencyKey {
-        root_handle: &observation.root_handle,
-        basename,
-        rotation: &observation.rotation,
+impl PartialEq for PhysicalConsistencyKey<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
     }
 }
 
-fn compare_physical_consistency_observations(
-    left: &PhysicalConsistencyObservation<'_>,
-    right: &PhysicalConsistencyObservation<'_>,
-) -> Ordering {
-    compare_physical_consistency_keys(&left.key, &right.key)
+impl Eq for PhysicalConsistencyKey<'_> {}
+
+impl PartialOrd for PhysicalConsistencyKey<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
-fn compare_physical_consistency_keys(
-    left: &PhysicalConsistencyKey<'_>,
-    right: &PhysicalConsistencyKey<'_>,
-) -> Ordering {
-    #[cfg(test)]
-    CONSISTENCY_COMPARISONS.with(|count| count.set(count.get() + 1));
-    left.root_handle
-        .cmp(right.root_handle)
-        .then_with(|| compare_physical_consistency_basenames(&left.basename, &right.basename))
-        .then_with(|| rotation_order(left.rotation, right.rotation))
-}
-
-fn exact_rotation_eq(left: &SccmRotation, right: &SccmRotation) -> bool {
-    #[cfg(test)]
-    CONSISTENCY_COMPARISONS.with(|count| count.set(count.get() + 1));
-    left == right
-}
-
-fn compare_physical_consistency_basenames(
-    left: &PhysicalConsistencyBasename<'_>,
-    right: &PhysicalConsistencyBasename<'_>,
-) -> Ordering {
-    match (left, right) {
-        (
-            PhysicalConsistencyBasename::Validated(left),
-            PhysicalConsistencyBasename::Validated(right),
-        ) => left.cmp(right),
-        (PhysicalConsistencyBasename::Validated(_), PhysicalConsistencyBasename::Rejected(_)) => {
-            Ordering::Less
+impl Ord for PhysicalConsistencyKey<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        #[cfg(test)]
+        CONSISTENCY_COMPARISONS.with(|count| count.set(count.get() + 1));
+        match (self, other) {
+            (
+                Self::Accepted {
+                    root_handle: left_root,
+                    canonical_basename: left_basename,
+                    rotation: left_rotation,
+                },
+                Self::Accepted {
+                    root_handle: right_root,
+                    canonical_basename: right_basename,
+                    rotation: right_rotation,
+                },
+            ) => left_root
+                .cmp(right_root)
+                .then_with(|| left_basename.cmp(right_basename))
+                .then_with(|| left_rotation.cmp(right_rotation)),
+            (Self::Accepted { .. }, Self::Rejected { .. }) => Ordering::Less,
+            (Self::Rejected { .. }, Self::Accepted { .. }) => Ordering::Greater,
+            (
+                Self::Rejected {
+                    root_handle: left_root,
+                    raw_basename: left_basename,
+                },
+                Self::Rejected {
+                    root_handle: right_root,
+                    raw_basename: right_basename,
+                },
+            ) => left_root
+                .cmp(right_root)
+                .then_with(|| left_basename.cmp(right_basename)),
         }
-        (PhysicalConsistencyBasename::Rejected(_), PhysicalConsistencyBasename::Validated(_)) => {
-            Ordering::Greater
-        }
-        (
-            PhysicalConsistencyBasename::Rejected(left),
-            PhysicalConsistencyBasename::Rejected(right),
-        ) => left.cmp(right),
     }
 }
 
 fn normalize_observations(
     input: &SccmClientDiscoveryInput,
 ) -> Result<NormalizedDiscovery<'_>, SccmClientDiscoveryError> {
-    let mut observations = BTreeMap::<PhysicalObservationKey, NormalizedObservation<'_>>::new();
+    let mut observations = BTreeMap::<PhysicalConsistencyKey<'_>, ConsistentObservation<'_>>::new();
     let mut coverage_issue_counts = BTreeMap::<CoverageIssueKey, u16>::new();
     for observation in &input.observations {
-        let Some(normalized) = normalize_observation(observation) else {
-            let count = coverage_issue_counts
-                .entry(coverage_issue_key(observation))
-                .or_insert(0_u16);
-            *count = count
-                .checked_add(1)
-                .expect("admitted discovery issue count fits in u16");
-            continue;
-        };
-        let key = PhysicalObservationKey {
-            root_handle: observation.root_handle.clone(),
-            canonical_basename: normalized.canonical_basename.clone(),
-            rotation: rotation_segment(&observation.rotation),
-        };
-        match observations.entry(key) {
+        #[cfg(test)]
+        NORMALIZATION_OPERATIONS.with(|count| count.set(count.get() + 1));
+        let root_is_valid = root_handle_digest(&observation.root_handle).is_some();
+        let canonical_basename =
+            classify_observation_source(&observation.basename, &observation.rotation);
+        #[cfg(test)]
+        CONSISTENCY_KEY_CONSTRUCTIONS.with(|count| count.set(count.get() + 1));
+
+        let (consistency_key, normalized, coverage_issue) =
+            match (root_is_valid, canonical_basename) {
+                (true, Some(canonical_basename)) => {
+                    let consistency_key = PhysicalConsistencyKey::Accepted {
+                        root_handle: &observation.root_handle,
+                        canonical_basename: canonical_basename.clone(),
+                        rotation: rotation_segment(&observation.rotation),
+                    };
+                    let normalized = NormalizedObservation {
+                        observation,
+                        logical_artifact_ids: logical_artifact_ids(&canonical_basename),
+                        canonical_basename,
+                    };
+                    (consistency_key, Some(normalized), None)
+                }
+                (root_is_valid, catalog_basename) => {
+                    let consistency_key = PhysicalConsistencyKey::Rejected {
+                        root_handle: &observation.root_handle,
+                        raw_basename: &observation.basename,
+                    };
+                    let coverage_issue = coverage_issue_key(
+                        root_is_valid,
+                        catalog_basename.as_deref(),
+                        &observation.rotation,
+                    );
+                    (consistency_key, None, Some(coverage_issue))
+                }
+            };
+
+        match observations.entry(consistency_key) {
             std::collections::btree_map::Entry::Vacant(entry) => {
-                entry.insert(normalized);
+                entry.insert(ConsistentObservation {
+                    state: observation.state,
+                    normalized,
+                });
             }
             std::collections::btree_map::Entry::Occupied(mut entry) => {
-                if entry.get().observation.state != observation.state {
+                if entry.get().state != observation.state {
                     return Err(SccmClientDiscoveryError::ConflictingObservation);
                 }
-                if compare_observation_order(&normalized, entry.get()) == Ordering::Less {
-                    entry.insert(normalized);
+                if let Some(normalized) = normalized {
+                    let retained = entry
+                        .get_mut()
+                        .normalized
+                        .as_mut()
+                        .expect("accepted consistency keys retain normalized observations");
+                    if compare_observation_order(&normalized, retained) == Ordering::Less {
+                        *retained = normalized;
+                    }
                 }
             }
         }
+
+        if let Some(coverage_issue) = coverage_issue {
+            let count = coverage_issue_counts.entry(coverage_issue).or_insert(0_u16);
+            *count = count
+                .checked_add(1)
+                .expect("admitted discovery issue count fits in u16");
+        }
     }
-    let mut observations = observations.into_values().collect::<Vec<_>>();
+    let mut observations = observations
+        .into_values()
+        .filter_map(|observation| observation.normalized)
+        .collect::<Vec<_>>();
     observations.sort_by(compare_observation_order);
     debug_assert!(coverage_issue_counts.len() <= MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES);
     Ok(NormalizedDiscovery {
@@ -412,45 +396,30 @@ fn normalize_observations(
     })
 }
 
-fn normalize_observation(
-    observation: &SccmClientDiscoveryObservation,
-) -> Option<NormalizedObservation<'_>> {
-    #[cfg(test)]
-    NORMALIZATION_OPERATIONS.with(|count| count.set(count.get() + 1));
-    root_handle_digest(&observation.root_handle)?;
-    let canonical_basename =
-        classify_observation_source(&observation.basename, &observation.rotation)?;
-    let logical_artifact_ids = logical_artifact_ids(&canonical_basename);
-    Some(NormalizedObservation {
-        observation,
-        canonical_basename,
-        logical_artifact_ids,
-    })
-}
-
-fn coverage_issue_key(observation: &SccmClientDiscoveryObservation) -> CoverageIssueKey {
-    let root_is_valid = root_handle_digest(&observation.root_handle).is_some();
-    let catalog_basename =
-        classify_observation_source(&observation.basename, &observation.rotation);
+fn coverage_issue_key(
+    root_is_valid: bool,
+    catalog_basename: Option<&str>,
+    rotation: &SccmRotation,
+) -> CoverageIssueKey {
     let state = if root_is_valid {
         SccmClientDiscoveryCoverageIssueState::Unsupported
     } else {
         SccmClientDiscoveryCoverageIssueState::InvalidProvenance
     };
     let catalog_entry_id = catalog_basename
-        .as_deref()
         .map(catalog_entry_id)
         .unwrap_or_else(|| "sccm-client-source:v1:none".to_owned());
     let logical_artifact_ids = if state == SccmClientDiscoveryCoverageIssueState::InvalidProvenance
     {
         catalog_basename
-            .as_deref()
             .map(logical_artifact_ids)
             .unwrap_or_default()
     } else {
         Vec::new()
     };
-    let rotation_category = rotation_category(&observation.rotation);
+    let rotation_category = catalog_basename
+        .map(|_| rotation_category(rotation))
+        .unwrap_or(SccmClientDiscoveryRotationCategory::Unknown);
     CoverageIssueKey {
         catalog_entry_id,
         logical_artifact_ids,

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -3,6 +3,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
+use std::num::NonZeroU16;
 
 #[cfg(test)]
 use std::cell::Cell;
@@ -71,6 +72,9 @@ pub struct SccmClientDiscoveryCoverageIssue {
     pub logical_artifact_ids: Vec<String>,
     pub rotation_category: SccmClientDiscoveryRotationCategory,
     pub state: SccmClientDiscoveryCoverageIssueState,
+    /// Number of supplied observations represented by this privacy-safe issue
+    /// category. The category identity intentionally remains count-independent.
+    pub occurrence_count: NonZeroU16,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -227,10 +231,15 @@ fn normalize_observations(
     input: &SccmClientDiscoveryInput,
 ) -> Result<NormalizedDiscovery<'_>, SccmClientDiscoveryError> {
     let mut observations = BTreeMap::<PhysicalObservationKey, NormalizedObservation<'_>>::new();
-    let mut coverage_issues = BTreeSet::new();
+    let mut coverage_issue_counts = BTreeMap::new();
     for observation in &input.observations {
         let Some(normalized) = normalize_observation(observation) else {
-            coverage_issues.insert(coverage_issue_from_observation(observation));
+            let count = coverage_issue_counts
+                .entry(coverage_issue_from_observation(observation))
+                .or_insert(0_u16);
+            *count = count
+                .checked_add(1)
+                .expect("admitted discovery issue count fits in u16");
             continue;
         };
         let key = PhysicalObservationKey {
@@ -254,10 +263,17 @@ fn normalize_observations(
     }
     let mut observations = observations.into_values().collect::<Vec<_>>();
     observations.sort_by(compare_observation_order);
-    debug_assert!(coverage_issues.len() <= MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES);
+    debug_assert!(coverage_issue_counts.len() <= MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES);
     Ok(NormalizedDiscovery {
         observations,
-        coverage_issues: coverage_issues.into_iter().collect(),
+        coverage_issues: coverage_issue_counts
+            .into_iter()
+            .map(|(mut issue, count)| {
+                issue.occurrence_count = NonZeroU16::new(count)
+                    .expect("every coverage issue represents an admitted observation");
+                issue
+            })
+            .collect(),
     })
 }
 
@@ -307,6 +323,7 @@ fn coverage_issue_from_observation(
         logical_artifact_ids,
         rotation_category,
         state,
+        occurrence_count: NonZeroU16::MIN,
     }
 }
 

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -13,7 +13,7 @@ use super::contract::{
     rotation_order, rotation_segment, sha256_bytes, source_identity_digest,
     SccmManifestSourceState,
 };
-use cmtraceopen_parser::sccm::SccmRotation;
+use cmtraceopen_parser::sccm::{classify_artifact_name, SccmRole, SccmRotation};
 
 pub const MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS: usize = 4_096;
 /// Defensive bound for supplied observations. Native enumeration must report
@@ -21,12 +21,17 @@ pub const MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS: usize = 4_096;
 /// discard observations beyond the contract.
 pub const MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS: usize =
     MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS + 1;
+/// Coverage issues are derived only from admitted observations. They remain
+/// separately bounded without sharing the declaration budget, so a capture
+/// frontier cannot hide coverage loss.
+pub const MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES: usize = MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SccmClientDiscoveryObservationState {
     Found,
     AccessDenied,
     NotFound,
+    Skipped,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,6 +40,37 @@ pub enum SccmClientDiscoveryState {
     AccessDenied,
     NotFound,
     Capped,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SccmClientDiscoveryCoverageIssueState {
+    InvalidProvenance,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SccmClientDiscoveryRotationCategory {
+    Current,
+    LoUnderscore,
+    Numbered,
+    Timestamped,
+    Unknown,
+}
+
+/// Coverage-only metadata intentionally kept out of declarations. These
+/// issues cannot be captured or interpreted as workflow evidence.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SccmClientDiscoveryCoverageIssue {
+    pub artifact_id: String,
+    /// A validated catalog identity or the fixed `none` category. It never
+    /// derives from an unvalidated basename or root handle.
+    pub catalog_entry_id: String,
+    /// Invalid provenance can affect a known workflow group; unsupported
+    /// observations always have zero memberships.
+    pub logical_artifact_ids: Vec<String>,
+    pub rotation_category: SccmClientDiscoveryRotationCategory,
+    pub state: SccmClientDiscoveryCoverageIssueState,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -69,6 +105,7 @@ pub struct SccmClientDiscoveryDeclaration {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct SccmClientDiscoveryResult {
     pub declarations: Vec<SccmClientDiscoveryDeclaration>,
+    pub coverage_issues: Vec<SccmClientDiscoveryCoverageIssue>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -112,6 +149,11 @@ struct NormalizedObservation<'a> {
     logical_artifact_ids: Vec<String>,
 }
 
+struct NormalizedDiscovery<'a> {
+    observations: Vec<NormalizedObservation<'a>>,
+    coverage_issues: Vec<SccmClientDiscoveryCoverageIssue>,
+}
+
 #[cfg(test)]
 thread_local! {
     static CANDIDATE_CONSTRUCTIONS: Cell<usize> = const { Cell::new(0) };
@@ -127,7 +169,8 @@ pub fn discover_client_sources(
         return Err(SccmClientDiscoveryError::ObservationLimitExceeded);
     }
 
-    let observations = normalize_observations(input)?;
+    let normalized = normalize_observations(input)?;
+    let observations = normalized.observations;
     let mut found_per_source = BTreeMap::<(String, String), usize>::new();
     let mut capped_sources = BTreeSet::<(String, String)>::new();
     let mut declarations = Vec::with_capacity(
@@ -158,7 +201,10 @@ pub fn discover_client_sources(
                 candidate_from_observation(&first_omitted).expect("prevalidated observation"),
                 SccmClientDiscoveryState::Capped,
             ));
-            return Ok(SccmClientDiscoveryResult { declarations });
+            return Ok(SccmClientDiscoveryResult {
+                declarations,
+                coverage_issues: normalized.coverage_issues,
+            });
         } else {
             first_omitted = Some((observation, state));
         }
@@ -171,15 +217,20 @@ pub fn discover_client_sources(
         ));
     }
 
-    Ok(SccmClientDiscoveryResult { declarations })
+    Ok(SccmClientDiscoveryResult {
+        declarations,
+        coverage_issues: normalized.coverage_issues,
+    })
 }
 
 fn normalize_observations(
     input: &SccmClientDiscoveryInput,
-) -> Result<Vec<NormalizedObservation<'_>>, SccmClientDiscoveryError> {
+) -> Result<NormalizedDiscovery<'_>, SccmClientDiscoveryError> {
     let mut observations = BTreeMap::<PhysicalObservationKey, NormalizedObservation<'_>>::new();
+    let mut coverage_issues = BTreeSet::new();
     for observation in &input.observations {
         let Some(normalized) = normalize_observation(observation) else {
+            coverage_issues.insert(coverage_issue_from_observation(observation));
             continue;
         };
         let key = PhysicalObservationKey {
@@ -203,7 +254,11 @@ fn normalize_observations(
     }
     let mut observations = observations.into_values().collect::<Vec<_>>();
     observations.sort_by(compare_observation_order);
-    Ok(observations)
+    debug_assert!(coverage_issues.len() <= MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES);
+    Ok(NormalizedDiscovery {
+        observations,
+        coverage_issues: coverage_issues.into_iter().collect(),
+    })
 }
 
 fn normalize_observation(
@@ -219,6 +274,81 @@ fn normalize_observation(
         canonical_basename,
         logical_artifact_ids,
     })
+}
+
+fn coverage_issue_from_observation(
+    observation: &SccmClientDiscoveryObservation,
+) -> SccmClientDiscoveryCoverageIssue {
+    let root_is_valid = root_handle_digest(&observation.root_handle).is_some();
+    let catalog_basename = catalogued_basename(&observation.basename);
+    let state = if root_is_valid {
+        SccmClientDiscoveryCoverageIssueState::Unsupported
+    } else {
+        SccmClientDiscoveryCoverageIssueState::InvalidProvenance
+    };
+    let catalog_entry_id = catalog_basename
+        .as_deref()
+        .map(catalog_entry_id)
+        .unwrap_or_else(|| "sccm-client-source:v1:none".to_owned());
+    let logical_artifact_ids = if state == SccmClientDiscoveryCoverageIssueState::InvalidProvenance
+    {
+        catalog_basename
+            .as_deref()
+            .map(logical_artifact_ids)
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let rotation_category = rotation_category(&observation.rotation);
+    let artifact_id = coverage_issue_id(&catalog_entry_id, rotation_category, state);
+    SccmClientDiscoveryCoverageIssue {
+        artifact_id,
+        catalog_entry_id,
+        logical_artifact_ids,
+        rotation_category,
+        state,
+    }
+}
+
+fn catalogued_basename(basename: &str) -> Option<String> {
+    let classified = classify_artifact_name(basename, SccmRole::Client);
+    (!logical_artifact_ids_for_basename(&classified.basename).is_empty())
+        .then_some(classified.basename)
+}
+
+fn rotation_category(rotation: &SccmRotation) -> SccmClientDiscoveryRotationCategory {
+    match rotation {
+        SccmRotation::Current => SccmClientDiscoveryRotationCategory::Current,
+        SccmRotation::LoUnderscore => SccmClientDiscoveryRotationCategory::LoUnderscore,
+        SccmRotation::Numbered(_) => SccmClientDiscoveryRotationCategory::Numbered,
+        SccmRotation::Timestamped(_) => SccmClientDiscoveryRotationCategory::Timestamped,
+        SccmRotation::Unknown(_) => SccmClientDiscoveryRotationCategory::Unknown,
+    }
+}
+
+fn coverage_issue_id(
+    catalog_entry_id: &str,
+    rotation_category: SccmClientDiscoveryRotationCategory,
+    state: SccmClientDiscoveryCoverageIssueState,
+) -> String {
+    let rotation = match rotation_category {
+        SccmClientDiscoveryRotationCategory::Current => "current",
+        SccmClientDiscoveryRotationCategory::LoUnderscore => "lo",
+        SccmClientDiscoveryRotationCategory::Numbered => "numbered",
+        SccmClientDiscoveryRotationCategory::Timestamped => "timestamped",
+        SccmClientDiscoveryRotationCategory::Unknown => "unknown",
+    };
+    let state = match state {
+        SccmClientDiscoveryCoverageIssueState::InvalidProvenance => "invalid-provenance",
+        SccmClientDiscoveryCoverageIssueState::Unsupported => "unsupported",
+    };
+    let value = format!(
+        "cmtraceopen.sccm.discovery.coverage.v1\\0{catalog_entry_id}\\0{rotation}\\0{state}"
+    );
+    format!(
+        "sccm-discovery-coverage:v1:sha256:{}",
+        sha256_bytes(value.as_bytes())
+    )
 }
 
 fn selection_state(
@@ -245,6 +375,7 @@ fn selection_state(
         }
         SccmClientDiscoveryObservationState::AccessDenied => SccmClientDiscoveryState::AccessDenied,
         SccmClientDiscoveryObservationState::NotFound => SccmClientDiscoveryState::NotFound,
+        SccmClientDiscoveryObservationState::Skipped => SccmClientDiscoveryState::Skipped,
     })
 }
 
@@ -300,6 +431,13 @@ fn declaration_from_candidate(
         SccmClientDiscoveryState::Capped => marker_id(
             &candidate.catalog_entry_id,
             SccmManifestSourceState::Capped,
+            &candidate.observation.rotation,
+            &candidate.observation.basename,
+            &path_fingerprint,
+        ),
+        SccmClientDiscoveryState::Skipped => marker_id(
+            &candidate.catalog_entry_id,
+            SccmManifestSourceState::Skipped,
             &candidate.observation.rotation,
             &candidate.observation.basename,
             &path_fingerprint,
@@ -394,6 +532,7 @@ fn state_rank(state: SccmClientDiscoveryObservationState) -> u8 {
         SccmClientDiscoveryObservationState::Found => 0,
         SccmClientDiscoveryObservationState::AccessDenied => 1,
         SccmClientDiscoveryObservationState::NotFound => 2,
+        SccmClientDiscoveryObservationState::Skipped => 3,
     }
 }
 

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -744,6 +744,13 @@ mod tests {
         }
     }
 
+    fn unsupported_rotation(suffix: &str) -> SccmRotation {
+        SccmRotation::Unknown(cmtraceopen_parser::sccm::SccmUnknownRotation {
+            kind: "filenameSuffix".to_owned(),
+            value: Some(serde_json::Value::String(suffix.to_owned())),
+        })
+    }
+
     fn construction_counts() -> (usize, usize) {
         (
             CANDIDATE_CONSTRUCTIONS.with(Cell::get),
@@ -941,10 +948,7 @@ mod tests {
             .map(|_| SccmClientDiscoveryObservation {
                 root_handle: "unvalidated-root".to_owned(),
                 basename: "Unrelated.log.backup".to_owned(),
-                rotation: SccmRotation::Unknown(cmtraceopen_parser::sccm::SccmUnknownRotation {
-                    kind: "filenameSuffix".to_owned(),
-                    value: Some(serde_json::Value::String(".backup".to_owned())),
-                }),
+                rotation: unsupported_rotation(".backup"),
                 state: SccmClientDiscoveryObservationState::Found,
             })
             .collect();

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -244,6 +244,8 @@ pub fn discover_client_sources(
     }
 
     if selected.len() > MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS {
+        // Retain the first MAX - 1 sorted observations and the deterministic
+        // terminal observation; summarize only the omitted middle declarations.
         let terminal = selected
             .pop()
             .expect("an over-cap selection has a terminal observation");
@@ -468,6 +470,10 @@ fn coverage_issue_from_key(
         state,
         omitted_declaration_state,
     } = key;
+    assert!(
+        logical_artifact_ids.is_empty(),
+        "coverage issues cannot assert workflow membership"
+    );
     let artifact_id = coverage_issue_id(
         &catalog_entry_id,
         rotation_category,

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -69,8 +69,8 @@ pub struct SccmClientDiscoveryCoverageIssue {
     /// A validated catalog identity or the fixed `none` category. It never
     /// derives from an unvalidated basename or root handle.
     pub catalog_entry_id: String,
-    /// Invalid provenance can affect a known workflow group; unsupported
-    /// observations always have zero memberships.
+    /// Rejected observations never assert workflow membership, even when a
+    /// privacy-safe catalog identity can still be retained.
     pub logical_artifact_ids: Vec<String>,
     pub rotation_category: SccmClientDiscoveryRotationCategory,
     pub state: SccmClientDiscoveryCoverageIssueState,
@@ -341,11 +341,8 @@ fn normalize_observations(
                         root_handle: &observation.root_handle,
                         raw_basename: &observation.basename,
                     };
-                    let coverage_issue = coverage_issue_key(
-                        root_is_valid,
-                        catalog_basename.as_deref(),
-                        &observation.rotation,
-                    );
+                    let coverage_issue =
+                        coverage_issue_key(root_is_valid, catalog_basename.as_deref());
                     (consistency_key, None, Some(coverage_issue))
                 }
             };
@@ -396,11 +393,7 @@ fn normalize_observations(
     })
 }
 
-fn coverage_issue_key(
-    root_is_valid: bool,
-    catalog_basename: Option<&str>,
-    rotation: &SccmRotation,
-) -> CoverageIssueKey {
+fn coverage_issue_key(root_is_valid: bool, catalog_basename: Option<&str>) -> CoverageIssueKey {
     let state = if root_is_valid {
         SccmClientDiscoveryCoverageIssueState::Unsupported
     } else {
@@ -409,21 +402,10 @@ fn coverage_issue_key(
     let catalog_entry_id = catalog_basename
         .map(catalog_entry_id)
         .unwrap_or_else(|| "sccm-client-source:v1:none".to_owned());
-    let logical_artifact_ids = if state == SccmClientDiscoveryCoverageIssueState::InvalidProvenance
-    {
-        catalog_basename
-            .map(logical_artifact_ids)
-            .unwrap_or_default()
-    } else {
-        Vec::new()
-    };
-    let rotation_category = catalog_basename
-        .map(|_| rotation_category(rotation))
-        .unwrap_or(SccmClientDiscoveryRotationCategory::Unknown);
     CoverageIssueKey {
         catalog_entry_id,
-        logical_artifact_ids,
-        rotation_category,
+        logical_artifact_ids: Vec::new(),
+        rotation_category: SccmClientDiscoveryRotationCategory::Unknown,
         state,
     }
 }
@@ -454,16 +436,6 @@ fn classify_observation_source(basename: &str, rotation: &SccmRotation) -> Optio
     #[cfg(test)]
     CLASSIFIER_INVOCATIONS.with(|count| count.set(count.get() + 1));
     canonical_client_source(basename, rotation)
-}
-
-fn rotation_category(rotation: &SccmRotation) -> SccmClientDiscoveryRotationCategory {
-    match rotation {
-        SccmRotation::Current => SccmClientDiscoveryRotationCategory::Current,
-        SccmRotation::LoUnderscore => SccmClientDiscoveryRotationCategory::LoUnderscore,
-        SccmRotation::Numbered(_) => SccmClientDiscoveryRotationCategory::Numbered,
-        SccmRotation::Timestamped(_) => SccmClientDiscoveryRotationCategory::Timestamped,
-        SccmRotation::Unknown(_) => SccmClientDiscoveryRotationCategory::Unknown,
-    }
 }
 
 fn coverage_issue_id(

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -156,23 +156,30 @@ struct NormalizedDiscovery<'a> {
 }
 
 #[derive(Debug)]
-enum PhysicalConsistencyKey<'a> {
-    Accepted {
-        root_handle: &'a str,
-        canonical_basename: String,
-        rotation: String,
-    },
-    /// Raw rejected metadata is borrowed only while this bounded map exists.
-    /// Caller-supplied rotation metadata is deliberately excluded.
-    Rejected {
-        root_handle: &'a str,
-        raw_basename: &'a str,
-    },
+struct RawPhysicalIdentity<'a> {
+    /// Raw metadata is borrowed only while the bounded consistency map exists.
+    /// Rotation and classification never change this exact physical identity.
+    root_handle: &'a str,
+    raw_basename: &'a str,
 }
 
-struct ConsistentObservation<'a> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ObservationDisposition {
+    Accepted,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ObservationFacts {
     state: SccmClientDiscoveryObservationState,
-    normalized: Option<NormalizedObservation<'a>>,
+    disposition: ObservationDisposition,
+}
+
+#[derive(Debug)]
+struct CanonicalPhysicalIdentity<'a> {
+    root_handle: &'a str,
+    canonical_basename: String,
+    rotation: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -255,62 +262,64 @@ pub fn discover_client_sources(
     })
 }
 
-impl PartialEq for PhysicalConsistencyKey<'_> {
+impl PartialEq for RawPhysicalIdentity<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal
     }
 }
 
-impl Eq for PhysicalConsistencyKey<'_> {}
+impl Eq for RawPhysicalIdentity<'_> {}
 
-impl PartialOrd for PhysicalConsistencyKey<'_> {
+impl PartialOrd for RawPhysicalIdentity<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for PhysicalConsistencyKey<'_> {
+impl Ord for RawPhysicalIdentity<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
-        #[cfg(test)]
-        CONSISTENCY_COMPARISONS.with(|count| count.set(count.get() + 1));
-        match (self, other) {
-            (
-                Self::Accepted {
-                    root_handle: left_root,
-                    canonical_basename: left_basename,
-                    rotation: left_rotation,
-                },
-                Self::Accepted {
-                    root_handle: right_root,
-                    canonical_basename: right_basename,
-                    rotation: right_rotation,
-                },
-            ) => left_root
-                .cmp(right_root)
-                .then_with(|| left_basename.cmp(right_basename))
-                .then_with(|| left_rotation.cmp(right_rotation)),
-            (Self::Accepted { .. }, Self::Rejected { .. }) => Ordering::Less,
-            (Self::Rejected { .. }, Self::Accepted { .. }) => Ordering::Greater,
-            (
-                Self::Rejected {
-                    root_handle: left_root,
-                    raw_basename: left_basename,
-                },
-                Self::Rejected {
-                    root_handle: right_root,
-                    raw_basename: right_basename,
-                },
-            ) => left_root
-                .cmp(right_root)
-                .then_with(|| left_basename.cmp(right_basename)),
-        }
+        record_consistency_comparison();
+        self.root_handle
+            .cmp(other.root_handle)
+            .then_with(|| self.raw_basename.cmp(other.raw_basename))
     }
+}
+
+impl PartialEq for CanonicalPhysicalIdentity<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for CanonicalPhysicalIdentity<'_> {}
+
+impl PartialOrd for CanonicalPhysicalIdentity<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CanonicalPhysicalIdentity<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        record_consistency_comparison();
+        self.root_handle
+            .cmp(other.root_handle)
+            .then_with(|| self.canonical_basename.cmp(&other.canonical_basename))
+            .then_with(|| self.rotation.cmp(&other.rotation))
+    }
+}
+
+fn record_consistency_comparison() {
+    #[cfg(test)]
+    CONSISTENCY_COMPARISONS.with(|count| count.set(count.get() + 1));
 }
 
 fn normalize_observations(
     input: &SccmClientDiscoveryInput,
 ) -> Result<NormalizedDiscovery<'_>, SccmClientDiscoveryError> {
-    let mut observations = BTreeMap::<PhysicalConsistencyKey<'_>, ConsistentObservation<'_>>::new();
+    let mut physical_facts = BTreeMap::<RawPhysicalIdentity<'_>, ObservationFacts>::new();
+    let mut observations =
+        BTreeMap::<CanonicalPhysicalIdentity<'_>, NormalizedObservation<'_>>::new();
     let mut coverage_issue_counts = BTreeMap::<CoverageIssueKey, u16>::new();
     for observation in &input.observations {
         #[cfg(test)]
@@ -321,67 +330,66 @@ fn normalize_observations(
         #[cfg(test)]
         CONSISTENCY_KEY_CONSTRUCTIONS.with(|count| count.set(count.get() + 1));
 
-        let (consistency_key, normalized, coverage_issue) =
-            match (root_is_valid, canonical_basename) {
-                (true, Some(canonical_basename)) => {
-                    let consistency_key = PhysicalConsistencyKey::Accepted {
-                        root_handle: &observation.root_handle,
-                        canonical_basename: canonical_basename.clone(),
-                        rotation: rotation_segment(&observation.rotation),
-                    };
-                    let normalized = NormalizedObservation {
-                        observation,
-                        logical_artifact_ids: logical_artifact_ids(&canonical_basename),
-                        canonical_basename,
-                    };
-                    (consistency_key, Some(normalized), None)
-                }
-                (root_is_valid, catalog_basename) => {
-                    let consistency_key = PhysicalConsistencyKey::Rejected {
-                        root_handle: &observation.root_handle,
-                        raw_basename: &observation.basename,
-                    };
-                    let coverage_issue =
-                        coverage_issue_key(root_is_valid, catalog_basename.as_deref());
-                    (consistency_key, None, Some(coverage_issue))
-                }
-            };
-
-        match observations.entry(consistency_key) {
+        let disposition = if root_is_valid && canonical_basename.is_some() {
+            ObservationDisposition::Accepted
+        } else {
+            ObservationDisposition::Rejected
+        };
+        let facts = ObservationFacts {
+            state: observation.state,
+            disposition,
+        };
+        let raw_identity = RawPhysicalIdentity {
+            root_handle: &observation.root_handle,
+            raw_basename: &observation.basename,
+        };
+        match physical_facts.entry(raw_identity) {
             std::collections::btree_map::Entry::Vacant(entry) => {
-                entry.insert(ConsistentObservation {
-                    state: observation.state,
-                    normalized,
-                });
+                entry.insert(facts);
             }
-            std::collections::btree_map::Entry::Occupied(mut entry) => {
-                if entry.get().state != observation.state {
+            std::collections::btree_map::Entry::Occupied(entry) => {
+                if *entry.get() != facts {
                     return Err(SccmClientDiscoveryError::ConflictingObservation);
                 }
-                if let Some(normalized) = normalized {
-                    let retained = entry
-                        .get_mut()
-                        .normalized
-                        .as_mut()
-                        .expect("accepted consistency keys retain normalized observations");
-                    if compare_observation_order(&normalized, retained) == Ordering::Less {
-                        *retained = normalized;
+            }
+        }
+
+        match (root_is_valid, canonical_basename) {
+            (true, Some(canonical_basename)) => {
+                let key = CanonicalPhysicalIdentity {
+                    root_handle: &observation.root_handle,
+                    canonical_basename: canonical_basename.clone(),
+                    rotation: rotation_segment(&observation.rotation),
+                };
+                let normalized = NormalizedObservation {
+                    observation,
+                    logical_artifact_ids: logical_artifact_ids(&canonical_basename),
+                    canonical_basename,
+                };
+                match observations.entry(key) {
+                    std::collections::btree_map::Entry::Vacant(entry) => {
+                        entry.insert(normalized);
+                    }
+                    std::collections::btree_map::Entry::Occupied(mut entry) => {
+                        if entry.get().observation.state != observation.state {
+                            return Err(SccmClientDiscoveryError::ConflictingObservation);
+                        }
+                        if compare_observation_order(&normalized, entry.get()) == Ordering::Less {
+                            entry.insert(normalized);
+                        }
                     }
                 }
             }
-        }
-
-        if let Some(coverage_issue) = coverage_issue {
-            let count = coverage_issue_counts.entry(coverage_issue).or_insert(0_u16);
-            *count = count
-                .checked_add(1)
-                .expect("admitted discovery issue count fits in u16");
+            (root_is_valid, catalog_basename) => {
+                let coverage_issue = coverage_issue_key(root_is_valid, catalog_basename.as_deref());
+                let count = coverage_issue_counts.entry(coverage_issue).or_insert(0_u16);
+                *count = count
+                    .checked_add(1)
+                    .expect("admitted discovery issue count fits in u16");
+            }
         }
     }
-    let mut observations = observations
-        .into_values()
-        .filter_map(|observation| observation.normalized)
-        .collect::<Vec<_>>();
+    let mut observations = observations.into_values().collect::<Vec<_>>();
     observations.sort_by(compare_observation_order);
     debug_assert!(coverage_issue_counts.len() <= MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES);
     Ok(NormalizedDiscovery {

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -193,6 +193,8 @@ thread_local! {
     static NORMALIZATION_OPERATIONS: Cell<usize> = const { Cell::new(0) };
     static LOGICAL_ARTIFACT_ID_LOOKUPS: Cell<usize> = const { Cell::new(0) };
     static CONSISTENCY_KEY_CONSTRUCTIONS: Cell<usize> = const { Cell::new(0) };
+    static CLASSIFIER_INVOCATIONS: Cell<usize> = const { Cell::new(0) };
+    static CONSISTENCY_COMPARISONS: Cell<usize> = const { Cell::new(0) };
 }
 
 pub fn discover_client_sources(
@@ -283,7 +285,7 @@ fn validate_observation_consistency(
         if matches!(keyed[group_start].key.rotation, SccmRotation::Unknown(_)) {
             for current in group_start..group_end {
                 for previous in group_start..current {
-                    if keyed[previous].key.rotation == keyed[current].key.rotation
+                    if exact_rotation_eq(keyed[previous].key.rotation, keyed[current].key.rotation)
                         && keyed[previous].state != keyed[current].state
                     {
                         return Err(SccmClientDiscoveryError::ConflictingObservation);
@@ -307,7 +309,7 @@ fn physical_consistency_key(
 ) -> PhysicalConsistencyKey<'_> {
     #[cfg(test)]
     CONSISTENCY_KEY_CONSTRUCTIONS.with(|count| count.set(count.get() + 1));
-    let basename = canonical_client_source(&observation.basename, &observation.rotation)
+    let basename = classify_observation_source(&observation.basename, &observation.rotation)
         .map(PhysicalConsistencyBasename::Validated)
         .unwrap_or_else(|| PhysicalConsistencyBasename::Rejected(&observation.basename));
     PhysicalConsistencyKey {
@@ -328,10 +330,18 @@ fn compare_physical_consistency_keys(
     left: &PhysicalConsistencyKey<'_>,
     right: &PhysicalConsistencyKey<'_>,
 ) -> Ordering {
+    #[cfg(test)]
+    CONSISTENCY_COMPARISONS.with(|count| count.set(count.get() + 1));
     left.root_handle
         .cmp(right.root_handle)
         .then_with(|| compare_physical_consistency_basenames(&left.basename, &right.basename))
         .then_with(|| rotation_order(left.rotation, right.rotation))
+}
+
+fn exact_rotation_eq(left: &SccmRotation, right: &SccmRotation) -> bool {
+    #[cfg(test)]
+    CONSISTENCY_COMPARISONS.with(|count| count.set(count.get() + 1));
+    left == right
 }
 
 fn compare_physical_consistency_basenames(
@@ -408,7 +418,8 @@ fn normalize_observation(
     #[cfg(test)]
     NORMALIZATION_OPERATIONS.with(|count| count.set(count.get() + 1));
     root_handle_digest(&observation.root_handle)?;
-    let canonical_basename = canonical_client_source(&observation.basename, &observation.rotation)?;
+    let canonical_basename =
+        classify_observation_source(&observation.basename, &observation.rotation)?;
     let logical_artifact_ids = logical_artifact_ids(&canonical_basename);
     Some(NormalizedObservation {
         observation,
@@ -419,7 +430,8 @@ fn normalize_observation(
 
 fn coverage_issue_key(observation: &SccmClientDiscoveryObservation) -> CoverageIssueKey {
     let root_is_valid = root_handle_digest(&observation.root_handle).is_some();
-    let catalog_basename = canonical_client_source(&observation.basename, &observation.rotation);
+    let catalog_basename =
+        classify_observation_source(&observation.basename, &observation.rotation);
     let state = if root_is_valid {
         SccmClientDiscoveryCoverageIssueState::Unsupported
     } else {
@@ -467,6 +479,12 @@ fn coverage_issue_from_key(
         occurrence_count: NonZeroU16::new(occurrence_count)
             .expect("every coverage issue represents an admitted observation"),
     }
+}
+
+fn classify_observation_source(basename: &str, rotation: &SccmRotation) -> Option<String> {
+    #[cfg(test)]
+    CLASSIFIER_INVOCATIONS.with(|count| count.set(count.get() + 1));
+    canonical_client_source(basename, rotation)
 }
 
 fn rotation_category(rotation: &SccmRotation) -> SccmClientDiscoveryRotationCategory {
@@ -745,6 +763,27 @@ mod tests {
         CONSISTENCY_KEY_CONSTRUCTIONS.with(|count| count.set(0));
     }
 
+    fn classifier_invocation_count() -> usize {
+        CLASSIFIER_INVOCATIONS.with(Cell::get)
+    }
+
+    fn consistency_comparison_count() -> usize {
+        CONSISTENCY_COMPARISONS.with(Cell::get)
+    }
+
+    fn reset_classification_work_counts() {
+        CLASSIFIER_INVOCATIONS.with(|count| count.set(0));
+        CONSISTENCY_COMPARISONS.with(|count| count.set(0));
+    }
+
+    fn comparison_budget(observation_count: usize) -> usize {
+        let log_bound =
+            usize::BITS as usize - observation_count.saturating_sub(1).leading_zeros() as usize;
+        observation_count
+            .saturating_mul(log_bound.saturating_add(2))
+            .saturating_mul(4)
+    }
+
     #[test]
     fn defensive_observation_limit_rejects_before_any_normalization_or_construction() {
         let observations = (1..=MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS + 1)
@@ -764,6 +803,7 @@ mod tests {
         reset_construction_counts();
         reset_normalization_count();
         reset_consistency_key_count();
+        reset_classification_work_counts();
         assert_eq!(
             discover_client_sources(&input),
             Err(SccmClientDiscoveryError::ObservationLimitExceeded),
@@ -784,6 +824,8 @@ mod tests {
             0,
             "the defensive limit rejects before ephemeral consistency keys are built"
         );
+        assert_eq!(classifier_invocation_count(), 0);
+        assert_eq!(consistency_comparison_count(), 0);
     }
 
     #[test]
@@ -814,6 +856,7 @@ mod tests {
             reset_construction_counts();
             reset_normalization_count();
             reset_consistency_key_count();
+            reset_classification_work_counts();
             let result = discover_client_sources(&SccmClientDiscoveryInput {
                 max_found_fragments_per_source: MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
                 observations,
@@ -829,6 +872,18 @@ mod tests {
                 consistency_key_count(),
                 MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
                 "the bounded consistency pass builds exactly one borrowed key per observation"
+            );
+            assert_eq!(
+                classifier_invocation_count(),
+                MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
+                "every admitted observation is classified at most once"
+            );
+            assert!(
+                consistency_comparison_count()
+                    <= comparison_budget(MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS),
+                "consistency work must remain O(n log n): {} comparisons exceeded {}",
+                consistency_comparison_count(),
+                comparison_budget(MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS),
             );
             assert!(
                 result.declarations.len() <= MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
@@ -860,6 +915,47 @@ mod tests {
             logical_artifact_id_lookup_count(),
             64,
             "sorting and declaration construction must reuse each normalized observation's cached logical IDs"
+        );
+    }
+
+    #[test]
+    fn rejected_duplicate_boundary_has_bounded_classification_and_consistency_work() {
+        let observations = (0..MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS)
+            .map(|_| SccmClientDiscoveryObservation {
+                root_handle: "unvalidated-root".to_owned(),
+                basename: "Unrelated.log.backup".to_owned(),
+                rotation: SccmRotation::Unknown(cmtraceopen_parser::sccm::SccmUnknownRotation {
+                    kind: "filenameSuffix".to_owned(),
+                    value: Some(serde_json::Value::String(".backup".to_owned())),
+                }),
+                state: SccmClientDiscoveryObservationState::Found,
+            })
+            .collect();
+
+        reset_classification_work_counts();
+        let result = discover_client_sources(&SccmClientDiscoveryInput {
+            max_found_fragments_per_source: MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
+            observations,
+        })
+        .expect("same-state rejected duplicates remain countable at the admission boundary");
+
+        assert!(result.declarations.is_empty());
+        assert_eq!(result.coverage_issues.len(), 1);
+        assert_eq!(
+            result.coverage_issues[0].occurrence_count.get() as usize,
+            MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS
+        );
+        assert!(
+            consistency_comparison_count()
+                <= comparison_budget(MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS),
+            "rejected consistency work must remain O(n log n): {} comparisons exceeded {}",
+            consistency_comparison_count(),
+            comparison_budget(MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS),
+        );
+        assert_eq!(
+            classifier_invocation_count(),
+            MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
+            "every rejected observation is classified at most once"
         );
     }
 

--- a/src-tauri/src/sccm/discovery.rs
+++ b/src-tauri/src/sccm/discovery.rs
@@ -26,6 +26,8 @@ pub const MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS: usize =
 /// separately bounded without sharing the declaration budget, so a capture
 /// frontier cannot hide coverage loss.
 pub const MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES: usize = MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS;
+/// Privacy-safe catalog identity used when no validated catalog entry exists.
+const NO_CATALOG_ENTRY_ID: &str = "sccm-client-source:v1:none";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SccmClientDiscoveryObservationState {
@@ -393,8 +395,9 @@ fn normalize_observations(
                     }
                 }
             }
-            (root_is_valid, catalog_basename) => {
-                let coverage_issue = coverage_issue_key(root_is_valid, catalog_basename.as_deref());
+            (rejected_root_is_valid, catalog_basename) => {
+                let coverage_issue =
+                    coverage_issue_key(rejected_root_is_valid, catalog_basename.as_deref());
                 add_coverage_issue_count(&mut coverage_issue_counts, coverage_issue, 1);
             }
         }
@@ -416,7 +419,7 @@ fn coverage_issue_key(root_is_valid: bool, catalog_basename: Option<&str>) -> Co
     };
     let catalog_entry_id = catalog_basename
         .map(catalog_entry_id)
-        .unwrap_or_else(|| "sccm-client-source:v1:none".to_owned());
+        .unwrap_or_else(|| NO_CATALOG_ENTRY_ID.to_owned());
     CoverageIssueKey {
         catalog_entry_id,
         logical_artifact_ids: Vec::new(),
@@ -430,7 +433,7 @@ fn declaration_limit_issue_key(
     omitted_declaration_state: SccmClientDiscoveryState,
 ) -> CoverageIssueKey {
     CoverageIssueKey {
-        catalog_entry_id: "sccm-client-source:v1:none".to_owned(),
+        catalog_entry_id: NO_CATALOG_ENTRY_ID.to_owned(),
         logical_artifact_ids: Vec::new(),
         rotation_category: SccmClientDiscoveryRotationCategory::Unknown,
         state: SccmClientDiscoveryCoverageIssueState::DeclarationLimitExceeded,
@@ -438,6 +441,7 @@ fn declaration_limit_issue_key(
     }
 }
 
+const _: () = assert!(MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS > 0);
 const _: () = assert!(MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS <= u16::MAX as usize);
 
 fn add_coverage_issue_count(

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -1,8 +1,9 @@
 use app_lib::sccm::{
     discover_client_sources, SccmClientDiscoveryCoverageIssueState, SccmClientDiscoveryError,
     SccmClientDiscoveryInput, SccmClientDiscoveryObservation, SccmClientDiscoveryObservationState,
-    SccmClientDiscoveryState, MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES,
-    MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS, MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
+    SccmClientDiscoveryRotationCategory, SccmClientDiscoveryState,
+    MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES, MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
+    MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
 };
 use cmtraceopen_parser::sccm::{SccmRotation, SccmUnknownRotation};
 use serde_json::Value;
@@ -931,6 +932,7 @@ fn discovery_never_assigns_catalog_memberships_to_rejected_rotation_candidates()
     assert!(result.coverage_issues.iter().all(|issue| {
         issue.catalog_entry_id == "sccm-client-source:v1:none"
             && issue.logical_artifact_ids.is_empty()
+            && issue.rotation_category == SccmClientDiscoveryRotationCategory::Unknown
             && !format!("{issue:?}").contains(raw_root)
             && !format!("{issue:?}").contains("PolicyAgent.log.backup")
             && !format!("{issue:?}").contains("PolicyAgent.log.1")

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -208,6 +208,69 @@ fn discovery_at_the_exact_global_boundary_does_not_manufacture_a_gap() {
 }
 
 #[test]
+fn discovery_global_capacity_preserves_explicit_states_and_reports_a_coverage_gap() {
+    let mut observations = (1..=MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS as u32)
+        .map(|number| {
+            observation(
+                ROOT_A,
+                &format!("AppEnforce.log.{number}"),
+                SccmRotation::Numbered(number),
+                SccmClientDiscoveryObservationState::AccessDenied,
+            )
+        })
+        .collect::<Vec<_>>();
+    observations.push(observation(
+        ROOT_B,
+        "ScanAgent.log",
+        SccmRotation::Current,
+        SccmClientDiscoveryObservationState::Skipped,
+    ));
+    let input = SccmClientDiscoveryInput {
+        max_found_fragments_per_source: MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
+        observations,
+    };
+
+    let result =
+        discover_client_sources(&input).expect("global capacity remains a bounded coverage result");
+    let mut reversed = input;
+    reversed.observations.reverse();
+    let reversed = discover_client_sources(&reversed)
+        .expect("capacity selection is independent of observation order");
+
+    assert_eq!(result, reversed);
+    assert_eq!(
+        result.declarations.len(),
+        MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS
+    );
+    assert!(result.declarations.iter().any(|declaration| {
+        declaration.basename == "ScanAgent.log"
+            && declaration.state == SccmClientDiscoveryState::Skipped
+    }));
+    assert!(result
+        .declarations
+        .iter()
+        .all(|declaration| declaration.state != SccmClientDiscoveryState::Capped));
+    assert_eq!(
+        result.coverage_issues.len(),
+        1,
+        "one omitted explicit declaration becomes one coverage gap"
+    );
+    let capacity_gap = &result.coverage_issues[0];
+    assert!(
+        capacity_gap.state != SccmClientDiscoveryCoverageIssueState::InvalidProvenance
+            && capacity_gap.state != SccmClientDiscoveryCoverageIssueState::Unsupported,
+        "capacity needs a dedicated coverage state"
+    );
+    assert_eq!(capacity_gap.catalog_entry_id, "sccm-client-source:v1:none");
+    assert!(capacity_gap.logical_artifact_ids.is_empty());
+    assert_eq!(
+        capacity_gap.rotation_category,
+        SccmClientDiscoveryRotationCategory::Unknown
+    );
+    assert_eq!(capacity_gap.occurrence_count.get(), 1);
+}
+
+#[test]
 fn discovery_enforces_each_source_cap_and_retains_the_first_omitted_rotation_gap() {
     let result = discover_client_sources(&SccmClientDiscoveryInput {
         max_found_fragments_per_source: 2,

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -498,6 +498,39 @@ fn discovery_rejects_conflicting_states_for_one_canonical_physical_source() {
 }
 
 #[test]
+fn discovery_rejects_accepted_and_rejected_facts_for_one_raw_physical_observation() {
+    let input = SccmClientDiscoveryInput {
+        max_found_fragments_per_source: 8,
+        observations: vec![
+            observation(
+                ROOT_A,
+                "AppEnforce.log",
+                SccmRotation::Current,
+                SccmClientDiscoveryObservationState::Found,
+            ),
+            observation(
+                ROOT_A,
+                "AppEnforce.log",
+                unsupported_rotation(".backup"),
+                SccmClientDiscoveryObservationState::AccessDenied,
+            ),
+        ],
+    };
+
+    let error = discover_client_sources(&input)
+        .expect_err("classification disagreement cannot split one raw physical observation");
+    let mut reversed = input;
+    reversed.observations.reverse();
+    let reversed_error = discover_client_sources(&reversed)
+        .expect_err("accepted/rejected conflicts remain order independent");
+
+    assert_eq!(error, SccmClientDiscoveryError::ConflictingObservation);
+    assert_eq!(reversed_error, error);
+    assert!(!error.to_string().contains(ROOT_A));
+    assert!(!error.to_string().contains("AppEnforce.log"));
+}
+
+#[test]
 fn discovery_rejects_late_conflicts_after_the_global_declaration_frontier() {
     let mut observations = Vec::new();
     for number in 1..=2_047 {

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -754,11 +754,24 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
         "skipped, absent, and found remain separate coverage states"
     );
     assert_eq!(result.coverage_issues.len(), 2);
-    assert!(result.coverage_issues.iter().any(|issue| {
-        issue.state == SccmClientDiscoveryCoverageIssueState::InvalidProvenance
-            && issue.catalog_entry_id == expected_catalog_entry_id("AppEnforce.log")
-            && issue.logical_artifact_ids == ["client-app-enforce"]
-    }));
+    let invalid_provenance = result
+        .coverage_issues
+        .iter()
+        .find(|issue| issue.state == SccmClientDiscoveryCoverageIssueState::InvalidProvenance)
+        .expect("known source with malformed provenance is explicit");
+    assert_eq!(
+        invalid_provenance.catalog_entry_id,
+        expected_catalog_entry_id("AppEnforce.log")
+    );
+    assert!(
+        invalid_provenance.logical_artifact_ids.is_empty(),
+        "rejected provenance cannot assert derived workflow membership"
+    );
+    assert_eq!(
+        invalid_provenance.rotation_category,
+        SccmClientDiscoveryRotationCategory::Unknown,
+        "rejected provenance cannot retain caller-supplied rotation trust"
+    );
     let unsupported = result
         .coverage_issues
         .iter()
@@ -793,11 +806,6 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
         )],
     })
     .expect("invalid provenance remains coverage-only");
-    let invalid_provenance = result
-        .coverage_issues
-        .iter()
-        .find(|issue| issue.state == SccmClientDiscoveryCoverageIssueState::InvalidProvenance)
-        .expect("known source with malformed provenance is explicit");
     assert_eq!(
         distinct_malformed_root.coverage_issues[0].artifact_id, invalid_provenance.artifact_id,
         "invalid-root identities must not hash or otherwise depend on raw root input"

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -109,10 +109,7 @@ fn expected_evidence_identity(
     rotation: &SccmRotation,
     physical_basename: &str,
 ) -> String {
-    let catalog_entry_id = format!(
-        "sccm-client-source:v1:sha256:{}",
-        sha256(canonical_basename)
-    );
+    let catalog_entry_id = expected_catalog_entry_id(canonical_basename);
     let fingerprint = path_fingerprint(root_handle, canonical_basename);
     let source_digest = fingerprint
         .strip_prefix("sha256:")

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -1019,7 +1019,7 @@ fn discovery_does_not_conflict_distinct_rejected_alias_spellings() {
 }
 
 #[test]
-fn discovery_does_not_conflict_distinct_exact_rejected_rotations() {
+fn discovery_conflicts_rejected_states_even_when_untrusted_rotations_differ() {
     let raw_root = "C:\\private\\ccm\\logs";
     let input = SccmClientDiscoveryInput {
         max_found_fragments_per_source: 8,
@@ -1039,16 +1039,15 @@ fn discovery_does_not_conflict_distinct_exact_rejected_rotations() {
         ],
     };
 
-    let result = discover_client_sources(&input)
-        .expect("distinct exact rejected rotations are separate physical observations");
-    let reversed = discover_client_sources(&SccmClientDiscoveryInput {
-        max_found_fragments_per_source: input.max_found_fragments_per_source,
-        observations: input.observations.into_iter().rev().collect(),
-    })
-    .expect("distinct exact rejected rotations remain nonconflicting under reversal");
+    let error = discover_client_sources(&input)
+        .expect_err("rejected physical identity ignores caller-supplied rotation metadata");
+    let mut reversed = input;
+    reversed.observations.reverse();
+    let reversed_error = discover_client_sources(&reversed)
+        .expect_err("rejected rotation metadata cannot make conflicts order-dependent");
 
-    assert_eq!(result, reversed);
-    assert!(result.declarations.is_empty());
-    assert_eq!(result.coverage_issues.len(), 1);
-    assert_eq!(result.coverage_issues[0].occurrence_count.get(), 2);
+    assert_eq!(error, SccmClientDiscoveryError::ConflictingObservation);
+    assert_eq!(reversed_error, error);
+    assert!(!error.to_string().contains(raw_root));
+    assert!(!error.to_string().contains("PolicyAgent.log.backup"));
 }

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -797,6 +797,39 @@ fn discovery_rejects_accepted_and_rejected_facts_for_one_raw_physical_observatio
 }
 
 #[test]
+fn discovery_rejects_accepted_and_rejected_dispositions_for_one_same_state_observation() {
+    let input = SccmClientDiscoveryInput {
+        max_found_fragments_per_source: 8,
+        observations: vec![
+            observation(
+                ROOT_A,
+                "AppEnforce.log",
+                SccmRotation::Current,
+                SccmClientDiscoveryObservationState::Found,
+            ),
+            observation(
+                ROOT_A,
+                "AppEnforce.log",
+                unsupported_rotation(".backup"),
+                SccmClientDiscoveryObservationState::Found,
+            ),
+        ],
+    };
+
+    let error = discover_client_sources(&input)
+        .expect_err("classification disagreement fails closed even when states match");
+    let mut reversed = input;
+    reversed.observations.reverse();
+    let reversed_error = discover_client_sources(&reversed)
+        .expect_err("same-state disposition conflicts remain order independent");
+
+    assert_eq!(error, SccmClientDiscoveryError::ConflictingObservation);
+    assert_eq!(reversed_error, error);
+    assert!(!error.to_string().contains(ROOT_A));
+    assert!(!error.to_string().contains("AppEnforce.log"));
+}
+
+#[test]
 fn discovery_rejects_late_conflicts_after_the_global_declaration_frontier() {
     let mut observations = Vec::new();
     for number in 1..=2_047 {

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -912,6 +912,7 @@ fn discovery_rejects_observations_beyond_its_defensive_contract() {
 #[test]
 fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw_roots() {
     let malformed_root = "C:\\private\\SCCM\\Client\\Logs";
+    let escaped_malformed_root = malformed_root.escape_debug().to_string();
     let input = SccmClientDiscoveryInput {
         max_found_fragments_per_source: 8,
         observations: vec![
@@ -1027,7 +1028,7 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
         "coalesced unsupported metadata retains the bounded count of supplied observations"
     );
     assert!(result.coverage_issues.iter().all(|issue| {
-        !format!("{issue:?}").contains(malformed_root)
+        !format!("{issue:?}").contains(escaped_malformed_root.as_str())
             && !issue.artifact_id.contains(malformed_root)
             && !issue.catalog_entry_id.contains(malformed_root)
     }));
@@ -1138,6 +1139,7 @@ fn discovery_preserves_coverage_issue_cardinality_at_the_exact_admission_boundar
 #[test]
 fn discovery_never_assigns_catalog_memberships_to_rejected_rotation_candidates() {
     let raw_root = "C:\\private\\ccm\\logs";
+    let escaped_raw_root = raw_root.escape_debug().to_string();
     let input = SccmClientDiscoveryInput {
         max_found_fragments_per_source: 8,
         observations: vec![
@@ -1177,7 +1179,7 @@ fn discovery_never_assigns_catalog_memberships_to_rejected_rotation_candidates()
             && issue.logical_artifact_ids.is_empty()
             && issue.rotation_category == SccmClientDiscoveryRotationCategory::Unknown
             && issue.omitted_declaration_state.is_none()
-            && !format!("{issue:?}").contains(raw_root)
+            && !format!("{issue:?}").contains(escaped_raw_root.as_str())
             && !format!("{issue:?}").contains("PolicyAgent.log.backup")
             && !format!("{issue:?}").contains("PolicyAgent.log.1")
     }));

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -180,16 +180,15 @@ fn discovery_coverage_issue_ids_without_omitted_state_use_nul_domain_separators(
         .iter()
         .find(|issue| issue.state == SccmClientDiscoveryCoverageIssueState::InvalidProvenance)
         .expect("invalid provenance has a coverage issue");
+    let catalog_entry_id = expected_catalog_entry_id("AppEnforce.log");
+    let expected_payload = format!(
+        "cmtraceopen.sccm.discovery.coverage.v1\0{catalog_entry_id}\0unknown\0invalid-provenance"
+    );
     assert_eq!(
         invalid_provenance_issue.artifact_id,
         format!(
             "sccm-discovery-coverage:v1:sha256:{}",
-            sha256(concat!(
-                "cmtraceopen.sccm.discovery.coverage.v1\0",
-                "sccm-client-source:v1:sha256:",
-                "0e25c53307bce0649d0b969c2ae8354ac27100c97fdc6a532267b9a8c0a3f548\0",
-                "unknown\0invalid-provenance",
-            ))
+            sha256(expected_payload)
         ),
         "coverage IDs without an omitted state must hash true NUL-separated fields"
     );

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -685,6 +685,18 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
                 SccmClientDiscoveryObservationState::Found,
             ),
             observation(
+                ROOT_A,
+                "AnotherUnrelated.log",
+                SccmRotation::Current,
+                SccmClientDiscoveryObservationState::Found,
+            ),
+            observation(
+                ROOT_B,
+                "Unrelated.log",
+                SccmRotation::Current,
+                SccmClientDiscoveryObservationState::Found,
+            ),
+            observation(
                 ROOT_B,
                 "AppEnforce.log.1",
                 SccmRotation::Current,
@@ -747,6 +759,16 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
     assert!(unsupported
         .iter()
         .all(|issue| issue.logical_artifact_ids.is_empty()));
+    assert_eq!(
+        unsupported
+            .iter()
+            .find(|issue| issue.catalog_entry_id == "sccm-client-source:v1:none")
+            .expect("arbitrary supplied names have one privacy-safe unsupported category")
+            .occurrence_count
+            .get(),
+        3,
+        "coalesced unsupported metadata retains the bounded count of supplied observations"
+    );
     assert!(result.coverage_issues.iter().all(|issue| {
         !format!("{issue:?}").contains(malformed_root)
             && !issue.artifact_id.contains(malformed_root)
@@ -813,8 +835,37 @@ fn discovery_retains_coverage_issues_past_the_declaration_cap_without_admitting_
         result.coverage_issues[0].state,
         SccmClientDiscoveryCoverageIssueState::InvalidProvenance
     );
+    assert_eq!(result.coverage_issues[0].occurrence_count.get(), 1);
     assert!(result
         .declarations
         .iter()
         .all(|declaration| declaration.artifact_id != result.coverage_issues[0].artifact_id));
+}
+
+#[test]
+fn discovery_preserves_coverage_issue_cardinality_at_the_exact_admission_boundary() {
+    let observations = (0..MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS)
+        .map(|_| {
+            observation(
+                ROOT_A,
+                "Unrelated.log",
+                SccmRotation::Current,
+                SccmClientDiscoveryObservationState::Found,
+            )
+        })
+        .collect();
+
+    let result = discover_client_sources(&SccmClientDiscoveryInput {
+        max_found_fragments_per_source: MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
+        observations,
+    })
+    .expect("the admission boundary retains every coverage-only observation");
+
+    assert!(result.declarations.is_empty());
+    assert_eq!(result.coverage_issues.len(), 1);
+    assert_eq!(
+        result.coverage_issues[0].occurrence_count.get() as usize,
+        MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
+        "privacy-safe issue coalescing must retain exact duplicate cardinality"
+    );
 }

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -1,7 +1,9 @@
 use app_lib::sccm::{
-    discover_client_sources, SccmClientDiscoveryError, SccmClientDiscoveryInput,
-    SccmClientDiscoveryObservation, SccmClientDiscoveryObservationState, SccmClientDiscoveryState,
-    MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS, MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
+    discover_client_sources, SccmClientDiscoveryCoverageIssueState, SccmClientDiscoveryError,
+    SccmClientDiscoveryInput, SccmClientDiscoveryObservation,
+    SccmClientDiscoveryObservationState, SccmClientDiscoveryState,
+    MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES, MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
+    MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
 };
 use cmtraceopen_parser::sccm::SccmRotation;
 use sha2::{Digest, Sha256};
@@ -84,6 +86,10 @@ fn expected_marker_artifact_id(
             rotation_segment(rotation)
         ))
     )
+}
+
+fn expected_catalog_entry_id(canonical_basename: &str) -> String {
+    format!("sccm-client-source:v1:sha256:{}", sha256(canonical_basename))
 }
 
 fn expected_evidence_identity(
@@ -659,12 +665,13 @@ fn discovery_rejects_observations_beyond_its_defensive_contract() {
 }
 
 #[test]
-fn discovery_skips_malformed_roots_and_unsupported_basenames() {
-    let result = discover_client_sources(&SccmClientDiscoveryInput {
+fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw_roots() {
+    let malformed_root = "C:\\private\\SCCM\\Client\\Logs";
+    let input = SccmClientDiscoveryInput {
         max_found_fragments_per_source: 8,
         observations: vec![
             observation(
-                "root-not-a-sha256-handle",
+                malformed_root,
                 "AppEnforce.log",
                 SccmRotation::Current,
                 SccmClientDiscoveryObservationState::Found,
@@ -677,15 +684,113 @@ fn discovery_skips_malformed_roots_and_unsupported_basenames() {
             ),
             observation(
                 ROOT_B,
+                "AppEnforce.log.1",
+                SccmRotation::Current,
+                SccmClientDiscoveryObservationState::Found,
+            ),
+            observation(
+                ROOT_A,
+                "CIAgent.log",
+                SccmRotation::Current,
+                SccmClientDiscoveryObservationState::Skipped,
+            ),
+            observation(
+                ROOT_A,
+                "ScanAgent.log",
+                SccmRotation::Current,
+                SccmClientDiscoveryObservationState::NotFound,
+            ),
+            observation(
+                ROOT_B,
                 "PolicyAgent.log",
                 SccmRotation::Current,
                 SccmClientDiscoveryObservationState::Found,
             ),
         ],
+    };
+    let result = discover_client_sources(&input)
+        .expect("invalid observations remain explicit coverage without aborting valid sources");
+    let reversed = discover_client_sources(&SccmClientDiscoveryInput {
+        max_found_fragments_per_source: input.max_found_fragments_per_source,
+        observations: input.observations.into_iter().rev().collect(),
     })
-    .expect("malformed roots are skipped rather than becoming a discovery failure");
+    .expect("coverage results remain deterministic under input reversal");
 
-    assert_eq!(result.declarations.len(), 1);
-    assert_eq!(result.declarations[0].root_handle, ROOT_B);
-    assert_eq!(result.declarations[0].basename, "PolicyAgent.log");
+    assert_eq!(result, reversed);
+    assert_eq!(
+        result
+            .declarations
+            .iter()
+            .map(|declaration| (declaration.basename.as_str(), declaration.state))
+            .collect::<Vec<_>>(),
+        vec![
+            ("CIAgent.log", SccmClientDiscoveryState::Skipped),
+            ("PolicyAgent.log", SccmClientDiscoveryState::Discovered),
+            ("ScanAgent.log", SccmClientDiscoveryState::NotFound),
+        ],
+        "skipped, absent, and found remain separate coverage states"
+    );
+    assert_eq!(result.coverage_issues.len(), 3);
+    assert!(result.coverage_issues.iter().any(|issue| {
+        issue.state == SccmClientDiscoveryCoverageIssueState::InvalidProvenance
+            && issue.catalog_entry_id == expected_catalog_entry_id("AppEnforce.log")
+            && issue.logical_artifact_ids == ["client-app-enforce"]
+    }));
+    let unsupported = result
+        .coverage_issues
+        .iter()
+        .filter(|issue| issue.state == SccmClientDiscoveryCoverageIssueState::Unsupported)
+        .collect::<Vec<_>>();
+    assert_eq!(unsupported.len(), 2);
+    assert!(unsupported
+        .iter()
+        .all(|issue| issue.logical_artifact_ids.is_empty()));
+    assert!(result.coverage_issues.iter().all(|issue| {
+        !format!("{issue:?}").contains(malformed_root)
+            && !issue.artifact_id.contains(malformed_root)
+            && !issue.catalog_entry_id.contains(malformed_root)
+    }));
+    assert!(result.declarations.iter().all(|declaration| {
+        declaration.artifact_id != result.coverage_issues[0].artifact_id
+            && declaration.artifact_id != result.coverage_issues[1].artifact_id
+            && declaration.artifact_id != result.coverage_issues[2].artifact_id
+    }));
+}
+
+#[test]
+fn discovery_retains_coverage_issues_past_the_declaration_cap_without_admitting_them_as_capture() {
+    let mut observations = (1..=MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS)
+        .map(|number| {
+            observation(
+                ROOT_A,
+                &format!("AppEnforce.log.{number}"),
+                SccmRotation::Numbered(number as u32),
+                SccmClientDiscoveryObservationState::Found,
+            )
+        })
+        .collect::<Vec<_>>();
+    observations.push(observation(
+        "not-a-root-handle",
+        "CIAgent.log",
+        SccmRotation::Current,
+        SccmClientDiscoveryObservationState::Found,
+    ));
+
+    let result = discover_client_sources(&SccmClientDiscoveryInput {
+        max_found_fragments_per_source: MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
+        observations,
+    })
+    .expect("a malformed observation cannot hide coverage behind declaration capping");
+
+    assert_eq!(result.declarations.len(), MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS);
+    assert_eq!(result.coverage_issues.len(), 1);
+    assert!(result.coverage_issues.len() <= MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES);
+    assert_eq!(
+        result.coverage_issues[0].state,
+        SccmClientDiscoveryCoverageIssueState::InvalidProvenance
+    );
+    assert!(result
+        .declarations
+        .iter()
+        .all(|declaration| declaration.artifact_id != result.coverage_issues[0].artifact_id));
 }

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -1,9 +1,8 @@
 use app_lib::sccm::{
     discover_client_sources, SccmClientDiscoveryCoverageIssueState, SccmClientDiscoveryError,
-    SccmClientDiscoveryInput, SccmClientDiscoveryObservation,
-    SccmClientDiscoveryObservationState, SccmClientDiscoveryState,
-    MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES, MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
-    MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
+    SccmClientDiscoveryInput, SccmClientDiscoveryObservation, SccmClientDiscoveryObservationState,
+    SccmClientDiscoveryState, MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES,
+    MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS, MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
 };
 use cmtraceopen_parser::sccm::SccmRotation;
 use sha2::{Digest, Sha256};
@@ -89,7 +88,10 @@ fn expected_marker_artifact_id(
 }
 
 fn expected_catalog_entry_id(canonical_basename: &str) -> String {
-    format!("sccm-client-source:v1:sha256:{}", sha256(canonical_basename))
+    format!(
+        "sccm-client-source:v1:sha256:{}",
+        sha256(canonical_basename)
+    )
 }
 
 fn expected_evidence_identity(
@@ -724,8 +726,8 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
             .map(|declaration| (declaration.basename.as_str(), declaration.state))
             .collect::<Vec<_>>(),
         vec![
-            ("CIAgent.log", SccmClientDiscoveryState::Skipped),
             ("PolicyAgent.log", SccmClientDiscoveryState::Discovered),
+            ("CIAgent.log", SccmClientDiscoveryState::Skipped),
             ("ScanAgent.log", SccmClientDiscoveryState::NotFound),
         ],
         "skipped, absent, and found remain separate coverage states"
@@ -750,6 +752,25 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
             && !issue.artifact_id.contains(malformed_root)
             && !issue.catalog_entry_id.contains(malformed_root)
     }));
+    let distinct_malformed_root = discover_client_sources(&SccmClientDiscoveryInput {
+        max_found_fragments_per_source: 8,
+        observations: vec![observation(
+            "root-also-not-validated",
+            "AppEnforce.log",
+            SccmRotation::Current,
+            SccmClientDiscoveryObservationState::Found,
+        )],
+    })
+    .expect("invalid provenance remains coverage-only");
+    let invalid_provenance = result
+        .coverage_issues
+        .iter()
+        .find(|issue| issue.state == SccmClientDiscoveryCoverageIssueState::InvalidProvenance)
+        .expect("known source with malformed provenance is explicit");
+    assert_eq!(
+        distinct_malformed_root.coverage_issues[0].artifact_id, invalid_provenance.artifact_id,
+        "invalid-root identities must not hash or otherwise depend on raw root input"
+    );
     assert!(result.declarations.iter().all(|declaration| {
         declaration.artifact_id != result.coverage_issues[0].artifact_id
             && declaration.artifact_id != result.coverage_issues[1].artifact_id
@@ -782,7 +803,10 @@ fn discovery_retains_coverage_issues_past_the_declaration_cap_without_admitting_
     })
     .expect("a malformed observation cannot hide coverage behind declaration capping");
 
-    assert_eq!(result.declarations.len(), MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS);
+    assert_eq!(
+        result.declarations.len(),
+        MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS
+    );
     assert_eq!(result.coverage_issues.len(), 1);
     assert!(result.coverage_issues.len() <= MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES);
     assert_eq!(

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -752,7 +752,7 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
         ],
         "skipped, absent, and found remain separate coverage states"
     );
-    assert_eq!(result.coverage_issues.len(), 3);
+    assert_eq!(result.coverage_issues.len(), 2);
     assert!(result.coverage_issues.iter().any(|issue| {
         issue.state == SccmClientDiscoveryCoverageIssueState::InvalidProvenance
             && issue.catalog_entry_id == expected_catalog_entry_id("AppEnforce.log")
@@ -801,11 +801,10 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
         distinct_malformed_root.coverage_issues[0].artifact_id, invalid_provenance.artifact_id,
         "invalid-root identities must not hash or otherwise depend on raw root input"
     );
-    assert!(result.declarations.iter().all(|declaration| {
-        declaration.artifact_id != result.coverage_issues[0].artifact_id
-            && declaration.artifact_id != result.coverage_issues[1].artifact_id
-            && declaration.artifact_id != result.coverage_issues[2].artifact_id
-    }));
+    assert!(result.declarations.iter().all(|declaration| result
+        .coverage_issues
+        .iter()
+        .all(|issue| declaration.artifact_id != issue.artifact_id)));
 }
 
 #[test]
@@ -934,6 +933,7 @@ fn discovery_never_assigns_catalog_memberships_to_rejected_rotation_candidates()
             && issue.logical_artifact_ids.is_empty()
             && !format!("{issue:?}").contains(raw_root)
             && !format!("{issue:?}").contains("PolicyAgent.log.backup")
+            && !format!("{issue:?}").contains("PolicyAgent.log.1")
     }));
 }
 
@@ -1016,4 +1016,39 @@ fn discovery_does_not_conflict_distinct_rejected_alias_spellings() {
         "sccm-client-source:v1:none"
     );
     assert!(result.coverage_issues[0].logical_artifact_ids.is_empty());
+}
+
+#[test]
+fn discovery_does_not_conflict_distinct_exact_rejected_rotations() {
+    let raw_root = "C:\\private\\ccm\\logs";
+    let input = SccmClientDiscoveryInput {
+        max_found_fragments_per_source: 8,
+        observations: vec![
+            observation(
+                raw_root,
+                "PolicyAgent.log.backup",
+                unsupported_rotation(".backup"),
+                SccmClientDiscoveryObservationState::Found,
+            ),
+            observation(
+                raw_root,
+                "PolicyAgent.log.backup",
+                unsupported_rotation(".archive"),
+                SccmClientDiscoveryObservationState::AccessDenied,
+            ),
+        ],
+    };
+
+    let result = discover_client_sources(&input)
+        .expect("distinct exact rejected rotations are separate physical observations");
+    let reversed = discover_client_sources(&SccmClientDiscoveryInput {
+        max_found_fragments_per_source: input.max_found_fragments_per_source,
+        observations: input.observations.into_iter().rev().collect(),
+    })
+    .expect("distinct exact rejected rotations remain nonconflicting under reversal");
+
+    assert_eq!(result, reversed);
+    assert!(result.declarations.is_empty());
+    assert_eq!(result.coverage_issues.len(), 1);
+    assert_eq!(result.coverage_issues[0].occurrence_count.get(), 2);
 }

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -4,7 +4,8 @@ use app_lib::sccm::{
     SccmClientDiscoveryState, MAX_SCCM_CLIENT_DISCOVERY_COVERAGE_ISSUES,
     MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS, MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
 };
-use cmtraceopen_parser::sccm::SccmRotation;
+use cmtraceopen_parser::sccm::{SccmRotation, SccmUnknownRotation};
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 const ROOT_A: &str = "root-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -22,6 +23,13 @@ fn observation(
         rotation,
         state,
     }
+}
+
+fn unsupported_rotation(suffix: &str) -> SccmRotation {
+    SccmRotation::Unknown(SccmUnknownRotation {
+        kind: "filenameSuffix".to_owned(),
+        value: Some(Value::String(suffix.to_owned())),
+    })
 }
 
 fn sha256(value: impl AsRef<[u8]>) -> String {
@@ -755,7 +763,7 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
         .iter()
         .filter(|issue| issue.state == SccmClientDiscoveryCoverageIssueState::Unsupported)
         .collect::<Vec<_>>();
-    assert_eq!(unsupported.len(), 2);
+    assert_eq!(unsupported.len(), 1);
     assert!(unsupported
         .iter()
         .all(|issue| issue.logical_artifact_ids.is_empty()));
@@ -766,7 +774,7 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
             .expect("arbitrary supplied names have one privacy-safe unsupported category")
             .occurrence_count
             .get(),
-        3,
+        4,
         "coalesced unsupported metadata retains the bounded count of supplied observations"
     );
     assert!(result.coverage_issues.iter().all(|issue| {
@@ -863,9 +871,149 @@ fn discovery_preserves_coverage_issue_cardinality_at_the_exact_admission_boundar
 
     assert!(result.declarations.is_empty());
     assert_eq!(result.coverage_issues.len(), 1);
+    let single = discover_client_sources(&SccmClientDiscoveryInput {
+        max_found_fragments_per_source: MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
+        observations: vec![observation(
+            ROOT_A,
+            "Unrelated.log",
+            SccmRotation::Current,
+            SccmClientDiscoveryObservationState::Found,
+        )],
+    })
+    .expect("one unsupported observation remains explicit");
+    assert_eq!(
+        result.coverage_issues[0].artifact_id, single.coverage_issues[0].artifact_id,
+        "coverage issue identity must not depend on its aggregated count"
+    );
     assert_eq!(
         result.coverage_issues[0].occurrence_count.get() as usize,
         MAX_SCCM_CLIENT_DISCOVERY_OBSERVATIONS,
         "privacy-safe issue coalescing must retain exact duplicate cardinality"
     );
+}
+
+#[test]
+fn discovery_never_assigns_catalog_memberships_to_rejected_rotation_candidates() {
+    let raw_root = "C:\\private\\ccm\\logs";
+    let input = SccmClientDiscoveryInput {
+        max_found_fragments_per_source: 8,
+        observations: vec![
+            observation(
+                raw_root,
+                "PolicyAgent.log.backup",
+                unsupported_rotation(".backup"),
+                SccmClientDiscoveryObservationState::Found,
+            ),
+            observation(
+                ROOT_A,
+                "PolicyAgent.log.1",
+                SccmRotation::Current,
+                SccmClientDiscoveryObservationState::Found,
+            ),
+            observation(
+                ROOT_B,
+                "PolicyAgent.log",
+                SccmRotation::Current,
+                SccmClientDiscoveryObservationState::Found,
+            ),
+        ],
+    };
+
+    let result = discover_client_sources(&input).expect("rejected candidates remain coverage-only");
+    let reversed = discover_client_sources(&SccmClientDiscoveryInput {
+        max_found_fragments_per_source: input.max_found_fragments_per_source,
+        observations: input.observations.into_iter().rev().collect(),
+    })
+    .expect("rejected candidate coverage is order independent");
+
+    assert_eq!(result, reversed);
+    assert_eq!(result.declarations.len(), 1);
+    assert_eq!(result.coverage_issues.len(), 2);
+    assert!(result.coverage_issues.iter().all(|issue| {
+        issue.catalog_entry_id == "sccm-client-source:v1:none"
+            && issue.logical_artifact_ids.is_empty()
+            && !format!("{issue:?}").contains(raw_root)
+            && !format!("{issue:?}").contains("PolicyAgent.log.backup")
+    }));
+}
+
+#[test]
+fn discovery_rejects_conflicting_states_for_the_same_rejected_physical_observation() {
+    let raw_root = "C:\\private\\ccm\\logs";
+    let raw_basename = "PolicyAgent.log.backup";
+    let input = SccmClientDiscoveryInput {
+        max_found_fragments_per_source: 8,
+        observations: vec![
+            observation(
+                raw_root,
+                raw_basename,
+                unsupported_rotation(".backup"),
+                SccmClientDiscoveryObservationState::Found,
+            ),
+            observation(
+                raw_root,
+                raw_basename,
+                unsupported_rotation(".backup"),
+                SccmClientDiscoveryObservationState::AccessDenied,
+            ),
+            observation(
+                ROOT_A,
+                "AppEnforce.log",
+                SccmRotation::Current,
+                SccmClientDiscoveryObservationState::Found,
+            ),
+        ],
+    };
+
+    let error = discover_client_sources(&input)
+        .expect_err("one rejected physical observation cannot carry contradictory states");
+    let mut reversed = input;
+    reversed.observations.reverse();
+    let reversed_error = discover_client_sources(&reversed)
+        .expect_err("rejected physical conflicts remain order independent");
+
+    assert_eq!(error, SccmClientDiscoveryError::ConflictingObservation);
+    assert_eq!(reversed_error, error);
+    assert!(!error.to_string().contains(raw_root));
+    assert!(!error.to_string().contains(raw_basename));
+}
+
+#[test]
+fn discovery_does_not_conflict_distinct_rejected_alias_spellings() {
+    let raw_root = "C:\\private\\ccm\\logs";
+    let input = SccmClientDiscoveryInput {
+        max_found_fragments_per_source: 8,
+        observations: vec![
+            observation(
+                raw_root,
+                "PolicyAgent.log.backup",
+                unsupported_rotation(".backup"),
+                SccmClientDiscoveryObservationState::Found,
+            ),
+            observation(
+                raw_root,
+                "policyagent.log.backup",
+                unsupported_rotation(".backup"),
+                SccmClientDiscoveryObservationState::AccessDenied,
+            ),
+        ],
+    };
+
+    let result = discover_client_sources(&input)
+        .expect("distinct raw rejected spellings are not one physical observation");
+    let reversed = discover_client_sources(&SccmClientDiscoveryInput {
+        max_found_fragments_per_source: input.max_found_fragments_per_source,
+        observations: input.observations.into_iter().rev().collect(),
+    })
+    .expect("distinct rejected aliases remain nonconflicting under reversal");
+
+    assert_eq!(result, reversed);
+    assert!(result.declarations.is_empty());
+    assert_eq!(result.coverage_issues.len(), 1);
+    assert_eq!(result.coverage_issues[0].occurrence_count.get(), 2);
+    assert_eq!(
+        result.coverage_issues[0].catalog_entry_id,
+        "sccm-client-source:v1:none"
+    );
+    assert!(result.coverage_issues[0].logical_artifact_ids.is_empty());
 }

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -271,6 +271,56 @@ fn discovery_global_capacity_preserves_explicit_states_and_reports_a_coverage_ga
 }
 
 #[test]
+fn discovery_capacity_gap_retains_an_omitted_per_source_capped_state() {
+    let mut observations = (1..=MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS as u32)
+        .map(|number| {
+            observation(
+                ROOT_A,
+                &format!("AppEnforce.log.{number}"),
+                SccmRotation::Numbered(number),
+                SccmClientDiscoveryObservationState::Found,
+            )
+        })
+        .collect::<Vec<_>>();
+    observations.push(observation(
+        ROOT_B,
+        "ScanAgent.log",
+        SccmRotation::Current,
+        SccmClientDiscoveryObservationState::Skipped,
+    ));
+    let input = SccmClientDiscoveryInput {
+        max_found_fragments_per_source: MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS - 1,
+        observations,
+    };
+
+    let result = discover_client_sources(&input)
+        .expect("per-source and global capacity remain explicit coverage");
+    let mut reversed_input = input;
+    reversed_input.observations.reverse();
+    let reversed = discover_client_sources(&reversed_input)
+        .expect("capacity coverage remains order independent");
+
+    assert_eq!(result, reversed);
+    assert_eq!(
+        result.coverage_issues.len(),
+        1,
+        "the globally omitted per-source marker needs an explicit capacity issue"
+    );
+    assert!(
+        format!("{:?}", result.coverage_issues[0]).contains("Capped"),
+        "the capacity issue must retain the omitted declaration's Capped state"
+    );
+    assert!(result.declarations.iter().any(|declaration| {
+        declaration.basename == "ScanAgent.log"
+            && declaration.state == SccmClientDiscoveryState::Skipped
+    }));
+    assert!(result
+        .declarations
+        .iter()
+        .all(|declaration| declaration.state != SccmClientDiscoveryState::Capped));
+}
+
+#[test]
 fn discovery_enforces_each_source_cap_and_retains_the_first_omitted_rotation_gap() {
     let result = discover_client_sources(&SccmClientDiscoveryInput {
         max_found_fragments_per_source: 2,

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -127,7 +127,7 @@ fn expected_evidence_identity(
 }
 
 #[test]
-fn discovery_uses_one_global_declaration_budget_and_marks_the_first_omitted_rotation() {
+fn discovery_uses_one_global_declaration_budget_and_reports_capacity_coverage() {
     let mut observations = Vec::new();
     for number in 1..=2_048 {
         observations.push(observation(
@@ -161,21 +161,32 @@ fn discovery_uses_one_global_declaration_budget_and_marks_the_first_omitted_rota
         MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
         "the 4096 declaration budget must be shared by all roots and sources"
     );
-    let gap = result
+    let terminal = result
         .declarations
         .last()
-        .expect("the globally capped result retains the first omitted declaration");
-    assert_eq!(gap.basename, "PolicyAgent.log.2048");
-    assert_eq!(gap.rotation, SccmRotation::Numbered(2_048));
-    assert_eq!(gap.state, SccmClientDiscoveryState::Capped);
+        .expect("the globally bounded result retains its deterministic terminal observation");
+    assert_eq!(terminal.basename, "PolicyAgent.log.2049");
+    assert_eq!(terminal.rotation, SccmRotation::Numbered(2_049));
+    assert_eq!(terminal.state, SccmClientDiscoveryState::Discovered);
     assert_eq!(
         result
             .declarations
             .iter()
             .filter(|declaration| declaration.state == SccmClientDiscoveryState::Discovered)
             .count(),
-        MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS - 1
+        MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS
     );
+    assert_eq!(result.coverage_issues.len(), 1);
+    let capacity_gap = &result.coverage_issues[0];
+    assert_eq!(
+        capacity_gap.state,
+        SccmClientDiscoveryCoverageIssueState::DeclarationLimitExceeded
+    );
+    assert_eq!(
+        capacity_gap.omitted_declaration_state,
+        Some(SccmClientDiscoveryState::Discovered)
+    );
+    assert_eq!(capacity_gap.occurrence_count.get(), 1);
 }
 
 #[test]
@@ -256,10 +267,15 @@ fn discovery_global_capacity_preserves_explicit_states_and_reports_a_coverage_ga
         "one omitted explicit declaration becomes one coverage gap"
     );
     let capacity_gap = &result.coverage_issues[0];
-    assert!(
-        capacity_gap.state != SccmClientDiscoveryCoverageIssueState::InvalidProvenance
-            && capacity_gap.state != SccmClientDiscoveryCoverageIssueState::Unsupported,
-        "capacity needs a dedicated coverage state"
+    assert_eq!(
+        capacity_gap.state,
+        SccmClientDiscoveryCoverageIssueState::DeclarationLimitExceeded,
+        "capacity has a dedicated coverage state"
+    );
+    assert_eq!(
+        capacity_gap.omitted_declaration_state,
+        Some(SccmClientDiscoveryState::AccessDenied),
+        "the privacy-safe gap retains the omitted physical fact's actual state"
     );
     assert_eq!(capacity_gap.catalog_entry_id, "sccm-client-source:v1:none");
     assert!(capacity_gap.logical_artifact_ids.is_empty());
@@ -306,8 +322,9 @@ fn discovery_capacity_gap_retains_an_omitted_per_source_capped_state() {
         1,
         "the globally omitted per-source marker needs an explicit capacity issue"
     );
-    assert!(
-        format!("{:?}", result.coverage_issues[0]).contains("Capped"),
+    assert_eq!(
+        result.coverage_issues[0].omitted_declaration_state,
+        Some(SccmClientDiscoveryState::Capped),
         "the capacity issue must retain the omitted declaration's Capped state"
     );
     assert!(result.declarations.iter().any(|declaration| {
@@ -318,6 +335,77 @@ fn discovery_capacity_gap_retains_an_omitted_per_source_capped_state() {
         .declarations
         .iter()
         .all(|declaration| declaration.state != SccmClientDiscoveryState::Capped));
+}
+
+#[test]
+fn discovery_capacity_gaps_retain_each_omitted_nonfound_state() {
+    for (omitted_input_state, expected_omitted_state, terminal_state, expected_terminal_state) in [
+        (
+            SccmClientDiscoveryObservationState::NotFound,
+            SccmClientDiscoveryState::NotFound,
+            SccmClientDiscoveryObservationState::Skipped,
+            SccmClientDiscoveryState::Skipped,
+        ),
+        (
+            SccmClientDiscoveryObservationState::Skipped,
+            SccmClientDiscoveryState::Skipped,
+            SccmClientDiscoveryObservationState::NotFound,
+            SccmClientDiscoveryState::NotFound,
+        ),
+    ] {
+        let mut observations = (1..=MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS as u32)
+            .map(|number| {
+                observation(
+                    ROOT_A,
+                    &format!("AppEnforce.log.{number}"),
+                    SccmRotation::Numbered(number),
+                    omitted_input_state,
+                )
+            })
+            .collect::<Vec<_>>();
+        observations.push(observation(
+            ROOT_B,
+            "ScanAgent.log",
+            SccmRotation::Current,
+            terminal_state,
+        ));
+        let input = SccmClientDiscoveryInput {
+            max_found_fragments_per_source: MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS,
+            observations,
+        };
+
+        let result = discover_client_sources(&input).expect("bounded explicit-state coverage");
+        let mut reversed_input = input;
+        reversed_input.observations.reverse();
+        let reversed = discover_client_sources(&reversed_input)
+            .expect("explicit-state capacity coverage is order independent");
+
+        assert_eq!(result, reversed);
+        assert_eq!(
+            result.declarations.len(),
+            MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS
+        );
+        assert!(result.declarations.iter().any(|declaration| {
+            declaration.basename == "ScanAgent.log" && declaration.state == expected_terminal_state
+        }));
+        assert!(result
+            .declarations
+            .iter()
+            .all(|declaration| declaration.state != SccmClientDiscoveryState::Capped));
+        assert_eq!(result.coverage_issues.len(), 1);
+        let capacity_gap = &result.coverage_issues[0];
+        assert_eq!(
+            capacity_gap.state,
+            SccmClientDiscoveryCoverageIssueState::DeclarationLimitExceeded
+        );
+        assert_eq!(
+            capacity_gap.omitted_declaration_state,
+            Some(expected_omitted_state)
+        );
+        assert_eq!(capacity_gap.occurrence_count.get(), 1);
+        assert!(!format!("{capacity_gap:?}").contains(ROOT_A));
+        assert!(!format!("{capacity_gap:?}").contains("AppEnforce.log"));
+    }
 }
 
 #[test]
@@ -918,6 +1006,7 @@ fn discovery_preserves_valid_coverage_and_reports_invalid_provenance_without_raw
         SccmClientDiscoveryRotationCategory::Unknown,
         "rejected provenance cannot retain caller-supplied rotation trust"
     );
+    assert_eq!(invalid_provenance.omitted_declaration_state, None);
     let unsupported = result
         .coverage_issues
         .iter()
@@ -1087,6 +1176,7 @@ fn discovery_never_assigns_catalog_memberships_to_rejected_rotation_candidates()
         issue.catalog_entry_id == "sccm-client-source:v1:none"
             && issue.logical_artifact_ids.is_empty()
             && issue.rotation_category == SccmClientDiscoveryRotationCategory::Unknown
+            && issue.omitted_declaration_state.is_none()
             && !format!("{issue:?}").contains(raw_root)
             && !format!("{issue:?}").contains("PolicyAgent.log.backup")
             && !format!("{issue:?}").contains("PolicyAgent.log.1")

--- a/src-tauri/tests/sccm_client_discovery.rs
+++ b/src-tauri/tests/sccm_client_discovery.rs
@@ -127,6 +127,75 @@ fn expected_evidence_identity(
 }
 
 #[test]
+fn discovery_coverage_issue_ids_with_omitted_state_use_nul_domain_separators() {
+    let capacity = discover_client_sources(&SccmClientDiscoveryInput {
+        max_found_fragments_per_source: 1,
+        observations: (0..=MAX_SCCM_CLIENT_DISCOVERY_DECLARATIONS)
+            .map(|number| {
+                observation(
+                    &format!("root-{number:064x}"),
+                    "AppEnforce.log",
+                    SccmRotation::Current,
+                    SccmClientDiscoveryObservationState::Found,
+                )
+            })
+            .collect(),
+    })
+    .expect("the global frontier emits a coverage issue");
+    let capacity_issue = capacity
+        .coverage_issues
+        .iter()
+        .find(|issue| {
+            issue.state == SccmClientDiscoveryCoverageIssueState::DeclarationLimitExceeded
+        })
+        .expect("the omitted declaration has a capacity issue");
+    assert_eq!(
+        capacity_issue.artifact_id,
+        format!(
+            "sccm-discovery-coverage:v1:sha256:{}",
+            sha256(concat!(
+                "cmtraceopen.sccm.discovery.coverage.v1\0",
+                "sccm-client-source:v1:none\0",
+                "unknown\0declaration-limit-exceeded\0discovered",
+            ))
+        ),
+        "coverage IDs with an omitted state must hash true NUL-separated fields"
+    );
+}
+
+#[test]
+fn discovery_coverage_issue_ids_without_omitted_state_use_nul_domain_separators() {
+    let invalid_provenance = discover_client_sources(&SccmClientDiscoveryInput {
+        max_found_fragments_per_source: 1,
+        observations: vec![observation(
+            "not-a-root-handle",
+            "AppEnforce.log",
+            SccmRotation::Current,
+            SccmClientDiscoveryObservationState::Found,
+        )],
+    })
+    .expect("invalid provenance remains explicit coverage");
+    let invalid_provenance_issue = invalid_provenance
+        .coverage_issues
+        .iter()
+        .find(|issue| issue.state == SccmClientDiscoveryCoverageIssueState::InvalidProvenance)
+        .expect("invalid provenance has a coverage issue");
+    assert_eq!(
+        invalid_provenance_issue.artifact_id,
+        format!(
+            "sccm-discovery-coverage:v1:sha256:{}",
+            sha256(concat!(
+                "cmtraceopen.sccm.discovery.coverage.v1\0",
+                "sccm-client-source:v1:sha256:",
+                "0e25c53307bce0649d0b969c2ae8354ac27100c97fdc6a532267b9a8c0a3f548\0",
+                "unknown\0invalid-provenance",
+            ))
+        ),
+        "coverage IDs without an omitted state must hash true NUL-separated fields"
+    );
+}
+
+#[test]
 fn discovery_uses_one_global_declaration_budget_and_reports_capacity_coverage() {
     let mut observations = Vec::new();
     for number in 1..=2_048 {


### PR DESCRIPTION
Follow-up to merged #444, based on its exact integration commit `c622c9ec`.

This 23-commit correction keeps SCCM client discovery deterministic and privacy-safe when supplied observations are rejected or declaration capacity is reached:

- retain rejected and unsupported observations as bounded coverage-only issues without promoting them to declarations or workflow membership;
- reject contradictory raw physical observations before classification and classify each admitted observation once;
- prevent untrusted roots, basenames, and rotations from becoming coverage authority;
- preserve deterministic order, exact coalesced cardinality, and distinct `Skipped`/`NotFound`/`Found` states; and
- report declaration-capacity loss separately while retaining the terminal selected declaration's real state.

The first 16 commits preserve the reviewed RED/GREEN sequence. `d3c096f1` is a test-only local-CodeRabbit fix for derived-`Debug` Windows-path privacy assertions. Hosted Copilot then found that coverage identity payloads used printable `\\0` separators instead of the SCCM identity convention of NUL boundaries. RED `7589ccdd` pins both omitted-state branches; GREEN `207ac2f7` changes only those payload strings to actual NUL separators. Hosted CodeRabbit then requested invariant hardenings: `b362e89e` reuses the canonical catalog-ID helper in the separator regression and proves the observation ceiling fits the `u16` coverage counter; `f1f126bb` removes a shadowed binding, centralizes the no-catalog identity, and proves the declaration ceiling is nonzero; `f5ab362a` enforces empty workflow membership before the current four-field coverage-ID hash, documents deterministic terminal retention, and reuses the test catalog-ID helper. These commits do not change valid runtime output or IDs. `c2454d4a` adds the hosted-requested same-state accepted/rejected disposition regression and consolidates repeated unsupported-rotation test setup; it changes no production behavior.

CodeRabbit's requested mixed rejection-plus-declaration-cap regression is mathematically unreachable under the defensive contract and was not fabricated: the cap branch requires all 4,097 permitted observations to be accepted/selected, leaving no input slot for a rejected observation. Existing executable guards pin both reachable edges: 4,096 valid plus one rejected yields only rejection coverage, while 4,097 selected valid observations yields declaration-cap coverage.

Exact scope remains `src-tauri/src/sccm/discovery.rs` and `src-tauri/tests/sccm_client_discovery.rs` only.

Verification at the corrected candidate:

- focused discovery 25/25, discovery units 6/6, and client manifest 21/21;
- full parser `--all-targets`, strict app/parser Clippy, and parser wasm32;
- scoped Rustfmt, `git diff --check`, clean branch status, and TypeScript `tsc --noEmit`;
- CodeRabbit CLI exact full original range `c622c9ec..d3c096f1`: zero findings; exact hosted-fix delta `d3c096f1..207ac2f7`: zero findings; exact hardening deltas `207ac2f7..b362e89e`, `b362e89e..f1f126bb`, and `f1f126bb..f5ab362a` and final test-only delta `f5ab362a..c2454d4a`: zero findings;
- independent full functional review: GO at `0c4cf545`; scoped privacy-fix review: GO at `d3c096f1`; exact hosted-separator fix review: GO at `207ac2f7`; exact hardening reviews: GO at `b362e89e`, `f1f126bb`, controller GO at `f5ab362a`, and controller plus local CodeRabbit review of the test-only `c2454d4a` delta, all with no P0-P3 findings.

Repository-wide `cargo fmt --check --all` retains inherited drift at the integration base in unrelated files; both changed Rust files pass scoped Rustfmt.

No native Windows collection, live SCCM validation, capture, workflow diagnosis, correlation, or production acceptance is claimed.

This is intentionally a draft. Fresh hosted exact-head CodeRabbit, GitHub Copilot, all CI including Windows, zero unresolved actionable threads, and a final live base/head merge guard are required before merge.

Refs #319
Refs #317


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SCCM discovery now reports skipped observations and coverage issues, including unsupported sources, invalid provenance, and omitted declarations.
  * Discovery results include bounded, privacy-safe diagnostic details for rejected or incomplete observations.
  * Skipped observations now receive identifiable markers for clearer result tracking.

* **Bug Fixes**
  * Improved handling of duplicate and conflicting physical identities.
  * Declaration selection now preserves a terminal declaration while consistently reporting omitted results.
  * Results are deterministic regardless of observation order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
