### PR TITLE
feat(sccm): define optional WSUS supplemental intake contract

### DIFF
--- a/crates/cmtraceopen-parser/src/sccm/server/windows/catalog.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/catalog.rs
@@ -5,6 +5,7 @@ pub enum SccmServerSourceKind {
     CcmLog,
     IisW3c,
     StructuredSupplement,
+    ProfileDefined,
 }
 
 #[derive(Debug)]
@@ -13,6 +14,9 @@ pub struct SccmServerSourceSpec {
     pub producer_role: SccmRole,
     pub workflow_subject_role: Option<SccmRole>,
     pub logical_names: &'static [&'static str],
+    /// Exact basename required for a bounded, profile-defined supplemental
+    /// source. CCM sources use `logical_names` instead.
+    pub explicit_basename: Option<&'static str>,
     pub source_kind: SccmServerSourceKind,
     pub supplemental: bool,
 }
@@ -23,6 +27,7 @@ const SERVER_SOURCE_SPECS: &[SccmServerSourceSpec] = &[
         producer_role: SccmRole::SiteServer,
         workflow_subject_role: None,
         logical_names: &["sitecomp", "hman"],
+        explicit_basename: None,
         source_kind: SccmServerSourceKind::CcmLog,
         supplemental: false,
     },
@@ -31,6 +36,7 @@ const SERVER_SOURCE_SPECS: &[SccmServerSourceSpec] = &[
         producer_role: SccmRole::SiteServer,
         workflow_subject_role: None,
         logical_names: &["statmgr", "statesys"],
+        explicit_basename: None,
         source_kind: SccmServerSourceKind::CcmLog,
         supplemental: false,
     },
@@ -39,6 +45,7 @@ const SERVER_SOURCE_SPECS: &[SccmServerSourceSpec] = &[
         producer_role: SccmRole::ManagementPoint,
         workflow_subject_role: None,
         logical_names: &["mpGetAuth", "mpCliReg", "mpRegistrationManager"],
+        explicit_basename: None,
         source_kind: SccmServerSourceKind::CcmLog,
         supplemental: false,
     },
@@ -47,6 +54,7 @@ const SERVER_SOURCE_SPECS: &[SccmServerSourceSpec] = &[
         producer_role: SccmRole::ManagementPoint,
         workflow_subject_role: None,
         logical_names: &["mpGetPolicy", "mpLocation"],
+        explicit_basename: None,
         source_kind: SccmServerSourceKind::CcmLog,
         supplemental: false,
     },
@@ -55,6 +63,7 @@ const SERVER_SOURCE_SPECS: &[SccmServerSourceSpec] = &[
         producer_role: SccmRole::SiteServer,
         workflow_subject_role: Some(SccmRole::ManagementPoint),
         logical_names: &["mpcontrol"],
+        explicit_basename: None,
         source_kind: SccmServerSourceKind::CcmLog,
         supplemental: false,
     },
@@ -63,6 +72,7 @@ const SERVER_SOURCE_SPECS: &[SccmServerSourceSpec] = &[
         producer_role: SccmRole::ManagementPoint,
         workflow_subject_role: None,
         logical_names: &[],
+        explicit_basename: None,
         source_kind: SccmServerSourceKind::IisW3c,
         supplemental: true,
     },
@@ -71,6 +81,7 @@ const SERVER_SOURCE_SPECS: &[SccmServerSourceSpec] = &[
         producer_role: SccmRole::SiteServer,
         workflow_subject_role: Some(SccmRole::DistributionPoint),
         logical_names: &["distmgr", "pkgXferMgr"],
+        explicit_basename: None,
         source_kind: SccmServerSourceKind::CcmLog,
         supplemental: false,
     },
@@ -79,6 +90,7 @@ const SERVER_SOURCE_SPECS: &[SccmServerSourceSpec] = &[
         producer_role: SccmRole::DistributionPoint,
         workflow_subject_role: None,
         logical_names: &["smsDpProv", "pullDp"],
+        explicit_basename: None,
         source_kind: SccmServerSourceKind::CcmLog,
         supplemental: false,
     },
@@ -87,6 +99,7 @@ const SERVER_SOURCE_SPECS: &[SccmServerSourceSpec] = &[
         producer_role: SccmRole::SiteServer,
         workflow_subject_role: Some(SccmRole::SoftwareUpdatePoint),
         logical_names: &["wcm", "wsyncmgr"],
+        explicit_basename: None,
         source_kind: SccmServerSourceKind::CcmLog,
         supplemental: false,
     },
@@ -95,8 +108,18 @@ const SERVER_SOURCE_SPECS: &[SccmServerSourceSpec] = &[
         producer_role: SccmRole::SoftwareUpdatePoint,
         workflow_subject_role: None,
         logical_names: &["wsusCtrl", "supSetup"],
+        explicit_basename: None,
         source_kind: SccmServerSourceKind::CcmLog,
         supplemental: false,
+    },
+    SccmServerSourceSpec {
+        source_id: "server-sup-wsus",
+        producer_role: SccmRole::WsUs,
+        workflow_subject_role: Some(SccmRole::SoftwareUpdatePoint),
+        logical_names: &[],
+        explicit_basename: Some("WsusHealth.json"),
+        source_kind: SccmServerSourceKind::ProfileDefined,
+        supplemental: true,
     },
 ];
 
@@ -122,6 +145,12 @@ pub(crate) fn classify_declared_server_source(
     })?;
 
     if spec.source_kind != SccmServerSourceKind::CcmLog {
+        if spec
+            .explicit_basename
+            .is_some_and(|declared| declared != basename)
+        {
+            return None;
+        }
         return Some((spec, None));
     }
 
@@ -146,7 +175,7 @@ pub(crate) fn expected_family(source_id: &str) -> Option<SccmArtifactFamily> {
             SccmArtifactFamily::ManagementPoint
         }
         "server-dp-distribution" => SccmArtifactFamily::DistributionPoint,
-        "server-sup-sync" => SccmArtifactFamily::SoftwareUpdatePoint,
+        "server-sup-sync" | "server-sup-wsus" => SccmArtifactFamily::SoftwareUpdatePoint,
         _ => return None,
     })
 }
@@ -160,5 +189,6 @@ fn source_kind_matches(expected: SccmServerSourceKind, actual: &str) -> bool {
                 SccmServerSourceKind::StructuredSupplement,
                 "structuredSupplement"
             )
+            | (SccmServerSourceKind::ProfileDefined, "profileDefined")
     )
 }

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -2406,6 +2406,7 @@ fn safe_manifest_artifact_id(value: &str, synthetic_fixture: bool) -> bool {
                 | "sitecomp-current"
                 | "sup-sync-capped"
                 | "sup-sync-current"
+                | "sup-wsus-health-skipped"
                 | "unknown-db-export"
                 | "z-site-status"
         );
@@ -2423,6 +2424,7 @@ fn safe_source_id(value: &str, allow_unknown: bool, synthetic_fixture: bool) -> 
             | "server-mp-iis"
             | "server-dp-distribution"
             | "server-sup-sync"
+            | "server-sup-wsus"
             | "unknown-db-supplement"
     ) || (allow_unknown
         && !synthetic_fixture
@@ -2432,7 +2434,7 @@ fn safe_source_id(value: &str, allow_unknown: bool, synthetic_fixture: bool) -> 
 fn safe_source_kind(value: &str, allow_unknown: bool, synthetic_fixture: bool) -> bool {
     matches!(
         value,
-        "ccmLog" | "iisW3c" | "structuredSupplement" | "unknown"
+        "ccmLog" | "iisW3c" | "structuredSupplement" | "profileDefined" | "unknown"
     ) || (allow_unknown
         && !synthetic_fixture
         && opaque_sha256_handle(value, "cmtraceopen.source-kind.sha256.v1:"))
@@ -2466,6 +2468,7 @@ fn safe_lineage_id(value: &str, synthetic_fixture: bool) -> bool {
                 | "sitecomp-lab"
                 | "sup-sync-cap"
                 | "sup-sync-lab"
+                | "sup-wsus-health"
                 | "unknown-db-export"
         );
     }
@@ -2487,6 +2490,7 @@ fn safe_path_fingerprint(value: &str, synthetic_fixture: bool) -> bool {
                 | "synthetic:path:site-default"
                 | "synthetic:path:site-dp-control"
                 | "synthetic:path:site-sup-control"
+                | "synthetic:path:sup-wsus-health"
                 | "synthetic:path:unsupported-db"
                 | "synthetic:path:z-site"
         );
@@ -2612,7 +2616,10 @@ fn safe_optional_handle(value: Option<&str>, synthetic_fixture: bool, domain: &s
     };
     if synthetic_fixture {
         return match domain {
-            "host" => matches!(value, "synthetic:host:mp-01" | "synthetic:host:site-01"),
+            "host" => matches!(
+                value,
+                "synthetic:host:mp-01" | "synthetic:host:site-01" | "synthetic:host:wsus-01"
+            ),
             "subject" => {
                 matches!(
                     value,

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -16,7 +16,9 @@ use crate::sccm::{
     SccmArtifactRequest, SccmCoverageState, SccmEvidence, SccmFinding, SccmRole, SccmRotation,
 };
 
-use super::catalog::{classify_declared_server_source, expected_family, SccmServerSourceKind};
+use super::catalog::{
+    classify_declared_server_source, expected_family, SccmServerSourceKind, SccmServerSourceSpec,
+};
 
 /// Keep parser-side work bounded even when the manifest did not come from the
 /// native collector. These match the existing bounded bundle intake envelope.
@@ -1074,6 +1076,13 @@ fn normalize_artifact(
 
     let (family, original_basename, rotation, mut parser_eligible) =
         if let Some((spec, classified)) = classification {
+            validate_declared_source_tuple(
+                &artifact,
+                spec,
+                source_version.as_deref(),
+                synthetic_fixture,
+                roles_observed,
+            )?;
             let family =
                 expected_family(spec.source_id).ok_or(SccmServerIntakeError::InvalidArtifact)?;
             if let Some(classified) = classified {
@@ -2293,6 +2302,47 @@ fn normalize_source_version(
         return Err(SccmServerIntakeError::InvalidArtifact);
     }
     Ok(Some(value.to_owned()))
+}
+
+fn validate_declared_source_tuple(
+    artifact: &RawServerArtifact,
+    spec: &SccmServerSourceSpec,
+    source_version: Option<&str>,
+    synthetic_fixture: bool,
+    roles_observed: &[SccmRole],
+) -> Result<(), SccmServerIntakeError> {
+    if spec.source_id != "server-sup-wsus" {
+        return Ok(());
+    }
+
+    let subject = artifact
+        .workflow_subject
+        .as_ref()
+        .ok_or(SccmServerIntakeError::InvalidArtifact)?;
+    if spec.source_kind != SccmServerSourceKind::ProfileDefined
+        || artifact.producer_role != SccmRole::WsUs
+        || subject.role != SccmRole::SoftwareUpdatePoint
+        || !roles_observed.contains(&SccmRole::WsUs)
+        || !roles_observed.contains(&SccmRole::SoftwareUpdatePoint)
+        || artifact.producer_host_handle.is_none()
+        || subject.instance_handle.is_none()
+        || source_version.is_none()
+    {
+        return Err(SccmServerIntakeError::InvalidArtifact);
+    }
+
+    if synthetic_fixture
+        && (artifact.producer_host_handle.as_deref() != Some("synthetic:host:wsus-01")
+            || subject.instance_handle.as_deref() != Some("synthetic:subject:sup-01")
+            || source_version != Some("5.00.TEST")
+            || artifact.configured_path_provenance.path_fingerprint
+                != "synthetic:path:sup-wsus-health"
+            || artifact.rotation.lineage_id != "sup-wsus-health")
+    {
+        return Err(SccmServerIntakeError::InvalidArtifact);
+    }
+
+    Ok(())
 }
 
 fn validate_artifact_annotations(

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -2337,6 +2337,8 @@ fn validate_declared_source_tuple(
             || source_version != Some("5.00.TEST")
             || artifact.configured_path_provenance.path_fingerprint
                 != "synthetic:path:sup-wsus-health"
+            || artifact.rotation.kind != "providerDefined"
+            || artifact.rotation.value.is_some()
             || artifact.rotation.lineage_id != "sup-wsus-health")
     {
         return Err(SccmServerIntakeError::InvalidArtifact);

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/intake/supplemental-wsus-skipped/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/intake/supplemental-wsus-skipped/expected.json
@@ -1,0 +1,9 @@
+{
+  "pre318ExpectedVersion": 1,
+  "coverage": [{ "producerRole": "wsUs", "workflowSubjectRole": "softwareUpdatePoint", "sourceId": "server-sup-wsus", "state": "skipped", "requiredness": "optionalSupplemental" }],
+  "nonCapturedProvenance": { "encoding": "omitted", "collectionLimit": "omitted" },
+  "requiredSourceFailure": false,
+  "terminalSoftwareUpdatePointHealth": false,
+  "roleHealthFinding": "none",
+  "privacy": "synthetic"
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/intake/supplemental-wsus-skipped/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/intake/supplemental-wsus-skipped/expected.json
@@ -1,6 +1,6 @@
 {
   "pre318ExpectedVersion": 1,
-  "coverage": [{ "producerRole": "wsUs", "workflowSubjectRole": "softwareUpdatePoint", "sourceId": "server-sup-wsus", "state": "skipped", "requiredness": "optionalSupplemental" }],
+  "coverage": [{ "producerRole": "wsUs", "workflowSubjectRole": "softwareUpdatePoint", "sourceId": "server-sup-wsus", "state": "skipped" }],
   "nonCapturedProvenance": { "encoding": "omitted", "collectionLimit": "omitted" },
   "requiredSourceFailure": false,
   "terminalSoftwareUpdatePointHealth": false,

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/server/intake/supplemental-wsus-skipped/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/server/intake/supplemental-wsus-skipped/manifest.json
@@ -1,0 +1,38 @@
+{
+  "sccmManifestVersion": 1,
+  "syntheticFixture": true,
+  "proposalOnly": true,
+  "privacy": { "synthetic": true, "rawPaths": "redacted" },
+  "bundleRole": "server",
+  "topology": {
+    "captureHost": "LAB-CM01",
+    "siteCode": "LAB",
+    "rolesObserved": ["softwareUpdatePoint", "wsUs"]
+  },
+  "artifacts": [
+    {
+      "artifactId": "sup-wsus-health-skipped",
+      "producerRole": "wsUs",
+      "producerHostHandle": "synthetic:host:wsus-01",
+      "workflowSubject": {
+        "role": "softwareUpdatePoint",
+        "instanceHandle": "synthetic:subject:sup-01"
+      },
+      "sourceId": "server-sup-wsus",
+      "sourceKind": "profileDefined",
+      "sourceVersion": "5.00.TEST",
+      "originalPath": "REDACTED_WSUS_HEALTH_EXPORT",
+      "originalBasename": "WsusHealth.json",
+      "configuredPathProvenance": {
+        "state": "notRequested",
+        "pathFingerprint": "synthetic:path:sup-wsus-health"
+      },
+      "rotation": { "kind": "providerDefined", "lineageId": "sup-wsus-health" },
+      "captureState": "skipped",
+      "skipReason": "optional supplemental source not requested",
+      "collectedUtc": "2026-07-30T00:08:00Z",
+      "relativePath": null,
+      "bytesCopied": 0
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -1787,6 +1787,35 @@ fn server_intake_admits_only_the_catalogued_optional_wsus_supplement_contract() 
 }
 
 #[test]
+fn wsus_supplement_expected_coverage_uses_only_serialized_fields() {
+    let expected = load_expected("supplemental-wsus-skipped");
+    let (manifest_json, payloads) = load_bundle("supplemental-wsus-skipped");
+    let assessment = assess_server_intake(&manifest_json, &payloads)
+        .expect("the catalogued optional WSUS supplement is assessable");
+    let actual = serde_json::to_value(&assessment).expect("assessment serializes");
+    let expected_coverage = expected["coverage"]
+        .as_array()
+        .expect("expected coverage is an array");
+    let actual_coverage = actual["coverage"]
+        .as_array()
+        .expect("assessment coverage is an array");
+
+    assert_eq!(actual_coverage.len(), expected_coverage.len());
+    for (actual_row, expected_row) in actual_coverage.iter().zip(expected_coverage) {
+        for (key, expected_value) in expected_row
+            .as_object()
+            .expect("expected coverage row is an object")
+        {
+            assert_eq!(
+                actual_row.get(key),
+                Some(expected_value),
+                "WSUS expected coverage must assert an actual serialized coverage field: {key}"
+            );
+        }
+    }
+}
+
+#[test]
 fn server_intake_rejects_wsus_supplement_cross_tuple_mutations() {
     type ManifestMutation = (&'static str, fn(&mut Value));
 

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -1788,8 +1788,10 @@ fn server_intake_admits_only_the_catalogued_optional_wsus_supplement_contract() 
 
 #[test]
 fn server_intake_rejects_wsus_supplement_cross_tuple_mutations() {
+    type ManifestMutation = (&'static str, fn(&mut Value));
+
     let (manifest_json, payloads) = load_bundle("supplemental-wsus-skipped");
-    let mutations: [(&str, fn(&mut Value)); 8] = [
+    let mutations: [ManifestMutation; 8] = [
         ("subject role not observed", |manifest| {
             manifest["topology"]["rolesObserved"] = json!(["wsUs"]);
         }),
@@ -1843,6 +1845,49 @@ fn server_intake_rejects_wsus_supplement_cross_tuple_mutations() {
         "WSUS supplemental tuple mutations must fail closed:\n{}",
         unexpected.join("\n")
     );
+}
+
+#[test]
+fn server_intake_accepts_profile_validated_production_wsus_tuple_with_opaque_provenance() {
+    let (manifest_json, payloads) = load_bundle("supplemental-wsus-skipped");
+    let mut manifest = manifest_value(&manifest_json);
+    let artifact_id = opaque_handle("cmtraceopen.artifact.sha256.v1:", 201);
+
+    manifest["syntheticFixture"] = Value::Bool(false);
+    manifest
+        .as_object_mut()
+        .expect("manifest is an object")
+        .remove("proposalOnly");
+    manifest
+        .as_object_mut()
+        .expect("manifest is an object")
+        .remove("privacy");
+    manifest["topology"]["captureHost"] =
+        Value::String(opaque_handle("cmtraceopen.host.sha256.v1:", 202));
+    manifest["topology"]["siteCode"] =
+        Value::String(opaque_handle("cmtraceopen.site.sha256.v1:", 203));
+    manifest["artifacts"][0]["artifactId"] = Value::String(artifact_id.clone());
+    manifest["artifacts"][0]["producerHostHandle"] =
+        Value::String(opaque_handle("cmtraceopen.host.sha256.v1:", 204));
+    manifest["artifacts"][0]["workflowSubject"]["instanceHandle"] =
+        Value::String(opaque_handle("cmtraceopen.subject.sha256.v1:", 205));
+    manifest["artifacts"][0]["sourceVersion"] = Value::String("5.00.9999.9999".to_owned());
+    manifest["artifacts"][0]["originalPath"] = Value::String("REDACTED".to_owned());
+    manifest["artifacts"][0]["configuredPathProvenance"]["pathFingerprint"] =
+        Value::String(opaque_handle("cmtraceopen.path.sha256.v1:", 206));
+    manifest["artifacts"][0]["rotation"]["lineageId"] =
+        Value::String(opaque_handle("cmtraceopen.lineage.sha256.v1:", 207));
+    manifest["artifacts"][0]["skipReason"] =
+        Value::String(opaque_handle("cmtraceopen.skip-reason.sha256.v1:", 208));
+
+    let assessment = assess_server_intake(&serialize_manifest(&manifest), &payloads)
+        .expect("profile-validated production WSUS provenance remains assessable");
+    let public = serde_json::to_value(assessment).expect("assessment serializes");
+    let artifact = artifact_json(&public, &artifact_id);
+    assert_eq!(artifact["producerRole"], "wsUs");
+    assert_eq!(artifact["workflowSubjectRole"], "softwareUpdatePoint");
+    assert_eq!(artifact["sourceVersion"], "5.00.9999.9999");
+    assert_eq!(artifact["state"], "skipped");
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -1,6 +1,7 @@
 use cmtraceopen_parser::models::log_entry::Severity;
 use cmtraceopen_parser::sccm::server::windows::{
-    assess_server_intake, SccmServerArtifactPayload, SccmServerIntakeError,
+    assess_server_intake, declared_server_source_catalog, SccmServerArtifactPayload,
+    SccmServerIntakeError, SccmServerSourceKind,
 };
 use cmtraceopen_parser::sccm::{
     SccmConfidence, SccmCoverageState, SccmFinding, SccmFindingBuilder, SccmFindingClass,
@@ -1710,6 +1711,78 @@ fn server_intake_rejects_unversioned_future_unsupported_source_labels() {
     assert!(
         assess_server_intake(&serialize_manifest(&manifest), &payloads).is_err(),
         "future provenance needs a versioned opaque handle, not an arbitrary public label"
+    );
+}
+
+#[test]
+fn server_intake_admits_only_the_catalogued_optional_wsus_supplement_contract() {
+    let (manifest_json, payloads) = load_bundle("supplemental-wsus-skipped");
+    let assessment = assess_server_intake(&manifest_json, &payloads)
+        .expect("the catalogued optional WSUS supplement is assessable");
+    let serialized = serde_json::to_value(&assessment).expect("assessment serializes");
+    let artifact = artifact_json(&serialized, "sup-wsus-health-skipped");
+
+    let source = declared_server_source_catalog()
+        .iter()
+        .find(|source| source.source_id == "server-sup-wsus")
+        .expect("WSUS supplemental source is declared");
+    assert_eq!(source.producer_role, SccmRole::WsUs);
+    assert_eq!(
+        source.workflow_subject_role,
+        Some(SccmRole::SoftwareUpdatePoint)
+    );
+    assert_eq!(source.source_kind, SccmServerSourceKind::ProfileDefined);
+    assert!(source.supplemental);
+
+    assert_eq!(
+        serialized["topology"]["rolesObserved"],
+        json!(["softwareUpdatePoint", "wsUs"])
+    );
+    assert_eq!(artifact["producerRole"], "wsUs");
+    assert_eq!(artifact["workflowSubjectRole"], "softwareUpdatePoint");
+    assert_eq!(artifact["sourceId"], "server-sup-wsus");
+    assert_eq!(artifact["sourceKind"], "profileDefined");
+    assert_eq!(artifact["sourceVersion"], "5.00.TEST");
+    assert_eq!(
+        artifact["pathFingerprint"],
+        "synthetic:path:sup-wsus-health"
+    );
+    assert_eq!(artifact["rotationLineageHandle"], "sup-wsus-health");
+    assert_eq!(artifact["state"], "skipped");
+    assert_eq!(artifact["family"], "softwareUpdatePoint");
+    assert!(!artifact["parserEligible"]
+        .as_bool()
+        .expect("parser eligibility"));
+    assert!(serialized["findings"]
+        .as_array()
+        .expect("findings")
+        .is_empty());
+    assert!(serialized["nextArtifactRequests"]
+        .as_array()
+        .expect("requests")
+        .is_empty());
+
+    for (field, replacement) in [
+        ("artifactId", "free-form-wsus-artifact"),
+        ("sourceId", "free-form-wsus-source"),
+        ("sourceKind", "structuredSupplement"),
+        ("originalBasename", "WSUSHealth.json"),
+    ] {
+        let mut manifest = manifest_value(&manifest_json);
+        manifest["artifacts"][0][field] = Value::String(replacement.to_owned());
+        assert_eq!(
+            assess_server_intake(&serialize_manifest(&manifest), &payloads),
+            Err(SccmServerIntakeError::InvalidArtifact),
+            "{field} must remain in the frozen WSUS supplemental vocabulary"
+        );
+    }
+
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["artifacts"][0]["sourceVersion"] = Value::String("5.00.TEST.0001".to_owned());
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads),
+        Err(SccmServerIntakeError::InvalidArtifact),
+        "synthetic WSUS supplemental evidence accepts only version 5.00.TEST"
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -1877,6 +1877,34 @@ fn server_intake_rejects_wsus_supplement_cross_tuple_mutations() {
 }
 
 #[test]
+fn server_intake_rejects_timestamped_rotation_for_synthetic_wsus_tuple() {
+    let (manifest_json, payloads) = load_bundle("supplemental-wsus-skipped");
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["artifacts"][0]["rotation"]["kind"] = Value::String("timestamped".to_owned());
+    manifest["artifacts"][0]["rotation"]["value"] = Value::String("20260729-235700".to_owned());
+
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads),
+        Err(SccmServerIntakeError::InvalidArtifact),
+        "the frozen synthetic WSUS tuple cannot discard a valid timestamped rotation"
+    );
+}
+
+#[test]
+fn server_intake_rejects_provider_defined_value_for_synthetic_wsus_tuple() {
+    let (manifest_json, payloads) = load_bundle("supplemental-wsus-skipped");
+    let mut manifest = manifest_value(&manifest_json);
+    manifest["artifacts"][0]["rotation"]["value"] =
+        Value::String("unexpected-provider-value".to_owned());
+
+    assert_eq!(
+        assess_server_intake(&serialize_manifest(&manifest), &payloads),
+        Err(SccmServerIntakeError::InvalidArtifact),
+        "the frozen synthetic WSUS provider-defined rotation cannot carry a value"
+    );
+}
+
+#[test]
 fn server_intake_accepts_profile_validated_production_wsus_tuple_with_opaque_provenance() {
     let (manifest_json, payloads) = load_bundle("supplemental-wsus-skipped");
     let mut manifest = manifest_value(&manifest_json);

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake.rs
@@ -1787,6 +1787,65 @@ fn server_intake_admits_only_the_catalogued_optional_wsus_supplement_contract() 
 }
 
 #[test]
+fn server_intake_rejects_wsus_supplement_cross_tuple_mutations() {
+    let (manifest_json, payloads) = load_bundle("supplemental-wsus-skipped");
+    let mutations: [(&str, fn(&mut Value)); 8] = [
+        ("subject role not observed", |manifest| {
+            manifest["topology"]["rolesObserved"] = json!(["wsUs"]);
+        }),
+        ("workflow subject omitted", |manifest| {
+            manifest["artifacts"][0]
+                .as_object_mut()
+                .expect("artifact is an object")
+                .remove("workflowSubject");
+        }),
+        ("workflow subject role changed", |manifest| {
+            manifest["artifacts"][0]["workflowSubject"]["role"] =
+                Value::String("distributionPoint".to_owned());
+        }),
+        ("producer host rebound", |manifest| {
+            manifest["artifacts"][0]["producerHostHandle"] =
+                Value::String("synthetic:host:mp-01".to_owned());
+        }),
+        ("subject handle rebound", |manifest| {
+            manifest["artifacts"][0]["workflowSubject"]["instanceHandle"] =
+                Value::String("synthetic:subject:dp-01".to_owned());
+        }),
+        ("source version omitted", |manifest| {
+            manifest["artifacts"][0]
+                .as_object_mut()
+                .expect("artifact is an object")
+                .remove("sourceVersion");
+        }),
+        ("path fingerprint substituted", |manifest| {
+            manifest["artifacts"][0]["configuredPathProvenance"]["pathFingerprint"] =
+                Value::String("synthetic:path:site-sup-control".to_owned());
+        }),
+        ("rotation lineage substituted", |manifest| {
+            manifest["artifacts"][0]["rotation"]["lineageId"] =
+                Value::String("sup-sync-lab".to_owned());
+        }),
+    ];
+
+    let mut unexpected = Vec::new();
+    for (name, mutate) in mutations {
+        let mut manifest = manifest_value(&manifest_json);
+        mutate(&mut manifest);
+        match assess_server_intake(&serialize_manifest(&manifest), &payloads) {
+            Err(SccmServerIntakeError::InvalidArtifact) => {}
+            Err(error) => unexpected.push(format!("{name}: returned {error:?}")),
+            Ok(_) => unexpected.push(format!("{name}: was accepted")),
+        }
+    }
+
+    assert!(
+        unexpected.is_empty(),
+        "WSUS supplemental tuple mutations must fail closed:\n{}",
+        unexpected.join("\n")
+    );
+}
+
+#[test]
 fn server_intake_rejects_opaque_future_source_ids_in_synthetic_fixtures() {
     let (manifest_json, payloads) = load_bundle("unsupported-db-supplement");
     let mut manifest = manifest_value(&manifest_json);

--- a/crates/cmtraceopen-parser/tests/sccm_server_intake_fixture_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_intake_fixture_contract.rs
@@ -37,7 +37,7 @@ fn server_intake_manifests() -> Vec<(String, Value)> {
 #[test]
 fn server_intake_uses_canonical_site_and_rotation_contracts() {
     let manifests = server_intake_manifests();
-    assert_eq!(manifests.len(), 11, "server intake scenario matrix changed");
+    assert_eq!(manifests.len(), 12, "server intake scenario matrix changed");
 
     let mut failures = Vec::new();
     for (scenario, manifest) in &manifests {


### PR DESCRIPTION
## Scope

Bounded pure-parser SCCM Server intake/catalog/fixture contract for the optional `server-sup-wsus` supplemental source. This adds no native collector, Windows I/O, diagnosis reducer, broad parser, or live acceptance claim.

## Contract

- Profiles the optional exact `WsusHealth.json` source with `wsUs` producer and `softwareUpdatePoint` workflow subject.
- Validates synthetic `5.00.TEST` fixture/version, configured-path fingerprint, role topology, host/subject handles, lineage, exact provider-defined rotation shape, and version/profile provenance.
- Keeps the supplemental source **coverage-only**: a skipped source produces coverage state without a server finding or capture request.
- A missing default path remains a coverage state, never evidence that the role is absent or broken.
- Uses sanitized synthetic fixture material only.

## Exact head and base

Head: `a1de6d76d6ca23682a5d0d3583acd2e5d5663433`

Base: `bc5d4f854362e31ffbfae46d9a07950955690887`

The branch was fast-forwarded without force from `51564000dbca5087df4396a5272bb86f872d2184`. The new commit changes exactly server intake validation and its focused tests.

## Review corrections

- The WSUS expected coverage row no longer asserts `requiredness`, which is not serialized on `SccmServerCoverage`; a regression proves every expected WSUS coverage key exists in the serialized assessment.
- The frozen synthetic WSUS tuple now requires rotation kind `providerDefined` with no value. Focused RED tests proved that a valid timestamped shape and a provider-defined value were previously accepted and then discarded as `rotation: None`; both now fail closed.
- The rotation fix is restricted to `server-sup-wsus && synthetic_fixture`. Generic profile-defined parsing and non-synthetic production-style WSUS provenance are unchanged.
- The exact `server-sup-wsus` guard remains intentional. Broadening it to all `profileDefined` sources would impose WSUS-only role, subject, version, host, path, and rotation constraints on future source cards.

## Verification on exact head

- focused rotation regressions — 2/2
- production-style WSUS provenance regression — 1/1
- `cargo test -p cmtraceopen-parser --test sccm_server_intake` — 68/68
- server-intake fixture contract — 1/1
- SUP fixture contract — 18/18
- DP adapter — 16/16
- full parser suite — pass
- strict parser Clippy — pass
- parser wasm32 check — pass
- `npx tsc --noEmit` — pass
- scoped `rustfmt --check` — pass
- `git diff --check` — pass
- independent exact-range review — GO
- local exact-range CodeRabbit — zero findings

Fresh hosted CodeRabbit, Copilot, and CI are required on exact head `a1de6d76` before merge. Earlier hosted results are not counted for this head.

## Dependencies and non-goals

Native configured-path discovery/capture, native Windows/server-lab validation, semantic SUP/WSUS diagnosis, and client/server correlation remain separate follow-on work. A missing default path is not evidence a role is absent or broken.

Closes none; the server-intake issue remains open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for WSUS health supplemental sources and profile-defined server sources.
  * Added software update point classification for WSUS health data.
  * Added exact filename validation for applicable server-source artifacts.

* **Bug Fixes**
  * Strengthened validation of WSUS artifact metadata, provenance, identity, and source details.

* **Tests**
  * Added coverage for skipped WSUS health artifacts, metadata validation, mutation rejection, and production-style provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
