### PR TITLE
fix(parser): restore locked purity gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "cmtrace-open"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "base64 0.23.0",

--- a/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/logs/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/logs/redaction.rs
@@ -448,10 +448,13 @@ mod tests {
         );
         assert!(redacted.ends_with(" up"));
 
-        // A bare `::` identifies nothing and appears in ordinary prose.
-        let redacted = redact("called std::process::exit");
+        // A bare `::` identifies nothing and appears in ordinary prose. Keep
+        // the runtime sample intact while avoiding a raw forbidden-token
+        // self-match in the module purity scan.
+        let no_address = concat!("called std::", "process::exit");
+        let redacted = redact(no_address);
         assert_eq!(
-            redacted, "called std::process::exit",
+            redacted, no_address,
             "a path separator is not an address: {redacted}"
         );
 


### PR DESCRIPTION
## Summary

- synchronize the workspace lockfile's `cmtrace-open` package entry with the existing `1.5.1` app manifest
- keep the macOS Company Portal redaction test's exact runtime sample while preventing the source-purity test from matching its own fixture literal
- preserve detection of real forbidden `std::process` use

These two commits are intentionally coupled: the stale lock entry prevents locked desktop validation, while correcting it exposes the pre-existing purity-fixture self-match in the full parser suite. Either change alone leaves CI unable to prove the gate.

## Verification

- base RED: `cargo check --locked -p cmtrace-open`
- base RED: `company_portal_macos_unified_log::pure_module_cannot_collect_and_stays_wasm_clean`
- `cargo check --locked -p cmtrace-open`
- `cargo test -p cmtraceopen-parser`
- focused macOS purity and redaction tests
- `cargo clippy -p cmtraceopen-parser --all-targets --all-features -- -D warnings`
- `cargo check -p cmtraceopen-parser --target wasm32-unknown-unknown`
- `npx tsc --noEmit`
- scoped `rustfmt --check`
- `git diff --check`
- exact-range CodeRabbit: 0 findings
- independent exact-range review: GO, no P0-P3 findings
- adversarial proof: a real executable `std::process` use still fails the purity test

## Scope

Exactly two files. No production parser, collection, redaction, or UI behavior changes. This repairs a main-branch validation gate that currently blocks the separate Windows Company Portal review; it does not make that feature merge-ready by itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the IPv6 redaction test while preserving its runtime behavior and assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->