### PR TITLE
feat(sccm): analyze Software Update Point coverage

### DIFF
--- a/crates/cmtraceopen-parser/src/lib.rs
+++ b/crates/cmtraceopen-parser/src/lib.rs
@@ -15,4 +15,3 @@ pub mod intune;
 pub mod models;
 pub mod parser;
 pub mod sccm;
-pub(crate) mod wire;

--- a/crates/cmtraceopen-parser/src/lib.rs
+++ b/crates/cmtraceopen-parser/src/lib.rs
@@ -15,3 +15,4 @@ pub mod intune;
 pub mod models;
 pub mod parser;
 pub mod sccm;
+pub(crate) mod wire;

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -1573,6 +1573,9 @@ fn canonical_intake_integrity_with_structure(
 
     let normalized_topology = normalized_topology_or_none(topology)?;
     let mut normalized_requests = requests.to_vec();
+    for request in &mut normalized_requests {
+        request.reason = request.reason.trim().to_owned();
+    }
     normalized_requests.sort_by(|left, right| {
         (
             left.logical_id.as_str(),
@@ -1963,6 +1966,25 @@ mod intake_integrity_tests {
             intake_integrity_work_probe(),
             (0, 0),
             "request aggregate bounds must reject oversized mutations before canonical JSON"
+        );
+    }
+
+    #[test]
+    fn whitespace_equivalent_requests_are_rejected_as_duplicates() {
+        let mut assessment = canonical_assessment();
+        let request = SccmArtifactRequest {
+            logical_id: "wsyncmgr".to_owned(),
+            role: SccmRole::SiteServer,
+            reason: "Collect the complete wsyncmgr.log file.".to_owned(),
+        };
+        let mut whitespace_variant = request.clone();
+        whitespace_variant.reason = format!("  {}  ", whitespace_variant.reason);
+        assessment.next_artifact_requests = vec![request, whitespace_variant];
+
+        assert_eq!(
+            integrity(&assessment),
+            None,
+            "requests with identical canonical wire identities must not evade deduplication"
         );
     }
 

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -738,7 +738,7 @@ pub fn assess_server_intake(
             let request_key = (
                 request.logical_id.clone(),
                 role_sort_key(&request.role).to_owned(),
-                request.reason.clone(),
+                request.reason.trim().to_owned(),
             );
             if request_keys.insert(request_key) {
                 next_artifact_requests.push(request);
@@ -771,12 +771,12 @@ pub fn assess_server_intake(
         (
             left.logical_id.as_str(),
             role_sort_key(&left.role),
-            left.reason.as_str(),
+            left.reason.trim(),
         )
             .cmp(&(
                 right.logical_id.as_str(),
                 role_sort_key(&right.role),
-                right.reason.as_str(),
+                right.reason.trim(),
             ))
     });
     let schema_version = 1;

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -68,8 +68,8 @@ pub struct SccmServerIntakeAssessment {
     pub next_artifact_requests: Vec<SccmArtifactRequest>,
     /// Private integrity binding for the canonical projection that server-role
     /// reducers consume. It is sequence-independent, but every authoritative
-    /// schema, topology, artifact, coverage, and evidence field remains bound
-    /// to the assessment produced by intake.
+    /// schema, topology, artifact, coverage, evidence, and artifact-request
+    /// field remains bound to the assessment produced by intake.
     intake_integrity: SccmServerIntakeIntegrity,
     /// Versioned opaque manifest extensions retained without interpreting them.
     extensions: Vec<SccmServerOpaqueExtension>,
@@ -222,6 +222,7 @@ impl SccmServerIntakeAssessment {
             || self.artifacts.len() != self.intake_integrity.artifacts.len()
             || self.coverage.len() != self.intake_integrity.coverage.len()
             || self.evidence.len() != self.intake_integrity.evidence.len()
+            || self.next_artifact_requests.len() != self.intake_integrity.request_count
         {
             return false;
         }
@@ -231,6 +232,7 @@ impl SccmServerIntakeAssessment {
             &self.artifacts,
             &self.coverage,
             &self.evidence,
+            &self.next_artifact_requests,
             &self.intake_integrity,
         )
         .as_ref()
@@ -267,6 +269,8 @@ struct SccmServerIntakeIntegrity {
     artifacts: BTreeMap<ArtifactIntegrityIdentity, IntakeIntegrityRecord>,
     coverage: BTreeMap<CoverageIdentityKey, IntakeIntegrityRecord>,
     evidence: BTreeMap<EvidenceIntegrityIdentity, IntakeIntegrityRecord>,
+    request_count: usize,
+    requests: IntakeIntegrityRecord,
 }
 
 type IntakeIntegrityDigest = [u8; 32];
@@ -286,6 +290,7 @@ struct IntakeIntegrityStructure {
     artifact_string_bytes: usize,
     coverage_string_bytes: usize,
     evidence_string_bytes: usize,
+    request_string_bytes: usize,
     coverage_artifact_memberships: usize,
 }
 
@@ -405,6 +410,9 @@ impl SccmServerIntakeIntegrity {
                         + record.digest.len()
                 })
                 .sum::<usize>()
+            + std::mem::size_of_val(&self.request_count)
+            + std::mem::size_of_val(&self.requests.payload_len)
+            + self.requests.digest.len()
     }
 }
 
@@ -772,9 +780,15 @@ pub fn assess_server_intake(
             ))
     });
     let schema_version = 1;
-    let intake_integrity =
-        canonical_intake_integrity(schema_version, &topology, &artifacts, &coverage, &evidence)
-            .ok_or(SccmServerIntakeError::InvalidArtifact)?;
+    let intake_integrity = canonical_intake_integrity(
+        schema_version,
+        &topology,
+        &artifacts,
+        &coverage,
+        &evidence,
+        &next_artifact_requests,
+    )
+    .ok_or(SccmServerIntakeError::InvalidArtifact)?;
 
     Ok(SccmServerIntakeAssessment {
         schema_version,
@@ -1450,11 +1464,22 @@ fn evidence_string_bytes(evidence: &[SccmEvidence]) -> Option<usize> {
     Some(total)
 }
 
+fn request_string_bytes(requests: &[SccmArtifactRequest]) -> Option<usize> {
+    let mut total = 0usize;
+    for request in requests {
+        checked_add_string_bytes(&mut total, &request.logical_id)?;
+        checked_add_string_bytes(&mut total, role_sort_key(&request.role))?;
+        checked_add_string_bytes(&mut total, &request.reason)?;
+    }
+    Some(total)
+}
+
 fn intake_integrity_structure(
     topology: &SccmServerTopologyAssessment,
     artifacts: &[SccmServerArtifactAssessment],
     coverage: &[SccmServerCoverage],
     evidence: &[SccmEvidence],
+    requests: &[SccmArtifactRequest],
     coverage_artifact_memberships: usize,
 ) -> Option<IntakeIntegrityStructure> {
     Some(IntakeIntegrityStructure {
@@ -1462,6 +1487,7 @@ fn intake_integrity_structure(
         artifact_string_bytes: artifact_string_bytes(artifacts)?,
         coverage_string_bytes: coverage_string_bytes(coverage)?,
         evidence_string_bytes: evidence_string_bytes(evidence)?,
+        request_string_bytes: request_string_bytes(requests)?,
         coverage_artifact_memberships,
     })
 }
@@ -1472,6 +1498,7 @@ fn canonical_intake_integrity(
     artifacts: &[SccmServerArtifactAssessment],
     coverage: &[SccmServerCoverage],
     evidence: &[SccmEvidence],
+    requests: &[SccmArtifactRequest],
 ) -> Option<SccmServerIntakeIntegrity> {
     let coverage_artifact_memberships = coverage_artifact_memberships(coverage)?;
     let structure = intake_integrity_structure(
@@ -1479,6 +1506,7 @@ fn canonical_intake_integrity(
         artifacts,
         coverage,
         evidence,
+        requests,
         coverage_artifact_memberships,
     )?;
     canonical_intake_integrity_with_structure(
@@ -1487,6 +1515,7 @@ fn canonical_intake_integrity(
         artifacts,
         coverage,
         evidence,
+        requests,
         structure,
         None,
     )
@@ -1498,6 +1527,7 @@ fn canonical_intake_integrity_for_adapter(
     artifacts: &[SccmServerArtifactAssessment],
     coverage: &[SccmServerCoverage],
     evidence: &[SccmEvidence],
+    requests: &[SccmArtifactRequest],
     expected: &SccmServerIntakeIntegrity,
 ) -> Option<SccmServerIntakeIntegrity> {
     let coverage_artifact_memberships = coverage_artifact_memberships(coverage)?;
@@ -1509,6 +1539,7 @@ fn canonical_intake_integrity_for_adapter(
         artifacts,
         coverage,
         evidence,
+        requests,
         coverage_artifact_memberships,
     )?;
     if structure != expected.structure {
@@ -1520,6 +1551,7 @@ fn canonical_intake_integrity_for_adapter(
         artifacts,
         coverage,
         evidence,
+        requests,
         structure,
         Some(expected),
     )
@@ -1532,6 +1564,7 @@ fn canonical_intake_integrity_with_structure(
     artifacts: &[SccmServerArtifactAssessment],
     coverage: &[SccmServerCoverage],
     evidence: &[SccmEvidence],
+    requests: &[SccmArtifactRequest],
     structure: IntakeIntegrityStructure,
     expected: Option<&SccmServerIntakeIntegrity>,
 ) -> Option<SccmServerIntakeIntegrity> {
@@ -1539,6 +1572,25 @@ fn canonical_intake_integrity_with_structure(
     INTAKE_CANONICALIZATION_CALLS.with(|calls| calls.set(calls.get().saturating_add(1)));
 
     let normalized_topology = normalized_topology_or_none(topology)?;
+    let mut normalized_requests = requests.to_vec();
+    normalized_requests.sort_by(|left, right| {
+        (
+            left.logical_id.as_str(),
+            role_sort_key(&left.role),
+            left.reason.as_str(),
+        )
+            .cmp(&(
+                right.logical_id.as_str(),
+                role_sort_key(&right.role),
+                right.reason.as_str(),
+            ))
+    });
+    if normalized_requests
+        .windows(2)
+        .any(|requests| requests[0] == requests[1])
+    {
+        return None;
+    }
 
     let mut normalized_coverage = coverage.to_vec();
     for record in &mut normalized_coverage {
@@ -1629,6 +1681,12 @@ fn canonical_intake_integrity_with_structure(
         artifacts: artifact_integrity,
         coverage: coverage_integrity,
         evidence: evidence_integrity,
+        request_count: normalized_requests.len(),
+        requests: canonical_record_digest_bounded(
+            b"artifact-requests",
+            &normalized_requests,
+            expected.map(|expected| expected.requests.payload_len),
+        )?,
     })
 }
 
@@ -1777,6 +1835,7 @@ mod intake_integrity_tests {
             &assessment.artifacts,
             &assessment.coverage,
             &assessment.evidence,
+            &assessment.next_artifact_requests,
         )
     }
 
@@ -1869,6 +1928,42 @@ mod intake_integrity_tests {
             .roles_observed
             .push(SccmRole::ManagementPoint);
         assert_eq!(integrity(&duplicate_topology_role), None);
+    }
+
+    #[test]
+    fn oversized_request_mutation_fails_before_canonical_serialization() {
+        let directory = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/sccm/server/intake/capped-sup");
+        let manifest_json =
+            fs::read_to_string(directory.join("manifest.json")).expect("fixture manifest");
+        let manifest: Value = serde_json::from_str(&manifest_json).expect("fixture JSON");
+        let payloads = manifest["artifacts"]
+            .as_array()
+            .expect("fixture artifacts")
+            .iter()
+            .filter_map(|artifact| {
+                let relative_path = artifact["relativePath"].as_str()?;
+                Some(SccmServerArtifactPayload {
+                    manifest_artifact_id: artifact["artifactId"]
+                        .as_str()
+                        .expect("fixture artifact ID")
+                        .to_owned(),
+                    bytes: fs::read(directory.join(relative_path)).expect("fixture payload"),
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut assessment =
+            assess_server_intake(&manifest_json, &payloads).expect("canonical fixture");
+        assert_eq!(assessment.next_artifact_requests.len(), 1);
+        assessment.next_artifact_requests[0].reason = "x".repeat(1024 * 1024);
+
+        reset_intake_integrity_work_probe();
+        assert!(!assessment.adapter_authority_is_intake_bound());
+        assert_eq!(
+            intake_integrity_work_probe(),
+            (0, 0),
+            "request aggregate bounds must reject oversized mutations before canonical JSON"
+        );
     }
 
     #[test]

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/mod.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/mod.rs
@@ -3,9 +3,11 @@ mod distribution_point;
 mod intake;
 mod management_point;
 mod site_core;
+mod software_update_point;
 
 pub use catalog::*;
 pub use distribution_point::*;
 pub use intake::*;
 pub use management_point::*;
 pub use site_core::*;
+pub use software_update_point::*;

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/software_update_point.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/software_update_point.rs
@@ -16,6 +16,8 @@ pub const SCCM_SOFTWARE_UPDATE_POINT_SYNC_SOURCE_ID: &str = "server-sup-sync";
 pub const SCCM_SOFTWARE_UPDATE_POINT_WSUS_SOURCE_ID: &str = "server-sup-wsus";
 const SCCM_SOFTWARE_UPDATE_POINT_INTAKE_AUTHORITY_REASON: &str =
     "Canonical server intake authority could not be verified.";
+const SCCM_SOFTWARE_UPDATE_POINT_ROLE_ABSENT_REASON: &str =
+    "Canonical intake topology does not report a Software Update Point role; no outcome is inferred.";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -103,11 +105,31 @@ pub fn analyze_software_update_point(
     coverage_rows
         .sort_by(|left, right| coverage_row_sort_key(left).cmp(&coverage_row_sort_key(right)));
 
-    let coverage_gaps = coverage_rows
-        .iter()
-        .filter(|row| needs_coverage_gap(row))
-        .map(coverage_gap_for_row)
-        .collect();
+    let coverage_gaps = if coverage_rows.is_empty()
+        && !intake
+            .topology
+            .roles_observed
+            .contains(&SccmRole::SoftwareUpdatePoint)
+    {
+        vec![SccmSoftwareUpdatePointCoverageGap {
+            artifact_id: None,
+            source_id: SCCM_SOFTWARE_UPDATE_POINT_SYNC_SOURCE_ID.to_owned(),
+            producer_role: None,
+            producer_host_handle: None,
+            workflow_subject_role: Some(SccmRole::SoftwareUpdatePoint),
+            workflow_subject_handle: None,
+            capture_state: SccmCoverageState::Absent,
+            rotation_fragment_complete: None,
+            profile_eligible: false,
+            reason: SCCM_SOFTWARE_UPDATE_POINT_ROLE_ABSENT_REASON.to_owned(),
+        }]
+    } else {
+        coverage_rows
+            .iter()
+            .filter(|row| needs_coverage_gap(row))
+            .map(coverage_gap_for_row)
+            .collect()
+    };
 
     SccmSoftwareUpdatePointAnalysis {
         schema_version: SCCM_SOFTWARE_UPDATE_POINT_ANALYSIS_SCHEMA_VERSION,

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/software_update_point.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/software_update_point.rs
@@ -1,0 +1,231 @@
+//! Coverage-only projection for Software Update Point and supplemental WSUS intake.
+//!
+//! This adapter intentionally projects no parsed evidence, health, transaction,
+//! or outcome interpretation. Canonical server intake owns source admission,
+//! topology, and bounded recollection requests; this module retains that
+//! coverage provenance as a deterministic, source-local view.
+
+use serde::Serialize;
+
+use crate::sccm::{SccmArtifactFamily, SccmArtifactRequest, SccmCoverageState, SccmRole};
+
+use super::SccmServerIntakeAssessment;
+
+pub const SCCM_SOFTWARE_UPDATE_POINT_ANALYSIS_SCHEMA_VERSION: u32 = 1;
+pub const SCCM_SOFTWARE_UPDATE_POINT_SYNC_SOURCE_ID: &str = "server-sup-sync";
+pub const SCCM_SOFTWARE_UPDATE_POINT_WSUS_SOURCE_ID: &str = "server-sup-wsus";
+const SCCM_SOFTWARE_UPDATE_POINT_INTAKE_AUTHORITY_REASON: &str =
+    "Canonical server intake authority could not be verified.";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmSoftwareUpdatePointWorkflow {
+    SoftwareUpdatePoint,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmSoftwareUpdatePointDiagnosticMeaning {
+    CoverageOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSoftwareUpdatePointCoverageRow {
+    pub artifact_id: String,
+    pub source_id: String,
+    pub producer_role: SccmRole,
+    pub producer_host_handle: Option<String>,
+    pub workflow_subject_role: Option<SccmRole>,
+    pub workflow_subject_handle: Option<String>,
+    pub capture_state: SccmCoverageState,
+    pub rotation_fragment_complete: Option<bool>,
+    pub profile_eligible: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSoftwareUpdatePointCoverageGap {
+    pub artifact_id: Option<String>,
+    pub source_id: String,
+    pub producer_role: Option<SccmRole>,
+    pub producer_host_handle: Option<String>,
+    pub workflow_subject_role: Option<SccmRole>,
+    pub workflow_subject_handle: Option<String>,
+    pub capture_state: SccmCoverageState,
+    pub rotation_fragment_complete: Option<bool>,
+    pub profile_eligible: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmSoftwareUpdatePointAnalysis {
+    pub schema_version: u32,
+    pub workflow: SccmSoftwareUpdatePointWorkflow,
+    pub diagnostic_meaning: SccmSoftwareUpdatePointDiagnosticMeaning,
+    pub coverage_rows: Vec<SccmSoftwareUpdatePointCoverageRow>,
+    pub coverage_gaps: Vec<SccmSoftwareUpdatePointCoverageGap>,
+    pub next_artifact_requests: Vec<SccmArtifactRequest>,
+    pub cross_side_correlation_performed: bool,
+}
+
+/// Project canonical Software Update Point/WSUS capture coverage without
+/// inspecting source text or inferring an operational outcome.
+pub fn analyze_software_update_point(
+    intake: &SccmServerIntakeAssessment,
+) -> SccmSoftwareUpdatePointAnalysis {
+    let adapter_authority_is_intake_bound = intake.adapter_authority_is_intake_bound();
+    let topology_authority_is_intake_bound = intake.topology_authority_is_intake_bound();
+    if !adapter_authority_is_intake_bound || !topology_authority_is_intake_bound {
+        return intake_authority_invalid_analysis();
+    }
+
+    let mut coverage_rows = intake
+        .artifacts
+        .iter()
+        .filter(|artifact| {
+            artifact.family == SccmArtifactFamily::SoftwareUpdatePoint
+                && is_software_update_point_source(&artifact.source_id)
+        })
+        .map(|artifact| SccmSoftwareUpdatePointCoverageRow {
+            artifact_id: artifact.artifact_id.clone(),
+            source_id: artifact.source_id.clone(),
+            producer_role: artifact.producer_role.clone(),
+            producer_host_handle: artifact.producer_host_handle.clone(),
+            workflow_subject_role: artifact.workflow_subject_role.clone(),
+            workflow_subject_handle: artifact.workflow_subject_handle.clone(),
+            capture_state: artifact.state.clone(),
+            rotation_fragment_complete: artifact.fragment_complete,
+            profile_eligible: artifact.profile_eligible,
+        })
+        .collect::<Vec<_>>();
+    coverage_rows
+        .sort_by(|left, right| coverage_row_sort_key(left).cmp(&coverage_row_sort_key(right)));
+
+    let coverage_gaps = coverage_rows
+        .iter()
+        .filter(|row| needs_coverage_gap(row))
+        .map(coverage_gap_for_row)
+        .collect();
+
+    SccmSoftwareUpdatePointAnalysis {
+        schema_version: SCCM_SOFTWARE_UPDATE_POINT_ANALYSIS_SCHEMA_VERSION,
+        workflow: SccmSoftwareUpdatePointWorkflow::SoftwareUpdatePoint,
+        diagnostic_meaning: SccmSoftwareUpdatePointDiagnosticMeaning::CoverageOnly,
+        coverage_rows,
+        coverage_gaps,
+        next_artifact_requests: intake.next_artifact_requests.clone(),
+        cross_side_correlation_performed: false,
+    }
+}
+
+fn intake_authority_invalid_analysis() -> SccmSoftwareUpdatePointAnalysis {
+    SccmSoftwareUpdatePointAnalysis {
+        schema_version: SCCM_SOFTWARE_UPDATE_POINT_ANALYSIS_SCHEMA_VERSION,
+        workflow: SccmSoftwareUpdatePointWorkflow::SoftwareUpdatePoint,
+        diagnostic_meaning: SccmSoftwareUpdatePointDiagnosticMeaning::CoverageOnly,
+        coverage_rows: Vec::new(),
+        coverage_gaps: vec![SccmSoftwareUpdatePointCoverageGap {
+            artifact_id: None,
+            source_id: SCCM_SOFTWARE_UPDATE_POINT_SYNC_SOURCE_ID.to_owned(),
+            producer_role: None,
+            producer_host_handle: None,
+            workflow_subject_role: Some(SccmRole::SoftwareUpdatePoint),
+            workflow_subject_handle: None,
+            capture_state: SccmCoverageState::ParseFailed,
+            rotation_fragment_complete: None,
+            profile_eligible: false,
+            reason: SCCM_SOFTWARE_UPDATE_POINT_INTAKE_AUTHORITY_REASON.to_owned(),
+        }],
+        next_artifact_requests: Vec::new(),
+        cross_side_correlation_performed: false,
+    }
+}
+
+fn is_software_update_point_source(source_id: &str) -> bool {
+    matches!(
+        source_id,
+        SCCM_SOFTWARE_UPDATE_POINT_SYNC_SOURCE_ID | SCCM_SOFTWARE_UPDATE_POINT_WSUS_SOURCE_ID
+    )
+}
+
+fn needs_coverage_gap(row: &SccmSoftwareUpdatePointCoverageRow) -> bool {
+    row.capture_state != SccmCoverageState::Captured
+        || row.rotation_fragment_complete == Some(false)
+        || !row.profile_eligible
+}
+
+fn coverage_gap_for_row(
+    row: &SccmSoftwareUpdatePointCoverageRow,
+) -> SccmSoftwareUpdatePointCoverageGap {
+    SccmSoftwareUpdatePointCoverageGap {
+        artifact_id: Some(row.artifact_id.clone()),
+        source_id: row.source_id.clone(),
+        producer_role: Some(row.producer_role.clone()),
+        producer_host_handle: row.producer_host_handle.clone(),
+        workflow_subject_role: row.workflow_subject_role.clone(),
+        workflow_subject_handle: row.workflow_subject_handle.clone(),
+        capture_state: row.capture_state.clone(),
+        rotation_fragment_complete: row.rotation_fragment_complete,
+        profile_eligible: row.profile_eligible,
+        reason: coverage_gap_reason(row),
+    }
+}
+
+fn coverage_gap_reason(row: &SccmSoftwareUpdatePointCoverageRow) -> String {
+    if row.capture_state != SccmCoverageState::Captured {
+        return format!(
+            "Software Update Point source coverage is {}; canonical intake has no captured artifact to interpret.",
+            coverage_state_label(&row.capture_state)
+        );
+    }
+    if row.rotation_fragment_complete == Some(false) {
+        return "Software Update Point source coverage has an incomplete rotation fragment."
+            .to_owned();
+    }
+    "Software Update Point source is outside the canonical intake profile.".to_owned()
+}
+
+fn coverage_row_sort_key(
+    row: &SccmSoftwareUpdatePointCoverageRow,
+) -> (&str, &str, &str, &str, &str, &str, &str) {
+    (
+        row.source_id.as_str(),
+        role_sort_key(&row.producer_role),
+        row.producer_host_handle.as_deref().unwrap_or_default(),
+        row.workflow_subject_role
+            .as_ref()
+            .map(role_sort_key)
+            .unwrap_or_default(),
+        row.workflow_subject_handle.as_deref().unwrap_or_default(),
+        coverage_state_label(&row.capture_state),
+        row.artifact_id.as_str(),
+    )
+}
+
+fn coverage_state_label(state: &SccmCoverageState) -> &'static str {
+    match state {
+        SccmCoverageState::Captured => "captured",
+        SccmCoverageState::Absent => "absent",
+        SccmCoverageState::AccessDenied => "accessDenied",
+        SccmCoverageState::Capped => "capped",
+        SccmCoverageState::Skipped => "skipped",
+        SccmCoverageState::Unsupported => "unsupported",
+        SccmCoverageState::ParseFailed => "parseFailed",
+    }
+}
+
+fn role_sort_key(role: &SccmRole) -> &str {
+    match role {
+        SccmRole::Client => "client",
+        SccmRole::SiteServer => "siteServer",
+        SccmRole::ManagementPoint => "managementPoint",
+        SccmRole::DistributionPoint => "distributionPoint",
+        SccmRole::SoftwareUpdatePoint => "softwareUpdatePoint",
+        SccmRole::WsUs => "wsUs",
+        SccmRole::Provider => "provider",
+        SccmRole::AdminService => "adminService",
+        SccmRole::Unknown(value) => value,
+    }
+}

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/software_update_point.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/software_update_point.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use crate::sccm::{SccmArtifactFamily, SccmArtifactRequest, SccmCoverageState, SccmRole};
 
-use super::SccmServerIntakeAssessment;
+use super::{declared_server_source_catalog, SccmServerIntakeAssessment};
 
 pub const SCCM_SOFTWARE_UPDATE_POINT_ANALYSIS_SCHEMA_VERSION: u32 = 1;
 pub const SCCM_SOFTWARE_UPDATE_POINT_SYNC_SOURCE_ID: &str = "server-sup-sync";
@@ -115,7 +115,9 @@ pub fn analyze_software_update_point(
         diagnostic_meaning: SccmSoftwareUpdatePointDiagnosticMeaning::CoverageOnly,
         coverage_rows,
         coverage_gaps,
-        next_artifact_requests: intake.next_artifact_requests.clone(),
+        next_artifact_requests: software_update_point_artifact_requests(
+            &intake.next_artifact_requests,
+        ),
         cross_side_correlation_performed: false,
     }
 }
@@ -176,7 +178,7 @@ fn coverage_gap_for_row(
 fn coverage_gap_reason(row: &SccmSoftwareUpdatePointCoverageRow) -> String {
     if row.capture_state != SccmCoverageState::Captured {
         return format!(
-            "Software Update Point source coverage is {}; canonical intake has no captured artifact to interpret.",
+            "Canonical intake reports Software Update Point source coverage as {}; no outcome is inferred.",
             coverage_state_label(&row.capture_state)
         );
     }
@@ -185,6 +187,25 @@ fn coverage_gap_reason(row: &SccmSoftwareUpdatePointCoverageRow) -> String {
             .to_owned();
     }
     "Software Update Point source is outside the canonical intake profile.".to_owned()
+}
+
+fn software_update_point_artifact_requests(
+    requests: &[SccmArtifactRequest],
+) -> Vec<SccmArtifactRequest> {
+    requests
+        .iter()
+        .filter(|request| {
+            declared_server_source_catalog().iter().any(|source| {
+                is_software_update_point_source(source.source_id)
+                    && source.producer_role == request.role
+                    && source
+                        .logical_names
+                        .iter()
+                        .any(|logical_name| *logical_name == request.logical_id)
+            })
+        })
+        .cloned()
+        .collect()
 }
 
 fn coverage_row_sort_key(

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/software_update_point.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/software_update_point.rs
@@ -192,7 +192,7 @@ fn coverage_gap_reason(row: &SccmSoftwareUpdatePointCoverageRow) -> String {
 fn software_update_point_artifact_requests(
     requests: &[SccmArtifactRequest],
 ) -> Vec<SccmArtifactRequest> {
-    requests
+    let mut requests = requests
         .iter()
         .filter(|request| {
             declared_server_source_catalog().iter().any(|source| {
@@ -205,7 +205,20 @@ fn software_update_point_artifact_requests(
             })
         })
         .cloned()
-        .collect()
+        .collect::<Vec<_>>();
+    requests.sort_by(|left, right| {
+        (
+            left.logical_id.as_str(),
+            role_sort_key(&left.role),
+            left.reason.as_str(),
+        )
+            .cmp(&(
+                right.logical_id.as_str(),
+                role_sort_key(&right.role),
+                right.reason.as_str(),
+            ))
+    });
+    requests
 }
 
 fn coverage_row_sort_key(
@@ -248,5 +261,40 @@ fn role_sort_key(role: &SccmRole) -> &str {
         SccmRole::Provider => "provider",
         SccmRole::AdminService => "adminService",
         SccmRole::Unknown(value) => value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eligible_requests_are_projected_in_canonical_order() {
+        let requests = vec![
+            SccmArtifactRequest {
+                logical_id: "wsyncmgr".to_owned(),
+                role: SccmRole::SiteServer,
+                reason: "Collect the complete wsyncmgr.log file.".to_owned(),
+            },
+            SccmArtifactRequest {
+                logical_id: "wcm".to_owned(),
+                role: SccmRole::SiteServer,
+                reason: "Collect the complete WCM.log file.".to_owned(),
+            },
+        ];
+        let mut reordered = requests.clone();
+        reordered.reverse();
+
+        assert_eq!(
+            software_update_point_artifact_requests(&requests),
+            software_update_point_artifact_requests(&reordered)
+        );
+        assert_eq!(
+            software_update_point_artifact_requests(&requests)
+                .iter()
+                .map(|request| request.logical_id.as_str())
+                .collect::<Vec<_>>(),
+            ["wcm", "wsyncmgr"]
+        );
     }
 }

--- a/crates/cmtraceopen-parser/tests/sccm_server_software_update_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_software_update_point.rs
@@ -1,0 +1,206 @@
+use std::path::{Path, PathBuf};
+
+use cmtraceopen_parser::sccm::server::windows::{
+    analyze_software_update_point, assess_server_intake, SccmServerArtifactPayload,
+    SccmServerIntakeAssessment, SccmSoftwareUpdatePointDiagnosticMeaning,
+};
+use cmtraceopen_parser::sccm::{SccmCoverageState, SccmRole};
+use serde_json::Value;
+
+fn intake_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sccm/server/intake")
+}
+
+fn load_manifest_and_payloads(scenario: &str) -> (Value, Vec<SccmServerArtifactPayload>) {
+    let scenario_root = intake_root().join(scenario);
+    let manifest_json =
+        std::fs::read_to_string(scenario_root.join("manifest.json")).expect("manifest is readable");
+    let manifest: Value = serde_json::from_str(&manifest_json).expect("manifest is valid JSON");
+    let payloads = manifest["artifacts"]
+        .as_array()
+        .expect("artifacts are an array")
+        .iter()
+        .filter_map(|artifact| {
+            let relative_path = artifact["relativePath"].as_str()?;
+            Some(SccmServerArtifactPayload {
+                manifest_artifact_id: artifact["artifactId"]
+                    .as_str()
+                    .expect("artifact ID is a string")
+                    .to_owned(),
+                bytes: std::fs::read(scenario_root.join(relative_path))
+                    .expect("captured payload is readable"),
+            })
+        })
+        .collect();
+
+    (manifest, payloads)
+}
+
+fn load_assessment(scenario: &str) -> SccmServerIntakeAssessment {
+    let (manifest, payloads) = load_manifest_and_payloads(scenario);
+    assess_server_intake(
+        &serde_json::to_string(&manifest).expect("manifest serializes"),
+        &payloads,
+    )
+    .expect("fixture is accepted by canonical server intake")
+}
+
+#[test]
+fn capped_sup_projects_only_canonical_coverage_and_its_bounded_recapture() {
+    let assessment = load_assessment("capped-sup");
+
+    let analysis = analyze_software_update_point(&assessment);
+
+    assert_eq!(
+        analysis.diagnostic_meaning,
+        SccmSoftwareUpdatePointDiagnosticMeaning::CoverageOnly
+    );
+    assert!(!analysis.cross_side_correlation_performed);
+    assert_eq!(analysis.coverage_rows.len(), 1);
+    let row = &analysis.coverage_rows[0];
+    assert_eq!(row.artifact_id, "sup-sync-capped");
+    assert_eq!(row.source_id, "server-sup-sync");
+    assert_eq!(row.producer_role, SccmRole::SiteServer);
+    assert_eq!(
+        row.producer_host_handle.as_deref(),
+        Some("synthetic:host:site-01")
+    );
+    assert_eq!(
+        row.workflow_subject_role,
+        Some(SccmRole::SoftwareUpdatePoint)
+    );
+    assert_eq!(
+        row.workflow_subject_handle.as_deref(),
+        Some("synthetic:subject:sup-01")
+    );
+    assert_eq!(row.capture_state, SccmCoverageState::Capped);
+    assert_eq!(row.rotation_fragment_complete, Some(false));
+    assert!(row.profile_eligible);
+
+    assert_eq!(analysis.coverage_gaps.len(), 1);
+    assert_eq!(
+        analysis.coverage_gaps[0].artifact_id.as_deref(),
+        Some("sup-sync-capped")
+    );
+    assert_eq!(
+        analysis.coverage_gaps[0].capture_state,
+        SccmCoverageState::Capped
+    );
+    assert_eq!(
+        analysis.coverage_gaps[0].workflow_subject_role,
+        Some(SccmRole::SoftwareUpdatePoint)
+    );
+    assert_eq!(
+        analysis.next_artifact_requests,
+        assessment.next_artifact_requests
+    );
+}
+
+#[test]
+fn captured_wsyncmgr_is_an_observation_without_a_health_or_outcome_interpretation() {
+    let assessment = load_assessment("complete-multi-role");
+
+    let analysis = analyze_software_update_point(&assessment);
+    let serialized = serde_json::to_value(&analysis).expect("coverage analysis serializes");
+
+    assert_eq!(analysis.coverage_rows.len(), 1);
+    assert_eq!(analysis.coverage_rows[0].artifact_id, "sup-sync-current");
+    assert_eq!(
+        analysis.coverage_rows[0].capture_state,
+        SccmCoverageState::Captured
+    );
+    assert!(analysis.coverage_gaps.is_empty());
+    assert!(analysis.next_artifact_requests.is_empty());
+    assert_eq!(
+        serialized["diagnosticMeaning"],
+        Value::String("coverageOnly".to_owned())
+    );
+    for forbidden in [
+        "transaction",
+        "health",
+        "success",
+        "failure",
+        "finding",
+        "evidence",
+    ] {
+        assert!(
+            !serialized.to_string().contains(forbidden),
+            "coverage-only output must not expose {forbidden} interpretation"
+        );
+    }
+}
+
+#[test]
+fn skipped_supplemental_wsus_is_coverage_not_wsus_health_proof() {
+    let assessment = load_assessment("supplemental-wsus-skipped");
+
+    let analysis = analyze_software_update_point(&assessment);
+
+    assert_eq!(analysis.coverage_rows.len(), 1);
+    let row = &analysis.coverage_rows[0];
+    assert_eq!(row.artifact_id, "sup-wsus-health-skipped");
+    assert_eq!(row.source_id, "server-sup-wsus");
+    assert_eq!(row.producer_role, SccmRole::WsUs);
+    assert_eq!(
+        row.workflow_subject_role,
+        Some(SccmRole::SoftwareUpdatePoint)
+    );
+    assert_eq!(row.capture_state, SccmCoverageState::Skipped);
+    assert_eq!(row.rotation_fragment_complete, None);
+    assert!(row.profile_eligible);
+    assert_eq!(analysis.coverage_gaps.len(), 1);
+    assert_eq!(
+        analysis.coverage_gaps[0].producer_role,
+        Some(SccmRole::WsUs)
+    );
+    assert_eq!(
+        analysis.coverage_gaps[0].workflow_subject_role,
+        Some(SccmRole::SoftwareUpdatePoint)
+    );
+    assert_eq!(
+        analysis.coverage_gaps[0].capture_state,
+        SccmCoverageState::Skipped
+    );
+    assert_eq!(
+        analysis.next_artifact_requests,
+        assessment.next_artifact_requests
+    );
+}
+
+#[test]
+fn tampered_intake_fails_closed_to_one_authority_coverage_gap() {
+    let mut assessment = load_assessment("complete-multi-role");
+    assessment.artifacts[0].artifact_id = "forged-artifact".to_owned();
+
+    let analysis = analyze_software_update_point(&assessment);
+
+    assert!(analysis.coverage_rows.is_empty());
+    assert!(analysis.next_artifact_requests.is_empty());
+    assert_eq!(analysis.coverage_gaps.len(), 1);
+    assert_eq!(
+        analysis.coverage_gaps[0].reason,
+        "Canonical server intake authority could not be verified."
+    );
+    assert_eq!(
+        analysis.coverage_gaps[0].capture_state,
+        SccmCoverageState::ParseFailed
+    );
+    assert!(!analysis.cross_side_correlation_performed);
+}
+
+#[test]
+fn reordered_sealed_intake_serializes_to_identical_coverage_analysis() {
+    let assessment = load_assessment("complete-multi-role");
+    let mut reordered = assessment.clone();
+    reordered.artifacts.reverse();
+    reordered.coverage.reverse();
+    reordered.evidence.reverse();
+    reordered.topology.roles_observed.reverse();
+
+    assert_eq!(
+        serde_json::to_vec(&analyze_software_update_point(&assessment))
+            .expect("original coverage analysis serializes"),
+        serde_json::to_vec(&analyze_software_update_point(&reordered))
+            .expect("reordered coverage analysis serializes")
+    );
+}

--- a/crates/cmtraceopen-parser/tests/sccm_server_software_update_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_software_update_point.rs
@@ -138,6 +138,39 @@ fn captured_wsyncmgr_is_an_observation_without_a_health_or_outcome_interpretatio
 }
 
 #[test]
+fn missing_sup_topology_role_projects_one_absent_coverage_gap() {
+    let (mut manifest, mut payloads) = load_manifest_and_payloads("complete-multi-role");
+    manifest["topology"]["rolesObserved"]
+        .as_array_mut()
+        .expect("rolesObserved is an array")
+        .retain(|role| role != "softwareUpdatePoint");
+    manifest["artifacts"]
+        .as_array_mut()
+        .expect("artifacts are an array")
+        .retain(|artifact| artifact["artifactId"] != "sup-sync-current");
+    payloads.retain(|payload| payload.manifest_artifact_id != "sup-sync-current");
+
+    let analysis = analyze_software_update_point(&assess_manifest(&manifest, &payloads));
+
+    assert!(analysis.coverage_rows.is_empty());
+    assert!(analysis.next_artifact_requests.is_empty());
+    assert_eq!(analysis.coverage_gaps.len(), 1);
+    let gap = &analysis.coverage_gaps[0];
+    assert_eq!(gap.artifact_id, None);
+    assert_eq!(gap.source_id, "server-sup-sync");
+    assert_eq!(gap.producer_role, None);
+    assert_eq!(
+        gap.workflow_subject_role,
+        Some(SccmRole::SoftwareUpdatePoint)
+    );
+    assert_eq!(gap.capture_state, SccmCoverageState::Absent);
+    assert_eq!(
+        gap.reason,
+        "Canonical intake topology does not report a Software Update Point role; no outcome is inferred."
+    );
+}
+
+#[test]
 fn sup_analysis_excludes_an_unrelated_management_point_recapture_request() {
     let (mut manifest, mut payloads) = load_manifest_and_payloads("complete-multi-role");
     let management_point = manifest["artifacts"]

--- a/crates/cmtraceopen-parser/tests/sccm_server_software_update_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_software_update_point.rs
@@ -285,12 +285,32 @@ fn topology_only_tampering_fails_closed_to_one_authority_coverage_gap() {
 }
 
 #[test]
+fn same_size_catalog_valid_request_tampering_fails_closed_to_one_authority_coverage_gap() {
+    let mut assessment = load_assessment("capped-sup");
+    assert_eq!(assessment.next_artifact_requests.len(), 1);
+    assessment.next_artifact_requests[0]
+        .reason
+        .replace_range(0..1, "X");
+
+    let analysis = analyze_software_update_point(&assessment);
+
+    assert!(analysis.coverage_rows.is_empty());
+    assert!(analysis.next_artifact_requests.is_empty());
+    assert_eq!(analysis.coverage_gaps.len(), 1);
+    assert_eq!(
+        analysis.coverage_gaps[0].reason,
+        "Canonical server intake authority could not be verified."
+    );
+}
+
+#[test]
 fn reordered_sealed_intake_serializes_to_identical_coverage_analysis() {
     let assessment = load_assessment("complete-multi-role");
     let mut reordered = assessment.clone();
     reordered.artifacts.reverse();
     reordered.coverage.reverse();
     reordered.evidence.reverse();
+    reordered.next_artifact_requests.reverse();
     reordered.topology.roles_observed.reverse();
 
     assert_eq!(

--- a/crates/cmtraceopen-parser/tests/sccm_server_software_update_point.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_software_update_point.rs
@@ -38,9 +38,16 @@ fn load_manifest_and_payloads(scenario: &str) -> (Value, Vec<SccmServerArtifactP
 
 fn load_assessment(scenario: &str) -> SccmServerIntakeAssessment {
     let (manifest, payloads) = load_manifest_and_payloads(scenario);
+    assess_manifest(&manifest, &payloads)
+}
+
+fn assess_manifest(
+    manifest: &Value,
+    payloads: &[SccmServerArtifactPayload],
+) -> SccmServerIntakeAssessment {
     assess_server_intake(
         &serde_json::to_string(&manifest).expect("manifest serializes"),
-        &payloads,
+        payloads,
     )
     .expect("fixture is accepted by canonical server intake")
 }
@@ -131,6 +138,79 @@ fn captured_wsyncmgr_is_an_observation_without_a_health_or_outcome_interpretatio
 }
 
 #[test]
+fn sup_analysis_excludes_an_unrelated_management_point_recapture_request() {
+    let (mut manifest, mut payloads) = load_manifest_and_payloads("complete-multi-role");
+    let management_point = manifest["artifacts"]
+        .as_array_mut()
+        .expect("artifacts are an array")
+        .iter_mut()
+        .find(|artifact| artifact["artifactId"] == "mp-policy-current")
+        .expect("complete multi-role fixture includes MP_GetPolicy");
+    management_point["captureState"] = Value::String("accessDenied".to_owned());
+    management_point["collectionDetail"] = Value::String("synthetic permission denial".to_owned());
+    management_point["relativePath"] = Value::Null;
+    management_point["bytesCopied"] = Value::from(0);
+    let fields = management_point
+        .as_object_mut()
+        .expect("artifact is an object");
+    fields.remove("encoding");
+    fields.remove("collectionLimit");
+    payloads.retain(|payload| payload.manifest_artifact_id != "mp-policy-current");
+
+    let assessment = assess_manifest(&manifest, &payloads);
+    assert_eq!(assessment.next_artifact_requests.len(), 1);
+    assert_eq!(
+        assessment.next_artifact_requests[0].logical_id, "mpGetPolicy",
+        "canonical intake keeps the MP recapture request"
+    );
+    assert_eq!(
+        assessment.next_artifact_requests[0].role,
+        SccmRole::ManagementPoint
+    );
+
+    let analysis = analyze_software_update_point(&assessment);
+
+    assert_eq!(analysis.coverage_rows.len(), 1);
+    assert_eq!(analysis.coverage_rows[0].artifact_id, "sup-sync-current");
+    assert!(analysis.next_artifact_requests.is_empty());
+}
+
+#[test]
+fn non_captured_sup_gaps_report_the_canonical_state_without_claiming_no_capture() {
+    let capped = analyze_software_update_point(&load_assessment("capped-sup"));
+    assert_eq!(capped.coverage_gaps.len(), 1);
+    assert_eq!(
+        capped.coverage_gaps[0].reason,
+        "Canonical intake reports Software Update Point source coverage as capped; no outcome is inferred."
+    );
+
+    let (mut manifest, mut payloads) = load_manifest_and_payloads("complete-multi-role");
+    let payload = payloads
+        .iter_mut()
+        .find(|payload| payload.manifest_artifact_id == "sup-sync-current")
+        .expect("complete multi-role fixture includes wsyncmgr bytes");
+    payload.bytes = b"not a complete CCM logical record".to_vec();
+    let software_update_point = manifest["artifacts"]
+        .as_array_mut()
+        .expect("artifacts are an array")
+        .iter_mut()
+        .find(|artifact| artifact["artifactId"] == "sup-sync-current")
+        .expect("complete multi-role fixture includes wsyncmgr");
+    software_update_point["bytesCopied"] = Value::from(payload.bytes.len() as u64);
+
+    let parse_failed = analyze_software_update_point(&assess_manifest(&manifest, &payloads));
+    assert_eq!(parse_failed.coverage_gaps.len(), 1);
+    assert_eq!(
+        parse_failed.coverage_gaps[0].capture_state,
+        SccmCoverageState::ParseFailed
+    );
+    assert_eq!(
+        parse_failed.coverage_gaps[0].reason,
+        "Canonical intake reports Software Update Point source coverage as parseFailed; no outcome is inferred."
+    );
+}
+
+#[test]
 fn skipped_supplemental_wsus_is_coverage_not_wsus_health_proof() {
     let assessment = load_assessment("supplemental-wsus-skipped");
 
@@ -186,6 +266,22 @@ fn tampered_intake_fails_closed_to_one_authority_coverage_gap() {
         SccmCoverageState::ParseFailed
     );
     assert!(!analysis.cross_side_correlation_performed);
+}
+
+#[test]
+fn topology_only_tampering_fails_closed_to_one_authority_coverage_gap() {
+    let mut assessment = load_assessment("complete-multi-role");
+    assessment.topology.roles_observed.pop();
+
+    let analysis = analyze_software_update_point(&assessment);
+
+    assert!(analysis.coverage_rows.is_empty());
+    assert!(analysis.next_artifact_requests.is_empty());
+    assert_eq!(analysis.coverage_gaps.len(), 1);
+    assert_eq!(
+        analysis.coverage_gaps[0].reason,
+        "Canonical server intake authority could not be verified."
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- adds the issue-scoped Software Update Point/WSUS coverage-only adapter
- preserves canonical intake coverage states without inferring health or outcomes
- scopes bounded recapture requests to declared SUP sources
- binds `next_artifact_requests` into canonical server-intake authority so post-intake mutation fails closed

## Dependency and scope

Targets the SCCM integration branch `codex/parser-family-skeleton`, not `main`. The reviewed stack descends directly from integration head `8329522742a4889565fba2c838f832208b7e7443` and contains exactly three commits:

- `4908d12c` — SUP coverage-only intake adapter
- `76e2b0b9` — request scoping and conservative coverage wording
- `3cd037b9` — request-authority sealing and deterministic projection

The diff is limited to four parser-crate files under the SCCM server/SUP surface.

## Evidence

- focused SUP: 9 passed
- intake/SUP/spine aggregate: 257 passed
- full parser suite: green
- wasm32 check: green
- strict Clippy (`-D warnings`): green
- changed-file rustfmt and `git diff --check`: green
- exact-range CodeRabbit: 0 findings
- independent quality gate: ACCEPT, high confidence
- adversarial request mutation, duplication, reordering, and oversize cases fail closed or serialize deterministically

## State

- committed/pushed/reviewed: yes at `3cd037b9199e3414f599994e2156d85e0cfb3608`
- merged: no
- live Windows validated: no; this is pure-parser coverage logic

Closes #330 only when the integration and acceptance criteria are complete. Part of #317.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Software Update Point/WSUS coverage analysis for SCCM server intake data.
  * Reports captured coverage, missing or incomplete sources, profile eligibility gaps, and relevant follow-up requests.
  * Provides deterministic analysis results and clear diagnostics when intake or topology validation fails.

* **Bug Fixes**
  * Strengthened intake integrity validation to detect modified, duplicated, or reordered artifact requests.

* **Tests**
  * Added comprehensive coverage for request integrity, filtering, failure handling, and order-independent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->