### PR TITLE
feat(sccm): bind DP sources to sealed server intake

### DIFF
--- a/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
@@ -1,0 +1,336 @@
+//! Canonical-intake adapter for Distribution Point source evidence.
+//!
+//! This is deliberately an evidence and coverage reducer, not a content
+//! transaction reducer. It consumes the already-normalized server intake
+//! assessment and admits only the declared DP distribution CCM sources. Until
+//! a versioned semantic fact profile is independently validated, it makes no
+//! package outcome, client-impact, or cross-side causal claim.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+
+use crate::sccm::{
+    classify_artifact_name, SccmArtifactFamily, SccmArtifactRequest, SccmCoverageState,
+    SccmEvidenceRef, SccmRole, SccmRotation, SccmTimeOrderingState, SccmTimestamp,
+};
+
+use super::{
+    declared_server_source_catalog, SccmServerArtifactAssessment, SccmServerCoverage,
+    SccmServerIntakeAssessment, SccmServerSourceKind,
+};
+
+pub const SCCM_DISTRIBUTION_POINT_ANALYSIS_SCHEMA_VERSION: u32 = 1;
+pub const SCCM_DISTRIBUTION_POINT_INTAKE_PROFILE_ID: &str = "sccm-dp-intake-envelope";
+pub const SCCM_DISTRIBUTION_POINT_INTAKE_PROFILE_VERSION: u32 = 1;
+pub const SCCM_DISTRIBUTION_POINT_SOURCE_ID: &str = "server-dp-distribution";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmDistributionPointWorkflow {
+    DistributionPointContent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmDistributionPointProfile {
+    pub id: String,
+    pub version: u32,
+    pub stability: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmDistributionPointSourceObservation {
+    pub artifact_id: String,
+    pub producer_role: SccmRole,
+    pub producer_host_handle: Option<String>,
+    pub workflow_subject_role: Option<SccmRole>,
+    pub workflow_subject_handle: Option<String>,
+    pub source_id: String,
+    pub source_version: Option<String>,
+    pub rotation: Option<SccmRotation>,
+    pub rotation_lineage_handle: String,
+    pub evidence: SccmEvidenceRef,
+    pub timestamp: SccmTimestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmDistributionPointCoverageGap {
+    pub source_id: String,
+    pub producer_role: Option<SccmRole>,
+    pub workflow_subject_role: Option<SccmRole>,
+    pub state: Option<SccmCoverageState>,
+    pub artifact_ids: Vec<String>,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmDistributionPointAnalysis {
+    pub schema_version: u32,
+    pub workflow: SccmDistributionPointWorkflow,
+    pub profile: SccmDistributionPointProfile,
+    pub source_observations: Vec<SccmDistributionPointSourceObservation>,
+    pub coverage_gaps: Vec<SccmDistributionPointCoverageGap>,
+    pub artifact_requests: Vec<SccmArtifactRequest>,
+    pub cross_side_correlation_performed: bool,
+}
+
+/// Project only complete, profile-eligible logical CCM records from the
+/// canonical server intake. The output is source-local and intentionally does
+/// not interpret message text as a package/content success or failure.
+pub fn analyze_distribution_point(
+    intake: &SccmServerIntakeAssessment,
+) -> SccmDistributionPointAnalysis {
+    let artifacts = intake
+        .artifacts
+        .iter()
+        .filter(|artifact| is_dp_distribution_artifact(artifact))
+        .map(|artifact| (artifact.artifact_id.as_str(), artifact))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut source_observations = intake
+        .evidence
+        .iter()
+        .filter_map(|evidence| {
+            let artifact = artifacts.get(evidence.reference.artifact_id.as_str())?;
+            admitted_for_source_observation(artifact, evidence).then(|| {
+                SccmDistributionPointSourceObservation {
+                    artifact_id: artifact.artifact_id.clone(),
+                    producer_role: artifact.producer_role.clone(),
+                    producer_host_handle: artifact.producer_host_handle.clone(),
+                    workflow_subject_role: artifact.workflow_subject_role.clone(),
+                    workflow_subject_handle: artifact.workflow_subject_handle.clone(),
+                    source_id: artifact.source_id.clone(),
+                    source_version: artifact.source_version.clone(),
+                    rotation: artifact.rotation.clone(),
+                    rotation_lineage_handle: artifact.rotation_lineage_handle.clone(),
+                    evidence: evidence.reference.clone(),
+                    timestamp: evidence.timestamp.clone(),
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    source_observations.sort_by(|left, right| {
+        source_observation_sort_key(left).cmp(&source_observation_sort_key(right))
+    });
+
+    let mut coverage_gaps = coverage_gaps(intake, &artifacts, &source_observations);
+    coverage_gaps.sort_by_key(coverage_gap_sort_key);
+
+    let artifact_requests = artifact_requests(&coverage_gaps);
+
+    SccmDistributionPointAnalysis {
+        schema_version: SCCM_DISTRIBUTION_POINT_ANALYSIS_SCHEMA_VERSION,
+        workflow: SccmDistributionPointWorkflow::DistributionPointContent,
+        profile: SccmDistributionPointProfile {
+            id: SCCM_DISTRIBUTION_POINT_INTAKE_PROFILE_ID.to_owned(),
+            version: SCCM_DISTRIBUTION_POINT_INTAKE_PROFILE_VERSION,
+            stability: "experimental".to_owned(),
+        },
+        source_observations,
+        coverage_gaps,
+        artifact_requests,
+        cross_side_correlation_performed: false,
+    }
+}
+
+fn is_dp_distribution_artifact(artifact: &SccmServerArtifactAssessment) -> bool {
+    let Some(basename) = artifact.original_basename.as_deref() else {
+        return false;
+    };
+    let classified = classify_artifact_name(basename, artifact.producer_role.clone());
+
+    artifact.source_id == SCCM_DISTRIBUTION_POINT_SOURCE_ID
+        && artifact.source_kind == "ccmLog"
+        && artifact.family == SccmArtifactFamily::DistributionPoint
+        && classified.supported_for_diagnosis
+        && declared_server_source_catalog().iter().any(|spec| {
+            spec.source_id == artifact.source_id
+                && spec.producer_role == artifact.producer_role
+                && spec.workflow_subject_role.as_ref() == artifact.workflow_subject_role.as_ref()
+                && spec.source_kind == SccmServerSourceKind::CcmLog
+                && spec
+                    .logical_names
+                    .iter()
+                    .any(|logical_name| *logical_name == classified.logical_name)
+        })
+}
+
+fn admitted_for_source_observation(
+    artifact: &SccmServerArtifactAssessment,
+    evidence: &crate::sccm::SccmEvidence,
+) -> bool {
+    artifact.state == SccmCoverageState::Captured
+        && artifact.profile_eligible
+        && artifact.parser_eligible
+        && artifact.fragment_complete != Some(false)
+        && evidence.role == artifact.producer_role
+        && evidence.timestamp.ordering_state == SccmTimeOrderingState::NormalizedUtc
+}
+
+fn coverage_gaps(
+    intake: &SccmServerIntakeAssessment,
+    artifacts: &BTreeMap<&str, &SccmServerArtifactAssessment>,
+    observations: &[SccmDistributionPointSourceObservation],
+) -> Vec<SccmDistributionPointCoverageGap> {
+    let observed_artifact_ids = observations
+        .iter()
+        .map(|observation| observation.artifact_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut gaps = intake
+        .coverage
+        .iter()
+        .filter(|coverage| is_dp_distribution_coverage(coverage))
+        .filter_map(|coverage| {
+            let artifact_ids = coverage
+                .artifact_ids
+                .iter()
+                .filter(|artifact_id| artifacts.contains_key(artifact_id.as_str()))
+                .cloned()
+                .collect::<Vec<_>>();
+            let all_admitted = coverage.state == SccmCoverageState::Captured
+                && !artifact_ids.is_empty()
+                && artifact_ids
+                    .iter()
+                    .all(|artifact_id| observed_artifact_ids.contains(artifact_id.as_str()));
+            (!all_admitted).then(|| SccmDistributionPointCoverageGap {
+                source_id: coverage.source_id.clone(),
+                producer_role: Some(coverage.producer_role.clone()),
+                workflow_subject_role: coverage.workflow_subject_role.clone(),
+                state: Some(coverage.state.clone()),
+                artifact_ids,
+                reason: coverage_gap_reason(coverage, &observed_artifact_ids),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if !intake.coverage.iter().any(is_dp_distribution_coverage) {
+        gaps.push(SccmDistributionPointCoverageGap {
+            source_id: SCCM_DISTRIBUTION_POINT_SOURCE_ID.to_owned(),
+            producer_role: None,
+            workflow_subject_role: Some(SccmRole::DistributionPoint),
+            state: None,
+            artifact_ids: Vec::new(),
+            reason: "No declared Distribution Point distribution source was supplied.".to_owned(),
+        });
+    }
+
+    gaps
+}
+
+fn is_dp_distribution_coverage(coverage: &SccmServerCoverage) -> bool {
+    coverage.source_id == SCCM_DISTRIBUTION_POINT_SOURCE_ID
+        && matches!(
+            (
+                &coverage.producer_role,
+                coverage.workflow_subject_role.as_ref()
+            ),
+            (SccmRole::SiteServer, Some(SccmRole::DistributionPoint))
+                | (SccmRole::DistributionPoint, None)
+        )
+}
+
+fn coverage_gap_reason(
+    coverage: &SccmServerCoverage,
+    observed_artifact_ids: &BTreeSet<&str>,
+) -> String {
+    if coverage.state != SccmCoverageState::Captured {
+        return format!(
+            "Distribution Point source coverage is {:?}; recollect the declared source without changing its state.",
+            coverage.state
+        );
+    }
+    if coverage
+        .artifact_ids
+        .iter()
+        .any(|artifact_id| !observed_artifact_ids.contains(artifact_id.as_str()))
+    {
+        return "Captured Distribution Point evidence is incomplete or outside the supported intake profile."
+            .to_owned();
+    }
+    "Distribution Point coverage requires a complete supported source.".to_owned()
+}
+
+fn artifact_requests(gaps: &[SccmDistributionPointCoverageGap]) -> Vec<SccmArtifactRequest> {
+    let mut requests = gaps
+        .iter()
+        .map(|gap| match gap.producer_role.as_ref() {
+            Some(SccmRole::DistributionPoint) => SccmArtifactRequest {
+                logical_id: "smsDpProv".to_owned(),
+                role: SccmRole::DistributionPoint,
+                reason: "Collect the complete SMSDPProv.log file.".to_owned(),
+            },
+            _ => SccmArtifactRequest {
+                logical_id: "distmgr".to_owned(),
+                role: SccmRole::SiteServer,
+                reason: "Collect the complete distmgr.log file.".to_owned(),
+            },
+        })
+        .collect::<Vec<_>>();
+    requests.sort_by(|left, right| {
+        (
+            left.logical_id.as_str(),
+            role_sort_key(&left.role),
+            left.reason.as_str(),
+        )
+            .cmp(&(
+                right.logical_id.as_str(),
+                role_sort_key(&right.role),
+                right.reason.as_str(),
+            ))
+    });
+    requests.dedup_by(|left, right| {
+        left.logical_id == right.logical_id
+            && left.role == right.role
+            && left.reason == right.reason
+    });
+    requests
+}
+
+fn source_observation_sort_key(
+    observation: &SccmDistributionPointSourceObservation,
+) -> (String, u32, u32, String) {
+    (
+        observation.artifact_id.clone(),
+        observation.evidence.line_start.unwrap_or_default(),
+        observation.evidence.line_end.unwrap_or_default(),
+        observation.evidence.entry_id.clone(),
+    )
+}
+
+fn coverage_gap_sort_key(
+    gap: &SccmDistributionPointCoverageGap,
+) -> (String, String, String, String, Vec<String>) {
+    (
+        gap.source_id.clone(),
+        gap.producer_role
+            .as_ref()
+            .map(role_sort_key)
+            .unwrap_or_default()
+            .to_owned(),
+        gap.workflow_subject_role
+            .as_ref()
+            .map(role_sort_key)
+            .unwrap_or_default()
+            .to_owned(),
+        format!("{:?}", gap.state),
+        gap.artifact_ids.clone(),
+    )
+}
+
+fn role_sort_key(role: &SccmRole) -> &str {
+    match role {
+        SccmRole::Client => "client",
+        SccmRole::SiteServer => "siteServer",
+        SccmRole::ManagementPoint => "managementPoint",
+        SccmRole::DistributionPoint => "distributionPoint",
+        SccmRole::SoftwareUpdatePoint => "softwareUpdatePoint",
+        SccmRole::WsUs => "wsUs",
+        SccmRole::Provider => "provider",
+        SccmRole::AdminService => "adminService",
+        SccmRole::Unknown(value) => value,
+    }
+}

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
@@ -474,8 +474,8 @@ fn coverage_gap_reason(
 ) -> String {
     if coverage.state != SccmCoverageState::Captured {
         return format!(
-            "Distribution Point source coverage is {:?}; recollect the declared source without changing its state.",
-            coverage.state
+            "Distribution Point source coverage is {}; recollect the declared source without changing its state.",
+            coverage_state_label(&coverage.state)
         );
     }
     if coverage
@@ -563,9 +563,25 @@ fn coverage_gap_sort_key(
             .map(role_sort_key)
             .unwrap_or_default()
             .to_owned(),
-        format!("{:?}", gap.state),
+        gap.state
+            .as_ref()
+            .map(coverage_state_label)
+            .unwrap_or_default()
+            .to_owned(),
         gap.artifact_ids.clone(),
     )
+}
+
+fn coverage_state_label(state: &SccmCoverageState) -> &'static str {
+    match state {
+        SccmCoverageState::Captured => "captured",
+        SccmCoverageState::Absent => "absent",
+        SccmCoverageState::AccessDenied => "accessDenied",
+        SccmCoverageState::Capped => "capped",
+        SccmCoverageState::Skipped => "skipped",
+        SccmCoverageState::Unsupported => "unsupported",
+        SccmCoverageState::ParseFailed => "parseFailed",
+    }
 }
 
 fn role_sort_key(role: &SccmRole) -> &str {

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
@@ -490,21 +490,33 @@ fn coverage_gap_reason(
 }
 
 fn artifact_requests(gaps: &[SccmDistributionPointCoverageGap]) -> Vec<SccmArtifactRequest> {
-    let mut requests = gaps
-        .iter()
-        .map(|gap| match gap.producer_role.as_ref() {
-            Some(SccmRole::DistributionPoint) => SccmArtifactRequest {
-                logical_id: "smsDpProv".to_owned(),
-                role: SccmRole::DistributionPoint,
-                reason: "Collect the complete SMSDPProv.log file.".to_owned(),
-            },
-            _ => SccmArtifactRequest {
+    let mut requests = Vec::with_capacity(gaps.len());
+    for gap in gaps {
+        if gap.producer_role.is_none() {
+            requests.push(SccmArtifactRequest {
                 logical_id: "distmgr".to_owned(),
                 role: SccmRole::SiteServer,
                 reason: "Collect the complete distmgr.log file.".to_owned(),
-            },
-        })
-        .collect::<Vec<_>>();
+            });
+            requests.push(SccmArtifactRequest {
+                logical_id: "smsDpProv".to_owned(),
+                role: SccmRole::DistributionPoint,
+                reason: "Collect the complete SMSDPProv.log file.".to_owned(),
+            });
+        } else if gap.producer_role == Some(SccmRole::DistributionPoint) {
+            requests.push(SccmArtifactRequest {
+                logical_id: "smsDpProv".to_owned(),
+                role: SccmRole::DistributionPoint,
+                reason: "Collect the complete SMSDPProv.log file.".to_owned(),
+            });
+        } else {
+            requests.push(SccmArtifactRequest {
+                logical_id: "distmgr".to_owned(),
+                role: SccmRole::SiteServer,
+                reason: "Collect the complete distmgr.log file.".to_owned(),
+            });
+        }
+    }
     requests.sort_by(|left, right| {
         (
             left.logical_id.as_str(),

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 
 use crate::sccm::{
     classify_artifact_name, SccmArtifactFamily, SccmArtifactRequest, SccmCoverageState,
-    SccmEvidenceRef, SccmRole, SccmRotation, SccmTimeOrderingState, SccmTimestamp,
+    SccmEvidence, SccmEvidenceRef, SccmRole, SccmRotation, SccmTimeOrderingState, SccmTimestamp,
 };
 
 use super::{
@@ -84,10 +84,37 @@ pub struct SccmDistributionPointAnalysis {
 pub fn analyze_distribution_point(
     intake: &SccmServerIntakeAssessment,
 ) -> SccmDistributionPointAnalysis {
+    let artifact_id_counts =
+        intake
+            .artifacts
+            .iter()
+            .fold(BTreeMap::<&str, usize>::new(), |mut counts, artifact| {
+                *counts.entry(artifact.artifact_id.as_str()).or_default() += 1;
+                counts
+            });
+    let evidence_by_artifact = intake.evidence.iter().fold(
+        BTreeMap::<&str, Vec<&SccmEvidence>>::new(),
+        |mut grouped, evidence| {
+            grouped
+                .entry(evidence.reference.artifact_id.as_str())
+                .or_default()
+                .push(evidence);
+            grouped
+        },
+    );
     let artifacts = intake
         .artifacts
         .iter()
-        .filter(|artifact| is_dp_distribution_artifact(artifact))
+        .filter(|artifact| {
+            artifact_id_counts
+                .get(artifact.artifact_id.as_str())
+                .is_some_and(|count| *count == 1)
+                && is_dp_distribution_artifact(artifact)
+                && artifact_metadata_is_congruent(intake, artifact, &artifact_id_counts)
+                && evidence_by_artifact
+                    .get(artifact.artifact_id.as_str())
+                    .is_some_and(|evidence| canonical_evidence_set(artifact, evidence))
+        })
         .map(|artifact| (artifact.artifact_id.as_str(), artifact))
         .collect::<BTreeMap<_, _>>();
 
@@ -169,6 +196,181 @@ fn admitted_for_source_observation(
         && artifact.fragment_complete != Some(false)
         && evidence.role == artifact.producer_role
         && evidence.timestamp.ordering_state == SccmTimeOrderingState::NormalizedUtc
+}
+
+fn artifact_metadata_is_congruent(
+    intake: &SccmServerIntakeAssessment,
+    artifact: &SccmServerArtifactAssessment,
+    artifact_id_counts: &BTreeMap<&str, usize>,
+) -> bool {
+    artifact.state == SccmCoverageState::Captured
+        && artifact.profile_eligible
+        && artifact.parser_eligible
+        && artifact.fragment_complete != Some(false)
+        && supported_source_version(artifact.source_version.as_deref())
+        && rotation_is_canonical_for_artifact(artifact)
+        && safe_assessed_handle(&intake.topology.capture_host_handle)
+        && safe_assessed_handle(&intake.topology.site_handle)
+        && artifact
+            .producer_host_handle
+            .as_deref()
+            .is_some_and(safe_assessed_handle)
+        && subject_handle_is_congruent(artifact)
+        && topology_is_congruent(intake, artifact)
+        && coverage_is_congruent(intake, artifact, artifact_id_counts)
+}
+
+fn supported_source_version(value: Option<&str>) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    if value == "5.00.TEST" {
+        return true;
+    }
+    let mut parts = value.split('.');
+    matches!(
+        (
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+        ),
+        (Some("5"), Some("00"), Some(build), Some(revision), None)
+            if build.len() == 4
+                && revision.len() == 4
+                && build.bytes().all(|byte| byte.is_ascii_digit())
+                && revision.bytes().all(|byte| byte.is_ascii_digit())
+    )
+}
+
+fn rotation_is_canonical_for_artifact(artifact: &SccmServerArtifactAssessment) -> bool {
+    let Some(basename) = artifact.original_basename.as_deref() else {
+        return false;
+    };
+    let classified = classify_artifact_name(basename, artifact.producer_role.clone());
+    artifact.rotation.as_ref() == Some(&classified.rotation)
+        && safe_assessed_handle(&artifact.rotation_lineage_handle)
+}
+
+fn safe_assessed_handle(value: &str) -> bool {
+    !value.is_empty()
+        && value.trim() == value
+        && !value.chars().any(char::is_control)
+        && value.len() <= 256
+}
+
+fn subject_handle_is_congruent(artifact: &SccmServerArtifactAssessment) -> bool {
+    match (
+        &artifact.producer_role,
+        artifact.workflow_subject_role.as_ref(),
+        artifact.workflow_subject_handle.as_deref(),
+    ) {
+        (SccmRole::SiteServer, Some(SccmRole::DistributionPoint), Some(handle)) => {
+            safe_assessed_handle(handle)
+        }
+        (SccmRole::DistributionPoint, None, None) => true,
+        _ => false,
+    }
+}
+
+fn topology_is_congruent(
+    intake: &SccmServerIntakeAssessment,
+    artifact: &SccmServerArtifactAssessment,
+) -> bool {
+    role_occurrences(&intake.topology.roles_observed, &artifact.producer_role) == 1
+        && artifact
+            .workflow_subject_role
+            .as_ref()
+            .is_none_or(|role| role_occurrences(&intake.topology.roles_observed, role) == 1)
+}
+
+fn role_occurrences(roles: &[SccmRole], expected: &SccmRole) -> usize {
+    roles.iter().filter(|role| *role == expected).count()
+}
+
+fn coverage_is_congruent(
+    intake: &SccmServerIntakeAssessment,
+    artifact: &SccmServerArtifactAssessment,
+    artifact_id_counts: &BTreeMap<&str, usize>,
+) -> bool {
+    let memberships = intake
+        .coverage
+        .iter()
+        .filter(|coverage| {
+            coverage
+                .artifact_ids
+                .iter()
+                .any(|artifact_id| artifact_id == &artifact.artifact_id)
+        })
+        .collect::<Vec<_>>();
+    let Some(coverage) = memberships.first() else {
+        return false;
+    };
+    memberships.len() == 1
+        && coverage
+            .artifact_ids
+            .iter()
+            .filter(|artifact_id| *artifact_id == &artifact.artifact_id)
+            .count()
+            == 1
+        && coverage.producer_role == artifact.producer_role
+        && coverage.workflow_subject_role == artifact.workflow_subject_role
+        && coverage.source_id == artifact.source_id
+        && coverage.state == artifact.state
+        && coverage.artifact_ids.iter().all(|artifact_id| {
+            artifact_id_counts
+                .get(artifact_id.as_str())
+                .is_some_and(|count| *count == 1)
+                && intake.artifacts.iter().any(|candidate| {
+                    candidate.artifact_id == *artifact_id
+                        && candidate.producer_role == coverage.producer_role
+                        && candidate.workflow_subject_role == coverage.workflow_subject_role
+                        && candidate.source_id == coverage.source_id
+                        && candidate.state == coverage.state
+                        && is_dp_distribution_artifact(candidate)
+                        && rotation_is_canonical_for_artifact(candidate)
+                })
+        })
+}
+
+fn canonical_evidence_set(
+    artifact: &SccmServerArtifactAssessment,
+    evidence: &[&SccmEvidence],
+) -> bool {
+    if evidence.is_empty() {
+        return false;
+    }
+
+    let mut ranges = Vec::with_capacity(evidence.len());
+    let mut evidence_ids = BTreeSet::new();
+    let mut entry_ids = BTreeSet::new();
+    for item in evidence {
+        let (Some(line_start), Some(line_end)) =
+            (item.reference.line_start, item.reference.line_end)
+        else {
+            return false;
+        };
+        let expected_entry_id = format!("{}:{line_start}-{line_end}", artifact.artifact_id);
+        if line_start == 0
+            || line_end < line_start
+            || item.reference.artifact_id != artifact.artifact_id
+            || item.reference.entry_id != expected_entry_id
+            || item.evidence_id != item.reference.entry_id
+            || !evidence_ids.insert(item.evidence_id.as_str())
+            || !entry_ids.insert(item.reference.entry_id.as_str())
+            || item.role != artifact.producer_role
+            || item.timestamp.ordering_state != SccmTimeOrderingState::NormalizedUtc
+            || item.timestamp.offset_minutes.is_none()
+            || item.timestamp.utc_millis.is_none()
+        {
+            return false;
+        }
+        ranges.push((line_start, line_end));
+    }
+
+    ranges.sort_unstable();
+    ranges.windows(2).all(|pair| pair[0].1 < pair[1].0)
 }
 
 fn coverage_gaps(

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
@@ -144,7 +144,7 @@ pub fn analyze_distribution_point(
         source_observation_sort_key(left).cmp(&source_observation_sort_key(right))
     });
 
-    let mut coverage_gaps = coverage_gaps(intake, &artifacts, &source_observations);
+    let mut coverage_gaps = coverage_gaps(intake, &source_observations);
     coverage_gaps.sort_by_key(coverage_gap_sort_key);
 
     let artifact_requests = artifact_requests(&coverage_gaps);
@@ -370,12 +370,13 @@ fn canonical_evidence_set(
     }
 
     ranges.sort_unstable();
-    ranges.windows(2).all(|pair| pair[0].1 < pair[1].0)
+    ranges
+        .windows(2)
+        .all(|pair| pair[0].1.checked_add(1) == Some(pair[1].0))
 }
 
 fn coverage_gaps(
     intake: &SccmServerIntakeAssessment,
-    artifacts: &BTreeMap<&str, &SccmServerArtifactAssessment>,
     observations: &[SccmDistributionPointSourceObservation],
 ) -> Vec<SccmDistributionPointCoverageGap> {
     let observed_artifact_ids = observations
@@ -387,12 +388,8 @@ fn coverage_gaps(
         .iter()
         .filter(|coverage| is_dp_distribution_coverage(coverage))
         .filter_map(|coverage| {
-            let artifact_ids = coverage
-                .artifact_ids
-                .iter()
-                .filter(|artifact_id| artifacts.contains_key(artifact_id.as_str()))
-                .cloned()
-                .collect::<Vec<_>>();
+            let mut artifact_ids = coverage.artifact_ids.clone();
+            artifact_ids.sort();
             let all_admitted = coverage.state == SccmCoverageState::Captured
                 && !artifact_ids.is_empty()
                 && artifact_ids

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/distribution_point.rs
@@ -24,6 +24,8 @@ pub const SCCM_DISTRIBUTION_POINT_ANALYSIS_SCHEMA_VERSION: u32 = 1;
 pub const SCCM_DISTRIBUTION_POINT_INTAKE_PROFILE_ID: &str = "sccm-dp-intake-envelope";
 pub const SCCM_DISTRIBUTION_POINT_INTAKE_PROFILE_VERSION: u32 = 1;
 pub const SCCM_DISTRIBUTION_POINT_SOURCE_ID: &str = "server-dp-distribution";
+const SCCM_DISTRIBUTION_POINT_INTAKE_AUTHORITY_REASON: &str =
+    "Canonical server intake authority could not be verified.";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -84,6 +86,10 @@ pub struct SccmDistributionPointAnalysis {
 pub fn analyze_distribution_point(
     intake: &SccmServerIntakeAssessment,
 ) -> SccmDistributionPointAnalysis {
+    if !intake.adapter_authority_is_intake_bound() || !intake.topology_authority_is_intake_bound() {
+        return intake_authority_invalid_analysis();
+    }
+
     let artifact_id_counts =
         intake
             .artifacts
@@ -158,6 +164,32 @@ pub fn analyze_distribution_point(
             stability: "experimental".to_owned(),
         },
         source_observations,
+        coverage_gaps,
+        artifact_requests,
+        cross_side_correlation_performed: false,
+    }
+}
+
+fn intake_authority_invalid_analysis() -> SccmDistributionPointAnalysis {
+    let coverage_gaps = vec![SccmDistributionPointCoverageGap {
+        source_id: SCCM_DISTRIBUTION_POINT_SOURCE_ID.to_owned(),
+        producer_role: None,
+        workflow_subject_role: Some(SccmRole::DistributionPoint),
+        state: Some(SccmCoverageState::ParseFailed),
+        artifact_ids: Vec::new(),
+        reason: SCCM_DISTRIBUTION_POINT_INTAKE_AUTHORITY_REASON.to_owned(),
+    }];
+    let artifact_requests = artifact_requests(&coverage_gaps);
+
+    SccmDistributionPointAnalysis {
+        schema_version: SCCM_DISTRIBUTION_POINT_ANALYSIS_SCHEMA_VERSION,
+        workflow: SccmDistributionPointWorkflow::DistributionPointContent,
+        profile: SccmDistributionPointProfile {
+            id: SCCM_DISTRIBUTION_POINT_INTAKE_PROFILE_ID.to_owned(),
+            version: SCCM_DISTRIBUTION_POINT_INTAKE_PROFILE_VERSION,
+            stability: "experimental".to_owned(),
+        },
+        source_observations: Vec::new(),
         coverage_gaps,
         artifact_requests,
         cross_side_correlation_performed: false,
@@ -315,7 +347,9 @@ fn coverage_is_congruent(
             .count()
             == 1
         && coverage.producer_role == artifact.producer_role
+        && coverage.producer_host_handle == artifact.producer_host_handle
         && coverage.workflow_subject_role == artifact.workflow_subject_role
+        && coverage.workflow_subject_handle == artifact.workflow_subject_handle
         && coverage.source_id == artifact.source_id
         && coverage.state == artifact.state
         && coverage.artifact_ids.iter().all(|artifact_id| {
@@ -325,7 +359,9 @@ fn coverage_is_congruent(
                 && intake.artifacts.iter().any(|candidate| {
                     candidate.artifact_id == *artifact_id
                         && candidate.producer_role == coverage.producer_role
+                        && candidate.producer_host_handle == coverage.producer_host_handle
                         && candidate.workflow_subject_role == coverage.workflow_subject_role
+                        && candidate.workflow_subject_handle == coverage.workflow_subject_handle
                         && candidate.source_id == coverage.source_id
                         && candidate.state == coverage.state
                         && is_dp_distribution_artifact(candidate)

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/mod.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/mod.rs
@@ -1,9 +1,11 @@
 mod catalog;
+mod distribution_point;
 mod intake;
 mod management_point;
 mod site_core;
 
 pub use catalog::*;
+pub use distribution_point::*;
 pub use intake::*;
 pub use management_point::*;
 pub use site_core::*;

--- a/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
@@ -1,0 +1,84 @@
+use std::path::{Path, PathBuf};
+
+use cmtraceopen_parser::sccm::server::windows::{
+    analyze_distribution_point, assess_server_intake, SccmServerArtifactPayload,
+};
+use cmtraceopen_parser::sccm::{SccmCoverageState, SccmRole, SccmTimeOrderingState};
+use serde_json::Value;
+
+fn intake_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sccm/server/intake")
+}
+
+fn load_assessment(scenario: &str) -> cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment {
+    let scenario_root = intake_root().join(scenario);
+    let manifest_json =
+        std::fs::read_to_string(scenario_root.join("manifest.json")).expect("manifest is readable");
+    let manifest: Value = serde_json::from_str(&manifest_json).expect("manifest is valid JSON");
+    let payloads = manifest["artifacts"]
+        .as_array()
+        .expect("artifacts are an array")
+        .iter()
+        .filter_map(|artifact| {
+            let relative_path = artifact["relativePath"].as_str()?;
+            Some(SccmServerArtifactPayload {
+                manifest_artifact_id: artifact["artifactId"]
+                    .as_str()
+                    .expect("artifact id is a string")
+                    .to_owned(),
+                bytes: std::fs::read(scenario_root.join(relative_path))
+                    .expect("captured evidence is readable"),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    assess_server_intake(&manifest_json, &payloads).expect("fixture intake is accepted")
+}
+
+#[test]
+fn distribution_point_adapter_projects_only_canonical_intake_observations_deterministically() {
+    let assessment = load_assessment("complete-multi-role");
+
+    let analysis = analyze_distribution_point(&assessment);
+
+    assert!(!analysis.cross_side_correlation_performed);
+    assert!(analysis.coverage_gaps.is_empty());
+    assert!(analysis.artifact_requests.is_empty());
+    assert_eq!(analysis.source_observations.len(), 1);
+
+    let observation = &analysis.source_observations[0];
+    assert_eq!(observation.artifact_id, "dp-dist-current");
+    assert_eq!(observation.producer_role, SccmRole::SiteServer);
+    assert_eq!(observation.workflow_subject_role, Some(SccmRole::DistributionPoint));
+    assert_eq!(observation.source_id, "server-dp-distribution");
+    assert_eq!(
+        observation.timestamp.ordering_state,
+        SccmTimeOrderingState::NormalizedUtc
+    );
+
+    let mut reordered = assessment.clone();
+    reordered.artifacts.reverse();
+    reordered.coverage.reverse();
+    reordered.evidence.reverse();
+    assert_eq!(
+        serde_json::to_value(&analysis).expect("analysis serializes"),
+        serde_json::to_value(analyze_distribution_point(&reordered))
+            .expect("reordered analysis serializes")
+    );
+}
+
+#[test]
+fn absent_dp_candidate_is_coverage_not_a_role_diagnosis() {
+    let assessment = load_assessment("absent-dp");
+
+    let analysis = analyze_distribution_point(&assessment);
+
+    assert!(!analysis.cross_side_correlation_performed);
+    assert!(analysis.source_observations.is_empty());
+    assert_eq!(analysis.coverage_gaps.len(), 1);
+    assert_eq!(analysis.coverage_gaps[0].state, SccmCoverageState::Absent);
+    assert_eq!(analysis.coverage_gaps[0].source_id, "server-dp-distribution");
+    assert_eq!(analysis.artifact_requests.len(), 1);
+    assert_eq!(analysis.artifact_requests[0].logical_id, "server-dp-distribution");
+    assert_eq!(analysis.artifact_requests[0].role, SccmRole::DistributionPoint);
+}

--- a/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
@@ -3,9 +3,7 @@ use std::path::{Path, PathBuf};
 use cmtraceopen_parser::sccm::server::windows::{
     analyze_distribution_point, assess_server_intake, SccmServerArtifactPayload,
 };
-use cmtraceopen_parser::sccm::{
-    SccmCoverageState, SccmRole, SccmRotation, SccmTimeOrderingState,
-};
+use cmtraceopen_parser::sccm::{SccmCoverageState, SccmRole, SccmRotation, SccmTimeOrderingState};
 use serde_json::Value;
 
 fn intake_root() -> PathBuf {

--- a/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
@@ -130,14 +130,25 @@ fn assert_dp_intake_authority_invalid(
         "{context}"
     );
     assert_eq!(analysis.artifact_requests.len(), 2, "{context}");
-    assert_eq!(analysis.artifact_requests[0].logical_id, "distmgr");
-    assert_eq!(analysis.artifact_requests[0].role, SccmRole::SiteServer);
-    assert_eq!(analysis.artifact_requests[1].logical_id, "smsDpProv");
+    assert_eq!(
+        analysis.artifact_requests[0].logical_id, "distmgr",
+        "{context}"
+    );
+    assert_eq!(
+        analysis.artifact_requests[0].role,
+        SccmRole::SiteServer,
+        "{context}"
+    );
+    assert_eq!(
+        analysis.artifact_requests[1].logical_id, "smsDpProv",
+        "{context}"
+    );
     assert_eq!(
         analysis.artifact_requests[1].role,
-        SccmRole::DistributionPoint
+        SccmRole::DistributionPoint,
+        "{context}"
     );
-    assert!(!analysis.cross_side_correlation_performed);
+    assert!(!analysis.cross_side_correlation_performed, "{context}");
     serde_json::to_value(analysis).expect("authority-invalid analysis serializes")
 }
 
@@ -313,6 +324,10 @@ fn absent_dp_candidate_is_coverage_not_a_role_diagnosis() {
     assert_eq!(
         analysis.coverage_gaps[0].source_id,
         "server-dp-distribution"
+    );
+    assert_eq!(
+        analysis.coverage_gaps[0].reason,
+        "Distribution Point source coverage is absent; recollect the declared source without changing its state."
     );
     assert_eq!(analysis.artifact_requests.len(), 1);
     assert_eq!(analysis.artifact_requests[0].logical_id, "distmgr");

--- a/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
@@ -105,6 +105,37 @@ fn assert_dp_coverage_only(
     serde_json::to_value(analysis).expect("coverage-only analysis serializes")
 }
 
+fn assert_dp_intake_authority_invalid(
+    assessment: &cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment,
+    context: &str,
+) -> Value {
+    let analysis = analyze_distribution_point(assessment);
+    assert!(
+        analysis.source_observations.is_empty(),
+        "{context}: unsealed intake must not export a source observation"
+    );
+    assert_eq!(analysis.coverage_gaps.len(), 1, "{context}");
+    let gap = &analysis.coverage_gaps[0];
+    assert_eq!(gap.source_id, "server-dp-distribution", "{context}");
+    assert_eq!(gap.producer_role, None, "{context}");
+    assert_eq!(
+        gap.workflow_subject_role,
+        Some(SccmRole::DistributionPoint),
+        "{context}"
+    );
+    assert_eq!(gap.state, Some(SccmCoverageState::ParseFailed), "{context}");
+    assert!(gap.artifact_ids.is_empty(), "{context}");
+    assert_eq!(
+        gap.reason, "Canonical server intake authority could not be verified.",
+        "{context}"
+    );
+    assert_eq!(analysis.artifact_requests.len(), 1, "{context}");
+    assert_eq!(analysis.artifact_requests[0].logical_id, "distmgr");
+    assert_eq!(analysis.artifact_requests[0].role, SccmRole::SiteServer);
+    assert!(!analysis.cross_side_correlation_performed);
+    serde_json::to_value(analysis).expect("authority-invalid analysis serializes")
+}
+
 #[test]
 fn distribution_point_adapter_projects_only_canonical_intake_observations_deterministically() {
     let assessment = load_assessment("complete-multi-role");
@@ -120,10 +151,20 @@ fn distribution_point_adapter_projects_only_canonical_intake_observations_determ
     assert_eq!(observation.artifact_id, "dp-dist-current");
     assert_eq!(observation.producer_role, SccmRole::SiteServer);
     assert_eq!(
+        observation.producer_host_handle.as_deref(),
+        Some("synthetic:host:site-01")
+    );
+    assert_eq!(
         observation.workflow_subject_role,
         Some(SccmRole::DistributionPoint)
     );
+    assert_eq!(
+        observation.workflow_subject_handle.as_deref(),
+        Some("synthetic:subject:dp-01")
+    );
     assert_eq!(observation.source_id, "server-dp-distribution");
+    assert_eq!(observation.rotation, Some(SccmRotation::Current));
+    assert_eq!(observation.rotation_lineage_handle, "dp-dist-lab");
     assert_eq!(
         observation.timestamp.ordering_state,
         SccmTimeOrderingState::NormalizedUtc
@@ -133,11 +174,122 @@ fn distribution_point_adapter_projects_only_canonical_intake_observations_determ
     reordered.artifacts.reverse();
     reordered.coverage.reverse();
     reordered.evidence.reverse();
+    reordered.topology.roles_observed.reverse();
     assert_eq!(
         serde_json::to_value(&analysis).expect("analysis serializes"),
         serde_json::to_value(analyze_distribution_point(&reordered))
             .expect("reordered analysis serializes")
     );
+}
+
+#[test]
+fn post_intake_topology_and_coverage_handle_mutations_fail_sealed_authority_closed() {
+    let assessment = load_assessment("complete-multi-role");
+    let artifact_index = dp_artifact_index(&assessment);
+    let coverage_index = assessment
+        .coverage
+        .iter()
+        .position(|coverage| coverage.source_id == "server-dp-distribution")
+        .expect("fixture contains DP coverage");
+
+    let mut coordinated_producer = assessment.clone();
+    coordinated_producer.artifacts[artifact_index].producer_host_handle =
+        Some("synthetic:host:forged-dp-producer".to_owned());
+    coordinated_producer.coverage[coverage_index].producer_host_handle =
+        Some("synthetic:host:forged-dp-producer".to_owned());
+    let producer_output = assert_dp_intake_authority_invalid(
+        &coordinated_producer,
+        "coordinated producer-host mutation",
+    );
+    assert!(!producer_output
+        .to_string()
+        .contains("synthetic:host:forged-dp-producer"));
+
+    let mut coordinated_subject = assessment.clone();
+    coordinated_subject.artifacts[artifact_index].workflow_subject_handle =
+        Some("synthetic:subject:forged-dp".to_owned());
+    coordinated_subject.coverage[coverage_index].workflow_subject_handle =
+        Some("synthetic:subject:forged-dp".to_owned());
+    let subject_output = assert_dp_intake_authority_invalid(
+        &coordinated_subject,
+        "coordinated workflow-subject mutation",
+    );
+    assert!(!subject_output
+        .to_string()
+        .contains("synthetic:subject:forged-dp"));
+
+    let mut changed_topology = assessment;
+    changed_topology.topology.capture_host_handle = "synthetic:host:forged-capture".to_owned();
+    changed_topology.topology.site_handle = "synthetic:site:forged".to_owned();
+    let topology_output =
+        assert_dp_intake_authority_invalid(&changed_topology, "topology handle mutation");
+    let topology_json = topology_output.to_string();
+    assert!(!topology_json.contains("synthetic:host:forged-capture"));
+    assert!(!topology_json.contains("synthetic:site:forged"));
+}
+
+#[test]
+fn post_intake_coverage_and_evidence_shape_mutations_fail_sealed_authority_closed() {
+    let assessment = load_assessment("complete-multi-role");
+    let evidence_index = dp_evidence_index(&assessment);
+
+    let mut missing_coverage = assessment.clone();
+    missing_coverage
+        .coverage
+        .retain(|coverage| coverage.source_id != "server-dp-distribution");
+
+    let mut duplicate_coverage = assessment.clone();
+    let dp_coverage = duplicate_coverage
+        .coverage
+        .iter()
+        .find(|coverage| coverage.source_id == "server-dp-distribution")
+        .expect("fixture contains DP coverage")
+        .clone();
+    duplicate_coverage.coverage.push(dp_coverage);
+
+    let mut holey_coverage = assessment.clone();
+    holey_coverage
+        .coverage
+        .iter_mut()
+        .find(|coverage| coverage.source_id == "server-dp-distribution")
+        .expect("fixture contains DP coverage")
+        .artifact_ids
+        .push("dp-dist-undeclared".to_owned());
+
+    let mut missing_evidence = assessment.clone();
+    missing_evidence.evidence.remove(evidence_index);
+
+    let mut duplicate_evidence = assessment.clone();
+    duplicate_evidence
+        .evidence
+        .push(duplicate_evidence.evidence[evidence_index].clone());
+
+    let mut holey_evidence = assessment.clone();
+    holey_evidence.evidence[evidence_index].evidence_id = "dp-dist-current:1-1".to_owned();
+    holey_evidence.evidence[evidence_index].reference.entry_id = "dp-dist-current:1-1".to_owned();
+    holey_evidence.evidence[evidence_index].reference.line_start = Some(1);
+    holey_evidence.evidence[evidence_index].reference.line_end = Some(1);
+    let mut after_hole = holey_evidence.evidence[evidence_index].clone();
+    after_hole.evidence_id = "dp-dist-current:3-3".to_owned();
+    after_hole.reference.entry_id = "dp-dist-current:3-3".to_owned();
+    after_hole.reference.line_start = Some(3);
+    after_hole.reference.line_end = Some(3);
+    holey_evidence.evidence.push(after_hole);
+
+    let mut mismatched_evidence = assessment;
+    mismatched_evidence.evidence[evidence_index].role = SccmRole::DistributionPoint;
+
+    for (context, mutated) in [
+        ("missing coverage", missing_coverage),
+        ("duplicate coverage", duplicate_coverage),
+        ("holey coverage", holey_coverage),
+        ("missing evidence", missing_evidence),
+        ("duplicate evidence", duplicate_evidence),
+        ("holey evidence", holey_evidence),
+        ("mismatched evidence", mismatched_evidence),
+    ] {
+        assert_dp_intake_authority_invalid(&mutated, context);
+    }
 }
 
 #[test]
@@ -223,7 +375,7 @@ fn evidence_ranges_with_a_physical_line_hole_are_coverage_only() {
 }
 
 #[test]
-fn coverage_gap_preserves_every_declared_member_when_a_peer_is_not_admitted() {
+fn post_intake_peer_mutations_fail_sealed_authority_closed() {
     for defect in [
         "profile-ineligible",
         "parser-ineligible",
@@ -256,25 +408,7 @@ fn coverage_gap_preserves_every_declared_member_when_a_peer_is_not_admitted() {
             _ => unreachable!("test defect is declared above"),
         }
 
-        let analysis = analyze_distribution_point(&assessment);
-        assert_eq!(
-            analysis
-                .source_observations
-                .iter()
-                .map(|observation| observation.artifact_id.as_str())
-                .collect::<Vec<_>>(),
-            vec!["dp-dist-current"],
-            "{defect} peer must not be admitted"
-        );
-        assert_eq!(analysis.coverage_gaps.len(), 1, "{defect}");
-        assert_eq!(
-            analysis.coverage_gaps[0].artifact_ids,
-            vec!["dp-dist-current", "dp-dist-peer"],
-            "{defect} coverage gap must preserve every declared member"
-        );
-        assert_eq!(analysis.artifact_requests.len(), 1, "{defect}");
-
-        let expected = serde_json::to_value(&analysis).expect("analysis serializes");
+        let expected = assert_dp_intake_authority_invalid(&assessment, defect);
         assessment.artifacts.reverse();
         assessment.evidence.reverse();
         assessment.coverage.reverse();
@@ -283,8 +417,7 @@ fn coverage_gap_preserves_every_declared_member_when_a_peer_is_not_admitted() {
         }
         assert_eq!(
             expected,
-            serde_json::to_value(analyze_distribution_point(&assessment))
-                .expect("reordered analysis serializes"),
+            assert_dp_intake_authority_invalid(&assessment, defect),
             "{defect} output must be deterministic"
         );
     }

--- a/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
@@ -57,6 +57,34 @@ fn dp_evidence_index(
         .expect("fixture contains the DP evidence")
 }
 
+fn add_dp_peer(
+    assessment: &mut cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment,
+) {
+    let artifact_index = dp_artifact_index(assessment);
+    let mut peer = assessment.artifacts[artifact_index].clone();
+    peer.artifact_id = "dp-dist-peer".to_owned();
+    peer.rotation_lineage_handle = "synthetic:lineage:dp-dist-peer".to_owned();
+    peer.path_fingerprint = "synthetic:path:site-dp-control-peer".to_owned();
+    assessment.artifacts.push(peer);
+
+    let evidence_index = dp_evidence_index(assessment);
+    let mut peer_evidence = assessment.evidence[evidence_index].clone();
+    peer_evidence.evidence_id = "dp-dist-peer:1-1".to_owned();
+    peer_evidence.reference.artifact_id = "dp-dist-peer".to_owned();
+    peer_evidence.reference.entry_id = "dp-dist-peer:1-1".to_owned();
+    peer_evidence.reference.line_start = Some(1);
+    peer_evidence.reference.line_end = Some(1);
+    assessment.evidence.push(peer_evidence);
+
+    assessment
+        .coverage
+        .iter_mut()
+        .find(|coverage| coverage.source_id == "server-dp-distribution")
+        .expect("fixture contains DP coverage")
+        .artifact_ids
+        .push("dp-dist-peer".to_owned());
+}
+
 fn assert_dp_coverage_only(
     assessment: &cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment,
 ) -> Value {
@@ -173,6 +201,93 @@ fn missing_duplicate_and_overlapping_evidence_ranges_are_coverage_only() {
     overlapping.reference.line_end = Some(2);
     overlap.evidence.push(overlapping);
     assert_dp_coverage_only(&overlap);
+}
+
+#[test]
+fn evidence_ranges_with_a_physical_line_hole_are_coverage_only() {
+    let mut assessment = load_assessment("complete-multi-role");
+    let evidence_index = dp_evidence_index(&assessment);
+    assessment.evidence[evidence_index].evidence_id = "dp-dist-current:1-1".to_owned();
+    assessment.evidence[evidence_index].reference.entry_id = "dp-dist-current:1-1".to_owned();
+    assessment.evidence[evidence_index].reference.line_start = Some(1);
+    assessment.evidence[evidence_index].reference.line_end = Some(1);
+
+    let mut after_hole = assessment.evidence[evidence_index].clone();
+    after_hole.evidence_id = "dp-dist-current:3-3".to_owned();
+    after_hole.reference.entry_id = "dp-dist-current:3-3".to_owned();
+    after_hole.reference.line_start = Some(3);
+    after_hole.reference.line_end = Some(3);
+    assessment.evidence.push(after_hole);
+
+    assert_dp_coverage_only(&assessment);
+}
+
+#[test]
+fn coverage_gap_preserves_every_declared_member_when_a_peer_is_not_admitted() {
+    for defect in [
+        "profile-ineligible",
+        "parser-ineligible",
+        "incomplete-fragment",
+        "invalid-evidence",
+    ] {
+        let mut assessment = load_assessment("complete-multi-role");
+        add_dp_peer(&mut assessment);
+        let peer_index = assessment
+            .artifacts
+            .iter()
+            .position(|artifact| artifact.artifact_id == "dp-dist-peer")
+            .expect("peer artifact exists");
+
+        match defect {
+            "profile-ineligible" => assessment.artifacts[peer_index].profile_eligible = false,
+            "parser-ineligible" => assessment.artifacts[peer_index].parser_eligible = false,
+            "incomplete-fragment" => {
+                assessment.artifacts[peer_index].fragment_complete = Some(false)
+            }
+            "invalid-evidence" => {
+                assessment
+                    .evidence
+                    .iter_mut()
+                    .find(|evidence| evidence.reference.artifact_id == "dp-dist-peer")
+                    .expect("peer evidence exists")
+                    .reference
+                    .line_start = None
+            }
+            _ => unreachable!("test defect is declared above"),
+        }
+
+        let analysis = analyze_distribution_point(&assessment);
+        assert_eq!(
+            analysis
+                .source_observations
+                .iter()
+                .map(|observation| observation.artifact_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["dp-dist-current"],
+            "{defect} peer must not be admitted"
+        );
+        assert_eq!(analysis.coverage_gaps.len(), 1, "{defect}");
+        assert_eq!(
+            analysis.coverage_gaps[0].artifact_ids,
+            vec!["dp-dist-current", "dp-dist-peer"],
+            "{defect} coverage gap must preserve every declared member"
+        );
+        assert_eq!(analysis.artifact_requests.len(), 1, "{defect}");
+
+        let expected = serde_json::to_value(&analysis).expect("analysis serializes");
+        assessment.artifacts.reverse();
+        assessment.evidence.reverse();
+        assessment.coverage.reverse();
+        for coverage in &mut assessment.coverage {
+            coverage.artifact_ids.reverse();
+        }
+        assert_eq!(
+            expected,
+            serde_json::to_value(analyze_distribution_point(&assessment))
+                .expect("reordered analysis serializes"),
+            "{defect} output must be deterministic"
+        );
+    }
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use cmtraceopen_parser::sccm::server::windows::{
     analyze_distribution_point, assess_server_intake, SccmServerArtifactPayload,
+    SccmServerIntakeAssessment, SccmServerIntakeError,
 };
 use cmtraceopen_parser::sccm::{SccmCoverageState, SccmRole, SccmRotation, SccmTimeOrderingState};
 use serde_json::Value;
@@ -10,9 +11,7 @@ fn intake_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sccm/server/intake")
 }
 
-fn load_assessment(
-    scenario: &str,
-) -> cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment {
+fn load_manifest_and_payloads(scenario: &str) -> (Value, Vec<SccmServerArtifactPayload>) {
     let scenario_root = intake_root().join(scenario);
     let manifest_json =
         std::fs::read_to_string(scenario_root.join("manifest.json")).expect("manifest is readable");
@@ -34,12 +33,40 @@ fn load_assessment(
         })
         .collect::<Vec<_>>();
 
-    assess_server_intake(&manifest_json, &payloads).expect("fixture intake is accepted")
+    (manifest, payloads)
 }
 
-fn dp_artifact_index(
-    assessment: &cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment,
-) -> usize {
+fn assess_manifest(
+    manifest: &Value,
+    payloads: &[SccmServerArtifactPayload],
+) -> Result<SccmServerIntakeAssessment, SccmServerIntakeError> {
+    let manifest_json = serde_json::to_string(manifest).expect("manifest serializes");
+    assess_server_intake(&manifest_json, payloads)
+}
+
+fn assess_complete_manifest_after(
+    mutate: impl FnOnce(&mut Value),
+) -> Result<SccmServerIntakeAssessment, SccmServerIntakeError> {
+    let (mut manifest, payloads) = load_manifest_and_payloads("complete-multi-role");
+    mutate(&mut manifest);
+    assess_manifest(&manifest, &payloads)
+}
+
+fn load_assessment(scenario: &str) -> SccmServerIntakeAssessment {
+    let (manifest, payloads) = load_manifest_and_payloads(scenario);
+    assess_manifest(&manifest, &payloads).expect("fixture intake is accepted")
+}
+
+fn dp_manifest_artifact_mut(manifest: &mut Value) -> &mut Value {
+    manifest["artifacts"]
+        .as_array_mut()
+        .expect("artifacts are an array")
+        .iter_mut()
+        .find(|artifact| artifact["artifactId"] == "dp-dist-current")
+        .expect("fixture contains the DP artifact")
+}
+
+fn dp_artifact_index(assessment: &SccmServerIntakeAssessment) -> usize {
     assessment
         .artifacts
         .iter()
@@ -47,9 +74,7 @@ fn dp_artifact_index(
         .expect("fixture contains the DP artifact")
 }
 
-fn dp_evidence_index(
-    assessment: &cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment,
-) -> usize {
+fn dp_evidence_index(assessment: &SccmServerIntakeAssessment) -> usize {
     assessment
         .evidence
         .iter()
@@ -57,9 +82,7 @@ fn dp_evidence_index(
         .expect("fixture contains the DP evidence")
 }
 
-fn add_dp_peer(
-    assessment: &mut cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment,
-) {
+fn add_dp_peer(assessment: &mut SccmServerIntakeAssessment) {
     let artifact_index = dp_artifact_index(assessment);
     let mut peer = assessment.artifacts[artifact_index].clone();
     peer.artifact_id = "dp-dist-peer".to_owned();
@@ -85,35 +108,47 @@ fn add_dp_peer(
         .push("dp-dist-peer".to_owned());
 }
 
-fn assert_dp_coverage_only(
-    assessment: &cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment,
+fn assert_dp_sealed_guard_rejection(
+    assessment: &SccmServerIntakeAssessment,
+    context: &str,
 ) -> Value {
     let analysis = analyze_distribution_point(assessment);
     assert!(
         analysis.source_observations.is_empty(),
-        "invalid DP evidence must not become a source observation"
+        "{context}: rejected DP evidence must not become a source observation"
     );
-    assert!(
-        !analysis.coverage_gaps.is_empty(),
-        "invalid DP evidence must remain an explicit coverage gap"
+    assert_eq!(analysis.coverage_gaps.len(), 1, "{context}");
+    let gap = &analysis.coverage_gaps[0];
+    assert_eq!(gap.source_id, "server-dp-distribution", "{context}");
+    assert_eq!(gap.producer_role, Some(SccmRole::SiteServer), "{context}");
+    assert_eq!(
+        gap.workflow_subject_role,
+        Some(SccmRole::DistributionPoint),
+        "{context}"
     );
-    assert!(
-        analysis
-            .coverage_gaps
-            .iter()
-            .all(|gap| gap.reason != "Canonical server intake authority could not be verified."),
-        "predicate-focused tests must reach a sealed adapter guard, not the authority quarantine"
+    assert_eq!(gap.state, Some(SccmCoverageState::Captured), "{context}");
+    assert_eq!(gap.artifact_ids, vec!["dp-dist-current"], "{context}");
+    assert_eq!(
+        gap.reason,
+        "Captured Distribution Point evidence is incomplete or outside the supported intake profile.",
+        "{context}"
     );
-    assert!(
-        !analysis.artifact_requests.is_empty(),
-        "invalid DP evidence must request a bounded declared source"
+    assert_eq!(analysis.artifact_requests.len(), 1, "{context}");
+    assert_eq!(
+        analysis.artifact_requests[0].logical_id, "distmgr",
+        "{context}"
     );
-    assert!(!analysis.cross_side_correlation_performed);
+    assert_eq!(
+        analysis.artifact_requests[0].role,
+        SccmRole::SiteServer,
+        "{context}"
+    );
+    assert!(!analysis.cross_side_correlation_performed, "{context}");
     serde_json::to_value(analysis).expect("coverage-only analysis serializes")
 }
 
 fn assert_dp_intake_authority_invalid(
-    assessment: &cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment,
+    assessment: &SccmServerIntakeAssessment,
     context: &str,
 ) -> Value {
     let analysis = analyze_distribution_point(assessment);
@@ -202,6 +237,109 @@ fn distribution_point_adapter_projects_only_canonical_intake_observations_determ
         serde_json::to_value(&analysis).expect("analysis serializes"),
         serde_json::to_value(analyze_distribution_point(&reordered))
             .expect("reordered analysis serializes")
+    );
+}
+
+#[test]
+fn sealed_intake_without_dp_source_version_reaches_profile_eligibility_guard() {
+    let assessment = assess_complete_manifest_after(|manifest| {
+        dp_manifest_artifact_mut(manifest)
+            .as_object_mut()
+            .expect("DP artifact is an object")
+            .remove("sourceVersion");
+    })
+    .expect("missing source version is retained as sealed, profile-ineligible intake");
+    let artifact = &assessment.artifacts[dp_artifact_index(&assessment)];
+
+    assert_eq!(artifact.source_version, None);
+    assert!(!artifact.profile_eligible);
+    assert!(artifact.parser_eligible);
+    assert_eq!(
+        artifact.workflow_subject_handle.as_deref(),
+        Some("synthetic:subject:dp-01")
+    );
+    assert!(assessment
+        .topology
+        .roles_observed
+        .contains(&SccmRole::DistributionPoint));
+    assert_dp_sealed_guard_rejection(&assessment, "missing DP source version");
+}
+
+#[test]
+fn sealed_intake_without_dp_subject_handle_reaches_subject_congruence_guard() {
+    let assessment = assess_complete_manifest_after(|manifest| {
+        let subject = dp_manifest_artifact_mut(manifest)["workflowSubject"]
+            .as_object_mut()
+            .expect("workflow subject is an object");
+        subject.remove("instanceHandle");
+        subject.insert(
+            "basis".to_owned(),
+            Value::String("incidentScopeOnly".to_owned()),
+        );
+    })
+    .expect("missing subject handle is retained as sealed intake");
+    let artifact = &assessment.artifacts[dp_artifact_index(&assessment)];
+
+    assert!(artifact.profile_eligible);
+    assert!(artifact.parser_eligible);
+    assert_eq!(
+        artifact.workflow_subject_role,
+        Some(SccmRole::DistributionPoint)
+    );
+    assert_eq!(artifact.workflow_subject_handle, None);
+    assert!(assessment
+        .topology
+        .roles_observed
+        .contains(&SccmRole::DistributionPoint));
+    assert_dp_sealed_guard_rejection(&assessment, "missing DP subject handle");
+}
+
+#[test]
+fn sealed_intake_without_observed_dp_role_reaches_topology_congruence_guard() {
+    let assessment = assess_complete_manifest_after(|manifest| {
+        manifest["topology"]["rolesObserved"]
+            .as_array_mut()
+            .expect("observed roles are an array")
+            .retain(|role| role.as_str() != Some("distributionPoint"));
+    })
+    .expect("unobserved workflow-subject role is retained as sealed intake");
+    let artifact = &assessment.artifacts[dp_artifact_index(&assessment)];
+
+    assert!(artifact.profile_eligible);
+    assert!(artifact.parser_eligible);
+    assert_eq!(
+        artifact.workflow_subject_handle.as_deref(),
+        Some("synthetic:subject:dp-01")
+    );
+    assert!(!assessment
+        .topology
+        .roles_observed
+        .contains(&SccmRole::DistributionPoint));
+    assert_dp_sealed_guard_rejection(&assessment, "unobserved DP workflow-subject role");
+}
+
+#[test]
+fn dp_subject_role_mismatch_is_rejected_before_intake_sealing() {
+    let result = assess_complete_manifest_after(|manifest| {
+        dp_manifest_artifact_mut(manifest)["workflowSubject"]["role"] =
+            Value::String("managementPoint".to_owned());
+    });
+
+    assert!(
+        matches!(result, Err(SccmServerIntakeError::InvalidArtifact)),
+        "role/source mismatch must not produce a sealed assessment: {result:?}"
+    );
+}
+
+#[test]
+fn dp_rotation_mismatch_is_rejected_before_intake_sealing() {
+    let result = assess_complete_manifest_after(|manifest| {
+        dp_manifest_artifact_mut(manifest)["rotation"]["kind"] = Value::String("lo_".to_owned());
+    });
+
+    assert!(
+        matches!(result, Err(SccmServerIntakeError::InvalidArtifact)),
+        "basename/rotation mismatch must not produce a sealed assessment: {result:?}"
     );
 }
 
@@ -366,7 +504,7 @@ fn no_declared_dp_source_requests_both_bounded_sides_without_correlation() {
 }
 
 #[test]
-fn duplicate_dp_artifact_identity_fails_closed_independent_of_input_order() {
+fn post_intake_duplicate_dp_artifact_identity_is_authority_quarantined_deterministically() {
     let mut assessment = load_assessment("complete-multi-role");
     let artifact_index = dp_artifact_index(&assessment);
     let mut duplicate = assessment.artifacts[artifact_index].clone();
@@ -374,27 +512,28 @@ fn duplicate_dp_artifact_identity_fails_closed_independent_of_input_order() {
     duplicate.path_fingerprint = "synthetic:path:site-dp-control-02".to_owned();
     assessment.artifacts.push(duplicate);
 
-    let first = assert_dp_coverage_only(&assessment);
+    let first = assert_dp_intake_authority_invalid(&assessment, "duplicate DP artifact identity");
     assessment.artifacts.reverse();
-    let reversed = assert_dp_coverage_only(&assessment);
+    let reversed =
+        assert_dp_intake_authority_invalid(&assessment, "reordered duplicate DP artifact identity");
 
     assert_eq!(first, reversed);
 }
 
 #[test]
-fn missing_duplicate_and_overlapping_evidence_ranges_are_coverage_only() {
+fn post_intake_evidence_range_mutations_are_authority_quarantined() {
     let assessment = load_assessment("complete-multi-role");
     let evidence_index = dp_evidence_index(&assessment);
 
     let mut missing_range = assessment.clone();
     missing_range.evidence[evidence_index].reference.line_start = None;
-    assert_dp_coverage_only(&missing_range);
+    assert_dp_intake_authority_invalid(&missing_range, "missing evidence range start");
 
     let mut duplicate = assessment.clone();
     duplicate
         .evidence
         .push(duplicate.evidence[evidence_index].clone());
-    assert_dp_coverage_only(&duplicate);
+    assert_dp_intake_authority_invalid(&duplicate, "duplicate evidence range");
 
     let mut overlap = assessment.clone();
     let mut overlapping = overlap.evidence[evidence_index].clone();
@@ -402,11 +541,11 @@ fn missing_duplicate_and_overlapping_evidence_ranges_are_coverage_only() {
     overlapping.reference.entry_id = "dp-dist-current:1-2".to_owned();
     overlapping.reference.line_end = Some(2);
     overlap.evidence.push(overlapping);
-    assert_dp_coverage_only(&overlap);
+    assert_dp_intake_authority_invalid(&overlap, "overlapping evidence range");
 }
 
 #[test]
-fn evidence_ranges_with_a_physical_line_hole_are_coverage_only() {
+fn post_intake_physical_line_hole_is_authority_quarantined() {
     let mut assessment = load_assessment("complete-multi-role");
     let evidence_index = dp_evidence_index(&assessment);
     assessment.evidence[evidence_index].evidence_id = "dp-dist-current:1-1".to_owned();
@@ -421,7 +560,7 @@ fn evidence_ranges_with_a_physical_line_hole_are_coverage_only() {
     after_hole.reference.line_end = Some(3);
     assessment.evidence.push(after_hole);
 
-    assert_dp_coverage_only(&assessment);
+    assert_dp_intake_authority_invalid(&assessment, "physical evidence line hole");
 }
 
 #[test]
@@ -474,36 +613,39 @@ fn post_intake_peer_mutations_fail_sealed_authority_closed() {
 }
 
 #[test]
-fn source_observation_requires_exact_intake_coverage_membership() {
+fn post_intake_missing_exact_coverage_membership_is_authority_quarantined() {
+    // Canonical intake derives coverage membership from normalized artifacts.
+    // A missing membership is therefore a post-intake integrity mutation, not
+    // a separately reachable adapter-predicate state.
     let mut assessment = load_assessment("complete-multi-role");
     assessment
         .coverage
         .retain(|coverage| coverage.source_id != "server-dp-distribution");
 
-    assert_dp_coverage_only(&assessment);
+    assert_dp_intake_authority_invalid(&assessment, "missing exact coverage membership");
 }
 
 #[test]
-fn role_topology_profile_and_rotation_mutations_fail_closed() {
+fn post_intake_role_topology_profile_and_rotation_mutations_are_authority_quarantined() {
     let assessment = load_assessment("complete-multi-role");
     let artifact_index = dp_artifact_index(&assessment);
 
     let mut wrong_role = assessment.clone();
     wrong_role.artifacts[artifact_index].workflow_subject_role = Some(SccmRole::ManagementPoint);
-    assert_dp_coverage_only(&wrong_role);
+    assert_dp_intake_authority_invalid(&wrong_role, "workflow-subject role mutation");
 
     let mut missing_topology = assessment.clone();
     missing_topology
         .topology
         .roles_observed
         .retain(|role| role != &SccmRole::DistributionPoint);
-    assert_dp_coverage_only(&missing_topology);
+    assert_dp_intake_authority_invalid(&missing_topology, "topology role mutation");
 
     let mut ineligible_profile = assessment.clone();
     ineligible_profile.artifacts[artifact_index].profile_eligible = false;
-    assert_dp_coverage_only(&ineligible_profile);
+    assert_dp_intake_authority_invalid(&ineligible_profile, "profile eligibility mutation");
 
     let mut wrong_rotation = assessment.clone();
     wrong_rotation.artifacts[artifact_index].rotation = Some(SccmRotation::LoUnderscore);
-    assert_dp_coverage_only(&wrong_rotation);
+    assert_dp_intake_authority_invalid(&wrong_rotation, "rotation mutation");
 }

--- a/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
@@ -10,7 +10,9 @@ fn intake_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sccm/server/intake")
 }
 
-fn load_assessment(scenario: &str) -> cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment {
+fn load_assessment(
+    scenario: &str,
+) -> cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment {
     let scenario_root = intake_root().join(scenario);
     let manifest_json =
         std::fs::read_to_string(scenario_root.join("manifest.json")).expect("manifest is readable");
@@ -49,7 +51,10 @@ fn distribution_point_adapter_projects_only_canonical_intake_observations_determ
     let observation = &analysis.source_observations[0];
     assert_eq!(observation.artifact_id, "dp-dist-current");
     assert_eq!(observation.producer_role, SccmRole::SiteServer);
-    assert_eq!(observation.workflow_subject_role, Some(SccmRole::DistributionPoint));
+    assert_eq!(
+        observation.workflow_subject_role,
+        Some(SccmRole::DistributionPoint)
+    );
     assert_eq!(observation.source_id, "server-dp-distribution");
     assert_eq!(
         observation.timestamp.ordering_state,
@@ -76,9 +81,16 @@ fn absent_dp_candidate_is_coverage_not_a_role_diagnosis() {
     assert!(!analysis.cross_side_correlation_performed);
     assert!(analysis.source_observations.is_empty());
     assert_eq!(analysis.coverage_gaps.len(), 1);
-    assert_eq!(analysis.coverage_gaps[0].state, SccmCoverageState::Absent);
-    assert_eq!(analysis.coverage_gaps[0].source_id, "server-dp-distribution");
+    assert_eq!(
+        analysis.coverage_gaps[0].state,
+        Some(SccmCoverageState::Absent)
+    );
+    assert_eq!(
+        analysis.coverage_gaps[0].source_id,
+        "server-dp-distribution"
+    );
     assert_eq!(analysis.artifact_requests.len(), 1);
-    assert_eq!(analysis.artifact_requests[0].logical_id, "server-dp-distribution");
-    assert_eq!(analysis.artifact_requests[0].role, SccmRole::DistributionPoint);
+    assert_eq!(analysis.artifact_requests[0].logical_id, "distmgr");
+    assert_eq!(analysis.artifact_requests[0].role, SccmRole::SiteServer);
+    serde_json::to_value(&analysis).expect("coverage-only analysis serializes");
 }

--- a/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
@@ -98,6 +98,13 @@ fn assert_dp_coverage_only(
         "invalid DP evidence must remain an explicit coverage gap"
     );
     assert!(
+        analysis
+            .coverage_gaps
+            .iter()
+            .all(|gap| gap.reason != "Canonical server intake authority could not be verified."),
+        "predicate-focused tests must reach a sealed adapter guard, not the authority quarantine"
+    );
+    assert!(
         !analysis.artifact_requests.is_empty(),
         "invalid DP evidence must request a bounded declared source"
     );

--- a/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
@@ -3,7 +3,9 @@ use std::path::{Path, PathBuf};
 use cmtraceopen_parser::sccm::server::windows::{
     analyze_distribution_point, assess_server_intake, SccmServerArtifactPayload,
 };
-use cmtraceopen_parser::sccm::{SccmCoverageState, SccmRole, SccmTimeOrderingState};
+use cmtraceopen_parser::sccm::{
+    SccmCoverageState, SccmRole, SccmRotation, SccmTimeOrderingState,
+};
 use serde_json::Value;
 
 fn intake_root() -> PathBuf {
@@ -35,6 +37,46 @@ fn load_assessment(
         .collect::<Vec<_>>();
 
     assess_server_intake(&manifest_json, &payloads).expect("fixture intake is accepted")
+}
+
+fn dp_artifact_index(
+    assessment: &cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment,
+) -> usize {
+    assessment
+        .artifacts
+        .iter()
+        .position(|artifact| artifact.artifact_id == "dp-dist-current")
+        .expect("fixture contains the DP artifact")
+}
+
+fn dp_evidence_index(
+    assessment: &cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment,
+) -> usize {
+    assessment
+        .evidence
+        .iter()
+        .position(|evidence| evidence.reference.artifact_id == "dp-dist-current")
+        .expect("fixture contains the DP evidence")
+}
+
+fn assert_dp_coverage_only(
+    assessment: &cmtraceopen_parser::sccm::server::windows::SccmServerIntakeAssessment,
+) -> Value {
+    let analysis = analyze_distribution_point(assessment);
+    assert!(
+        analysis.source_observations.is_empty(),
+        "invalid DP evidence must not become a source observation"
+    );
+    assert!(
+        !analysis.coverage_gaps.is_empty(),
+        "invalid DP evidence must remain an explicit coverage gap"
+    );
+    assert!(
+        !analysis.artifact_requests.is_empty(),
+        "invalid DP evidence must request a bounded declared source"
+    );
+    assert!(!analysis.cross_side_correlation_performed);
+    serde_json::to_value(analysis).expect("coverage-only analysis serializes")
 }
 
 #[test]
@@ -93,4 +135,79 @@ fn absent_dp_candidate_is_coverage_not_a_role_diagnosis() {
     assert_eq!(analysis.artifact_requests[0].logical_id, "distmgr");
     assert_eq!(analysis.artifact_requests[0].role, SccmRole::SiteServer);
     serde_json::to_value(&analysis).expect("coverage-only analysis serializes");
+}
+
+#[test]
+fn duplicate_dp_artifact_identity_fails_closed_independent_of_input_order() {
+    let mut assessment = load_assessment("complete-multi-role");
+    let artifact_index = dp_artifact_index(&assessment);
+    let mut duplicate = assessment.artifacts[artifact_index].clone();
+    duplicate.producer_host_handle = Some("synthetic:host:site-02".to_owned());
+    duplicate.path_fingerprint = "synthetic:path:site-dp-control-02".to_owned();
+    assessment.artifacts.push(duplicate);
+
+    let first = assert_dp_coverage_only(&assessment);
+    assessment.artifacts.reverse();
+    let reversed = assert_dp_coverage_only(&assessment);
+
+    assert_eq!(first, reversed);
+}
+
+#[test]
+fn missing_duplicate_and_overlapping_evidence_ranges_are_coverage_only() {
+    let assessment = load_assessment("complete-multi-role");
+    let evidence_index = dp_evidence_index(&assessment);
+
+    let mut missing_range = assessment.clone();
+    missing_range.evidence[evidence_index].reference.line_start = None;
+    assert_dp_coverage_only(&missing_range);
+
+    let mut duplicate = assessment.clone();
+    duplicate
+        .evidence
+        .push(duplicate.evidence[evidence_index].clone());
+    assert_dp_coverage_only(&duplicate);
+
+    let mut overlap = assessment.clone();
+    let mut overlapping = overlap.evidence[evidence_index].clone();
+    overlapping.evidence_id = "dp-dist-current:1-2".to_owned();
+    overlapping.reference.entry_id = "dp-dist-current:1-2".to_owned();
+    overlapping.reference.line_end = Some(2);
+    overlap.evidence.push(overlapping);
+    assert_dp_coverage_only(&overlap);
+}
+
+#[test]
+fn source_observation_requires_exact_intake_coverage_membership() {
+    let mut assessment = load_assessment("complete-multi-role");
+    assessment
+        .coverage
+        .retain(|coverage| coverage.source_id != "server-dp-distribution");
+
+    assert_dp_coverage_only(&assessment);
+}
+
+#[test]
+fn role_topology_profile_and_rotation_mutations_fail_closed() {
+    let assessment = load_assessment("complete-multi-role");
+    let artifact_index = dp_artifact_index(&assessment);
+
+    let mut wrong_role = assessment.clone();
+    wrong_role.artifacts[artifact_index].workflow_subject_role = Some(SccmRole::ManagementPoint);
+    assert_dp_coverage_only(&wrong_role);
+
+    let mut missing_topology = assessment.clone();
+    missing_topology
+        .topology
+        .roles_observed
+        .retain(|role| role != &SccmRole::DistributionPoint);
+    assert_dp_coverage_only(&missing_topology);
+
+    let mut ineligible_profile = assessment.clone();
+    ineligible_profile.artifacts[artifact_index].profile_eligible = false;
+    assert_dp_coverage_only(&ineligible_profile);
+
+    let mut wrong_rotation = assessment.clone();
+    wrong_rotation.artifacts[artifact_index].rotation = Some(SccmRotation::LoUnderscore);
+    assert_dp_coverage_only(&wrong_rotation);
 }

--- a/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_distribution_point.rs
@@ -129,9 +129,14 @@ fn assert_dp_intake_authority_invalid(
         gap.reason, "Canonical server intake authority could not be verified.",
         "{context}"
     );
-    assert_eq!(analysis.artifact_requests.len(), 1, "{context}");
+    assert_eq!(analysis.artifact_requests.len(), 2, "{context}");
     assert_eq!(analysis.artifact_requests[0].logical_id, "distmgr");
     assert_eq!(analysis.artifact_requests[0].role, SccmRole::SiteServer);
+    assert_eq!(analysis.artifact_requests[1].logical_id, "smsDpProv");
+    assert_eq!(
+        analysis.artifact_requests[1].role,
+        SccmRole::DistributionPoint
+    );
     assert!(!analysis.cross_side_correlation_performed);
     serde_json::to_value(analysis).expect("authority-invalid analysis serializes")
 }
@@ -313,6 +318,29 @@ fn absent_dp_candidate_is_coverage_not_a_role_diagnosis() {
     assert_eq!(analysis.artifact_requests[0].logical_id, "distmgr");
     assert_eq!(analysis.artifact_requests[0].role, SccmRole::SiteServer);
     serde_json::to_value(&analysis).expect("coverage-only analysis serializes");
+}
+
+#[test]
+fn no_declared_dp_source_requests_both_bounded_sides_without_correlation() {
+    let assessment = load_assessment("collision-same-basename-configured-roots");
+
+    let analysis = analyze_distribution_point(&assessment);
+
+    assert!(analysis.source_observations.is_empty());
+    assert_eq!(analysis.coverage_gaps.len(), 1);
+    assert_eq!(analysis.coverage_gaps[0].producer_role, None);
+    assert_eq!(
+        analysis
+            .artifact_requests
+            .iter()
+            .map(|request| (request.logical_id.as_str(), &request.role))
+            .collect::<Vec<_>>(),
+        vec![
+            ("distmgr", &SccmRole::SiteServer),
+            ("smsDpProv", &SccmRole::DistributionPoint),
+        ]
+    );
+    assert!(!analysis.cross_side_correlation_performed);
 }
 
 #[test]


### PR DESCRIPTION
## Scope

Implements the first production slice of the Distribution Point workflow: a pure-Rust, wasm-compatible adapter that projects only canonical `server-dp-distribution` logical CCM evidence from the reviewed server-intake boundary.

This deliberately does **not** complete the Distribution Point diagnostic workflow. It emits cited source observations, explicit coverage gaps, and bounded source requests only. It does not yet reduce package/content/version transactions, emit terminal DP findings, perform native collection, or perform client/server correlation. The tracking issue remains open.

## Authority and safety contract

- Requires both canonical adapter and topology seals before exporting any observation.
- Preserves producer host, workflow-subject DP, source version, rotation lineage, line ranges, and normalized timestamp provenance.
- Rejects duplicate artifact identities, missing/duplicate/holey evidence, coverage mismatch, topology mismatch, unsupported profiles, incomplete fragments, and noncanonical rotation.
- Missing or unusable source coverage remains a coverage state and artifact request, never a role diagnosis.
- Requests both site-side `distmgr.log` and DP-side `SMSDPProv.log` when the missing side is not yet known.
- `cross_side_correlation_performed` is always false.

## Test-first history

The branch preserves separate RED and GREEN commits for canonical intake behavior, canonical evidence and coverage continuity, sealed adapter/topology authority, dual-source requests for unscoped gaps, stable serialized coverage reason labels, and the distinction between sealed lower-predicate tests and post-intake authority quarantine.

## Verification at current integration

Head: `0e63f6a09e61074f0e32c3745e2acb3921975815`

Base: `a185a68fe6c1290aece9d55805e4173262a61193`

Merge tree: `77ee09a69542e959715c52fed1c895af95558bed`

GitHub updated the branch without force. The new merge commit has parents `2150f85d` and `a185a68f`; its tree is byte-identical to the independently validated current-base synthetic merge.

- DP adapter: 16/16
- server intake: 62/62
- DP fixture contract: 48/48
- Management Point: 3/3
- Site Core: 42/42
- SUP fixture contract: 18/18
- advanced-role catalog: 7/7
- full parser: 444 unit tests plus all integration/doc tests
- strict parser Clippy: pass
- parser wasm32 check: pass
- `npx tsc --noEmit`: pass
- scoped `rustfmt --check` on all three changed files: pass
- `git diff --check`: pass
- independent current-base review: GO, no P0-P3 findings

Repository-wide `cargo fmt --check --all` reports inherited drift only in five non-#329 ESP files; no changed file overlaps those hunks.

Fresh hosted CodeRabbit, Copilot, and CI are required on this exact head before merge. Prior hosted reviews are not treated as current-head acceptance.

## Remaining dependency/state

The full package/content/version/DP state reducer remains required and will consume the already-merged ten-scenario synthetic corpus after this source boundary lands. Content-to-DP correlation remains blocked until both upstream semantic fact contracts are stable. Native Windows/SCCM validation remains future work; this PR makes no live-acceptance claim.

Closes no issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analysis for SCCM Distribution Point server intake.
  * Validates source authority, artifact identity, metadata, topology, coverage, rotation, versions, and evidence continuity.
  * Produces consistent source observations, coverage status, and role-specific collection requests.
  * Supports versioned analysis profiles and schema metadata.
* **Bug Fixes**
  * Invalid or incomplete intake data now fails safely with actionable collection requests.
  * Untrusted, malformed, or forged artifacts are excluded from analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->