### PR TITLE
feat(sccm): add private capture destination primitive

### DIFF
--- a/src-tauri/src/sccm/mod.rs
+++ b/src-tauri/src/sccm/mod.rs
@@ -7,6 +7,9 @@
 mod contract;
 mod discovery;
 mod manifest;
+// This destination-only primitive intentionally has no production caller until
+// native enumeration can supply a non-forgeable, handle-bound source token.
+#[allow(dead_code)]
 mod private_fs;
 
 pub use cmtraceopen_parser::sccm::{SccmCoverageState, SccmRole, SccmRotation};

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -1714,8 +1714,51 @@ mod tests {
         let linked_parent = temporary.path().join("linked-parent");
         std::os::unix::fs::symlink(&actual_parent, &linked_parent).expect("parent symlink");
 
-        open_private_capture_root(&linked_parent.join("private-root"))
+        let error = open_private_capture_root(&linked_parent.join("private-root"))
             .expect_err("capture-root traversal never follows a parent symlink");
+        assert!(
+            matches!(error.raw_os_error(), Some(code) if code == libc::ELOOP || code == libc::ENOTDIR),
+            "expected a no-follow component rejection, got {error:?}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_acl_entry_status_distinguishes_empty_acl_from_error() {
+        assert_eq!(
+            classify_macos_acl_entry_status(0).expect("entry status"),
+            MacosAclEntryStatus::Present
+        );
+        assert_eq!(
+            classify_macos_acl_entry_status(1).expect("empty ACL status"),
+            MacosAclEntryStatus::Empty
+        );
+        assert_eq!(
+            classify_macos_acl_entry_status(-1).expect("error status"),
+            MacosAclEntryStatus::Error
+        );
+        assert_eq!(
+            classify_macos_acl_entry_status(2)
+                .expect_err("unknown ACL status must fail closed")
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_ownership_flag_mask_conversion_fails_closed() {
+        assert_ne!(
+            macos_ownership_ignore_mask(libc::MNT_IGNORE_OWNERSHIP)
+                .expect("platform ownership flag is representable"),
+            0
+        );
+        assert_eq!(
+            macos_ownership_ignore_mask(-1)
+                .expect_err("negative flag must not disable the ownership check")
+                .kind(),
+            io::ErrorKind::Unsupported
+        );
     }
 
     #[test]

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -1719,12 +1719,13 @@ mod tests {
     #[test]
     fn private_capture_root_rejects_a_symlinked_parent_component() {
         let temporary = tempdir().expect("temporary root");
-        let actual_parent = temporary.path().join("actual-parent");
+        let canonical_temporary = temporary.path().canonicalize().expect("canonical root");
+        let actual_parent = canonical_temporary.join("actual-parent");
         let private_root = actual_parent.join("private-root");
         fs::create_dir_all(&private_root).expect("real private root");
         fs::set_permissions(&private_root, fs::Permissions::from_mode(0o700))
             .expect("private permissions");
-        let linked_parent = temporary.path().join("linked-parent");
+        let linked_parent = canonical_temporary.join("linked-parent");
         std::os::unix::fs::symlink(&actual_parent, &linked_parent).expect("parent symlink");
 
         open_private_capture_root(&private_root)
@@ -1949,7 +1950,8 @@ mod tests {
         use std::os::unix::ffi::OsStrExt;
 
         let temporary = tempdir().expect("temporary root");
-        let fifo = temporary.path().join("synthetic-fifo");
+        let canonical_temporary = temporary.path().canonicalize().expect("canonical root");
+        let fifo = canonical_temporary.join("synthetic-fifo");
         let fifo_name = CString::new(fifo.as_os_str().as_bytes()).expect("fifo path");
         assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
 

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -289,11 +289,11 @@ fn begin_private_bundle_transaction(
             "SCCM private publication limits are invalid",
         ));
     }
-    validate_single_component(bundle_name)?;
+    let bundle_component = validate_single_component(bundle_name)?;
 
     #[cfg(unix)]
     {
-        let name = OsStr::new(bundle_name);
+        let name = bundle_component.as_os_str();
         let transaction_parent = private_root.directory.try_clone()?;
         let destination_visibility = clone_directory_anchors(&private_root.visibility)?;
         create_directory_at(&private_root.directory, name)?;
@@ -348,7 +348,7 @@ fn begin_private_bundle_transaction(
 
     #[cfg(not(unix))]
     {
-        let _ = (private_root, bundle_name);
+        let _ = (private_root, bundle_component);
         Err(io::Error::new(
             io::ErrorKind::Unsupported,
             "handle-bound SCCM destination publication is not implemented on this platform",
@@ -600,20 +600,21 @@ impl Drop for PrivateBundleTransaction {
     }
 }
 
-fn validate_single_component(value: &str) -> io::Result<()> {
+fn validate_single_component(value: &str) -> io::Result<OsString> {
     let path = Path::new(value);
     let components = path.components().collect::<Vec<_>>();
-    if value.is_empty()
-        || value.len() > 160
-        || components.len() != 1
-        || !matches!(components[0], Component::Normal(_))
-    {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "SCCM bundle name is unsafe",
-        ));
-    }
-    Ok(())
+    let validated = if value.is_empty() || value.len() > 160 || components.len() != 1 {
+        None
+    } else {
+        match components[0] {
+            Component::Normal(component) if path.as_os_str() == component => {
+                Some(component.to_os_string())
+            }
+            _ => None,
+        }
+    };
+    validated
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "SCCM bundle name is unsafe"))
 }
 
 fn validate_relative_path(relative: &Path) -> io::Result<()> {
@@ -1835,6 +1836,18 @@ mod tests {
             .write_new_file(Path::new("aggregate.log"), b"12345")
             .expect_err("aggregate cap is checked before creation");
         assert!(!path.join("capture-002/aggregate.log").exists());
+    }
+
+    #[test]
+    fn bundle_name_requires_the_exact_validated_component() {
+        let (_temporary, path, root) = private_capture_root();
+
+        let error = begin_private_bundle_transaction(&root, "capture-001/", test_limits())
+            .expect_err("a normalized spelling must not reach handle-relative syscalls");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("bundle name is unsafe"));
+        assert!(!path.join("capture-001").exists());
     }
 
     #[test]

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -1727,6 +1727,8 @@ mod tests {
         let linked_parent = temporary.path().join("linked-parent");
         std::os::unix::fs::symlink(&actual_parent, &linked_parent).expect("parent symlink");
 
+        open_private_capture_root(&private_root)
+            .expect("control path reaches the real root before testing the parent symlink");
         let error = open_private_capture_root(&linked_parent.join("private-root"))
             .expect_err("capture-root traversal never follows a parent symlink");
         assert!(
@@ -1951,7 +1953,10 @@ mod tests {
         let fifo_name = CString::new(fifo.as_os_str().as_bytes()).expect("fifo path");
         assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
 
-        open_file_no_follow(&fifo).expect_err("FIFO is rejected through a nonblocking open");
+        let error =
+            open_file_no_follow(&fifo).expect_err("FIFO is rejected through a nonblocking open");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(error.to_string(), "SCCM bundle entry is not a regular file");
     }
 
     #[test]

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -757,6 +757,16 @@ fn verify_platform_namespace_security(_directory: &File) -> io::Result<()> {
 }
 
 #[cfg(target_os = "macos")]
+fn macos_ownership_ignore_mask(flag: libc::c_int) -> io::Result<u32> {
+    u32::try_from(flag).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::Unsupported,
+            "SCCM capture destination filesystem flags cannot be validated",
+        )
+    })
+}
+
+#[cfg(target_os = "macos")]
 fn verify_platform_namespace_security(directory: &File) -> io::Result<()> {
     use std::os::fd::AsRawFd;
 
@@ -765,7 +775,7 @@ fn verify_platform_namespace_security(directory: &File) -> io::Result<()> {
         return Err(io::Error::last_os_error());
     }
     let file_system = unsafe { file_system.assume_init() };
-    if file_system.f_flags & u32::try_from(libc::MNT_IGNORE_OWNERSHIP).unwrap_or_default() != 0 {
+    if file_system.f_flags & macos_ownership_ignore_mask(libc::MNT_IGNORE_OWNERSHIP)? != 0 {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             "SCCM capture destination filesystem ignores ownership",
@@ -817,6 +827,9 @@ fn reject_macos_extended_acl(directory: &File) -> io::Result<()> {
     }
 
     let mut entry = std::ptr::null_mut();
+    // macOS acl_get_entry(3) returns 0 for an entry and -1 with EINVAL when
+    // ACL_FIRST_ENTRY finds no entry. It does not use Linux libacl's positive
+    // end-of-list sentinel, and every unexpected errno remains an error.
     unsafe {
         *libc::__error() = 0;
     }
@@ -1719,29 +1732,6 @@ mod tests {
         assert!(
             matches!(error.raw_os_error(), Some(code) if code == libc::ELOOP || code == libc::ENOTDIR),
             "expected a no-follow component rejection, got {error:?}"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn macos_acl_entry_status_distinguishes_empty_acl_from_error() {
-        assert_eq!(
-            classify_macos_acl_entry_status(0).expect("entry status"),
-            MacosAclEntryStatus::Present
-        );
-        assert_eq!(
-            classify_macos_acl_entry_status(1).expect("empty ACL status"),
-            MacosAclEntryStatus::Empty
-        );
-        assert_eq!(
-            classify_macos_acl_entry_status(-1).expect("error status"),
-            MacosAclEntryStatus::Error
-        );
-        assert_eq!(
-            classify_macos_acl_entry_status(2)
-                .expect_err("unknown ACL status must fail closed")
-                .kind(),
-            io::ErrorKind::InvalidData
         );
     }
 

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -1,9 +1,10 @@
+use std::ffi::OsString;
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::{Component, Path};
 
 #[cfg(unix)]
-use std::ffi::{CString, OsStr, OsString};
+use std::ffi::{CString, OsStr};
 #[cfg(unix)]
 use std::path::PathBuf;
 

--- a/src-tauri/src/sccm/private_fs.rs
+++ b/src-tauri/src/sccm/private_fs.rs
@@ -2,6 +2,11 @@ use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::{Component, Path};
 
+#[cfg(unix)]
+use std::ffi::{CString, OsStr, OsString};
+#[cfg(unix)]
+use std::path::PathBuf;
+
 use crate::error::AppError;
 
 /// A bundle root whose identity remains bound for the lifetime of a native read.
@@ -96,6 +101,942 @@ impl VerifiedBundleRoot {
             ))
         }
     }
+}
+
+const MAX_PRIVATE_CAPTURE_FILES: usize = 4_096;
+const MAX_PRIVATE_CAPTURE_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_PRIVATE_CAPTURE_TOTAL_BYTES: u64 = 1024 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PrivateCaptureLimits {
+    max_files: usize,
+    max_file_bytes: u64,
+    max_total_bytes: u64,
+}
+
+impl PrivateCaptureLimits {
+    fn is_valid(self) -> bool {
+        self.max_files != 0
+            && self.max_files <= MAX_PRIVATE_CAPTURE_FILES
+            && self.max_file_bytes != 0
+            && self.max_file_bytes <= MAX_PRIVATE_CAPTURE_ARTIFACT_BYTES
+            && self.max_total_bytes != 0
+            && self.max_total_bytes <= MAX_PRIVATE_CAPTURE_TOTAL_BYTES
+            && self.max_file_bytes <= self.max_total_bytes
+    }
+}
+
+/// Non-forgeable destination authority rooted at a no-follow directory handle.
+///
+/// The source-capture seam deliberately does not exist yet. Native enumeration
+/// must eventually produce an equivalent handle-bound source token before any
+/// evidence-copy API can be added safely.
+#[derive(Debug)]
+struct PrivateCaptureRoot {
+    #[cfg(unix)]
+    directory: File,
+    #[cfg(unix)]
+    visibility: Vec<DirectoryAnchor>,
+}
+
+fn open_private_capture_root(path: &Path) -> io::Result<PrivateCaptureRoot> {
+    #[cfg(unix)]
+    {
+        let (directory, visibility) = open_absolute_directory_no_follow(path)?;
+        let metadata = directory.metadata()?;
+        verify_private_directory(path, &metadata).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "SCCM capture destination root is not private",
+            )
+        })?;
+        Ok(PrivateCaptureRoot {
+            directory,
+            visibility,
+        })
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "handle-bound SCCM destination publication is not implemented on this platform",
+        ))
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileIdentity {
+    device: u64,
+    inode: u64,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct DirectoryAnchor {
+    parent: File,
+    name: OsString,
+    identity: FileIdentity,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CreatedEntryKind {
+    File,
+    Directory,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct CreatedEntry {
+    parent: File,
+    name: OsString,
+    relative: PathBuf,
+    identity: FileIdentity,
+    kind: CreatedEntryKind,
+}
+
+#[cfg(unix)]
+struct PendingCreatedEntry<'a> {
+    parent: &'a File,
+    name: OsString,
+    identity: FileIdentity,
+    kind: CreatedEntryKind,
+    armed: bool,
+}
+
+#[cfg(unix)]
+struct PendingUnidentifiedEntry<'a> {
+    parent: &'a File,
+    name: OsString,
+    kind: CreatedEntryKind,
+    armed: bool,
+}
+
+#[cfg(unix)]
+impl PendingUnidentifiedEntry<'_> {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PendingUnidentifiedEntry<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            remove_private_name(self.parent, &self.name, self.kind);
+            let _ = self.parent.sync_all();
+        }
+    }
+}
+
+#[cfg(unix)]
+impl PendingCreatedEntry<'_> {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PendingCreatedEntry<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            remove_name_if_identity(self.parent, &self.name, self.identity, self.kind);
+            let _ = self.parent.sync_all();
+        }
+    }
+}
+
+/// A create-new destination transaction. Every mutation and rollback operation
+/// remains relative to verified open directory handles. Detected namespace
+/// replacement fails closed and may leave an inert private directory behind;
+/// cleanup never intentionally removes an observed replacement object. Root
+/// admission excludes lower-privilege namespace mutation; malicious same-euid
+/// or root mutation remains outside this primitive's threat boundary.
+#[derive(Debug)]
+struct PrivateBundleTransaction {
+    #[cfg(unix)]
+    destination_visibility: Vec<DirectoryAnchor>,
+    #[cfg(unix)]
+    parent: File,
+    #[cfg(unix)]
+    root: File,
+    #[cfg(unix)]
+    root_name: OsString,
+    #[cfg(unix)]
+    root_identity: FileIdentity,
+    #[cfg(unix)]
+    created_entries: Vec<CreatedEntry>,
+    #[cfg(unix)]
+    file_count: usize,
+    #[cfg(unix)]
+    total_bytes: u64,
+    limits: PrivateCaptureLimits,
+    poisoned: bool,
+    committed: bool,
+}
+
+fn begin_private_bundle_transaction(
+    private_root: &PrivateCaptureRoot,
+    bundle_name: &str,
+    limits: PrivateCaptureLimits,
+) -> io::Result<PrivateBundleTransaction> {
+    if !limits.is_valid() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM private publication limits are invalid",
+        ));
+    }
+    validate_single_component(bundle_name)?;
+
+    #[cfg(unix)]
+    {
+        let name = OsStr::new(bundle_name);
+        let transaction_parent = private_root.directory.try_clone()?;
+        let destination_visibility = clone_directory_anchors(&private_root.visibility)?;
+        create_directory_at(&private_root.directory, name)?;
+        let mut unidentified = PendingUnidentifiedEntry {
+            parent: &private_root.directory,
+            name: name.to_os_string(),
+            kind: CreatedEntryKind::Directory,
+            armed: true,
+        };
+        let root = open_directory_at(&private_root.directory, name)?;
+        let identity = file_identity(&root)?;
+        if identity_at(&private_root.directory, name)? != identity {
+            unidentified.disarm();
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SCCM destination identity changed during creation",
+            ));
+        }
+        let mut pending = PendingCreatedEntry {
+            parent: &private_root.directory,
+            name: name.to_os_string(),
+            identity,
+            kind: CreatedEntryKind::Directory,
+            armed: true,
+        };
+        unidentified.disarm();
+        drop(unidentified);
+        invoke_private_create_hook()?;
+        let metadata = root.metadata()?;
+        verify_private_directory(Path::new("."), &metadata).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "SCCM destination bundle is not private",
+            )
+        })?;
+        private_root.directory.sync_all()?;
+        pending.disarm();
+        Ok(PrivateBundleTransaction {
+            destination_visibility,
+            parent: transaction_parent,
+            root,
+            root_name: name.to_os_string(),
+            root_identity: identity,
+            created_entries: Vec::new(),
+            file_count: 0,
+            total_bytes: 0,
+            limits,
+            poisoned: false,
+            committed: false,
+        })
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (private_root, bundle_name);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "handle-bound SCCM destination publication is not implemented on this platform",
+        ))
+    }
+}
+
+impl PrivateBundleTransaction {
+    fn write_new_file(&mut self, relative: &Path, bytes: &[u8]) -> io::Result<()> {
+        if self.poisoned {
+            return Err(io::Error::other(
+                "SCCM destination transaction is already poisoned",
+            ));
+        }
+
+        #[cfg(unix)]
+        {
+            validate_relative_path(relative)?;
+            let byte_count = u64::try_from(bytes.len()).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "SCCM artifact is too large")
+            })?;
+            let next_total = self.total_bytes.checked_add(byte_count).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "SCCM byte budget overflow")
+            })?;
+            if self.file_count >= self.limits.max_files
+                || byte_count > self.limits.max_file_bytes
+                || next_total > self.limits.max_total_bytes
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "SCCM destination publication limit exceeded",
+                ));
+            }
+
+            let result = self.write_new_file_inner(relative, bytes, byte_count);
+            if result.is_err() {
+                self.poisoned = true;
+                return result;
+            }
+            self.file_count += 1;
+            self.total_bytes = next_total;
+            Ok(())
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = (relative, bytes);
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "handle-bound SCCM destination publication is not implemented on this platform",
+            ))
+        }
+    }
+
+    fn commit(mut self) -> io::Result<()> {
+        if self.poisoned {
+            return Err(io::Error::other(
+                "poisoned SCCM destination transaction cannot be committed",
+            ));
+        }
+        #[cfg(unix)]
+        {
+            self.validate_visible_namespace()?;
+            self.root.sync_all()?;
+            self.parent.sync_all()?;
+            self.validate_visible_namespace()?;
+        }
+        self.committed = true;
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn write_new_file_inner(
+        &mut self,
+        relative: &Path,
+        bytes: &[u8],
+        byte_count: u64,
+    ) -> io::Result<()> {
+        use std::io::Write as _;
+
+        let mut output = self.create_new_relative_file(relative)?;
+        output.write_all(bytes)?;
+        output.sync_all()?;
+        if output.metadata()?.len() != byte_count {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SCCM destination size changed during publication",
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn create_new_relative_file(&mut self, relative: &Path) -> io::Result<File> {
+        let components = relative.components().collect::<Vec<_>>();
+        let mut directory = self.root.try_clone()?;
+        let mut accumulated = PathBuf::new();
+        for component in &components[..components.len() - 1] {
+            let Component::Normal(name) = component else {
+                unreachable!("validated relative path")
+            };
+            accumulated.push(name);
+            let existing = self.created_entries.iter().find(|entry| {
+                entry.kind == CreatedEntryKind::Directory && entry.relative == accumulated
+            });
+            if let Some(existing) = existing {
+                let opened = open_directory_at(&directory, name)?;
+                if file_identity(&opened)? != existing.identity {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "SCCM destination ancestor identity changed",
+                    ));
+                }
+                directory = opened;
+                continue;
+            }
+
+            let tracked_parent = directory.try_clone()?;
+            create_directory_at(&directory, name)?;
+            let mut unidentified = PendingUnidentifiedEntry {
+                parent: &directory,
+                name: name.to_os_string(),
+                kind: CreatedEntryKind::Directory,
+                armed: true,
+            };
+            let opened = open_directory_at(&directory, name)?;
+            let identity = file_identity(&opened)?;
+            if identity_at(&directory, name)? != identity {
+                unidentified.disarm();
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "SCCM destination ancestor identity changed during creation",
+                ));
+            }
+            let mut pending = PendingCreatedEntry {
+                parent: &directory,
+                name: name.to_os_string(),
+                identity,
+                kind: CreatedEntryKind::Directory,
+                armed: true,
+            };
+            unidentified.disarm();
+            drop(unidentified);
+            directory.sync_all()?;
+            self.created_entries.push(CreatedEntry {
+                parent: tracked_parent,
+                name: name.to_os_string(),
+                relative: accumulated.clone(),
+                identity,
+                kind: CreatedEntryKind::Directory,
+            });
+            pending.disarm();
+            drop(pending);
+            directory = opened;
+        }
+
+        let Component::Normal(name) = components.last().expect("validated relative path") else {
+            unreachable!("validated relative path")
+        };
+        let tracked_parent = directory.try_clone()?;
+        let output = create_file_at(&directory, name)?;
+        let mut unidentified = PendingUnidentifiedEntry {
+            parent: &directory,
+            name: name.to_os_string(),
+            kind: CreatedEntryKind::File,
+            armed: true,
+        };
+        let identity = file_identity(&output)?;
+        if identity_at(&directory, name)? != identity {
+            unidentified.disarm();
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SCCM destination file identity changed during creation",
+            ));
+        }
+        let mut pending = PendingCreatedEntry {
+            parent: &directory,
+            name: name.to_os_string(),
+            identity,
+            kind: CreatedEntryKind::File,
+            armed: true,
+        };
+        unidentified.disarm();
+        drop(unidentified);
+        directory.sync_all()?;
+        self.created_entries.push(CreatedEntry {
+            parent: tracked_parent,
+            name: name.to_os_string(),
+            relative: relative.to_path_buf(),
+            identity,
+            kind: CreatedEntryKind::File,
+        });
+        pending.disarm();
+        Ok(output)
+    }
+
+    #[cfg(unix)]
+    fn validate_visible_namespace(&self) -> io::Result<()> {
+        validate_directory_anchors(&self.destination_visibility)?;
+        for directory in [&self.parent, &self.root] {
+            let metadata = directory.metadata()?;
+            verify_private_directory(Path::new("."), &metadata).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "SCCM destination transaction directory is no longer private",
+                )
+            })?;
+        }
+        if identity_at(&self.parent, &self.root_name)? != self.root_identity {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SCCM destination bundle is no longer visible at its committed name",
+            ));
+        }
+        for entry in &self.created_entries {
+            if identity_at(&entry.parent, &entry.name)? != entry.identity {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "SCCM destination entry is no longer visible at its committed name",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn rollback(&mut self) {
+        for entry in self.created_entries.iter().rev() {
+            remove_name_if_identity(&entry.parent, &entry.name, entry.identity, entry.kind);
+            let _ = entry.parent.sync_all();
+        }
+        let _ = self.root.sync_all();
+        remove_name_if_identity(
+            &self.parent,
+            &self.root_name,
+            self.root_identity,
+            CreatedEntryKind::Directory,
+        );
+        let _ = self.parent.sync_all();
+    }
+}
+
+impl Drop for PrivateBundleTransaction {
+    fn drop(&mut self) {
+        if !self.committed {
+            #[cfg(unix)]
+            self.rollback();
+        }
+    }
+}
+
+fn validate_single_component(value: &str) -> io::Result<()> {
+    let path = Path::new(value);
+    let components = path.components().collect::<Vec<_>>();
+    if value.is_empty()
+        || value.len() > 160
+        || components.len() != 1
+        || !matches!(components[0], Component::Normal(_))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM bundle name is unsafe",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_relative_path(relative: &Path) -> io::Result<()> {
+    let components = relative.components().collect::<Vec<_>>();
+    if components.is_empty()
+        || components.len() > 32
+        || relative.as_os_str().len() > 1024
+        || components
+            .iter()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM bundle relative path is unsafe",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_absolute_directory_no_follow(path: &Path) -> io::Result<(File, Vec<DirectoryAnchor>)> {
+    use std::os::fd::FromRawFd;
+
+    if !path.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM capture destination root must be absolute",
+        ));
+    }
+    let descriptor = unsafe {
+        libc::open(
+            c"/".as_ptr(),
+            libc::O_RDONLY
+                | libc::O_DIRECTORY
+                | libc::O_NOFOLLOW
+                | libc::O_NONBLOCK
+                | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut directory = unsafe { File::from_raw_fd(descriptor) };
+    let mut visibility = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::RootDir => {}
+            Component::Normal(name) => {
+                let parent = directory.try_clone()?;
+                let opened = open_directory_at(&directory, name)?;
+                let identity = file_identity(&opened)?;
+                if identity_at(&directory, name)? != identity {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "SCCM capture destination identity changed while opening",
+                    ));
+                }
+                verify_trusted_namespace_anchor(&directory, &opened)?;
+                visibility.push(DirectoryAnchor {
+                    parent,
+                    name: name.to_os_string(),
+                    identity,
+                });
+                directory = opened;
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "SCCM capture destination path is unsafe",
+                ));
+            }
+        }
+    }
+    Ok((directory, visibility))
+}
+
+#[cfg(unix)]
+fn clone_directory_anchors(anchors: &[DirectoryAnchor]) -> io::Result<Vec<DirectoryAnchor>> {
+    anchors
+        .iter()
+        .map(|anchor| {
+            Ok(DirectoryAnchor {
+                parent: anchor.parent.try_clone()?,
+                name: anchor.name.clone(),
+                identity: anchor.identity,
+            })
+        })
+        .collect()
+}
+
+#[cfg(unix)]
+fn validate_directory_anchors(anchors: &[DirectoryAnchor]) -> io::Result<()> {
+    for anchor in anchors {
+        let opened = open_directory_at(&anchor.parent, &anchor.name)?;
+        if file_identity(&opened)? != anchor.identity {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SCCM capture destination is no longer visible at its verified path",
+            ));
+        }
+        verify_trusted_namespace_anchor(&anchor.parent, &opened)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn verify_trusted_namespace_anchor(parent: &File, child: &File) -> io::Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let parent_metadata = parent.metadata()?;
+    let child_metadata = child.metadata()?;
+    let effective_user = unsafe { libc::geteuid() };
+    let trusted_owner = |uid| uid == 0 || uid == effective_user;
+    if !trusted_owner(parent_metadata.uid()) || !trusted_owner(child_metadata.uid()) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "SCCM capture destination has an untrusted namespace owner",
+        ));
+    }
+
+    let parent_mode = parent_metadata.permissions().mode();
+    let lower_privilege_writable = parent_mode & 0o022 != 0;
+    let sticky = parent_mode & 0o1000 != 0;
+    if lower_privilege_writable && !sticky {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "SCCM capture destination has a mutable ancestor namespace",
+        ));
+    }
+
+    verify_platform_namespace_security(parent)?;
+    verify_platform_namespace_security(child)
+}
+
+#[cfg(target_os = "linux")]
+fn verify_platform_namespace_security(_directory: &File) -> io::Result<()> {
+    // Linux access-ACL grants are bounded by the group-class mode mask checked
+    // above. A writable class is rejected unless sticky-directory ownership
+    // rules protect the trusted-owned child entry.
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn verify_platform_namespace_security(directory: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let mut file_system = std::mem::MaybeUninit::<libc::statfs>::uninit();
+    if unsafe { libc::fstatfs(directory.as_raw_fd(), file_system.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let file_system = unsafe { file_system.assume_init() };
+    if file_system.f_flags & u32::try_from(libc::MNT_IGNORE_OWNERSHIP).unwrap_or_default() != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "SCCM capture destination filesystem ignores ownership",
+        ));
+    }
+    reject_macos_extended_acl(directory)
+}
+
+#[cfg(target_os = "macos")]
+fn reject_macos_extended_acl(directory: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    const ACL_FIRST_ENTRY: libc::c_int = 0;
+    const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
+
+    extern "C" {
+        fn acl_free(object: *mut libc::c_void) -> libc::c_int;
+        fn acl_get_entry(
+            acl: *mut libc::c_void,
+            entry_id: libc::c_int,
+            entry: *mut *mut libc::c_void,
+        ) -> libc::c_int;
+        fn acl_get_fd_np(fd: libc::c_int, acl_type: libc::c_int) -> *mut libc::c_void;
+        fn acl_valid(acl: *mut libc::c_void) -> libc::c_int;
+    }
+
+    struct OwnedAcl(*mut libc::c_void);
+
+    impl Drop for OwnedAcl {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = acl_free(self.0);
+            }
+        }
+    }
+
+    let acl = unsafe { acl_get_fd_np(directory.as_raw_fd(), ACL_TYPE_EXTENDED) };
+    if acl.is_null() {
+        let error = io::Error::last_os_error();
+        return if error.raw_os_error() == Some(libc::ENOENT) {
+            Ok(())
+        } else {
+            Err(error)
+        };
+    }
+    let acl = OwnedAcl(acl);
+    if unsafe { acl_valid(acl.0) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut entry = std::ptr::null_mut();
+    unsafe {
+        *libc::__error() = 0;
+    }
+    if unsafe { acl_get_entry(acl.0, ACL_FIRST_ENTRY, &mut entry) } == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "SCCM capture destination has an extended ACL",
+        ));
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::EINVAL) {
+        Ok(())
+    } else {
+        Err(error)
+    }
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+fn verify_platform_namespace_security(_directory: &File) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "SCCM capture destination namespace validation is unavailable on this platform",
+    ))
+}
+
+#[cfg(unix)]
+fn create_directory_at(parent: &File, name: &OsStr) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+
+    let name = CString::new(name.as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM path contains an interior NUL",
+        )
+    })?;
+    if unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o700) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_directory_at(parent: &File, name: &OsStr) -> io::Result<File> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    let name = CString::new(name.as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM path contains an interior NUL",
+        )
+    })?;
+    let descriptor = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY
+                | libc::O_DIRECTORY
+                | libc::O_NOFOLLOW
+                | libc::O_NONBLOCK
+                | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let directory = unsafe { File::from_raw_fd(descriptor) };
+    let metadata = directory.metadata()?;
+    if is_reparse_point(&metadata) || !metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "SCCM path component is not a real directory",
+        ));
+    }
+    Ok(directory)
+}
+
+#[cfg(unix)]
+fn create_file_at(parent: &File, name: &OsStr) -> io::Result<File> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    let name = CString::new(name.as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM path contains an interior NUL",
+        )
+    })?;
+    let descriptor = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_WRONLY
+                | libc::O_CREAT
+                | libc::O_EXCL
+                | libc::O_NOFOLLOW
+                | libc::O_NONBLOCK
+                | libc::O_CLOEXEC,
+            0o600,
+        )
+    };
+    if descriptor < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(unsafe { File::from_raw_fd(descriptor) })
+}
+
+#[cfg(unix)]
+fn file_identity(file: &File) -> io::Result<FileIdentity> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = file.metadata()?;
+    Ok(FileIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+#[cfg(unix)]
+fn identity_at(parent: &File, name: &OsStr) -> io::Result<FileIdentity> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+
+    let name = CString::new(name.as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "SCCM path contains an interior NUL",
+        )
+    })?;
+    let mut status = std::mem::MaybeUninit::<libc::stat>::uninit();
+    if unsafe {
+        libc::fstatat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            status.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } != 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    let status = unsafe { status.assume_init() };
+    Ok(FileIdentity {
+        device: status.st_dev as u64,
+        inode: status.st_ino,
+    })
+}
+
+#[cfg(unix)]
+fn remove_name_if_identity(
+    parent: &File,
+    name: &OsStr,
+    expected: FileIdentity,
+    kind: CreatedEntryKind,
+) {
+    if identity_at(parent, name).ok() != Some(expected) {
+        return;
+    }
+    remove_private_name(parent, name, kind);
+}
+
+/// Removes a name created by this transaction from an euid-owned, mode-0700
+/// directory. POSIX has no conditional unlink-by-file-identity operation, so a
+/// malicious same-euid (or root) namespace mutator is outside this primitive's
+/// trust boundary. Every observable identity mismatch fails closed instead.
+#[cfg(unix)]
+fn remove_private_name(parent: &File, name: &OsStr, kind: CreatedEntryKind) {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+
+    let Ok(name) = CString::new(name.as_bytes()) else {
+        return;
+    };
+    let flags = if kind == CreatedEntryKind::Directory {
+        libc::AT_REMOVEDIR
+    } else {
+        0
+    };
+    let _ = unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), flags) };
+}
+
+#[cfg(all(test, unix))]
+thread_local! {
+    static FAIL_PRIVATE_CREATE_AFTER_MKDIR: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(all(test, unix))]
+#[derive(Debug)]
+struct PrivateCreateHookGuard;
+
+#[cfg(all(test, unix))]
+impl PrivateCreateHookGuard {
+    fn fail_after_mkdir() -> Self {
+        FAIL_PRIVATE_CREATE_AFTER_MKDIR.with(|fail| fail.set(true));
+        Self
+    }
+}
+
+#[cfg(all(test, unix))]
+impl Drop for PrivateCreateHookGuard {
+    fn drop(&mut self) {
+        FAIL_PRIVATE_CREATE_AFTER_MKDIR.with(|fail| fail.set(false));
+    }
+}
+
+#[cfg(all(test, unix))]
+fn invoke_private_create_hook() -> io::Result<()> {
+    if FAIL_PRIVATE_CREATE_AFTER_MKDIR.with(std::cell::Cell::get) {
+        Err(io::Error::other(
+            "injected SCCM destination creation failure",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(all(unix, not(test)))]
+fn invoke_private_create_hook() -> io::Result<()> {
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -735,11 +1676,250 @@ mod tests {
     use std::cell::RefCell;
     use std::io::Read;
     use std::os::fd::AsRawFd;
+    use std::os::unix::fs::PermissionsExt;
     use std::rc::Rc;
 
     use tempfile::tempdir;
 
     use super::*;
+
+    fn private_capture_root() -> (tempfile::TempDir, PathBuf, PrivateCaptureRoot) {
+        let temporary = tempdir().expect("temporary root");
+        fs::set_permissions(temporary.path(), fs::Permissions::from_mode(0o700))
+            .expect("private temporary root");
+        let canonical = temporary
+            .path()
+            .canonicalize()
+            .expect("canonical test root");
+        let root = open_private_capture_root(&canonical).expect("handle-bound private root");
+        (temporary, canonical, root)
+    }
+
+    fn test_limits() -> PrivateCaptureLimits {
+        PrivateCaptureLimits {
+            max_files: 1,
+            max_file_bytes: 8,
+            max_total_bytes: 10,
+        }
+    }
+
+    #[test]
+    fn private_capture_root_rejects_a_symlinked_parent_component() {
+        let temporary = tempdir().expect("temporary root");
+        let actual_parent = temporary.path().join("actual-parent");
+        let private_root = actual_parent.join("private-root");
+        fs::create_dir_all(&private_root).expect("real private root");
+        fs::set_permissions(&private_root, fs::Permissions::from_mode(0o700))
+            .expect("private permissions");
+        let linked_parent = temporary.path().join("linked-parent");
+        std::os::unix::fs::symlink(&actual_parent, &linked_parent).expect("parent symlink");
+
+        open_private_capture_root(&linked_parent.join("private-root"))
+            .expect_err("capture-root traversal never follows a parent symlink");
+    }
+
+    #[test]
+    fn private_capture_root_rejects_a_world_writable_nonsticky_parent() {
+        let temporary = tempdir().expect("temporary root");
+        let canonical_temporary = temporary.path().canonicalize().expect("canonical root");
+        let mutable_parent = canonical_temporary.join("mutable-parent");
+        let private_root = mutable_parent.join("private-root");
+        fs::create_dir_all(&private_root).expect("private root");
+        fs::set_permissions(&mutable_parent, fs::Permissions::from_mode(0o777))
+            .expect("mutable parent permissions");
+        fs::set_permissions(&private_root, fs::Permissions::from_mode(0o700))
+            .expect("private root permissions");
+
+        let error = open_private_capture_root(&private_root)
+            .expect_err("lower-privilege mutable parent is rejected");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(error.to_string().contains("mutable ancestor namespace"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn private_capture_root_rejects_a_parent_with_an_extended_allow_acl() {
+        let temporary = tempdir().expect("temporary root");
+        let canonical_temporary = temporary.path().canonicalize().expect("canonical root");
+        let acl_parent = canonical_temporary.join("acl-parent");
+        let private_root = acl_parent.join("private-root");
+        fs::create_dir_all(&private_root).expect("private root");
+        fs::set_permissions(&acl_parent, fs::Permissions::from_mode(0o700))
+            .expect("acl parent permissions");
+        fs::set_permissions(&private_root, fs::Permissions::from_mode(0o700))
+            .expect("private root permissions");
+        let status = std::process::Command::new("/bin/chmod")
+            .arg("+a")
+            .arg("everyone allow delete_child")
+            .arg(&acl_parent)
+            .status()
+            .expect("invoke chmod for ACL fixture");
+        assert!(status.success(), "install extended ACL fixture");
+
+        let error = open_private_capture_root(&private_root)
+            .expect_err("extended allow ACL on an anchor parent is rejected");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(error.to_string().contains("extended ACL"));
+    }
+
+    #[test]
+    fn destination_limits_fail_before_creating_the_rejected_entry() {
+        let (_temporary, path, root) = private_capture_root();
+        let mut transaction = begin_private_bundle_transaction(&root, "capture-001", test_limits())
+            .expect("new transaction");
+
+        transaction
+            .write_new_file(Path::new("too-large.log"), b"123456789")
+            .expect_err("per-file cap is checked before creation");
+        assert!(!path.join("capture-001/too-large.log").exists());
+
+        transaction
+            .write_new_file(Path::new("first.log"), b"123456")
+            .expect("first destination file");
+        transaction
+            .write_new_file(Path::new("second.log"), b"1")
+            .expect_err("global file count is checked before creation");
+        assert!(!path.join("capture-001/second.log").exists());
+
+        drop(transaction);
+        let mut aggregate_transaction = begin_private_bundle_transaction(
+            &root,
+            "capture-002",
+            PrivateCaptureLimits {
+                max_files: 2,
+                max_file_bytes: 8,
+                max_total_bytes: 10,
+            },
+        )
+        .expect("aggregate-limit transaction");
+        aggregate_transaction
+            .write_new_file(Path::new("first.log"), b"123456")
+            .expect("first aggregate file");
+        aggregate_transaction
+            .write_new_file(Path::new("aggregate.log"), b"12345")
+            .expect_err("aggregate cap is checked before creation");
+        assert!(!path.join("capture-002/aggregate.log").exists());
+    }
+
+    #[test]
+    fn production_security_ceilings_cannot_be_relaxed_by_a_caller() {
+        assert_eq!(MAX_PRIVATE_CAPTURE_ARTIFACT_BYTES, 256 * 1024 * 1024);
+        assert_eq!(MAX_PRIVATE_CAPTURE_TOTAL_BYTES, 1024 * 1024 * 1024);
+        assert_eq!(MAX_PRIVATE_CAPTURE_FILES, 4_096);
+        let (_temporary, path, root) = private_capture_root();
+        let relaxed = PrivateCaptureLimits {
+            max_files: MAX_PRIVATE_CAPTURE_FILES + 1,
+            max_file_bytes: MAX_PRIVATE_CAPTURE_ARTIFACT_BYTES + 1,
+            max_total_bytes: MAX_PRIVATE_CAPTURE_TOTAL_BYTES + 1,
+        };
+
+        begin_private_bundle_transaction(&root, "capture-001", relaxed)
+            .expect_err("immutable security ceilings reject relaxed limits");
+
+        assert!(!path.join("capture-001").exists());
+    }
+
+    #[test]
+    fn rollback_uses_open_handles_after_the_visible_bundle_name_is_replaced() {
+        let (_temporary, path, root) = private_capture_root();
+        let mut transaction = begin_private_bundle_transaction(&root, "capture-001", test_limits())
+            .expect("new transaction");
+        transaction
+            .write_new_file(Path::new("evidence/original.log"), b"owned")
+            .expect("transaction-owned evidence");
+
+        let replacement = path.join("replacement");
+        fs::create_dir(&replacement).expect("replacement directory");
+        fs::write(replacement.join("sentinel"), b"existing").expect("replacement sentinel");
+        let retired = path.join("retired");
+        fs::rename(path.join("capture-001"), &retired).expect("retire transaction root");
+        fs::rename(&replacement, path.join("capture-001")).expect("install replacement root");
+
+        transaction
+            .commit()
+            .expect_err("commit fails when the visible bundle identity is replaced");
+
+        assert_eq!(
+            fs::read(path.join("capture-001/sentinel")).expect("replacement survives"),
+            b"existing"
+        );
+        assert!(!retired.join("evidence/original.log").exists());
+    }
+
+    #[test]
+    fn commit_rejects_a_replaced_destination_root_component() {
+        let temporary = tempdir().expect("temporary root");
+        let canonical_temporary = temporary.path().canonicalize().expect("canonical root");
+        let destination = canonical_temporary.join("private");
+        fs::create_dir(&destination).expect("private destination");
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o700))
+            .expect("private destination permissions");
+        let root = open_private_capture_root(&destination).expect("handle-bound destination");
+        let mut transaction = begin_private_bundle_transaction(&root, "capture-001", test_limits())
+            .expect("new transaction");
+        transaction
+            .write_new_file(Path::new("evidence/original.log"), b"owned")
+            .expect("transaction-owned evidence");
+
+        let replacement = canonical_temporary.join("replacement");
+        fs::create_dir(&replacement).expect("replacement destination");
+        fs::set_permissions(&replacement, fs::Permissions::from_mode(0o700))
+            .expect("replacement destination permissions");
+        fs::write(replacement.join("sentinel"), b"existing").expect("replacement sentinel");
+        let retired = canonical_temporary.join("retired");
+        fs::rename(&destination, &retired).expect("retire destination root");
+        fs::rename(&replacement, &destination).expect("install replacement destination");
+
+        transaction
+            .commit()
+            .expect_err("commit fails when a destination-root component is replaced");
+
+        assert_eq!(
+            fs::read(destination.join("sentinel")).expect("replacement survives"),
+            b"existing"
+        );
+        assert!(!retired.join("capture-001/evidence/original.log").exists());
+    }
+
+    #[test]
+    fn injected_creation_failure_removes_the_directory_created_by_this_attempt() {
+        let (_temporary, path, root) = private_capture_root();
+        let _hook = PrivateCreateHookGuard::fail_after_mkdir();
+
+        begin_private_bundle_transaction(&root, "capture-001", test_limits())
+            .expect_err("injected post-mkdir failure");
+
+        assert!(!path.join("capture-001").exists());
+    }
+
+    #[test]
+    fn committed_destination_transaction_retains_only_create_new_files() {
+        let (_temporary, path, root) = private_capture_root();
+        let mut transaction = begin_private_bundle_transaction(&root, "capture-001", test_limits())
+            .expect("new transaction");
+        transaction
+            .write_new_file(Path::new("evidence/policy.log"), b"policy")
+            .expect("new evidence");
+        transaction.commit().expect("durable commit");
+
+        assert_eq!(
+            fs::read(path.join("capture-001/evidence/policy.log")).expect("committed evidence"),
+            b"policy"
+        );
+    }
+
+    #[test]
+    fn no_follow_open_rejects_a_fifo_without_blocking() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let temporary = tempdir().expect("temporary root");
+        let fifo = temporary.path().join("synthetic-fifo");
+        let fifo_name = CString::new(fifo.as_os_str().as_bytes()).expect("fifo path");
+        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+
+        open_file_no_follow(&fifo).expect_err("FIFO is rejected through a nonblocking open");
+    }
 
     #[test]
     fn safe_open_returns_only_regular_blocking_files() {


### PR DESCRIPTION
Part of #319.

This isolated native slice adds a destination-only private filesystem primitive for eventual SCCM bundle publication.

Scope:
- private module only; no public command, source enumeration, capture caller, or manifest publisher
- create-new handle-relative writes on Unix with fixed file and byte ceilings
- no-follow traversal, private-directory validation, identity-revalidated commit and rollback
- Windows destination creation remains explicitly Unsupported
- no live Windows or SCCM collection acceptance claim

Review disposition at cb0a3d9a:
- independent full and final normalized-name/cross-platform correction reviews: GO, no P0-P3 finding
- CodeRabbit ownership-mask fail-open finding fixed with explicit Unsupported conversion failure
- symlink/FIFO regressions now canonicalize macOS tempfile roots and prove the intended object-specific rejection
- normalized bundle-name aliases are rejected before syscalls; every handle-relative operation consumes the exact validated OsString
- hosted Windows MSRV caught and the final head fixes the platform-neutral OsString import; exact Windows MSRV is green
- Copilot macOS acl_get_entry claim rejected against the Apple 26.4 manual/SDK contract (0 or -1, not Linux libacl's positive sentinel)
- O_NONBLOCK remains nonblocking for this private unwired primitive; the reachable quadratic directory lookup is an explicit mandatory gate before any capture/public caller
- all handled threads have evidence replies and are resolved
- local CodeRabbit exact correction delta: zero findings
- fresh exact-head hosted CodeRabbit and Copilot reviews are requested below

Verification:
- cargo test -p cmtrace-open --features sccm-diagnostics --lib sccm::private_fs::tests (17 passed)
- cargo test -p cmtrace-open --test sccm_client_manifest --no-default-features --features sccm-diagnostics (21 passed)
- cargo check -p cmtrace-open --features sccm-diagnostics --target aarch64-apple-darwin
- full parser and parser wasm32 check
- strict app all-target/all-feature and parser Clippy with -D warnings
- npx --offline tsc --noEmit
- Vitest 40 files / 524 tests
- scoped rustfmt and exact-range git diff --check

Repository-wide format still has inherited unrelated drift; the exact owned file and range are clean.

Merge remains blocked on exact-head hosted CI, CodeRabbit, Copilot, zero unresolved threads, and a repeated live base/head/tree guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened private capture handling with stricter security limits and authorization checks.
  * Improved protection against symlinks, unexpected file replacements, invalid locations, and unsupported special files.
  * Added safer rollback and durable publishing so failed operations do not leave incomplete or inconsistent data.
  * Enhanced platform-specific permission and ownership validation, including additional protections on macOS.
  * Improved handling of filesystem identity changes during capture publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->