### PR TITLE
fix(sccm): capture client logs beside CcmExec

### DIFF
--- a/docs/superpowers/plans/2026-08-04-sccm-client-service-root-capture.md
+++ b/docs/superpowers/plans/2026-08-04-sccm-client-service-root-capture.md
@@ -1,0 +1,189 @@
+# SCCM Client Service-Root Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture evidence for #483–#485 from the exact client log root beside a validated `CcmExec.exe`, without exposing paths or weakening catalog/cap/reparse controls.
+
+**Architecture:** Extend the existing fixed Win32 service query to return only `Name` and `PathName`. Parse one exact `CcmExec` record, validate a drive-qualified `CcmExec.exe`, derive its sibling `Logs` directory privately, and feed that root into the unchanged native collector and manifest pipeline.
+
+**Tech Stack:** Rust, Serde JSON, Tauri native SCCM collector, existing manifest/contract tests, Windows lab validation.
+
+**Frozen base:** `8064b5aa1457f72ea8dbb7cb979ec3ea863c524c`
+
+---
+
+### Task 1: Parse the exact CcmExec service path
+
+**Files:**
+- Modify: `src-tauri/src/sccm/collector/discovery.rs`
+
+- [ ] **Step 1: Add red unit tests**
+
+Add:
+
+- `ccmexec_service_path_derives_one_sibling_logs_root`
+- `ccmexec_service_path_accepts_quotes_and_trailing_arguments`
+- `ccmexec_service_path_rejects_wrapper_relative_unc_and_wrong_basename`
+- `missing_legacy_windir_root_is_not_selected`
+- `fixed_cim_query_selects_only_exact_service_name_and_path`
+- `serialized_discovery_never_contains_service_path`
+- `ccmexec_role_is_retained_when_service_root_is_absent`
+
+Representative input/output:
+
+```rust
+let json = br#"{"Name":"CcmExec","PathName":"\"C:\\Program Files\\SMS_CCM\\CcmExec.exe\" -service"}"#;
+let root = client_root_from_service_output(json).expect("validated root");
+assert_eq!(root, PathBuf::from(r"C:\Program Files\SMS_CCM\Logs"));
+```
+
+- [ ] **Step 2: Run the red tests**
+
+```sh
+cargo test --locked -p cmtrace-open discovery::tests::ccmexec_service_path_derives_one_sibling_logs_root
+cargo test --locked -p cmtrace-open discovery::tests::missing_legacy_windir_root_is_not_selected
+```
+
+- [ ] **Step 3: Extend the fixed query and add a private parser**
+
+The PowerShell query remains fixed and non-interpolated:
+
+```rust
+const FIXED_ROLE_QUERY: &str = "$ErrorActionPreference='Stop'; Get-CimInstance -Namespace 'root/cimv2' -ClassName 'Win32_Service' -Filter \"Name='CcmExec' OR Name='SMS_EXECUTIVE' OR Name='SMS_ADMIN_SERVICE' OR Name='WSUSService'\" | Select-Object Name,PathName | ConvertTo-Json -Compress";
+```
+
+Use a deny-unknown-fields record and object-or-array wire shape:
+
+```rust
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+struct CimServiceFact {
+    name: String,
+    path_name: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum CimServiceFacts {
+    One(CimServiceFact),
+    Many(Vec<CimServiceFact>),
+}
+```
+
+The private path parser must:
+
+- admit only exact case-sensitive service `Name == "CcmExec"`;
+- parse quoted executable paths and ignore only trailing arguments after the closing quote;
+- parse an unquoted drive-qualified path only through the first case-insensitive `.exe` boundary;
+- require `[A-Za-z]:\` absolute form and exact case-insensitive basename `CcmExec.exe`;
+- reject UNC, relative, empty, wrapper, alternate-basename, control-bearing, forward-slash, repeated-separator, `.`/`..`, alternate data stream, and ambiguous forms;
+- derive exactly the executable parent plus `Logs`;
+- never return or serialize the raw `PathName` outside the private discovery structure.
+
+Use explicit string validation so tests behave identically on macOS and Windows; do not rely on host-platform `Path::components()` to interpret a Windows path.
+
+- [ ] **Step 4: Re-run and commit**
+
+```sh
+cargo test --locked -p cmtrace-open discovery::tests
+git add src-tauri/src/sccm/collector/discovery.rs
+git commit -m "fix(sccm): derive client root from CcmExec"
+```
+
+### Task 2: Use one private derived root and remove the fixed fallback
+
+**Files:**
+- Modify: `src-tauri/src/sccm/collector/discovery.rs`
+- Test: `src-tauri/tests/sccm_native_collection.rs`
+
+- [ ] **Step 1: Add red integration tests**
+
+Add:
+
+- `derived_client_root_emits_absent_rows_for_all_required_sources`
+- `client_capture_accepts_only_required_exact_basenames_and_rotations`
+- `client_manifest_contains_hashes_caps_and_opaque_provenance`
+- `client_capture_rejects_symlink_or_reparse_evidence`
+- `mtrmgr_is_not_admitted_without_catalog_evidence`
+
+- [ ] **Step 2: Run the focused red tests**
+
+```sh
+cargo test --locked -p cmtrace-open --test sccm_native_collection
+```
+
+- [ ] **Step 3: Wire the derived root into existing discovery**
+
+Remove the registry branch’s unconditional `%WINDIR%\CCM\Logs` insertion and remove `client_log_root()`. Registry may establish the Client role/version, while the exact service fact establishes the only private client root. A valid nonexistent derived root remains in the private environment so the existing engine emits explicit `Absent` rows. Unsafe/malformed `PathName` retains the Client role but supplies no root.
+
+Keep `engine.rs`, `client_manifest.rs`, `contract.rs`, and `commands/sccm.rs` behavior unchanged. Reuse direct enumeration, exact catalog membership, rotation checks, no-follow/reparse defenses, `MAX_FRAGMENTS_PER_SOURCE = 8`, `MAX_BYTES_PER_SOURCE = 16 * 1024 * 1024`, opaque handles, content hashes, and post-write manifest validation.
+
+Do not add `mtrmgr.log`: no reviewed observation exists. Keep `StateMessage.log` in its existing `client-policy-state` capture membership.
+
+- [ ] **Step 4: Re-run and commit**
+
+```sh
+cargo test --locked -p cmtrace-open --test sccm_native_collection
+git add src-tauri/src/sccm/collector/discovery.rs src-tauri/tests/sccm_native_collection.rs
+git commit -m "test(sccm): pin service-root client capture"
+```
+
+### Task 3: Run security, parser, and platform gates
+
+**Files:**
+- Test only; no new upload implementation
+
+- [ ] **Step 1: Verify exact-name and privacy behavior**
+
+The public discovery/result/manifest must contain neither the raw service path nor `C:\Program Files\SMS_CCM` nor `C:\Windows\CCM\Logs`. Only exact catalog basenames/rotations are eligible. Unknown/lookalike/temp files remain skipped/unsupported according to the existing engine.
+
+- [ ] **Step 2: Run all local gates**
+
+```sh
+cargo fmt --check --all
+cargo test --locked -p cmtrace-open --test sccm_native_collection
+cargo test --locked -p cmtrace-open --test sccm_client_discovery
+cargo test --locked -p cmtraceopen-parser --test sccm_spine_contract
+cargo test --locked -p cmtraceopen-parser --test sccm_client_inventory_compliance_metering_fixture_contract
+cargo clippy --locked -p cmtrace-open --all-targets --all-features -- -D warnings
+git diff --check
+```
+
+If `sccm_client_discovery` is not a standalone test target, run the exact discovery unit suite instead and record the correction. Pester is required only if an existing collection script changes; this plan makes no script change.
+
+- [ ] **Step 3: Commit any test-only corrections and prepare the evidence pack**
+
+```sh
+git diff --name-only 8064b5aa1457f72ea8dbb7cb979ec3ea863c524c..HEAD
+git show --check --oneline HEAD
+git status --porcelain
+```
+
+The handoff must include exact SHA, changed files, test counts/results, strict Clippy/fmt/diff results, clean status, and the Windows reproduction below. Do not merge; independent review follows.
+
+### Task 4: Validate on the authorized Windows lab
+
+**Files:**
+- No repository file changes; evidence goes only to the retained draft-release channel
+
+- [ ] **Step 1: Verify the service fact**
+
+```powershell
+Get-CimInstance -Namespace root/cimv2 -ClassName Win32_Service -Filter "Name='CcmExec'" |
+  Select-Object Name,PathName |
+  ConvertTo-Json -Compress
+```
+
+Expected: exact `CcmExec` and an executable rooted at `C:\Program Files\SMS_CCM\CcmExec.exe`.
+
+- [ ] **Step 2: Run a negative capture** with a valid but nonexistent sibling `Logs` directory. Every admitted client source must be `Absent`, with zero retained bytes and no raw root.
+- [ ] **Step 3: Run a positive capture** against the actual sibling `Logs` directory. Verify exact catalog IDs, rotations, byte counts, SHA-256, fragment/cap metadata, safe relative paths, and absence of raw roots. `mtrmgr.log` remains unadmitted.
+- [ ] **Step 4: Exercise caps and unsafe evidence** using lab-safe fixtures: over 16 MiB, more than eight rotations, lookalikes, unsupported rotations, ACL denial, and reparse entries. Verify bounded coverage states.
+- [ ] **Step 5: Package only the validated local bundle** and upload through the already-approved draft-release HTTPS/SAS path. SAS is transient, query data is redacted, upload failure retains the local bundle, and no raw evidence/URL/credential enters git or issue comments.
+
+## Self-review
+
+- Spec coverage: exact service/root derivation, one-root policy, catalog-only admission, caps, hashes, privacy, unsafe paths, absent/present captures, and Windows reproduction are explicit.
+- Placeholder scan: every validation and edge condition has a concrete test or lab step.
+- Type consistency: one private service fact feeds the existing `SccmCaptureRoot`; no new public path type or alternate collector exists.
+- Scope: no free-form override, PowerShell recapture, upload backend, parser/analyzer change, `mtrmgr.log` promotion, raw repo artifact, or compatibility fallback.

--- a/src-tauri/src/sccm/collector/discovery.rs
+++ b/src-tauri/src/sccm/collector/discovery.rs
@@ -307,8 +307,11 @@ fn client_root_from_service_facts(facts: &[CimServiceFact]) -> Option<std::path:
 
 #[cfg(any(test, target_os = "windows"))]
 fn client_root_from_service_path(path_name: &str) -> Option<std::path::PathBuf> {
+    if path_name.chars().any(char::is_control) {
+        return None;
+    }
     let path_name = path_name.trim();
-    if path_name.is_empty() || path_name.chars().any(char::is_control) {
+    if path_name.is_empty() {
         return None;
     }
 
@@ -441,6 +444,37 @@ mod tests {
         );
 
         assert_eq!(root, Some(PathBuf::from(r"C:\Program Files\SMS_CCM\Logs")));
+    }
+
+    #[test]
+    fn ccmexec_service_path_rejects_control_whitespace_around_exact_paths() {
+        let executable = r#"C:\Program Files\SMS_CCM\CcmExec.exe"#;
+        for control in ['\t', '\r', '\n'] {
+            for leading in [true, false] {
+                for quoted in [true, false] {
+                    let exact_path = if quoted {
+                        format!(r#""{executable}""#)
+                    } else {
+                        executable.to_owned()
+                    };
+                    let path_name = if leading {
+                        format!("{control}{exact_path}")
+                    } else {
+                        format!("{exact_path}{control}")
+                    };
+                    let output = serde_json::json!({
+                        "Name": "CcmExec",
+                        "PathName": path_name,
+                    });
+
+                    assert_eq!(
+                        client_root_from_service_output(output.to_string().as_bytes()),
+                        None,
+                        "control whitespace must not authorize a root: {control:?}, leading={leading}, quoted={quoted}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/src/sccm/collector/discovery.rs
+++ b/src-tauri/src/sccm/collector/discovery.rs
@@ -12,7 +12,23 @@ use super::{SccmDiscoveryIssue, SccmDiscoveryIssueCode};
 use crate::sccm::SccmRole;
 
 #[cfg(any(test, target_os = "windows"))]
-const FIXED_ROLE_QUERY: &str = "$ErrorActionPreference='Stop'; Get-CimInstance -Namespace 'root/cimv2' -ClassName 'Win32_Service' -Filter \"Name='CcmExec' OR Name='SMS_EXECUTIVE' OR Name='SMS_ADMIN_SERVICE' OR Name='WSUSService'\" | Select-Object -ExpandProperty Name | ConvertTo-Json -Compress";
+const FIXED_ROLE_QUERY: &str = "$ErrorActionPreference='Stop'; Get-CimInstance -Namespace 'root/cimv2' -ClassName 'Win32_Service' -Filter \"Name='CcmExec' OR Name='SMS_EXECUTIVE' OR Name='SMS_ADMIN_SERVICE' OR Name='WSUSService'\" | Select-Object Name,PathName | ConvertTo-Json -Compress";
+
+#[cfg(any(test, target_os = "windows"))]
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+struct CimServiceFact {
+    name: String,
+    path_name: Option<String>,
+}
+
+#[cfg(any(test, target_os = "windows"))]
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
+enum CimServiceFacts {
+    One(CimServiceFact),
+    Many(Vec<CimServiceFact>),
+}
 
 #[derive(Debug, Default)]
 pub struct NativeDiscoveryProvider;
@@ -118,12 +134,6 @@ fn discover_native() -> Result<PrivateSccmEnvironment, SccmDiscoveryFailure> {
                 basis: SccmDiscoveryBasis::Registry,
             });
             environment.configmgr_version = key.get_value::<String, _>("ProductVersion").ok();
-            if let Some(path) = client_log_root() {
-                environment.roots.push(SccmCaptureRoot {
-                    role: SccmRole::Client,
-                    path,
-                });
-            }
         }
         Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
             environment.issues.push(SccmDiscoveryIssue {
@@ -206,12 +216,10 @@ fn discover_native() -> Result<PrivateSccmEnvironment, SccmDiscoveryFailure> {
         .output()
     {
         Ok(output) if output.status.success() => {
-            let client_root = client_log_root();
             apply_cim_service_facts(
                 &mut environment,
                 &output.stdout,
                 server_install_root.as_deref(),
-                client_root.as_deref(),
             );
         }
         Ok(output) if !output.status.success() => {
@@ -230,37 +238,23 @@ fn discover_native() -> Result<PrivateSccmEnvironment, SccmDiscoveryFailure> {
     Ok(environment)
 }
 
-#[cfg(target_os = "windows")]
-fn client_log_root() -> Option<std::path::PathBuf> {
-    std::env::var_os("WINDIR")
-        .map(std::path::PathBuf::from)
-        .map(|path| path.join("CCM").join("Logs"))
-}
-
 #[cfg(any(test, target_os = "windows"))]
 fn apply_cim_service_facts(
     environment: &mut PrivateSccmEnvironment,
     output: &[u8],
     server_install_root: Option<&std::path::Path>,
-    allow_listed_client_root: Option<&std::path::Path>,
 ) {
-    #[derive(serde::Deserialize)]
-    #[serde(untagged)]
-    enum ServiceNames {
-        One(String),
-        Many(Vec<String>),
-    }
-
-    let Ok(names) = serde_json::from_slice::<ServiceNames>(output) else {
+    let Ok(facts) = serde_json::from_slice::<CimServiceFacts>(output) else {
         return;
     };
-    let names = match names {
-        ServiceNames::One(name) => vec![name],
-        ServiceNames::Many(names) => names,
+    let facts = match facts {
+        CimServiceFacts::One(fact) => vec![fact],
+        CimServiceFacts::Many(facts) => facts,
     };
+    let client_root = client_root_from_service_facts(&facts);
 
-    for service_name in names.into_iter().collect::<BTreeSet<_>>() {
-        let Some(role) = role_for_cim_service(&service_name) else {
+    for fact in facts {
+        let Some(role) = role_for_cim_service(&fact.name) else {
             continue;
         };
         environment.roles.push(SccmDetectedRole {
@@ -268,7 +262,7 @@ fn apply_cim_service_facts(
             basis: SccmDiscoveryBasis::Cim,
         });
         let path = match role {
-            SccmRole::Client => allow_listed_client_root.map(std::path::Path::to_path_buf),
+            SccmRole::Client => client_root.clone(),
             _ => server_install_root
                 .map(|path| path.join("Logs"))
                 .or_else(|| default_role_root(&role)),
@@ -277,6 +271,101 @@ fn apply_cim_service_facts(
             environment.roots.push(SccmCaptureRoot { role, path });
         }
     }
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn client_root_from_service_output(output: &[u8]) -> Option<std::path::PathBuf> {
+    let facts = serde_json::from_slice::<CimServiceFacts>(output).ok()?;
+    let facts = match facts {
+        CimServiceFacts::One(fact) => vec![fact],
+        CimServiceFacts::Many(facts) => facts,
+    };
+    client_root_from_service_facts(&facts)
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn client_root_from_service_facts(facts: &[CimServiceFact]) -> Option<std::path::PathBuf> {
+    let mut ccmexec_count = 0;
+    let mut roots = BTreeSet::new();
+    for fact in facts {
+        if fact.name != "CcmExec" {
+            continue;
+        }
+        ccmexec_count += 1;
+        if let Some(root) = fact
+            .path_name
+            .as_deref()
+            .and_then(client_root_from_service_path)
+        {
+            roots.insert(root);
+        }
+    }
+    (ccmexec_count == 1 && roots.len() == 1)
+        .then(|| roots.into_iter().next())
+        .flatten()
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn client_root_from_service_path(path_name: &str) -> Option<std::path::PathBuf> {
+    let path_name = path_name.trim();
+    if path_name.is_empty() || path_name.chars().any(char::is_control) {
+        return None;
+    }
+
+    let executable = if let Some(stripped) = path_name.strip_prefix('"') {
+        let closing_quote = stripped.find('"')?;
+        let trailing = &stripped[closing_quote + 1..];
+        if (!trailing.is_empty() && !trailing.starts_with(char::is_whitespace))
+            || trailing.contains('"')
+        {
+            return None;
+        }
+        &stripped[..closing_quote]
+    } else {
+        let lower = path_name.to_ascii_lowercase();
+        let executable_end = lower.find(".exe")? + ".exe".len();
+        let trailing = &path_name[executable_end..];
+        if !trailing.is_empty() && !trailing.starts_with(char::is_whitespace) {
+            return None;
+        }
+        &path_name[..executable_end]
+    };
+
+    if executable.contains('/')
+        || executable.contains(r"\\")
+        || executable.contains('"')
+        || executable.len() < 4
+    {
+        return None;
+    }
+    let bytes = executable.as_bytes();
+    if !bytes[0].is_ascii_alphabetic() || bytes[1] != b':' || bytes[2] != b'\\' {
+        return None;
+    }
+
+    let components = executable[3..].split('\\');
+    let mut last = None;
+    for component in components {
+        if component.is_empty()
+            || component == "."
+            || component == ".."
+            || component.contains(':')
+            || component.contains('*')
+            || component.contains('?')
+        {
+            return None;
+        }
+        last = Some(component);
+    }
+    if !last.is_some_and(|name| name.eq_ignore_ascii_case("CcmExec.exe")) {
+        return None;
+    }
+
+    let parent_end = executable.rfind('\\')?;
+    Some(std::path::PathBuf::from(format!(
+        "{}\\Logs",
+        &executable[..parent_end]
+    )))
 }
 
 #[cfg(any(test, target_os = "windows"))]
@@ -316,14 +405,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ccmexec_service_without_setup_registry_fact_admits_client_and_fixed_root() {
-        let client_root = PathBuf::from(r"C:\Windows\CCM\Logs");
+    fn ccmexec_service_path_derives_one_sibling_logs_root() {
+        let client_root = PathBuf::from(r"C:\Program Files\SMS_CCM\Logs");
         let mut environment = PrivateSccmEnvironment {
             supported: true,
             ..PrivateSccmEnvironment::default()
         };
 
-        apply_cim_service_facts(&mut environment, br#""CcmExec""#, None, Some(&client_root));
+        apply_cim_service_facts(
+            &mut environment,
+            br#"{"Name":"CcmExec","PathName":"C:\\Program Files\\SMS_CCM\\CcmExec.exe"}"#,
+            None,
+        );
 
         assert_eq!(
             environment.roles,
@@ -342,39 +435,85 @@ mod tests {
     }
 
     #[test]
-    fn similarly_named_or_untrusted_service_output_does_not_admit_client() {
-        for output in [
-            br#""CcmExecHelper""#.as_slice(),
-            br#""CCMEXEC""#.as_slice(),
-            br#"" CcmExec ""#.as_slice(),
-            br#"["NotCcmExec", "CcmExecAgent"]"#.as_slice(),
-            br#"{"Name":"CcmExec"}"#.as_slice(),
-            b"CcmExec".as_slice(),
-        ] {
-            let mut environment = PrivateSccmEnvironment::default();
-            let client_root = PathBuf::from(r"C:\Windows\CCM\Logs");
-            apply_cim_service_facts(&mut environment, output, None, Some(&client_root));
+    fn ccmexec_service_path_accepts_quotes_and_trailing_arguments() {
+        let root = client_root_from_service_output(
+            br#"{"Name":"CcmExec","PathName":"\"C:\\Program Files\\SMS_CCM\\CcmExec.exe\" -service"}"#,
+        );
 
-            assert!(environment.roles.is_empty());
-            assert!(environment.roots.is_empty());
+        assert_eq!(root, Some(PathBuf::from(r"C:\Program Files\SMS_CCM\Logs")));
+    }
+
+    #[test]
+    fn ccmexec_service_path_rejects_wrapper_relative_unc_and_wrong_basename() {
+        for output in [
+            br#"{"Name":"ccmexec","PathName":"C:\\Program Files\\SMS_CCM\\CcmExec.exe"}"#.as_slice(),
+            br#"{"Name":"CcmExec","PathName":"cmd.exe /c C:\\Program Files\\SMS_CCM\\CcmExec.exe"}"#.as_slice(),
+            br#"{"Name":"CcmExec","PathName":"CcmExec.exe"}"#.as_slice(),
+            br#"{"Name":"CcmExec","PathName":"\\\\server\\SMS_CCM\\CcmExec.exe"}"#.as_slice(),
+            br#"{"Name":"CcmExec","PathName":"C:\\Program Files\\SMS_CCM\\Other.exe"}"#.as_slice(),
+            br#"{"Name":"CcmExec","PathName":"C:\\Program Files\\SMS_CCM\\..\\CcmExec.exe"}"#.as_slice(),
+        ] {
+            assert_eq!(client_root_from_service_output(output), None);
         }
     }
 
     #[test]
-    fn ccmexec_service_never_supplies_or_invents_a_client_root() {
+    fn missing_legacy_windir_root_is_not_selected() {
         let mut environment = PrivateSccmEnvironment::default();
 
-        apply_cim_service_facts(&mut environment, br#""CcmExec""#, None, None);
+        apply_cim_service_facts(
+            &mut environment,
+            br#"{"Name":"CcmExec","PathName":"C:\\Program Files\\SMS_CCM\\CcmExec.exe"}"#,
+            None,
+        );
 
-        assert_eq!(environment.roles[0].role, SccmRole::Client);
-        assert!(environment.roots.is_empty());
+        assert_eq!(
+            environment.roots,
+            vec![SccmCaptureRoot {
+                role: SccmRole::Client,
+                path: PathBuf::from(r"C:\Program Files\SMS_CCM\Logs"),
+            }]
+        );
+        assert!(!environment
+            .roots
+            .iter()
+            .any(|root| root.path.to_string_lossy() == r"C:\Windows\CCM\Logs"));
     }
 
     #[test]
-    fn fixed_cim_query_requests_only_allow_listed_service_names() {
+    fn fixed_cim_query_selects_only_exact_service_name_and_path() {
         assert!(FIXED_ROLE_QUERY.contains("Name='CcmExec'"));
-        assert!(FIXED_ROLE_QUERY.contains("Select-Object -ExpandProperty Name"));
-        assert!(!FIXED_ROLE_QUERY.contains("PathName"));
+        assert!(FIXED_ROLE_QUERY.contains("Select-Object Name,PathName"));
+        assert!(FIXED_ROLE_QUERY.contains("PathName"));
         assert!(!FIXED_ROLE_QUERY.contains("StartName"));
+        assert!(!FIXED_ROLE_QUERY.contains("Select-Object -ExpandProperty Name"));
+    }
+
+    #[test]
+    fn serialized_discovery_never_contains_service_path() {
+        let service_path = r"C:\Program Files\SMS_CCM\CcmExec.exe";
+        let value = normalize_public_discovery(SccmEnvironmentDiscovery {
+            supported: true,
+            configmgr_version: None,
+            roles: vec![SccmDetectedRole {
+                role: SccmRole::Client,
+                basis: SccmDiscoveryBasis::Cim,
+            }],
+            sources: Vec::new(),
+            issues: Vec::new(),
+        });
+        let serialized = serde_json::to_string(&value).unwrap();
+        assert!(!serialized.contains(service_path));
+        assert!(!serialized.contains(r"C:\Windows\CCM\Logs"));
+    }
+
+    #[test]
+    fn ccmexec_role_is_retained_when_service_root_is_absent() {
+        let mut environment = PrivateSccmEnvironment::default();
+
+        apply_cim_service_facts(&mut environment, br#"{"Name":"CcmExec"}"#, None);
+
+        assert_eq!(environment.roles[0].role, SccmRole::Client);
+        assert!(environment.roots.is_empty());
     }
 }

--- a/src-tauri/src/sccm/collector/discovery.rs
+++ b/src-tauri/src/sccm/collector/discovery.rs
@@ -273,7 +273,7 @@ fn apply_cim_service_facts(
     }
 }
 
-#[cfg(any(test, target_os = "windows"))]
+#[cfg(test)]
 fn client_root_from_service_output(output: &[u8]) -> Option<std::path::PathBuf> {
     let facts = serde_json::from_slice::<CimServiceFacts>(output).ok()?;
     let facts = match facts {

--- a/src-tauri/tests/sccm_native_collection.rs
+++ b/src-tauri/tests/sccm_native_collection.rs
@@ -204,6 +204,168 @@ fn capture_collects_all_supported_client_rotations_and_validates_manifest() {
 }
 
 #[test]
+fn derived_client_root_emits_absent_rows_for_all_required_sources() {
+    let parent = tempfile::tempdir().unwrap();
+    let bundles = tempfile::tempdir().unwrap();
+    let root = parent.path().join("SMS_CCM").join("Logs");
+    let required = [
+        "InventoryAgent.log",
+        "InventoryProvider.log",
+        "InventoryAgentProvider.log",
+        "CIAgent.log",
+        "CITaskMgr.log",
+        "DCMAgent.log",
+        "DCMReporting.log",
+        "StateMessage.log",
+        "SWMTRReportGen.log",
+    ];
+
+    capture(
+        &provider(SccmRole::Client, [root.clone()]),
+        bundles.path(),
+        "absent-derived-root",
+    );
+    let manifest =
+        read_sccm_manifest_or_legacy(&bundles.path().join("absent-derived-root")).unwrap();
+    for basename in required {
+        assert!(manifest.artifacts.iter().any(|artifact| {
+            artifact.basename == basename
+                && artifact.state == app_lib::sccm::SccmManifestSourceState::Absent
+        }));
+    }
+    let serialized = fs::read_to_string(
+        bundles
+            .path()
+            .join("absent-derived-root/sccm-manifest.json"),
+    )
+    .unwrap();
+    assert!(!serialized.contains(root.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn client_capture_accepts_only_required_exact_basenames_and_rotations() {
+    let logs = tempfile::tempdir().unwrap();
+    let bundles = tempfile::tempdir().unwrap();
+    let required = [
+        "InventoryAgent.log",
+        "InventoryProvider.log",
+        "InventoryAgentProvider.log",
+        "CIAgent.log",
+        "CITaskMgr.log",
+        "DCMAgent.log",
+        "DCMReporting.log",
+        "StateMessage.log",
+        "SWMTRReportGen.log",
+    ];
+    for basename in required {
+        fs::write(logs.path().join(basename), basename.as_bytes()).unwrap();
+    }
+    fs::write(logs.path().join("InventoryAgent.log.1"), b"numbered").unwrap();
+    fs::write(logs.path().join("InventoryAgent.lo_"), b"lo").unwrap();
+    fs::write(logs.path().join("not-an-sccm-log.tmp"), b"temporary").unwrap();
+    fs::write(logs.path().join("mtrmgr.log"), b"not admitted").unwrap();
+
+    let result = capture(
+        &provider(SccmRole::Client, [logs.path().to_owned()]),
+        bundles.path(),
+        "exact-client-sources",
+    );
+    let manifest =
+        read_sccm_manifest_or_legacy(&bundles.path().join("exact-client-sources")).unwrap();
+    for basename in required {
+        assert!(manifest.artifacts.iter().any(|artifact| {
+            artifact.basename == basename
+                && artifact.state == app_lib::sccm::SccmManifestSourceState::Captured
+        }));
+    }
+    assert_eq!(
+        manifest
+            .artifacts
+            .iter()
+            .filter(|artifact| {
+                matches!(
+                    artifact.basename.as_str(),
+                    "InventoryAgent.log" | "InventoryAgent.log.1" | "InventoryAgent.lo_"
+                )
+            })
+            .filter(|artifact| artifact.state == app_lib::sccm::SccmManifestSourceState::Captured)
+            .count(),
+        3
+    );
+    assert!(!result.sources.iter().any(|source| {
+        source.source_id.eq_ignore_ascii_case("mtrmgr")
+            && source.state == SccmCoverageState::Captured
+    }));
+    let evidence = bundles
+        .path()
+        .join("exact-client-sources/evidence/sccm/client");
+    assert!(!evidence.join("mtrmgr.log").exists());
+    assert!(!evidence.join("not-an-sccm-log.tmp").exists());
+}
+
+#[test]
+fn mtrmgr_is_not_admitted_without_catalog_evidence() {
+    let logs = tempfile::tempdir().unwrap();
+    let bundles = tempfile::tempdir().unwrap();
+    fs::write(logs.path().join("mtrmgr.log"), b"not admitted").unwrap();
+
+    let result = capture(
+        &provider(SccmRole::Client, [logs.path().to_owned()]),
+        bundles.path(),
+        "mtrmgr-not-admitted",
+    );
+    assert!(!result.sources.iter().any(|source| {
+        source.source_id.eq_ignore_ascii_case("mtrmgr")
+            && source.state == SccmCoverageState::Captured
+    }));
+    let manifest = fs::read_to_string(
+        bundles
+            .path()
+            .join("mtrmgr-not-admitted/sccm-manifest.json"),
+    )
+    .unwrap();
+    assert!(!manifest.contains("mtrmgr.log"));
+}
+
+#[test]
+fn client_manifest_contains_hashes_caps_and_opaque_provenance() {
+    let logs = tempfile::tempdir().unwrap();
+    let bundles = tempfile::tempdir().unwrap();
+    let content = b"CIAgent evidence";
+    fs::write(logs.path().join("CIAgent.log"), content).unwrap();
+
+    capture(
+        &provider(SccmRole::Client, [logs.path().to_owned()]),
+        bundles.path(),
+        "manifest-contract",
+    );
+    let bundle_root = bundles.path().join("manifest-contract");
+    let manifest = read_sccm_manifest_or_legacy(&bundle_root).unwrap();
+    let artifact = manifest
+        .artifacts
+        .iter()
+        .find(|artifact| {
+            artifact.basename == "CIAgent.log"
+                && artifact.state == app_lib::sccm::SccmManifestSourceState::Captured
+        })
+        .expect("captured CIAgent artifact");
+    assert_eq!(artifact.bytes_copied, content.len() as u64);
+    assert!(artifact.content_sha256.is_some());
+    assert!(artifact.source_handle.is_some());
+    assert!(artifact.root_handle.is_some());
+    assert!(artifact.path_fingerprint.is_some());
+    assert!(artifact.rotation_lineage.is_some());
+    assert!(artifact
+        .relative_path
+        .as_deref()
+        .is_some_and(|path| !path.contains(logs.path().to_string_lossy().as_ref())));
+    let serialized = fs::read_to_string(bundle_root.join("sccm-manifest.json")).unwrap();
+    assert!(!serialized.contains(logs.path().to_string_lossy().as_ref()));
+    assert_eq!(manifest.max_files_per_source, MAX_FRAGMENTS_PER_SOURCE);
+    assert_eq!(manifest.max_bytes_per_source, MAX_BYTES_PER_SOURCE);
+}
+
+#[test]
 fn capture_reports_malformed_rotation_without_copying_it() {
     let logs = tempfile::tempdir().unwrap();
     let bundles = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary
- derive exactly one private client log root beside a strictly validated `CcmExec.exe` service path
- remove the fixed `%WINDIR%\\CCM\\Logs` fallback
- reject UNC, relative, wrapper, traversal, ambiguous, ADS, repeated-separator, wrong-basename, and control-bearing service paths
- reuse the existing exact catalog, rotation, cap, no-follow/reparse, hashing, opaque-provenance, and manifest pipeline
- keep `mtrmgr.log` unsupported until observed evidence exists

## Validation
- discovery: 21 passed
- native collection: 21 passed
- client discovery: 25 passed
- client manifest: 21 passed
- parser spine: 161 passed
- inventory/compliance/metering fixture contract: 47 passed
- strict Clippy, changed-file rustfmt, and diff checks: green
- independent review: initial REWORK on control validation after trim; fix at `e33b436a` independently ACCEPTED

Supports #483, #484, and #485. Those discovery issues remain open pending a fresh Windows capture and evidence audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SCCM log collection now derives the client log location from the exact `CcmExec` service configuration.
  * Added validation to reject invalid or unsafe service paths.
  * Added coverage for log selection, rotated logs, hashes, limits, and manifest integrity.

* **Bug Fixes**
  * Removed reliance on a fixed default SCCM log directory.
  * Excludes unlisted logs such as `mtrmgr.log` from collection.
  * Prevents source paths from appearing in collected manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->