### PR TITLE
feat(intune): implement Windows device compliance analyzer (#364)

### DIFF
--- a/crates/cmtraceopen-parser/src/intune/device/windows/compliance/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/compliance/mod.rs
@@ -1,10 +1,128 @@
-//! Intune device compliance evaluation and reporting evidence.
+//! Intune Windows device compliance: local evaluation and reporting evidence.
 //!
-//! Owner: issue #364 of epic #356. Implementation pending.
+//! Owner: issue #364 of epic #356.
 //!
-//! Does not equate Conditional Access denial, stale cloud state, or missing user evaluation with a failed local setting.
+//! # What this module refuses to do
 //!
-//! This is a reserved slot created by the parser-family skeleton so that issue
-//! #364 can be implemented without editing any file shared with a sibling issue.
-//! Add source classification, reduction, and findings submodules here, and
-//! consume the shared contracts in [`crate::intune::evidence`].
+//! Four different signals are routinely described as "the device is
+//! noncompliant", and conflating them is the single most common way a
+//! compliance investigation goes wrong. This module keeps them in four separate
+//! phases and never lets one become another:
+//!
+//! | Phase | Question it answers |
+//! |---|---|
+//! | [`ComplianceLocalPhase`] | what did the device evaluate, setting by setting? |
+//! | [`ComplianceAggregatePhase`] | what device-wide result follows from that? |
+//! | [`ComplianceReportingPhase`] | did the report submit, and how old is the service's copy? |
+//! | [`ComplianceAccessPhase`] | what happened downstream at sign-in? |
+//!
+//! Concretely:
+//!
+//! - a **Conditional Access denial** never produces a local setting state. With
+//!   no matching compliance record it is [`ComplianceAccessLinkage::NoMatchingComplianceEvidence`]
+//!   and yields an `Info`/`Low` finding that says outright that no causal claim
+//!   is being made. Even a fully correlated denial is capped at `Medium` and
+//!   described as coincidence, because Conditional Access policy is out of scope
+//!   here;
+//! - a **stale service state** never produces a local setting state. It is
+//!   reported as [`ComplianceServiceFreshness::Stale`] against the timestamp of
+//!   the most recent local evaluation, and its finding states the local
+//!   aggregate explicitly so the two cannot be confused;
+//! - a **user-targeted policy with no user context** is
+//!   [`ComplianceSettingState::NotEvaluated`], which is missing coverage, not a
+//!   failure;
+//! - a **custom-compliance script that crashed** is
+//!   [`ComplianceCustomState::ScriptFailed`], never
+//!   [`ComplianceCustomState::DiscoveryNoncompliant`]: a script that did not run
+//!   produced no verdict to report;
+//! - a report row whose outcome is `Failed` becomes
+//!   [`ComplianceSettingState::EvaluationError`], not `Noncompliant`. "Could not
+//!   evaluate" and "does not meet the requirement" are different claims.
+//!
+//! # I/O and platform
+//!
+//! None. The crate is `wasm32-unknown-unknown` clean, so the native adapter
+//! reads EVTX, the live event log, and MDM diagnostic exports, then hands this
+//! module the shared normalized shapes from [`crate::intune::normalized`] plus
+//! the supplied facts defined here. Everything below is pure reduction.
+//!
+//! # Example
+//!
+//! ```
+//! use cmtraceopen_parser::intune::device::windows::compliance::{
+//!     analyze_compliance_bundle, ComplianceAggregateState, ComplianceSourceInput,
+//! };
+//! use cmtraceopen_parser::intune::evidence::IntuneArtifactStatus;
+//!
+//! let events = r#"{
+//!   "complianceInputVersion": 1,
+//!   "kind": "windowsEvents",
+//!   "records": [{
+//!     "context": {
+//!       "evidenceRef": { "evidenceId": "evt-1", "sourceArtifactId": "mdm-events" },
+//!       "provenance": {
+//!         "sourceKind": "eventLog",
+//!         "sourceArtifactId": "mdm-events",
+//!         "filePath": null, "lineNumber": null, "recordNumber": 1,
+//!         "registry": null, "event": null
+//!       },
+//!       "sourceTimestamp": {
+//!         "rawText": "2026-07-31T10:00:00Z", "originalOffset": null,
+//!         "normalizedUtc": "2026-07-31T10:00:00Z", "kind": "utc"
+//!       },
+//!       "observedAtUtc": "2026-07-31T12:00:00Z",
+//!       "sensitivity": "public", "parseState": "parsed", "accessState": "available"
+//!     },
+//!     "channel": "DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+//!     "provider": "DeviceManagement-Enterprise-Diagnostics-Provider",
+//!     "eventId": 813, "level": "information",
+//!     "task": null, "keywords": null, "recordId": 1, "activityId": null,
+//!     "namedData": [
+//!       { "name": "SettingUri", "value": "./Device/Vendor/MSFT/Policy/Result/BitLocker" },
+//!       { "name": "EvaluationResult", "value": "noncompliant" }
+//!     ],
+//!     "message": null
+//!   }]
+//! }"#;
+//!
+//! let snapshot = analyze_compliance_bundle(
+//!     &[ComplianceSourceInput {
+//!         artifact_id: "mdm-events".to_string(),
+//!         family: "mdmEvents".to_string(),
+//!         status: IntuneArtifactStatus::Available,
+//!         captured_at_utc: "2026-07-31T12:00:00Z".to_string(),
+//!         content: Some(events.to_string()),
+//!     }],
+//!     "2026-07-31T12:00:00Z",
+//! );
+//!
+//! assert_eq!(snapshot.aggregate.state, ComplianceAggregateState::Noncompliant);
+//! assert!(snapshot
+//!     .findings
+//!     .iter()
+//!     .any(|finding| finding.finding_id == "compliance-local-setting-noncompliant"));
+//! ```
+
+mod models;
+mod redaction;
+mod reducer;
+mod rules;
+mod sources;
+
+pub use models::{
+    ComplianceAccessDecision, ComplianceAccessFact, ComplianceAccessLinkage,
+    ComplianceAccessObservation, ComplianceAccessPhase, ComplianceAggregatePhase,
+    ComplianceAggregateRationale, ComplianceAggregateState, ComplianceCustomEvaluation,
+    ComplianceCustomFact, ComplianceCustomState, ComplianceDeviceContextFact,
+    ComplianceDeviceContextView, ComplianceInput, ComplianceLocalPhase,
+    CompliancePolicyObservation, CompliancePolicyState, CompliancePrerequisite,
+    CompliancePrerequisiteState, ComplianceReportState, ComplianceReportingPhase, ComplianceScope,
+    ComplianceServiceFact, ComplianceServiceFreshness, ComplianceServiceResult,
+    ComplianceServiceState, ComplianceSettingEvaluation, ComplianceSettingKey,
+    ComplianceSettingState, ComplianceSnapshot, ComplianceUserContext,
+    INTUNE_COMPLIANCE_SCHEMA_VERSION,
+};
+pub use redaction::{redact_text, redacted_export_projection};
+pub use reducer::{analyze_compliance, analyze_compliance_bundle};
+pub use rules::derive_findings;
+pub use sources::{decode_bundle, ComplianceSourceInput, COMPLIANCE_INPUT_ENVELOPE_VERSION};

--- a/crates/cmtraceopen-parser/src/intune/device/windows/compliance/models.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/compliance/models.rs
@@ -1,0 +1,664 @@
+//! Typed model for Intune Windows device compliance.
+//!
+//! The single organizing idea here is that **four different things can each be
+//! called "the device is noncompliant", and they are not interchangeable**:
+//!
+//! 1. a device-local setting evaluated to noncompliant;
+//! 2. the aggregate result the device computed from those settings;
+//! 3. the state the service currently holds, which can be arbitrarily stale;
+//! 4. a downstream Conditional Access denial, which is a consequence of (3) at
+//!    best and unrelated at worst.
+//!
+//! So each is a separate phase on [`ComplianceSnapshot`] with its own state
+//! enum, and no reduction path lets one become another. A stale service record
+//! cannot produce a [`ComplianceSettingState::Noncompliant`], and an access
+//! denial cannot produce any local state at all.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::intune::evidence::{
+    intune_raw_preserving_string_enum, IntuneArtifactCoverage, IntuneErrorCode, IntuneEvidenceRef,
+    IntuneFinding, IntuneNamedValue, IntuneObservationContext, IntuneTimestamp,
+};
+use crate::intune::normalized::{NormalizedSettingReport, NormalizedWindowsEvent};
+
+/// Schema version for every serialized type in this module.
+pub const INTUNE_COMPLIANCE_SCHEMA_VERSION: u32 = 1;
+
+// ── Scope and identity ──────────────────────────────────────────────────────
+
+/// Whether a policy or setting was targeted at the device or at a user.
+///
+/// This is load-bearing rather than decorative: a user-targeted setting that was
+/// never evaluated because no user was signed in is a *coverage* fact, and
+/// treating it as a local failure is the specific mistake this module exists to
+/// avoid.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ComplianceScope {
+    Device,
+    User,
+    Unknown,
+}
+
+/// The identifiers a compliance setting can be keyed on.
+///
+/// All three are optional because different sources supply different subsets:
+/// an MDM event usually carries an OMA-DM node URI, an exported report row
+/// usually carries policy and setting GUIDs. Observations are only merged when
+/// they share a derived grouping token; see [`ComplianceSettingEvaluation::grouping_token`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceSettingKey {
+    pub policy_id: Option<String>,
+    pub setting_id: Option<String>,
+    pub setting_uri: Option<String>,
+}
+
+impl ComplianceSettingKey {
+    /// Whether the key carries any identifier at all.
+    pub fn is_identified(&self) -> bool {
+        [&self.policy_id, &self.setting_id, &self.setting_uri]
+            .into_iter()
+            .any(|part| {
+                part.as_deref()
+                    .is_some_and(|value| !value.trim().is_empty())
+            })
+    }
+
+    /// The token two observations must agree on to be merged.
+    ///
+    /// Returns `None` for an unidentified key. Epic #356 forbids creating a
+    /// correlation from an unknown identifier or from time proximity, so an
+    /// observation with no identity is never merged into another one.
+    pub fn grouping_token(&self) -> Option<String> {
+        let normalize = |value: &Option<String>| {
+            value
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_ascii_lowercase)
+        };
+
+        if let Some(uri) = normalize(&self.setting_uri) {
+            return Some(format!("uri:{uri}"));
+        }
+        match (normalize(&self.policy_id), normalize(&self.setting_id)) {
+            (Some(policy), Some(setting)) => Some(format!("policy:{policy}/setting:{setting}")),
+            (Some(policy), None) => Some(format!("policy:{policy}")),
+            (None, Some(setting)) => Some(format!("setting:{setting}")),
+            (None, None) => None,
+        }
+    }
+}
+
+// ── Local evaluation states ─────────────────────────────────────────────────
+
+/// The result of evaluating one compliance setting **on the device**.
+///
+/// `Noncompliant` is reachable only from a local evaluation source. No service
+/// record, report submission outcome, or access decision can produce it.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ComplianceSettingState {
+    Compliant,
+    Noncompliant,
+    /// The device tried to evaluate the setting and the evaluation itself failed.
+    EvaluationError,
+    /// The setting does not apply to this device (edition, SKU, hardware).
+    NotApplicable,
+    /// The setting was received but no evaluation happened in this context.
+    NotEvaluated,
+    /// A local precondition (for example an unmet CSP dependency) blocked evaluation.
+    PrerequisiteUnmet,
+    /// Two definite local sources disagree; neither is preferred over the other.
+    Contradictory,
+    /// A source mentioned the setting without stating a usable result.
+    InsufficientEvidence,
+}
+
+impl ComplianceSettingState {
+    /// Whether this state is a definite claim about the setting.
+    ///
+    /// Only definite states can contradict each other; mixing a definite state
+    /// with an indefinite one is not a contradiction, it is one source knowing
+    /// more than another.
+    pub fn is_definite(self) -> bool {
+        matches!(
+            self,
+            Self::Compliant | Self::Noncompliant | Self::EvaluationError | Self::NotApplicable
+        )
+    }
+}
+
+/// Whether a compliance policy was known to the device.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum CompliancePolicyState {
+    Received,
+    NotReceived,
+    Unknown,
+}
+
+/// Whether a local precondition for evaluation was satisfied.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum CompliancePrerequisiteState {
+    Met,
+    Unmet,
+    Unknown,
+}
+
+/// Outcome of a custom-compliance (HealthScripts) discovery run.
+///
+/// `ScriptFailed` and `DiscoveryNoncompliant` are deliberately distinct. A
+/// script that crashed produced no verdict at all; reporting that as "the device
+/// is noncompliant" invents a result the evidence does not contain.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ComplianceCustomState {
+    DiscoveryCompliant,
+    DiscoveryNoncompliant,
+    /// The script did not complete: nonzero exit, timeout, or launch failure.
+    ScriptFailed,
+    /// The script completed but its output could not be interpreted as a verdict.
+    OutputInvalid,
+    NotRun,
+    Unknown,
+}
+
+// ── Aggregate ───────────────────────────────────────────────────────────────
+
+/// The device-wide result derived from the local setting evaluations.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ComplianceAggregateState {
+    Compliant,
+    Noncompliant,
+    EvaluationError,
+    NotEvaluated,
+    InsufficientEvidence,
+}
+
+/// Why the aggregate landed where it did.
+///
+/// Carried explicitly so a consumer never has to re-derive the reason from the
+/// counts, and so "compliant" and "nothing was evaluated" cannot be confused.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ComplianceAggregateRationale {
+    LocalSettingNoncompliant,
+    CustomComplianceDiscoveryNoncompliant,
+    LocalEvaluationError,
+    CustomComplianceScriptFailed,
+    ContradictoryLocalEvidence,
+    AllEvaluatedSettingsCompliant,
+    NoSettingEvaluated,
+    NoLocalSourceAvailable,
+}
+
+// ── Reporting and service state ─────────────────────────────────────────────
+
+/// State of the device's own compliance report submission.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ComplianceReportState {
+    Queued,
+    Submitted,
+    Failed,
+    /// A submission succeeded, but it predates the most recent local evaluation.
+    Stale,
+    Unknown,
+}
+
+intune_raw_preserving_string_enum! {
+    /// The compliance state the service holds for this device.
+    ///
+    /// Raw-preserving because this vocabulary is the service's, not ours, and it
+    /// grows. An unrecognized token round-trips verbatim instead of collapsing
+    /// into a state we would then reason about incorrectly.
+    pub enum ComplianceServiceState {
+        Compliant => "compliant",
+        Noncompliant => "noncompliant",
+        InGracePeriod => "inGracePeriod",
+        ConfigManager => "configManager",
+        Error => "error",
+        NotEvaluated => "notEvaluated",
+        NotApplicable => "notApplicable",
+    }
+}
+
+/// Whether a service-held record reflects the most recent local evaluation.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ComplianceServiceFreshness {
+    /// Reported at or after the most recent local evaluation.
+    Fresh,
+    /// Reported before the most recent local evaluation, so it cannot describe it.
+    Stale,
+    /// One of the two timestamps is missing; freshness is unknowable.
+    Unknown,
+}
+
+// ── Downstream access ───────────────────────────────────────────────────────
+
+/// A sign-in outcome supplied as supplemental downstream evidence.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ComplianceAccessDecision {
+    Granted,
+    Denied,
+    Interrupted,
+    Unknown,
+}
+
+/// How strongly an access decision can be tied to a compliance record.
+///
+/// This is the guard rail for the whole module. An access decision only reaches
+/// [`ComplianceAccessLinkage::MatchedComplianceState`] when a device or user key
+/// matches *and* both sides carry a usable timestamp. Everything else is
+/// explicitly uncorrelated, and the rules refuse to make a causal claim for it.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ComplianceAccessLinkage {
+    MatchedComplianceState,
+    /// Keys were present on both sides and did not match.
+    IdentityMismatch,
+    /// No compliance record exists to match against.
+    NoMatchingComplianceEvidence,
+    /// A candidate record exists but identity or time provenance is missing.
+    InsufficientProvenance,
+}
+
+/// Whether a user was available for user-scoped evaluation.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ComplianceUserContext {
+    UserPresent,
+    NoUserSession,
+    /// The collector did not report whether a user session existed. This is the
+    /// default because assuming either answer changes how an unevaluated
+    /// user-scoped setting reads.
+    #[default]
+    Unknown,
+}
+
+// ── Supplied facts (inputs this module owns) ────────────────────────────────
+//
+// Windows events and setting-report rows are *not* redefined here: they arrive
+// as `crate::intune::normalized` types, which are shared with the sibling
+// configuration and update leaves. The three fact types below have no shared
+// counterpart, so they are defined here and nowhere else.
+
+/// One custom-compliance (HealthScripts) discovery outcome.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceCustomFact {
+    pub context: IntuneObservationContext,
+    pub policy_id: Option<String>,
+    pub run_id: Option<String>,
+    pub setting_name: Option<String>,
+    pub outcome: ComplianceCustomState,
+    pub error: Option<IntuneErrorCode>,
+    /// Raw script output. Always redacted by the export projection.
+    pub raw_output: Option<String>,
+    pub named_data: Vec<IntuneNamedValue>,
+}
+
+/// One service-reported compliance record imported with capture provenance.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceServiceFact {
+    pub context: IntuneObservationContext,
+    pub policy_id: Option<String>,
+    pub setting_id: Option<String>,
+    pub state: ComplianceServiceState,
+    pub reported_at: Option<IntuneTimestamp>,
+    pub device_key: Option<String>,
+    pub user_key: Option<String>,
+    pub named_data: Vec<IntuneNamedValue>,
+}
+
+/// One sign-in / Conditional Access outcome, supplemental evidence only.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceAccessFact {
+    pub context: IntuneObservationContext,
+    pub decision: ComplianceAccessDecision,
+    pub failure_code: Option<IntuneErrorCode>,
+    pub occurred_at: Option<IntuneTimestamp>,
+    pub device_key: Option<String>,
+    pub user_key: Option<String>,
+    pub resource: Option<String>,
+    pub named_data: Vec<IntuneNamedValue>,
+}
+
+/// Device, tenant, enrollment, and active-user context supplied by the collector.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceDeviceContextFact {
+    pub context: IntuneObservationContext,
+    pub device_key: Option<String>,
+    pub tenant_key: Option<String>,
+    pub enrollment_id: Option<String>,
+    pub windows_build: Option<String>,
+    pub active_user_key: Option<String>,
+    /// `Some(false)` means "we checked and no user was signed in", which is what
+    /// makes an unevaluated user-scoped setting explainable rather than mysterious.
+    pub user_session_present: Option<bool>,
+    pub named_data: Vec<IntuneNamedValue>,
+}
+
+/// Everything the reducer consumes.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceInput {
+    pub generated_at_utc: String,
+    pub events: Vec<NormalizedWindowsEvent>,
+    pub setting_reports: Vec<NormalizedSettingReport>,
+    pub custom_compliance: Vec<ComplianceCustomFact>,
+    pub service_results: Vec<ComplianceServiceFact>,
+    pub access_decisions: Vec<ComplianceAccessFact>,
+    pub device_context: Option<ComplianceDeviceContextFact>,
+    pub coverage: Vec<IntuneArtifactCoverage>,
+}
+
+// ── Snapshot phases ─────────────────────────────────────────────────────────
+
+/// Device, tenant, and user context as reduced for the snapshot.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceDeviceContextView {
+    pub device_key: Option<String>,
+    pub tenant_key: Option<String>,
+    pub enrollment_id: Option<String>,
+    pub windows_build: Option<String>,
+    pub active_user_key: Option<String>,
+    pub user_evaluation_context: ComplianceUserContext,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+/// One compliance policy the device is known to have received, or not.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CompliancePolicyObservation {
+    pub policy_id: String,
+    pub state: CompliancePolicyState,
+    pub scope: ComplianceScope,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+/// One local precondition for evaluation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CompliancePrerequisite {
+    pub name: String,
+    pub state: CompliancePrerequisiteState,
+    pub detail: Option<String>,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+/// One setting, reduced from every local observation that shares its key.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceSettingEvaluation {
+    pub key: ComplianceSettingKey,
+    /// The token the merge was performed on. Exposed so a consumer can see
+    /// *why* two observations were treated as the same setting.
+    pub grouping_token: String,
+    pub scope: ComplianceScope,
+    pub state: ComplianceSettingState,
+    pub display_name: Option<String>,
+    pub error: Option<IntuneErrorCode>,
+    pub evaluated_at: Option<IntuneTimestamp>,
+    /// Every definite state observed, in sorted order. More than one entry means
+    /// the sources disagreed and `state` is [`ComplianceSettingState::Contradictory`].
+    pub observed_states: Vec<ComplianceSettingState>,
+    /// The evaluation claims a time after the snapshot was generated.
+    pub time_contradiction: bool,
+    /// Two merged sources declared different values for the same identifier.
+    ///
+    /// The merge still happens — the sources agreed on the token they were
+    /// grouped by — but the disagreement is surfaced rather than silently
+    /// resolved first-wins.
+    pub identity_contradiction: bool,
+    pub evidence: Vec<IntuneEvidenceRef>,
+    pub named_data: Vec<IntuneNamedValue>,
+}
+
+/// One custom-compliance discovery result, reduced.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceCustomEvaluation {
+    pub policy_id: Option<String>,
+    pub run_id: Option<String>,
+    pub setting_name: Option<String>,
+    pub state: ComplianceCustomState,
+    pub error: Option<IntuneErrorCode>,
+    pub raw_output: Option<String>,
+    pub evidence: Vec<IntuneEvidenceRef>,
+    pub named_data: Vec<IntuneNamedValue>,
+}
+
+/// Phase 1: what the device itself evaluated.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceLocalPhase {
+    pub policies: Vec<CompliancePolicyObservation>,
+    pub prerequisites: Vec<CompliancePrerequisite>,
+    pub settings: Vec<ComplianceSettingEvaluation>,
+    pub custom_compliance: Vec<ComplianceCustomEvaluation>,
+    /// Local observations that named no setting identity and were therefore
+    /// never merged into an evaluation.
+    pub unkeyed_observations: Vec<IntuneEvidenceRef>,
+    pub latest_evaluation_at_utc: Option<String>,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+/// Phase 2: the device-wide result derived from phase 1.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceAggregatePhase {
+    pub state: ComplianceAggregateState,
+    pub rationale: ComplianceAggregateRationale,
+    pub compliant_count: usize,
+    pub noncompliant_count: usize,
+    pub error_count: usize,
+    pub not_applicable_count: usize,
+    pub not_evaluated_count: usize,
+    pub contradictory_count: usize,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+impl Default for ComplianceAggregatePhase {
+    fn default() -> Self {
+        Self {
+            state: ComplianceAggregateState::InsufficientEvidence,
+            rationale: ComplianceAggregateRationale::NoLocalSourceAvailable,
+            compliant_count: 0,
+            noncompliant_count: 0,
+            error_count: 0,
+            not_applicable_count: 0,
+            not_evaluated_count: 0,
+            contradictory_count: 0,
+            evidence: Vec::new(),
+        }
+    }
+}
+
+/// One service-held record, reduced with its freshness relative to phase 1.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceServiceResult {
+    pub policy_id: Option<String>,
+    pub setting_id: Option<String>,
+    pub state: ComplianceServiceState,
+    pub reported_at: Option<IntuneTimestamp>,
+    pub freshness: ComplianceServiceFreshness,
+    pub device_key: Option<String>,
+    pub user_key: Option<String>,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+/// Phase 3: what the device submitted and what the service currently holds.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceReportingPhase {
+    pub state: ComplianceReportState,
+    pub report_id: Option<String>,
+    pub last_submission_at: Option<IntuneTimestamp>,
+    pub error: Option<IntuneErrorCode>,
+    pub service_results: Vec<ComplianceServiceResult>,
+    pub service_freshness: ComplianceServiceFreshness,
+    /// The service state contradicts the locally derived aggregate.
+    pub service_disagrees_with_local: bool,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+impl Default for ComplianceReportingPhase {
+    fn default() -> Self {
+        Self {
+            state: ComplianceReportState::Unknown,
+            report_id: None,
+            last_submission_at: None,
+            error: None,
+            service_results: Vec::new(),
+            service_freshness: ComplianceServiceFreshness::Unknown,
+            service_disagrees_with_local: false,
+            evidence: Vec::new(),
+        }
+    }
+}
+
+/// One access decision and how well it could be tied to compliance evidence.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceAccessObservation {
+    pub decision: ComplianceAccessDecision,
+    pub linkage: ComplianceAccessLinkage,
+    pub failure_code: Option<IntuneErrorCode>,
+    pub occurred_at: Option<IntuneTimestamp>,
+    pub device_key: Option<String>,
+    pub user_key: Option<String>,
+    pub resource: Option<String>,
+    /// The compliance evidence the match was made against. Empty unless
+    /// `linkage` is [`ComplianceAccessLinkage::MatchedComplianceState`].
+    pub matched_evidence: Vec<IntuneEvidenceRef>,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+/// Phase 4: downstream impact only. Never a cause.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceAccessPhase {
+    pub decisions: Vec<ComplianceAccessObservation>,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+/// The immutable reduction of one compliance evidence bundle.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceSnapshot {
+    pub schema_version: u32,
+    pub generated_at_utc: String,
+    pub device_context: ComplianceDeviceContextView,
+    pub local_evaluation: ComplianceLocalPhase,
+    pub aggregate: ComplianceAggregatePhase,
+    pub reporting: ComplianceReportingPhase,
+    pub access_impact: ComplianceAccessPhase,
+    pub coverage: Vec<IntuneArtifactCoverage>,
+    pub findings: Vec<IntuneFinding>,
+}
+
+impl Default for ComplianceSnapshot {
+    fn default() -> Self {
+        Self {
+            schema_version: INTUNE_COMPLIANCE_SCHEMA_VERSION,
+            generated_at_utc: String::new(),
+            device_context: ComplianceDeviceContextView::default(),
+            local_evaluation: ComplianceLocalPhase::default(),
+            aggregate: ComplianceAggregatePhase::default(),
+            reporting: ComplianceReportingPhase::default(),
+            access_impact: ComplianceAccessPhase::default(),
+            coverage: Vec::new(),
+            findings: Vec::new(),
+        }
+    }
+}
+
+// ── Shared evidence helpers ─────────────────────────────────────────────────
+
+/// Sort and de-duplicate evidence references in place.
+///
+/// Every list a rule or phase emits goes through this, so the serialized output
+/// is byte-identical across runs regardless of source iteration order.
+pub(super) fn normalize_evidence(evidence: &mut Vec<IntuneEvidenceRef>) {
+    evidence.sort();
+    evidence.dedup();
+}
+
+/// Clone, sort, and de-duplicate an evidence iterator.
+pub(super) fn collect_evidence<'a>(
+    evidence: impl IntoIterator<Item = &'a IntuneEvidenceRef>,
+) -> Vec<IntuneEvidenceRef> {
+    let mut collected = evidence.into_iter().cloned().collect::<Vec<_>>();
+    normalize_evidence(&mut collected);
+    collected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setting_key_prefers_the_uri_when_present() {
+        let key = ComplianceSettingKey {
+            policy_id: Some("p".to_owned()),
+            setting_id: Some("s".to_owned()),
+            setting_uri: Some("./Device/Vendor/MSFT/Policy/Result/X".to_owned()),
+        };
+        assert_eq!(
+            key.grouping_token().as_deref(),
+            Some("uri:./device/vendor/msft/policy/result/x")
+        );
+    }
+
+    #[test]
+    fn an_unidentified_key_has_no_grouping_token() {
+        let key = ComplianceSettingKey {
+            policy_id: Some("   ".to_owned()),
+            setting_id: None,
+            setting_uri: None,
+        };
+        assert!(!key.is_identified());
+        assert_eq!(key.grouping_token(), None);
+    }
+
+    #[test]
+    fn only_definite_states_can_contradict() {
+        assert!(ComplianceSettingState::Noncompliant.is_definite());
+        assert!(!ComplianceSettingState::NotEvaluated.is_definite());
+        assert!(!ComplianceSettingState::InsufficientEvidence.is_definite());
+    }
+
+    #[test]
+    fn service_state_preserves_an_unrecognized_token() {
+        let decoded: ComplianceServiceState = serde_json::from_str("\"someFutureState\"").unwrap();
+        assert_eq!(
+            decoded,
+            ComplianceServiceState::Unknown("someFutureState".to_owned())
+        );
+        assert_eq!(
+            serde_json::to_string(&decoded).unwrap(),
+            "\"someFutureState\""
+        );
+    }
+
+    #[test]
+    fn snapshot_wire_form_is_camel_case() {
+        let encoded = serde_json::to_string(&ComplianceSnapshot::default()).unwrap();
+        assert!(encoded.contains("\"schemaVersion\""));
+        assert!(encoded.contains("\"localEvaluation\""));
+        assert!(encoded.contains("\"accessImpact\""));
+    }
+}

--- a/crates/cmtraceopen-parser/src/intune/device/windows/compliance/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/compliance/redaction.rs
@@ -1,0 +1,325 @@
+//! Deterministic privacy projection for compliance evidence.
+//!
+//! Compliance evidence names people. A setting display name can quote a UPN, a
+//! custom-compliance script prints whatever the author decided to print, and the
+//! device/tenant/user keys are identifiers for a real machine and a real person.
+//!
+//! The projection masks all of that while keeping the *shape* of the reduction
+//! intact: setting grouping tokens, states, timestamps, error codes, and
+//! evidence references survive, because those are what show whether two records
+//! belong to the same local evaluation. Masking is a pure function of the masked
+//! text, so the same identity produces the same token everywhere it appears and
+//! a reader can still see that two records mention the same device.
+//!
+//! The projection is idempotent: a replacement token cannot itself match a rule.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+use super::models::*;
+use crate::intune::evidence::{IntuneFinding, IntuneNamedValue};
+
+/// FNV-1a. Stable across runs, platforms, and processes, which the standard
+/// library's `DefaultHasher` explicitly is not.
+fn stable_token(kind: &str, value: &str) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("[{kind}:{hash:016x}]")
+}
+
+/// A user principal name or email address.
+fn upn_re() -> &'static Regex {
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    CELL.get_or_init(|| {
+        Regex::new(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+            .expect("UPN regex must compile")
+    })
+}
+
+/// A Windows security identifier.
+fn sid_re() -> &'static Regex {
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    CELL.get_or_init(|| Regex::new(r"S-1-(?:\d+-){3,}\d+").expect("SID regex must compile"))
+}
+
+/// The profile segment of a user path, in either slash direction.
+///
+/// The segment is bounded by a separator, a quote, or a line break rather than
+/// by whitespace, because Windows allows spaces in profile directory names. The
+/// leading `[` exclusion is what makes the projection idempotent: an
+/// already-masked `[user:…]` segment must not be masked a second time.
+fn user_path_re() -> &'static Regex {
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    CELL.get_or_init(|| {
+        Regex::new(r"(?i)(?P<prefix>[\\/]Users[\\/])(?P<user>[^\\/\r\n\x22\[][^\\/\r\n\x22]*)")
+            .expect("user path regex must compile")
+    })
+}
+
+/// Mask the sensitive spans inside a free-text value.
+pub fn redact_text(value: &str) -> String {
+    let masked = upn_re().replace_all(value, |caps: &regex::Captures<'_>| {
+        stable_token("upn", &caps[0])
+    });
+    let masked = sid_re().replace_all(&masked, |caps: &regex::Captures<'_>| {
+        stable_token("sid", &caps[0])
+    });
+    user_path_re()
+        .replace_all(&masked, |caps: &regex::Captures<'_>| {
+            format!("{}{}", &caps["prefix"], stable_token("user", &caps["user"]))
+        })
+        .into_owned()
+}
+
+/// Replace an identifier with a stable token, leaving an already-masked value alone.
+fn mask_key(kind: &str, value: &Option<String>) -> Option<String> {
+    value.as_ref().map(|value| {
+        if is_masked_token(kind, value) {
+            value.clone()
+        } else {
+            stable_token(kind, value)
+        }
+    })
+}
+
+/// Whether a value is exactly a token this module produced for `kind`.
+///
+/// The shape must match `[kind:<16 hex digits>]` in full. Treating any bracketed
+/// value as already masked would let a source-supplied identifier such as
+/// `[contoso\alice]` skip redaction simply by wearing brackets.
+fn is_masked_token(kind: &str, value: &str) -> bool {
+    let prefix = format!("[{kind}:");
+    let Some(rest) = value.strip_prefix(&prefix) else {
+        return false;
+    };
+    let Some(digits) = rest.strip_suffix(']') else {
+        return false;
+    };
+    digits.len() == 16 && digits.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn redact_opt_text(value: &Option<String>) -> Option<String> {
+    value.as_deref().map(redact_text)
+}
+
+fn redact_named(values: &[IntuneNamedValue]) -> Vec<IntuneNamedValue> {
+    values
+        .iter()
+        .map(|entry| IntuneNamedValue {
+            name: entry.name.clone(),
+            value: redact_text(&entry.value),
+        })
+        .collect()
+}
+
+/// Return a copy of the snapshot safe to export by default.
+///
+/// What survives: every state, count, timestamp, error code, coverage entry,
+/// evidence reference, grouping token, and finding structure. What is masked:
+/// device/tenant/user keys, enrollment id, display names, custom-compliance
+/// output, access-resource details, and any UPN, SID, or user profile path
+/// appearing in free text.
+pub fn redacted_export_projection(snapshot: &ComplianceSnapshot) -> ComplianceSnapshot {
+    let mut projected = snapshot.clone();
+
+    projected.device_context = ComplianceDeviceContextView {
+        device_key: mask_key("deviceKey", &snapshot.device_context.device_key),
+        tenant_key: mask_key("tenantKey", &snapshot.device_context.tenant_key),
+        enrollment_id: mask_key("enrollmentId", &snapshot.device_context.enrollment_id),
+        // The build number is a fleet-level fact, not an identity, and it is
+        // often the whole reason a setting is not applicable.
+        windows_build: snapshot.device_context.windows_build.clone(),
+        active_user_key: mask_key("userKey", &snapshot.device_context.active_user_key),
+        user_evaluation_context: snapshot.device_context.user_evaluation_context,
+        evidence: snapshot.device_context.evidence.clone(),
+    };
+
+    // Prerequisite detail is collector-supplied free text and routinely quotes
+    // the user or path that blocked evaluation, so it goes through the same
+    // masking as any other free-text field.
+    for prerequisite in &mut projected.local_evaluation.prerequisites {
+        prerequisite.name = redact_text(&prerequisite.name);
+        prerequisite.detail = redact_opt_text(&prerequisite.detail);
+    }
+
+    for setting in &mut projected.local_evaluation.settings {
+        setting.display_name = redact_opt_text(&setting.display_name);
+        setting.named_data = redact_named(&setting.named_data);
+    }
+
+    for custom in &mut projected.local_evaluation.custom_compliance {
+        custom.setting_name = redact_opt_text(&custom.setting_name);
+        // Script output is arbitrary author-controlled text. It is replaced
+        // wholesale rather than pattern-masked, because there is no vocabulary
+        // to reason about and a partial mask would be a false assurance.
+        // `mask_key` is what keeps this idempotent: re-projecting an already
+        // masked snapshot must not hash the token again.
+        custom.raw_output = mask_key("output", &custom.raw_output);
+        custom.named_data = redact_named(&custom.named_data);
+    }
+
+    for result in &mut projected.reporting.service_results {
+        result.device_key = mask_key("deviceKey", &result.device_key);
+        result.user_key = mask_key("userKey", &result.user_key);
+    }
+
+    for decision in &mut projected.access_impact.decisions {
+        decision.device_key = mask_key("deviceKey", &decision.device_key);
+        decision.user_key = mask_key("userKey", &decision.user_key);
+        decision.resource = mask_key("resource", &decision.resource);
+    }
+
+    projected.findings = projected
+        .findings
+        .iter()
+        .map(|finding| IntuneFinding {
+            title: redact_text(&finding.title),
+            summary: redact_text(&finding.summary),
+            recommended_checks: finding
+                .recommended_checks
+                .iter()
+                .map(|check| redact_text(check))
+                .collect(),
+            ..finding.clone()
+        })
+        .collect();
+
+    for entry in &mut projected.coverage {
+        entry.detail = redact_opt_text(&entry.detail);
+    }
+
+    projected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intune::evidence::IntuneEvidenceRef;
+
+    #[test]
+    fn a_upn_is_masked_and_the_same_upn_yields_the_same_token() {
+        let first = redact_text("evaluated for analyst@contoso.invalid");
+        let second = redact_text("reported by analyst@contoso.invalid");
+        assert!(!first.contains("analyst@contoso.invalid"));
+        let token = |text: &str| {
+            text.split('[')
+                .nth(1)
+                .and_then(|rest| rest.split(']').next())
+                .map(str::to_owned)
+        };
+        assert_eq!(token(&first), token(&second));
+    }
+
+    #[test]
+    fn a_sid_is_masked() {
+        let masked = redact_text("owner S-1-5-21-1004336348-1177238915-682003330-512 evaluated");
+        assert!(!masked.contains("S-1-5-21-"), "got {masked}");
+        assert!(masked.contains("[sid:"));
+    }
+
+    #[test]
+    fn a_user_profile_path_with_a_space_is_fully_masked() {
+        let masked = redact_text(r"D:\Users\Jane Roe\policy.json");
+        assert!(!masked.contains("Jane"), "got {masked}");
+        assert!(!masked.contains("Roe"), "got {masked}");
+    }
+
+    #[test]
+    fn redaction_is_idempotent() {
+        let once = redact_text(r"D:\Users\Jane Roe\p.json for analyst@contoso.invalid");
+        assert_eq!(redact_text(&once), once);
+    }
+
+    #[test]
+    fn script_output_is_replaced_wholesale() {
+        let snapshot = ComplianceSnapshot {
+            local_evaluation: ComplianceLocalPhase {
+                custom_compliance: vec![ComplianceCustomEvaluation {
+                    policy_id: Some("policy-1".to_owned()),
+                    run_id: Some("run-1".to_owned()),
+                    setting_name: Some("DiskEncryption".to_owned()),
+                    state: ComplianceCustomState::DiscoveryNoncompliant,
+                    error: None,
+                    raw_output: Some("{\"BitLocker\":\"Off\",\"Owner\":\"jane\"}".to_owned()),
+                    evidence: vec![IntuneEvidenceRef {
+                        evidence_id: "c1".to_owned(),
+                        source_artifact_id: "custom".to_owned(),
+                    }],
+                    named_data: Vec::new(),
+                }],
+                ..ComplianceLocalPhase::default()
+            },
+            ..ComplianceSnapshot::default()
+        };
+        let projected = redacted_export_projection(&snapshot);
+        let output = projected.local_evaluation.custom_compliance[0]
+            .raw_output
+            .as_deref()
+            .expect("output token");
+        assert!(output.starts_with("[output:"), "got {output}");
+        assert!(!output.contains("jane"));
+    }
+
+    #[test]
+    fn the_projection_preserves_states_and_evidence() {
+        let snapshot = ComplianceSnapshot {
+            aggregate: ComplianceAggregatePhase {
+                state: ComplianceAggregateState::Noncompliant,
+                rationale: ComplianceAggregateRationale::LocalSettingNoncompliant,
+                noncompliant_count: 1,
+                ..ComplianceAggregatePhase::default()
+            },
+            ..ComplianceSnapshot::default()
+        };
+        let projected = redacted_export_projection(&snapshot);
+        assert_eq!(projected.aggregate, snapshot.aggregate);
+    }
+
+    #[test]
+    fn a_bracketed_identifier_is_still_masked() {
+        let snapshot = ComplianceSnapshot {
+            device_context: ComplianceDeviceContextView {
+                device_key: Some("[deviceKey:not-a-real-token]".to_owned()),
+                ..ComplianceDeviceContextView::default()
+            },
+            ..ComplianceSnapshot::default()
+        };
+        let projected = redacted_export_projection(&snapshot);
+        let key = projected
+            .device_context
+            .device_key
+            .as_deref()
+            .expect("device key");
+        assert_ne!(
+            key, "[deviceKey:not-a-real-token]",
+            "a value that merely wears brackets must not bypass masking"
+        );
+        assert!(is_masked_token("deviceKey", key), "got {key}");
+    }
+
+    #[test]
+    fn masking_a_key_twice_is_stable() {
+        let snapshot = ComplianceSnapshot {
+            device_context: ComplianceDeviceContextView {
+                device_key: Some("11111111-2222-3333-4444-555555555555".to_owned()),
+                ..ComplianceDeviceContextView::default()
+            },
+            ..ComplianceSnapshot::default()
+        };
+        let once = redacted_export_projection(&snapshot);
+        let twice = redacted_export_projection(&once);
+        assert_eq!(
+            once.device_context.device_key,
+            twice.device_context.device_key
+        );
+        assert!(once
+            .device_context
+            .device_key
+            .as_deref()
+            .is_some_and(|key| key.starts_with("[deviceKey:")));
+    }
+}

--- a/crates/cmtraceopen-parser/src/intune/device/windows/compliance/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/compliance/reducer.rs
@@ -1,0 +1,1047 @@
+//! Reduce classified compliance observations into an immutable snapshot.
+//!
+//! The reduction runs strictly phase by phase and never lets a later phase
+//! rewrite an earlier one:
+//!
+//! 1. **local** — merge setting observations by grouping token;
+//! 2. **aggregate** — fold the local settings into one device result;
+//! 3. **reporting** — record submission state and compare service records
+//!    against the *timestamp* of the local evaluation, not against its verdict;
+//! 4. **access** — attach downstream decisions, correlated only on explicit
+//!    identity plus explicit time provenance.
+//!
+//! Findings are derived last, from the finished snapshot, so no rule can see a
+//! half-built state.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+
+use super::models::*;
+use super::rules::derive_findings;
+use super::sources::{
+    classify_event, classify_setting_report, decode_bundle, ComplianceSignal,
+    ComplianceSourceInput, SettingObservation,
+};
+use crate::intune::evidence::{IntuneEvidenceRef, IntuneTimestamp, IntuneTimestampKind};
+
+/// Decode a supplied evidence bundle and reduce it in one call.
+pub fn analyze_compliance_bundle(
+    sources: &[ComplianceSourceInput],
+    generated_at_utc: &str,
+) -> ComplianceSnapshot {
+    analyze_compliance(&decode_bundle(sources, generated_at_utc))
+}
+
+/// Reduce already-decoded compliance facts into a snapshot.
+pub fn analyze_compliance(input: &ComplianceInput) -> ComplianceSnapshot {
+    let generated_at = parse_rfc3339(&input.generated_at_utc);
+
+    let device_context = reduce_device_context(input);
+    let local = reduce_local(input, generated_at);
+    let aggregate = reduce_aggregate(&local);
+    let reporting = reduce_reporting(input, &local, &aggregate, generated_at);
+    let access_impact = reduce_access(input, &reporting);
+
+    let mut snapshot = ComplianceSnapshot {
+        schema_version: INTUNE_COMPLIANCE_SCHEMA_VERSION,
+        generated_at_utc: input.generated_at_utc.clone(),
+        device_context,
+        local_evaluation: local,
+        aggregate,
+        reporting,
+        access_impact,
+        coverage: input.coverage.clone(),
+        findings: Vec::new(),
+    };
+    snapshot.findings = derive_findings(&snapshot);
+    snapshot
+}
+
+// ── Device context ──────────────────────────────────────────────────────────
+
+fn reduce_device_context(input: &ComplianceInput) -> ComplianceDeviceContextView {
+    let Some(fact) = input.device_context.as_ref() else {
+        return ComplianceDeviceContextView::default();
+    };
+
+    // A user key alone does not prove a user session was available for
+    // evaluation; only the explicit flag does. Inferring presence from the key
+    // would make an unevaluated user-scoped setting look like a failure.
+    let user_evaluation_context = match fact.user_session_present {
+        Some(true) => ComplianceUserContext::UserPresent,
+        Some(false) => ComplianceUserContext::NoUserSession,
+        None => ComplianceUserContext::Unknown,
+    };
+
+    ComplianceDeviceContextView {
+        device_key: fact.device_key.clone(),
+        tenant_key: fact.tenant_key.clone(),
+        enrollment_id: fact.enrollment_id.clone(),
+        windows_build: fact.windows_build.clone(),
+        active_user_key: fact.active_user_key.clone(),
+        user_evaluation_context,
+        evidence: vec![fact.context.evidence_ref.clone()],
+    }
+}
+
+// ── Phase 1: local evaluation ───────────────────────────────────────────────
+
+fn reduce_local(
+    input: &ComplianceInput,
+    generated_at: Option<DateTime<Utc>>,
+) -> ComplianceLocalPhase {
+    let mut phase = ComplianceLocalPhase::default();
+    let mut grouped: BTreeMap<String, Vec<SettingObservation>> = BTreeMap::new();
+    let mut policies: BTreeMap<String, CompliancePolicyObservation> = BTreeMap::new();
+    let mut prerequisites: BTreeMap<String, CompliancePrerequisite> = BTreeMap::new();
+    let mut evidence = Vec::new();
+
+    for event in &input.events {
+        evidence.push(event.context.evidence_ref.clone());
+        let reference = event.context.evidence_ref.clone();
+        match classify_event(event) {
+            Some(ComplianceSignal::SettingEvaluation(observation)) => {
+                grouped
+                    .entry(observation.grouping_token.clone())
+                    .or_default()
+                    .push(*observation);
+            }
+            Some(ComplianceSignal::Prerequisite {
+                name,
+                state,
+                detail,
+            }) => {
+                let entry =
+                    prerequisites
+                        .entry(name.clone())
+                        .or_insert_with(|| CompliancePrerequisite {
+                            name,
+                            state,
+                            detail: detail.clone(),
+                            evidence: Vec::new(),
+                        });
+                // An unmet prerequisite outranks a met one: the device saying
+                // "blocked" at any point is the fact worth surfacing.
+                if state == CompliancePrerequisiteState::Unmet {
+                    entry.state = state;
+                    entry.detail = detail;
+                }
+                entry.evidence.push(reference);
+            }
+            Some(ComplianceSignal::PolicyState {
+                policy_id,
+                state,
+                scope,
+            }) => {
+                let entry = policies.entry(policy_id.clone()).or_insert_with(|| {
+                    CompliancePolicyObservation {
+                        policy_id,
+                        state,
+                        scope,
+                        evidence: Vec::new(),
+                    }
+                });
+                entry.evidence.push(reference);
+            }
+            // Reporting signals belong to phase 3.
+            Some(ComplianceSignal::ReportSubmission { .. }) => {}
+            // The record was supplied as compliance evidence but names no
+            // setting, policy, prerequisite, or report status. It is recorded as
+            // unattributed coverage rather than dropped, so a bundle that
+            // produced no result can be told apart from one that was never read.
+            None => phase.unkeyed_observations.push(reference),
+        }
+    }
+
+    for report in &input.setting_reports {
+        evidence.push(report.context.evidence_ref.clone());
+        match classify_setting_report(report) {
+            Some(observation) => grouped
+                .entry(observation.grouping_token.clone())
+                .or_default()
+                .push(observation),
+            None => phase
+                .unkeyed_observations
+                .push(report.context.evidence_ref.clone()),
+        }
+    }
+
+    phase.settings = grouped
+        .into_iter()
+        .map(|(token, observations)| merge_setting(token, observations, generated_at))
+        .collect();
+    phase.policies = policies.into_values().collect();
+    phase.prerequisites = prerequisites.into_values().collect();
+    for policy in &mut phase.policies {
+        normalize_evidence(&mut policy.evidence);
+    }
+    for prerequisite in &mut phase.prerequisites {
+        normalize_evidence(&mut prerequisite.evidence);
+    }
+
+    phase.custom_compliance = input
+        .custom_compliance
+        .iter()
+        .map(|fact| {
+            evidence.push(fact.context.evidence_ref.clone());
+            ComplianceCustomEvaluation {
+                policy_id: fact.policy_id.clone(),
+                run_id: fact.run_id.clone(),
+                setting_name: fact.setting_name.clone(),
+                state: fact.outcome,
+                error: fact.error.clone(),
+                raw_output: fact.raw_output.clone(),
+                evidence: vec![fact.context.evidence_ref.clone()],
+                named_data: fact.named_data.clone(),
+            }
+        })
+        .collect();
+
+    phase.latest_evaluation_at_utc = latest_evaluation(&phase.settings).map(format_utc);
+    normalize_evidence(&mut phase.unkeyed_observations);
+    normalize_evidence(&mut evidence);
+    phase.evidence = evidence;
+    phase
+}
+
+/// Fold every observation that shares a grouping token into one evaluation.
+///
+/// Two *definite* states that disagree produce
+/// [`ComplianceSettingState::Contradictory`] rather than an arbitrary winner.
+/// Preferring the newest would silently pick a side in exactly the case where
+/// the evidence does not support picking one.
+fn merge_setting(
+    grouping_token: String,
+    observations: Vec<SettingObservation>,
+    generated_at: Option<DateTime<Utc>>,
+) -> ComplianceSettingEvaluation {
+    let mut key = ComplianceSettingKey::default();
+    let mut scope = ComplianceScope::Unknown;
+    let mut display_name = None;
+    let mut error = None;
+    let mut evaluated_at: Option<IntuneTimestamp> = None;
+    let mut evidence = Vec::new();
+    let mut named_data = Vec::new();
+    let mut definite = Vec::new();
+    let mut indefinite = Vec::new();
+    let mut time_contradiction = false;
+    let mut identity_contradiction = false;
+
+    for observation in observations {
+        identity_contradiction |= conflicts(&key.policy_id, &observation.key.policy_id)
+            || conflicts(&key.setting_id, &observation.key.setting_id)
+            || conflicts(&key.setting_uri, &observation.key.setting_uri);
+        key.policy_id = key.policy_id.or(observation.key.policy_id);
+        key.setting_id = key.setting_id.or(observation.key.setting_id);
+        key.setting_uri = key.setting_uri.or(observation.key.setting_uri);
+        if scope == ComplianceScope::Unknown {
+            scope = observation.scope;
+        }
+        display_name = display_name.or(observation.display_name);
+        error = error.or(observation.error);
+
+        if observation.state.is_definite() {
+            definite.push(observation.state);
+        } else {
+            indefinite.push(observation.state);
+        }
+
+        if let Some(timestamp) = observation.evaluated_at {
+            if let (Some(candidate), Some(generated_at)) =
+                (normalized_timestamp(&timestamp), generated_at)
+            {
+                if candidate > generated_at {
+                    time_contradiction = true;
+                }
+            }
+            evaluated_at = Some(match evaluated_at {
+                Some(existing) if is_newer(&existing, &timestamp) => existing,
+                _ => timestamp,
+            });
+        }
+
+        evidence.push(observation.context.evidence_ref);
+        named_data.extend(observation.named_data);
+    }
+
+    definite.sort();
+    definite.dedup();
+    let state = match definite.len() {
+        1 => definite[0],
+        0 => most_informative_indefinite(&indefinite),
+        _ => ComplianceSettingState::Contradictory,
+    };
+
+    normalize_evidence(&mut evidence);
+    named_data.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.value.cmp(&right.value))
+    });
+    named_data.dedup();
+
+    ComplianceSettingEvaluation {
+        key,
+        grouping_token,
+        scope,
+        state,
+        display_name,
+        error,
+        evaluated_at,
+        observed_states: definite,
+        time_contradiction,
+        identity_contradiction,
+        evidence,
+        named_data,
+    }
+}
+
+/// Whether two sources declare different non-empty values for one identifier.
+fn conflicts(existing: &Option<String>, candidate: &Option<String>) -> bool {
+    let usable = |value: &Option<String>| {
+        value
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_ascii_lowercase)
+    };
+    match (usable(existing), usable(candidate)) {
+        (Some(existing), Some(candidate)) => existing != candidate,
+        _ => false,
+    }
+}
+
+/// Rank the non-definite states so a merge keeps the most informative one.
+fn most_informative_indefinite(states: &[ComplianceSettingState]) -> ComplianceSettingState {
+    let rank = |state: &ComplianceSettingState| match state {
+        ComplianceSettingState::PrerequisiteUnmet => 4,
+        ComplianceSettingState::Contradictory => 3,
+        ComplianceSettingState::NotEvaluated => 2,
+        ComplianceSettingState::InsufficientEvidence => 1,
+        _ => 0,
+    };
+    states
+        .iter()
+        .max_by_key(|state| rank(state))
+        .copied()
+        .unwrap_or(ComplianceSettingState::InsufficientEvidence)
+}
+
+fn is_newer(left: &IntuneTimestamp, right: &IntuneTimestamp) -> bool {
+    match (normalized_timestamp(left), normalized_timestamp(right)) {
+        (Some(left), Some(right)) => left > right,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+fn latest_evaluation(settings: &[ComplianceSettingEvaluation]) -> Option<DateTime<Utc>> {
+    settings
+        .iter()
+        .filter_map(|setting| setting.evaluated_at.as_ref())
+        .filter_map(normalized_timestamp)
+        .max()
+}
+
+// ── Phase 2: aggregate ──────────────────────────────────────────────────────
+
+/// Fold local settings and custom-compliance results into one device result.
+///
+/// Precedence is by severity of claim, and a custom-compliance *script failure*
+/// is folded in as an error, never as a noncompliance: a script that did not run
+/// produced no verdict to aggregate.
+fn reduce_aggregate(local: &ComplianceLocalPhase) -> ComplianceAggregatePhase {
+    let mut phase = ComplianceAggregatePhase::default();
+
+    for setting in &local.settings {
+        match setting.state {
+            ComplianceSettingState::Compliant => phase.compliant_count += 1,
+            ComplianceSettingState::Noncompliant => phase.noncompliant_count += 1,
+            ComplianceSettingState::EvaluationError => phase.error_count += 1,
+            ComplianceSettingState::NotApplicable => phase.not_applicable_count += 1,
+            ComplianceSettingState::NotEvaluated
+            | ComplianceSettingState::PrerequisiteUnmet
+            | ComplianceSettingState::InsufficientEvidence => phase.not_evaluated_count += 1,
+            ComplianceSettingState::Contradictory => phase.contradictory_count += 1,
+        }
+    }
+
+    let custom_noncompliant = local
+        .custom_compliance
+        .iter()
+        .filter(|custom| custom.state == ComplianceCustomState::DiscoveryNoncompliant)
+        .collect::<Vec<_>>();
+    let custom_failed = local
+        .custom_compliance
+        .iter()
+        .filter(|custom| {
+            matches!(
+                custom.state,
+                ComplianceCustomState::ScriptFailed | ComplianceCustomState::OutputInvalid
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let has_local_source = !local.settings.is_empty() || !local.custom_compliance.is_empty();
+
+    let (state, rationale, evidence) = if phase.noncompliant_count > 0 {
+        (
+            ComplianceAggregateState::Noncompliant,
+            ComplianceAggregateRationale::LocalSettingNoncompliant,
+            evidence_for(local, ComplianceSettingState::Noncompliant),
+        )
+    } else if !custom_noncompliant.is_empty() {
+        (
+            ComplianceAggregateState::Noncompliant,
+            ComplianceAggregateRationale::CustomComplianceDiscoveryNoncompliant,
+            collect_evidence(custom_noncompliant.iter().flat_map(|c| c.evidence.iter())),
+        )
+    } else if phase.error_count > 0 {
+        (
+            ComplianceAggregateState::EvaluationError,
+            ComplianceAggregateRationale::LocalEvaluationError,
+            evidence_for(local, ComplianceSettingState::EvaluationError),
+        )
+    } else if !custom_failed.is_empty() {
+        (
+            ComplianceAggregateState::EvaluationError,
+            ComplianceAggregateRationale::CustomComplianceScriptFailed,
+            collect_evidence(custom_failed.iter().flat_map(|c| c.evidence.iter())),
+        )
+    } else if phase.contradictory_count > 0 {
+        (
+            ComplianceAggregateState::InsufficientEvidence,
+            ComplianceAggregateRationale::ContradictoryLocalEvidence,
+            evidence_for(local, ComplianceSettingState::Contradictory),
+        )
+    } else if phase.compliant_count > 0 {
+        (
+            ComplianceAggregateState::Compliant,
+            ComplianceAggregateRationale::AllEvaluatedSettingsCompliant,
+            evidence_for(local, ComplianceSettingState::Compliant),
+        )
+    } else if has_local_source {
+        (
+            ComplianceAggregateState::NotEvaluated,
+            ComplianceAggregateRationale::NoSettingEvaluated,
+            collect_evidence(local.settings.iter().flat_map(|s| s.evidence.iter())),
+        )
+    } else {
+        (
+            ComplianceAggregateState::InsufficientEvidence,
+            ComplianceAggregateRationale::NoLocalSourceAvailable,
+            Vec::new(),
+        )
+    };
+
+    phase.state = state;
+    phase.rationale = rationale;
+    phase.evidence = evidence;
+    phase
+}
+
+fn evidence_for(
+    local: &ComplianceLocalPhase,
+    state: ComplianceSettingState,
+) -> Vec<IntuneEvidenceRef> {
+    collect_evidence(
+        local
+            .settings
+            .iter()
+            .filter(|setting| setting.state == state)
+            .flat_map(|setting| setting.evidence.iter()),
+    )
+}
+
+// ── Phase 3: reporting and service state ────────────────────────────────────
+
+fn reduce_reporting(
+    input: &ComplianceInput,
+    local: &ComplianceLocalPhase,
+    aggregate: &ComplianceAggregatePhase,
+    generated_at: Option<DateTime<Utc>>,
+) -> ComplianceReportingPhase {
+    let mut phase = ComplianceReportingPhase::default();
+    let mut evidence = Vec::new();
+    let latest_local = local
+        .latest_evaluation_at_utc
+        .as_deref()
+        .and_then(parse_rfc3339);
+
+    for event in &input.events {
+        let Some(ComplianceSignal::ReportSubmission {
+            state,
+            report_id,
+            error,
+            submitted_at,
+        }) = classify_event(event)
+        else {
+            continue;
+        };
+        evidence.push(event.context.evidence_ref.clone());
+        // A submission is the terminal outcome: once the bundle shows the report
+        // went out, a later queued or failed row cannot take that back. A failure
+        // still outranks queued, because a later "queued" does not undo an
+        // observed submission failure.
+        match state {
+            ComplianceReportState::Submitted => phase.state = state,
+            ComplianceReportState::Failed => {
+                if phase.state != ComplianceReportState::Submitted {
+                    phase.state = state;
+                }
+            }
+            _ => {
+                if !matches!(
+                    phase.state,
+                    ComplianceReportState::Submitted | ComplianceReportState::Failed
+                ) {
+                    phase.state = state;
+                }
+            }
+        }
+        phase.report_id = phase.report_id.or(report_id);
+        phase.error = phase.error.or(error);
+        if state == ComplianceReportState::Submitted {
+            phase.last_submission_at = submitted_at;
+        }
+    }
+
+    // A submission that predates the most recent local evaluation cannot carry
+    // that evaluation's result, whatever the submission itself reported.
+    if phase.state == ComplianceReportState::Submitted {
+        if let (Some(submitted), Some(latest_local)) = (
+            phase
+                .last_submission_at
+                .as_ref()
+                .and_then(normalized_timestamp),
+            latest_local,
+        ) {
+            if submitted < latest_local {
+                phase.state = ComplianceReportState::Stale;
+            }
+        }
+    }
+
+    phase.service_results = input
+        .service_results
+        .iter()
+        .map(|fact| {
+            evidence.push(fact.context.evidence_ref.clone());
+            let reported = fact.reported_at.as_ref().and_then(normalized_timestamp);
+            let freshness = match (reported, latest_local) {
+                (Some(reported), Some(local)) if reported >= local => {
+                    ComplianceServiceFreshness::Fresh
+                }
+                (Some(_), Some(_)) => ComplianceServiceFreshness::Stale,
+                _ => ComplianceServiceFreshness::Unknown,
+            };
+            ComplianceServiceResult {
+                policy_id: fact.policy_id.clone(),
+                setting_id: fact.setting_id.clone(),
+                state: fact.state.clone(),
+                reported_at: fact.reported_at.clone(),
+                freshness,
+                device_key: fact.device_key.clone(),
+                user_key: fact.user_key.clone(),
+                evidence: vec![fact.context.evidence_ref.clone()],
+            }
+        })
+        .collect();
+
+    phase.service_freshness = fold_freshness(&phase.service_results);
+    phase.service_disagrees_with_local = phase
+        .service_results
+        .iter()
+        .any(|result| disagrees(&result.state, aggregate.state));
+
+    // A service record stamped after the snapshot was generated is a provenance
+    // contradiction, not a fresher truth; surface it as unknown freshness.
+    if let Some(generated_at) = generated_at {
+        let future = phase.service_results.iter().any(|result| {
+            result
+                .reported_at
+                .as_ref()
+                .and_then(normalized_timestamp)
+                .is_some_and(|reported| reported > generated_at)
+        });
+        if future {
+            phase.service_freshness = ComplianceServiceFreshness::Unknown;
+        }
+    }
+
+    normalize_evidence(&mut evidence);
+    phase.evidence = evidence;
+    phase
+}
+
+fn fold_freshness(results: &[ComplianceServiceResult]) -> ComplianceServiceFreshness {
+    if results.is_empty() {
+        return ComplianceServiceFreshness::Unknown;
+    }
+    if results
+        .iter()
+        .any(|result| result.freshness == ComplianceServiceFreshness::Stale)
+    {
+        return ComplianceServiceFreshness::Stale;
+    }
+    if results
+        .iter()
+        .all(|result| result.freshness == ComplianceServiceFreshness::Fresh)
+    {
+        return ComplianceServiceFreshness::Fresh;
+    }
+    ComplianceServiceFreshness::Unknown
+}
+
+/// Whether a service-held state contradicts the locally derived aggregate.
+///
+/// Only the two unambiguous pairings count. An unrecognized service token, a
+/// grace period, or an error state is not a disagreement, because we cannot say
+/// what it disagrees with.
+fn disagrees(service: &ComplianceServiceState, aggregate: ComplianceAggregateState) -> bool {
+    matches!(
+        (service, aggregate),
+        (
+            ComplianceServiceState::Noncompliant,
+            ComplianceAggregateState::Compliant
+        ) | (
+            ComplianceServiceState::Compliant,
+            ComplianceAggregateState::Noncompliant
+        )
+    )
+}
+
+// ── Phase 4: downstream access ──────────────────────────────────────────────
+
+/// Attach access decisions as downstream impact.
+///
+/// A decision reaches [`ComplianceAccessLinkage::MatchedComplianceState`] only
+/// when a device or user key matches a compliance record *and* both sides carry
+/// a normalized timestamp with the compliance record preceding the decision.
+/// Everything weaker is explicitly uncorrelated; the rules then refuse to make a
+/// causal claim from it.
+fn reduce_access(
+    input: &ComplianceInput,
+    reporting: &ComplianceReportingPhase,
+) -> ComplianceAccessPhase {
+    let mut phase = ComplianceAccessPhase::default();
+    let mut evidence = Vec::new();
+
+    for fact in &input.access_decisions {
+        evidence.push(fact.context.evidence_ref.clone());
+        let occurred = fact.occurred_at.as_ref().and_then(normalized_timestamp);
+
+        let matched = reporting
+            .service_results
+            .iter()
+            .filter(|result| keys_match(fact, result))
+            .filter(|result| {
+                match (
+                    result.reported_at.as_ref().and_then(normalized_timestamp),
+                    occurred,
+                ) {
+                    (Some(reported), Some(occurred)) => reported <= occurred,
+                    // Time-only proximity, or no time at all, cannot correlate.
+                    _ => false,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let identity_declared = fact.device_key.is_some() || fact.user_key.is_some();
+        let candidates_exist = !reporting.service_results.is_empty();
+
+        let linkage = if !matched.is_empty() {
+            ComplianceAccessLinkage::MatchedComplianceState
+        } else if !candidates_exist {
+            ComplianceAccessLinkage::NoMatchingComplianceEvidence
+        } else if !identity_declared || occurred.is_none() {
+            ComplianceAccessLinkage::InsufficientProvenance
+        } else if reporting
+            .service_results
+            .iter()
+            .any(|result| keys_match(fact, result))
+        {
+            // Identity lines up but the times do not; provenance is incomplete.
+            ComplianceAccessLinkage::InsufficientProvenance
+        } else {
+            ComplianceAccessLinkage::IdentityMismatch
+        };
+
+        phase.decisions.push(ComplianceAccessObservation {
+            decision: fact.decision,
+            linkage,
+            failure_code: fact.failure_code.clone(),
+            occurred_at: fact.occurred_at.clone(),
+            device_key: fact.device_key.clone(),
+            user_key: fact.user_key.clone(),
+            resource: fact.resource.clone(),
+            matched_evidence: collect_evidence(matched.iter().flat_map(|r| r.evidence.iter())),
+            evidence: vec![fact.context.evidence_ref.clone()],
+        });
+    }
+
+    normalize_evidence(&mut evidence);
+    phase.evidence = evidence;
+    phase
+}
+
+/// Whether one access decision and one service record name the same subject.
+///
+/// Every identity the decision declares must match. A decision that names both a
+/// device and a user is only about the service record that names both the same
+/// way; accepting either half alone would correlate a denial for one user with
+/// another user's compliance state on the same device. A decision that declares
+/// no identity at all cannot be correlated with anything.
+fn keys_match(fact: &ComplianceAccessFact, result: &ComplianceServiceResult) -> bool {
+    let same = |left: &Option<String>, right: &Option<String>| match (left, right) {
+        (Some(left), Some(right)) => left.eq_ignore_ascii_case(right),
+        _ => false,
+    };
+
+    match (fact.device_key.is_some(), fact.user_key.is_some()) {
+        (true, true) => {
+            same(&fact.device_key, &result.device_key) && same(&fact.user_key, &result.user_key)
+        }
+        (true, false) => same(&fact.device_key, &result.device_key),
+        (false, true) => same(&fact.user_key, &result.user_key),
+        (false, false) => false,
+    }
+}
+
+// ── Time helpers ────────────────────────────────────────────────────────────
+
+/// Only a timestamp whose kind is trustworthy for ordering may be used.
+///
+/// A local or unspecified-zone timestamp has no known offset, so its normalized
+/// form is a guess; using it to order a submission against an evaluation, or a
+/// service record against an access decision, would manufacture a correlation
+/// out of an unknown. Such timestamps are declined here and surface as missing
+/// provenance instead.
+pub(super) fn normalized_timestamp(timestamp: &IntuneTimestamp) -> Option<DateTime<Utc>> {
+    match timestamp.kind {
+        IntuneTimestampKind::Utc | IntuneTimestampKind::Offset => {
+            timestamp.normalized_utc.as_deref().and_then(parse_rfc3339)
+        }
+        _ => None,
+    }
+}
+
+pub(super) fn parse_rfc3339(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
+}
+
+fn format_utc(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intune::evidence::{
+        IntuneAccessState, IntuneEvidenceRef, IntuneObservationContext, IntuneParseState,
+        IntuneProvenance, IntuneSensitivity, IntuneSourceKind, IntuneTimestampKind,
+    };
+    use crate::intune::normalized::{NormalizedEventLevel, NormalizedWindowsEvent};
+
+    fn context(evidence_id: &str, artifact: &str) -> IntuneObservationContext {
+        IntuneObservationContext {
+            evidence_ref: IntuneEvidenceRef {
+                evidence_id: evidence_id.to_owned(),
+                source_artifact_id: artifact.to_owned(),
+            },
+            provenance: IntuneProvenance {
+                source_kind: IntuneSourceKind::EventLog,
+                source_artifact_id: artifact.to_owned(),
+                file_path: None,
+                line_number: None,
+                record_number: None,
+                registry: None,
+                event: None,
+            },
+            source_timestamp: None,
+            observed_at_utc: "2026-07-31T00:00:00Z".to_owned(),
+            sensitivity: IntuneSensitivity::Public,
+            parse_state: IntuneParseState::Parsed,
+            access_state: IntuneAccessState::Available,
+        }
+    }
+
+    fn timestamp(value: &str) -> IntuneTimestamp {
+        IntuneTimestamp {
+            raw_text: value.to_owned(),
+            original_offset: None,
+            normalized_utc: Some(value.to_owned()),
+            kind: IntuneTimestampKind::Utc,
+        }
+    }
+
+    fn setting_event(
+        evidence_id: &str,
+        uri: &str,
+        result: &str,
+        at: &str,
+    ) -> NormalizedWindowsEvent {
+        NormalizedWindowsEvent {
+            context: IntuneObservationContext {
+                source_timestamp: Some(timestamp(at)),
+                ..context(evidence_id, "events")
+            },
+            channel: "channel".to_owned(),
+            provider: "provider".to_owned(),
+            event_id: 100,
+            level: NormalizedEventLevel::Information,
+            task: None,
+            keywords: None,
+            record_id: None,
+            activity_id: None,
+            named_data: vec![
+                crate::intune::evidence::IntuneNamedValue {
+                    name: "SettingUri".to_owned(),
+                    value: uri.to_owned(),
+                },
+                crate::intune::evidence::IntuneNamedValue {
+                    name: "EvaluationResult".to_owned(),
+                    value: result.to_owned(),
+                },
+            ],
+            message: None,
+        }
+    }
+
+    #[test]
+    fn two_disagreeing_definite_sources_produce_a_contradiction() {
+        let input = ComplianceInput {
+            generated_at_utc: "2026-07-31T12:00:00Z".to_owned(),
+            events: vec![
+                setting_event("e1", "./Device/X", "compliant", "2026-07-31T10:00:00Z"),
+                setting_event("e2", "./Device/X", "noncompliant", "2026-07-31T10:05:00Z"),
+            ],
+            ..ComplianceInput::default()
+        };
+        let snapshot = analyze_compliance(&input);
+        assert_eq!(snapshot.local_evaluation.settings.len(), 1);
+        assert_eq!(
+            snapshot.local_evaluation.settings[0].state,
+            ComplianceSettingState::Contradictory
+        );
+        assert_eq!(
+            snapshot.aggregate.state,
+            ComplianceAggregateState::InsufficientEvidence
+        );
+    }
+
+    #[test]
+    fn a_stale_service_record_never_changes_the_local_state() {
+        let input = ComplianceInput {
+            generated_at_utc: "2026-07-31T12:00:00Z".to_owned(),
+            events: vec![setting_event(
+                "e1",
+                "./Device/X",
+                "compliant",
+                "2026-07-31T10:00:00Z",
+            )],
+            service_results: vec![ComplianceServiceFact {
+                context: context("s1", "service"),
+                policy_id: None,
+                setting_id: None,
+                state: ComplianceServiceState::Noncompliant,
+                reported_at: Some(timestamp("2026-07-30T09:00:00Z")),
+                device_key: Some("device-1".to_owned()),
+                user_key: None,
+                named_data: Vec::new(),
+            }],
+            ..ComplianceInput::default()
+        };
+        let snapshot = analyze_compliance(&input);
+        assert_eq!(
+            snapshot.aggregate.state,
+            ComplianceAggregateState::Compliant
+        );
+        assert_eq!(
+            snapshot.reporting.service_freshness,
+            ComplianceServiceFreshness::Stale
+        );
+        assert!(snapshot.reporting.service_disagrees_with_local);
+        assert!(
+            snapshot
+                .local_evaluation
+                .settings
+                .iter()
+                .all(|setting| setting.state == ComplianceSettingState::Compliant),
+            "a service record must never rewrite a local setting state"
+        );
+    }
+
+    #[test]
+    fn an_access_denial_alone_correlates_to_nothing() {
+        let input = ComplianceInput {
+            generated_at_utc: "2026-07-31T12:00:00Z".to_owned(),
+            access_decisions: vec![ComplianceAccessFact {
+                context: context("a1", "access"),
+                decision: ComplianceAccessDecision::Denied,
+                failure_code: None,
+                occurred_at: Some(timestamp("2026-07-31T11:00:00Z")),
+                device_key: Some("device-1".to_owned()),
+                user_key: None,
+                resource: None,
+                named_data: Vec::new(),
+            }],
+            ..ComplianceInput::default()
+        };
+        let snapshot = analyze_compliance(&input);
+        assert_eq!(
+            snapshot.access_impact.decisions[0].linkage,
+            ComplianceAccessLinkage::NoMatchingComplianceEvidence
+        );
+        assert_eq!(
+            snapshot.aggregate.state,
+            ComplianceAggregateState::InsufficientEvidence,
+            "an access denial must not produce a local compliance verdict"
+        );
+    }
+
+    #[test]
+    fn a_custom_script_failure_is_an_error_not_a_noncompliance() {
+        let input = ComplianceInput {
+            generated_at_utc: "2026-07-31T12:00:00Z".to_owned(),
+            custom_compliance: vec![ComplianceCustomFact {
+                context: context("c1", "custom"),
+                policy_id: Some("policy-1".to_owned()),
+                run_id: Some("run-1".to_owned()),
+                setting_name: Some("DiskEncryption".to_owned()),
+                outcome: ComplianceCustomState::ScriptFailed,
+                error: None,
+                raw_output: None,
+                named_data: Vec::new(),
+            }],
+            ..ComplianceInput::default()
+        };
+        let snapshot = analyze_compliance(&input);
+        assert_eq!(
+            snapshot.aggregate.state,
+            ComplianceAggregateState::EvaluationError
+        );
+        assert_eq!(
+            snapshot.aggregate.rationale,
+            ComplianceAggregateRationale::CustomComplianceScriptFailed
+        );
+    }
+
+    #[test]
+    fn a_submission_predating_the_latest_evaluation_is_stale() {
+        let mut submitted = setting_event("e2", "./Device/Y", "compliant", "2026-07-31T09:00:00Z");
+        submitted.named_data = vec![crate::intune::evidence::IntuneNamedValue {
+            name: "ReportStatus".to_owned(),
+            value: "submitted".to_owned(),
+        }];
+        let input = ComplianceInput {
+            generated_at_utc: "2026-07-31T12:00:00Z".to_owned(),
+            events: vec![
+                setting_event("e1", "./Device/X", "compliant", "2026-07-31T10:00:00Z"),
+                submitted,
+            ],
+            ..ComplianceInput::default()
+        };
+        let snapshot = analyze_compliance(&input);
+        assert_eq!(snapshot.reporting.state, ComplianceReportState::Stale);
+    }
+
+    fn report_event(evidence_id: &str, status: &str, at: &str) -> NormalizedWindowsEvent {
+        let mut event = setting_event(evidence_id, "./Device/X", "compliant", at);
+        event.named_data = vec![crate::intune::evidence::IntuneNamedValue {
+            name: "ReportStatus".to_owned(),
+            value: status.to_owned(),
+        }];
+        event
+    }
+
+    #[test]
+    fn a_submission_after_a_failure_is_reported_as_submitted() {
+        let input = ComplianceInput {
+            generated_at_utc: "2026-07-31T12:00:00Z".to_owned(),
+            events: vec![
+                report_event("r1", "failed", "2026-07-31T10:00:00Z"),
+                report_event("r2", "submitted", "2026-07-31T11:00:00Z"),
+            ],
+            ..ComplianceInput::default()
+        };
+        let snapshot = analyze_compliance(&input);
+        assert_eq!(
+            snapshot.reporting.state,
+            ComplianceReportState::Submitted,
+            "a later successful submission must not stay hidden behind an earlier failure"
+        );
+    }
+
+    #[test]
+    fn a_queued_row_after_a_failure_does_not_undo_the_failure() {
+        let input = ComplianceInput {
+            generated_at_utc: "2026-07-31T12:00:00Z".to_owned(),
+            events: vec![
+                report_event("r1", "failed", "2026-07-31T10:00:00Z"),
+                report_event("r2", "queued", "2026-07-31T11:00:00Z"),
+            ],
+            ..ComplianceInput::default()
+        };
+        let snapshot = analyze_compliance(&input);
+        assert_eq!(snapshot.reporting.state, ComplianceReportState::Failed);
+    }
+
+    #[test]
+    fn a_denial_naming_a_different_user_on_the_same_device_is_not_correlated() {
+        let input = ComplianceInput {
+            generated_at_utc: "2026-07-31T12:00:00Z".to_owned(),
+            events: vec![setting_event(
+                "e1",
+                "./Device/X",
+                "compliant",
+                "2026-07-31T09:00:00Z",
+            )],
+            service_results: vec![ComplianceServiceFact {
+                context: context("s1", "service"),
+                policy_id: None,
+                setting_id: None,
+                state: ComplianceServiceState::Noncompliant,
+                reported_at: Some(timestamp("2026-07-31T10:00:00Z")),
+                device_key: Some("device-1".to_owned()),
+                user_key: Some("user-1".to_owned()),
+                named_data: Vec::new(),
+            }],
+            access_decisions: vec![ComplianceAccessFact {
+                context: context("a1", "access"),
+                decision: ComplianceAccessDecision::Denied,
+                failure_code: None,
+                occurred_at: Some(timestamp("2026-07-31T11:00:00Z")),
+                device_key: Some("device-1".to_owned()),
+                user_key: Some("user-2".to_owned()),
+                resource: None,
+                named_data: Vec::new(),
+            }],
+            ..ComplianceInput::default()
+        };
+        let snapshot = analyze_compliance(&input);
+        assert_eq!(
+            snapshot.access_impact.decisions[0].linkage,
+            ComplianceAccessLinkage::IdentityMismatch,
+            "a denial that names a different user must not borrow another user's state"
+        );
+    }
+
+    #[test]
+    fn a_timestamp_with_no_known_zone_cannot_order_anything() {
+        let unusable = IntuneTimestamp {
+            raw_text: "2026-07-31T10:00:00".to_owned(),
+            original_offset: None,
+            normalized_utc: Some("2026-07-31T10:00:00Z".to_owned()),
+            kind: IntuneTimestampKind::Unspecified,
+        };
+        assert_eq!(
+            normalized_timestamp(&unusable),
+            None,
+            "a zone-less timestamp must not be treated as an ordered UTC instant"
+        );
+    }
+}

--- a/crates/cmtraceopen-parser/src/intune/device/windows/compliance/rules.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/compliance/rules.rs
@@ -1,0 +1,778 @@
+//! Findings derived from a finished compliance snapshot.
+//!
+//! Every rule is a private `push_*` function driven from [`derive_findings`], and
+//! every rule obeys three constraints:
+//!
+//! * a finding cites evidence or a coverage gap, never neither;
+//! * a finding that claims a **local setting failed** cites local evaluation
+//!   evidence — never a service record and never a sign-in result;
+//! * a finding built only from access evidence is capped at
+//!   [`IntuneFindingConfidence::Low`] and [`IntuneFindingSeverity::Info`],
+//!   because a Conditional Access denial is a downstream symptom whose cause
+//!   this module does not analyze.
+
+use super::models::*;
+use crate::intune::evidence::{
+    IntuneArtifactStatus, IntuneEvidenceRef, IntuneFinding, IntuneFindingConfidence,
+    IntuneFindingSeverity,
+};
+
+/// Derive stable, read-only findings from an immutable snapshot.
+pub fn derive_findings(snapshot: &ComplianceSnapshot) -> Vec<IntuneFinding> {
+    let mut findings = Vec::new();
+
+    push_local_setting_noncompliant(snapshot, &mut findings);
+    push_local_evaluation_error(snapshot, &mut findings);
+    push_prerequisite_unmet(snapshot, &mut findings);
+    push_setting_not_applicable(snapshot, &mut findings);
+    push_user_scoped_not_evaluated(snapshot, &mut findings);
+    push_custom_discovery_noncompliant(snapshot, &mut findings);
+    push_custom_script_failed(snapshot, &mut findings);
+    push_contradictory_local_evidence(snapshot, &mut findings);
+    push_report_submission_failed(snapshot, &mut findings);
+    push_service_state_stale(snapshot, &mut findings);
+    push_access_denied_correlated(snapshot, &mut findings);
+    push_access_denied_uncorrelated(snapshot, &mut findings);
+    push_unkeyed_observations(snapshot, &mut findings);
+    push_source_unusable(snapshot, &mut findings);
+    push_device_compliant(snapshot, &mut findings);
+
+    findings
+}
+
+// ── Phase 1: local evaluation ───────────────────────────────────────────────
+
+fn push_local_setting_noncompliant(
+    snapshot: &ComplianceSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let settings = settings_in(snapshot, ComplianceSettingState::Noncompliant);
+    if settings.is_empty() {
+        return;
+    }
+    push(
+        findings,
+        finding(
+            "compliance-local-setting-noncompliant",
+            IntuneFindingSeverity::Error,
+            IntuneFindingConfidence::High,
+            "A device-local compliance setting evaluated as noncompliant",
+            &format!(
+                "{} evaluated as noncompliant on the device itself: {}.",
+                count_label(settings.len(), "setting", "settings"),
+                setting_labels(&settings)
+            ),
+            "Inspect the cited local evaluation records for the named setting and confirm the required configuration on the device.",
+            collect_evidence(settings.iter().flat_map(|setting| setting.evidence.iter())),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_local_evaluation_error(snapshot: &ComplianceSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let settings = settings_in(snapshot, ComplianceSettingState::EvaluationError);
+    if settings.is_empty() {
+        return;
+    }
+    push(
+        findings,
+        finding(
+            "compliance-local-evaluation-error",
+            IntuneFindingSeverity::Error,
+            IntuneFindingConfidence::High,
+            "A compliance setting could not be evaluated",
+            &format!(
+                "{} reported an evaluation error rather than a verdict: {}. An evaluation error is not the same as a noncompliant device.",
+                count_label(settings.len(), "setting", "settings"),
+                setting_labels(&settings)
+            ),
+            "Inspect the cited evaluation records for the reported error code and the CSP the setting resolves to.",
+            collect_evidence(settings.iter().flat_map(|setting| setting.evidence.iter())),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_prerequisite_unmet(snapshot: &ComplianceSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let unmet = snapshot
+        .local_evaluation
+        .prerequisites
+        .iter()
+        .filter(|prerequisite| prerequisite.state == CompliancePrerequisiteState::Unmet)
+        .collect::<Vec<_>>();
+    if unmet.is_empty() {
+        return;
+    }
+    push(
+        findings,
+        finding(
+            "compliance-prerequisite-unmet",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::High,
+            "A local prerequisite for compliance evaluation was not met",
+            &format!(
+                "The device reported an unmet prerequisite: {}. Settings gated on it were not evaluated, which is not the same as failing them.",
+                unmet
+                    .iter()
+                    .map(|prerequisite| prerequisite.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            "Resolve the cited prerequisite, then re-run compliance evaluation and re-collect the evidence.",
+            collect_evidence(unmet.iter().flat_map(|prerequisite| prerequisite.evidence.iter())),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_setting_not_applicable(snapshot: &ComplianceSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let settings = settings_in(snapshot, ComplianceSettingState::NotApplicable);
+    if settings.is_empty() {
+        return;
+    }
+    push(
+        findings,
+        finding(
+            "compliance-setting-not-applicable",
+            IntuneFindingSeverity::Info,
+            IntuneFindingConfidence::High,
+            "A compliance setting does not apply to this device",
+            &format!(
+                "{} reported as not applicable: {}. A not-applicable setting is excluded from the aggregate result rather than counted as a pass or a failure.",
+                count_label(settings.len(), "setting", "settings"),
+                setting_labels(&settings)
+            ),
+            "Confirm the cited setting's applicability rules against this device's edition and hardware.",
+            collect_evidence(settings.iter().flat_map(|setting| setting.evidence.iter())),
+            Vec::new(),
+        ),
+    );
+}
+
+/// A user-targeted setting that no user context evaluated.
+///
+/// This is the finding that keeps "nobody was signed in" from being read as "the
+/// device failed the setting". It is `Info`, never an error, and its summary
+/// says so explicitly.
+fn push_user_scoped_not_evaluated(
+    snapshot: &ComplianceSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let settings = snapshot
+        .local_evaluation
+        .settings
+        .iter()
+        .filter(|setting| {
+            setting.scope == ComplianceScope::User
+                && matches!(
+                    setting.state,
+                    ComplianceSettingState::NotEvaluated
+                        | ComplianceSettingState::InsufficientEvidence
+                )
+        })
+        .collect::<Vec<_>>();
+    if settings.is_empty() {
+        return;
+    }
+
+    let context_note = match snapshot.device_context.user_evaluation_context {
+        ComplianceUserContext::NoUserSession => {
+            "The collector reported that no user session was present."
+        }
+        ComplianceUserContext::UserPresent => {
+            "A user session was reported as present, so the absence of a result is unexplained."
+        }
+        ComplianceUserContext::Unknown => {
+            "The collector did not report whether a user session was present."
+        }
+    };
+
+    push(
+        findings,
+        finding(
+            "compliance-user-scoped-not-evaluated",
+            IntuneFindingSeverity::Info,
+            IntuneFindingConfidence::Medium,
+            "A user-targeted compliance setting was not evaluated in this context",
+            &format!(
+                "{} targeted at a user produced no local verdict: {}. {context_note} This is missing evaluation coverage, not a failed setting.",
+                count_label(settings.len(), "setting", "settings"),
+                setting_labels(&settings)
+            ),
+            "Re-collect evidence with the affected user signed in, then compare the cited settings' results.",
+            collect_evidence(settings.iter().flat_map(|setting| setting.evidence.iter())),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_custom_discovery_noncompliant(
+    snapshot: &ComplianceSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let results = custom_in(snapshot, &[ComplianceCustomState::DiscoveryNoncompliant]);
+    if results.is_empty() {
+        return;
+    }
+    push(
+        findings,
+        finding(
+            "compliance-custom-discovery-noncompliant",
+            IntuneFindingSeverity::Error,
+            IntuneFindingConfidence::High,
+            "A custom compliance discovery script returned a noncompliant result",
+            &format!(
+                "{} produced a noncompliant discovery result. The script ran to completion and reported this verdict, so it is a local result rather than an execution problem.",
+                count_label(results.len(), "custom compliance setting", "custom compliance settings")
+            ),
+            "Inspect the cited custom compliance run's discovered values against the policy's JSON rules.",
+            collect_evidence(results.iter().flat_map(|result| result.evidence.iter())),
+            Vec::new(),
+        ),
+    );
+}
+
+/// A custom-compliance script that did not complete.
+///
+/// Deliberately distinct from the rule above: a crashed script produced no
+/// verdict, and reporting it as a noncompliant device would invent one.
+fn push_custom_script_failed(snapshot: &ComplianceSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let results = custom_in(
+        snapshot,
+        &[
+            ComplianceCustomState::ScriptFailed,
+            ComplianceCustomState::OutputInvalid,
+        ],
+    );
+    if results.is_empty() {
+        return;
+    }
+    push(
+        findings,
+        finding(
+            "compliance-custom-script-failed",
+            IntuneFindingSeverity::Error,
+            IntuneFindingConfidence::High,
+            "A custom compliance script failed to produce a usable result",
+            &format!(
+                "{} failed to execute or returned output that could not be interpreted. No compliance verdict was produced, so this is an evaluation failure and not evidence that the device is noncompliant.",
+                count_label(results.len(), "custom compliance run", "custom compliance runs")
+            ),
+            "Inspect the cited run's exit code and output shape against the policy's expected discovery JSON.",
+            collect_evidence(results.iter().flat_map(|result| result.evidence.iter())),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_contradictory_local_evidence(
+    snapshot: &ComplianceSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let contradictory = settings_in(snapshot, ComplianceSettingState::Contradictory);
+    let out_of_order = snapshot
+        .local_evaluation
+        .settings
+        .iter()
+        .filter(|setting| setting.time_contradiction)
+        .collect::<Vec<_>>();
+    let mismatched_ids = snapshot
+        .local_evaluation
+        .settings
+        .iter()
+        .filter(|setting| setting.identity_contradiction)
+        .collect::<Vec<_>>();
+    if contradictory.is_empty() && out_of_order.is_empty() && mismatched_ids.is_empty() {
+        return;
+    }
+
+    let mut evidence = collect_evidence(
+        contradictory
+            .iter()
+            .chain(out_of_order.iter())
+            .chain(mismatched_ids.iter())
+            .flat_map(|setting| setting.evidence.iter()),
+    );
+    normalize_evidence(&mut evidence);
+
+    push(
+        findings,
+        finding(
+            "compliance-contradictory-evidence",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::Medium,
+            "Local compliance sources contradict each other",
+            &format!(
+                "{} setting(s) carry disagreeing verdicts, {} claim an evaluation time after this evidence was collected, and {} were described with conflicting identifiers. Any setting whose sources disagreed was left at its observed state or insufficiently evidenced rather than resolved to a single verdict.",
+                contradictory.len(),
+                out_of_order.len(),
+                mismatched_ids.len()
+            ),
+            "Compare the cited records' identifiers and timestamps; re-collect with a single consistent capture if the sources came from different runs.",
+            evidence,
+            Vec::new(),
+        ),
+    );
+}
+
+// ── Phase 3: reporting ──────────────────────────────────────────────────────
+
+fn push_report_submission_failed(snapshot: &ComplianceSnapshot, findings: &mut Vec<IntuneFinding>) {
+    if snapshot.reporting.state != ComplianceReportState::Failed {
+        return;
+    }
+    let code = snapshot
+        .reporting
+        .error
+        .as_ref()
+        .map(|error| format!(" Reported code: {}.", error.raw))
+        .unwrap_or_default();
+    push(
+        findings,
+        finding(
+            "compliance-report-submission-failed",
+            IntuneFindingSeverity::Error,
+            IntuneFindingConfidence::High,
+            "The device failed to submit its compliance report",
+            &format!(
+                "A compliance report submission failed.{code} The service therefore holds no result from this evaluation, which is a reporting problem and says nothing about whether the local settings pass."
+            ),
+            "Check device connectivity to the Intune service and the cited submission record's error code.",
+            snapshot.reporting.evidence.clone(),
+            Vec::new(),
+        ),
+    );
+}
+
+/// The service holds a state that predates the most recent local evaluation.
+///
+/// The summary states the local aggregate explicitly, so a reader cannot come
+/// away thinking the stale service record is a local failure.
+fn push_service_state_stale(snapshot: &ComplianceSnapshot, findings: &mut Vec<IntuneFinding>) {
+    if snapshot.reporting.service_freshness != ComplianceServiceFreshness::Stale {
+        return;
+    }
+    let stale = snapshot
+        .reporting
+        .service_results
+        .iter()
+        .filter(|result| result.freshness == ComplianceServiceFreshness::Stale)
+        .collect::<Vec<_>>();
+    if stale.is_empty() {
+        return;
+    }
+
+    let disagreement = if snapshot.reporting.service_disagrees_with_local {
+        " The stale service state also disagrees with the local result."
+    } else {
+        ""
+    };
+
+    push(
+        findings,
+        finding(
+            "compliance-service-state-stale",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::High,
+            "The service-held compliance state predates the local evaluation",
+            &format!(
+                "{} service-held record(s) were reported before the most recent local evaluation, so they cannot describe it. The device's own aggregate result is {}.{disagreement} This is a reporting-freshness problem, not a local setting failure.",
+                stale.len(),
+                aggregate_label(snapshot.aggregate.state)
+            ),
+            "Force a compliance check-in, wait for the report to submit, and re-read the service state before drawing conclusions from it.",
+            collect_evidence(stale.iter().flat_map(|result| result.evidence.iter())),
+            Vec::new(),
+        ),
+    );
+}
+
+// ── Phase 4: downstream access ──────────────────────────────────────────────
+
+/// A denial that lines up with a compliance record on identity **and** time.
+///
+/// Confidence is capped at Medium and the wording is coincidence, not cause:
+/// this module does not analyze Conditional Access policy, so it cannot know
+/// that compliance is why the sign-in was blocked.
+fn push_access_denied_correlated(snapshot: &ComplianceSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let denials = snapshot
+        .access_impact
+        .decisions
+        .iter()
+        .filter(|decision| {
+            decision.decision == ComplianceAccessDecision::Denied
+                && decision.linkage == ComplianceAccessLinkage::MatchedComplianceState
+        })
+        .collect::<Vec<_>>();
+    if denials.is_empty() {
+        return;
+    }
+
+    let mut evidence = collect_evidence(denials.iter().flat_map(|decision| {
+        decision
+            .evidence
+            .iter()
+            .chain(decision.matched_evidence.iter())
+    }));
+    normalize_evidence(&mut evidence);
+
+    push(
+        findings,
+        finding(
+            "compliance-access-denied-correlated",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::Medium,
+            "An access denial coincides with a matching compliance record",
+            &format!(
+                "{} access denial(s) match a compliance record on device or user identity and occurred after it was reported. The local aggregate result is {}. This is downstream impact; the Conditional Access policy itself is not analyzed here, so no cause is claimed.",
+                denials.len(),
+                aggregate_label(snapshot.aggregate.state)
+            ),
+            "Confirm in the sign-in log which Conditional Access policy applied, then compare its device-compliance requirement against the cited compliance record.",
+            evidence,
+            Vec::new(),
+        ),
+    );
+}
+
+/// A denial with nothing to match against.
+///
+/// Info + Low, always. This is the rule that would otherwise turn a sign-in
+/// error into a compliance diagnosis.
+fn push_access_denied_uncorrelated(
+    snapshot: &ComplianceSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let denials = snapshot
+        .access_impact
+        .decisions
+        .iter()
+        .filter(|decision| {
+            decision.decision == ComplianceAccessDecision::Denied
+                && decision.linkage != ComplianceAccessLinkage::MatchedComplianceState
+        })
+        .collect::<Vec<_>>();
+    if denials.is_empty() {
+        return;
+    }
+    push(
+        findings,
+        finding(
+            "compliance-access-denied-uncorrelated",
+            IntuneFindingSeverity::Info,
+            IntuneFindingConfidence::Low,
+            "An access denial was observed with no matching compliance evidence",
+            &format!(
+                "{} access denial(s) could not be tied to a compliance record by identity and time. No causal claim is made: this evidence does not show that device compliance was the reason for the denial, and it is not evidence that any local setting failed.",
+                denials.len()
+            ),
+            "Collect the sign-in record's full failure reason and the device compliance state captured at the same time, then re-run the analysis.",
+            collect_evidence(denials.iter().flat_map(|decision| decision.evidence.iter())),
+            Vec::new(),
+        ),
+    );
+}
+
+// ── Coverage ────────────────────────────────────────────────────────────────
+
+fn push_unkeyed_observations(snapshot: &ComplianceSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let unkeyed = &snapshot.local_evaluation.unkeyed_observations;
+    if unkeyed.is_empty() {
+        return;
+    }
+    push(
+        findings,
+        finding(
+            "compliance-unkeyed-observations",
+            IntuneFindingSeverity::Info,
+            IntuneFindingConfidence::Medium,
+            "Compliance records carried no setting identifier",
+            &format!(
+                "{} record(s) referenced compliance evaluation without naming a policy, setting, or CSP URI. They were not merged into any setting result, because an unidentified record cannot be correlated.",
+                unkeyed.len()
+            ),
+            "Re-collect with the source that supplies setting identifiers, or confirm the adapter is projecting them into named data.",
+            unkeyed.clone(),
+            Vec::new(),
+        ),
+    );
+}
+
+/// Expected sources that were missing, capped, denied, skipped, unsupported, or
+/// unreadable.
+///
+/// Split into two findings so a genuinely absent source and a source that was
+/// collected but could not be interpreted are never conflated.
+fn push_source_unusable(snapshot: &ComplianceSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let gaps = |statuses: &[IntuneArtifactStatus]| {
+        let mut ids = snapshot
+            .coverage
+            .iter()
+            .filter(|entry| statuses.contains(&entry.status))
+            .map(|entry| entry.artifact_id.clone())
+            .collect::<Vec<_>>();
+        ids.sort();
+        ids.dedup();
+        ids
+    };
+
+    let uncollected = gaps(&[
+        IntuneArtifactStatus::Missing,
+        IntuneArtifactStatus::PermissionDenied,
+        IntuneArtifactStatus::Skipped,
+        IntuneArtifactStatus::Capped,
+    ]);
+    if !uncollected.is_empty() {
+        push(
+            findings,
+            finding(
+                "compliance-source-missing",
+                IntuneFindingSeverity::Warning,
+                IntuneFindingConfidence::High,
+                "Expected compliance evidence was not collected",
+                &format!(
+                    "{} expected source(s) were absent, inaccessible, skipped, or truncated. Any conclusion drawn from the remaining evidence is incomplete, and the absence of a signal in this bundle proves nothing.",
+                    uncollected.len()
+                ),
+                "Re-collect the cited sources with sufficient privileges and without truncation, then re-run the analysis.",
+                Vec::new(),
+                uncollected,
+            ),
+        );
+    }
+
+    let unusable = gaps(&[
+        IntuneArtifactStatus::ParseFailed,
+        IntuneArtifactStatus::Unsupported,
+    ]);
+    if !unusable.is_empty() {
+        push(
+            findings,
+            finding(
+                "compliance-source-malformed",
+                IntuneFindingSeverity::Warning,
+                IntuneFindingConfidence::High,
+                "Compliance evidence was collected but could not be interpreted",
+                &format!(
+                    "{} source(s) were malformed or declared a schema this build does not support. Their contents contributed nothing to the result and were not guessed at.",
+                    unusable.len()
+                ),
+                "Check the cited sources' format and schema version against the collector that produced them.",
+                Vec::new(),
+                unusable,
+            ),
+        );
+    }
+}
+
+fn push_device_compliant(snapshot: &ComplianceSnapshot, findings: &mut Vec<IntuneFinding>) {
+    if snapshot.aggregate.state != ComplianceAggregateState::Compliant {
+        return;
+    }
+    // A clean result asserted over incomplete evidence is not a clean result,
+    // and an empty coverage list is the least complete evidence there is: an
+    // unqualified `all` over it would vacuously report high confidence.
+    let complete = !snapshot.coverage.is_empty()
+        && snapshot
+            .coverage
+            .iter()
+            .all(|entry| entry.status == IntuneArtifactStatus::Available);
+    let confidence = if complete {
+        IntuneFindingConfidence::High
+    } else {
+        IntuneFindingConfidence::Medium
+    };
+    push(
+        findings,
+        finding(
+            "compliance-device-compliant",
+            IntuneFindingSeverity::Info,
+            confidence,
+            "Every locally evaluated compliance setting passed",
+            &format!(
+                "{} setting(s) evaluated compliant on the device and none evaluated noncompliant or errored.",
+                snapshot.aggregate.compliant_count
+            ),
+            "Compare the cited local results against the service-held state to confirm the two agree.",
+            snapshot.aggregate.evidence.clone(),
+            Vec::new(),
+        ),
+    );
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn settings_in(
+    snapshot: &ComplianceSnapshot,
+    state: ComplianceSettingState,
+) -> Vec<&ComplianceSettingEvaluation> {
+    snapshot
+        .local_evaluation
+        .settings
+        .iter()
+        .filter(|setting| setting.state == state)
+        .collect()
+}
+
+fn custom_in<'a>(
+    snapshot: &'a ComplianceSnapshot,
+    states: &[ComplianceCustomState],
+) -> Vec<&'a ComplianceCustomEvaluation> {
+    snapshot
+        .local_evaluation
+        .custom_compliance
+        .iter()
+        .filter(|custom| states.contains(&custom.state))
+        .collect()
+}
+
+/// A short, de-duplicated label list for the cited settings.
+///
+/// Prefers the display name, falls back to the grouping token, and caps the
+/// list so a summary stays readable when a policy has many settings.
+fn setting_labels(settings: &[&ComplianceSettingEvaluation]) -> String {
+    const MAX_LABELS: usize = 6;
+    let mut labels: Vec<String> = Vec::new();
+    for setting in settings {
+        let label = setting
+            .display_name
+            .clone()
+            .unwrap_or_else(|| setting.grouping_token.clone());
+        if !labels.contains(&label) {
+            labels.push(label);
+        }
+    }
+    let extra = labels.len().saturating_sub(MAX_LABELS);
+    labels.truncate(MAX_LABELS);
+    let mut joined = labels.join(", ");
+    if extra > 0 {
+        joined.push_str(&format!(" (+{extra} more)"));
+    }
+    joined
+}
+
+fn count_label(count: usize, singular: &str, plural: &str) -> String {
+    if count == 1 {
+        format!("One {singular}")
+    } else {
+        format!("{count} {plural}")
+    }
+}
+
+fn aggregate_label(state: ComplianceAggregateState) -> &'static str {
+    match state {
+        ComplianceAggregateState::Compliant => "compliant",
+        ComplianceAggregateState::Noncompliant => "noncompliant",
+        ComplianceAggregateState::EvaluationError => "an evaluation error",
+        ComplianceAggregateState::NotEvaluated => "not evaluated",
+        ComplianceAggregateState::InsufficientEvidence => "insufficient evidence",
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finding(
+    id: &str,
+    severity: IntuneFindingSeverity,
+    confidence: IntuneFindingConfidence,
+    title: &str,
+    summary: &str,
+    check: &str,
+    evidence: Vec<IntuneEvidenceRef>,
+    coverage_gap_ids: Vec<String>,
+) -> Option<IntuneFinding> {
+    // The invariant from `intune::evidence`: a finding backed by neither
+    // evidence nor a coverage gap is an assertion, so it is never emitted.
+    if evidence.is_empty() && coverage_gap_ids.is_empty() {
+        return None;
+    }
+    Some(IntuneFinding {
+        finding_id: id.to_owned(),
+        severity,
+        confidence,
+        title: title.to_owned(),
+        summary: summary.to_owned(),
+        recommended_checks: vec![check.to_owned()],
+        evidence,
+        coverage_gap_ids,
+    })
+}
+
+fn push(findings: &mut Vec<IntuneFinding>, finding: Option<IntuneFinding>) {
+    if let Some(finding) = finding {
+        findings.push(finding);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn evidence_ref(id: &str, artifact: &str) -> IntuneEvidenceRef {
+        IntuneEvidenceRef {
+            evidence_id: id.to_owned(),
+            source_artifact_id: artifact.to_owned(),
+        }
+    }
+
+    fn snapshot_with_denial(linkage: ComplianceAccessLinkage) -> ComplianceSnapshot {
+        ComplianceSnapshot {
+            access_impact: ComplianceAccessPhase {
+                decisions: vec![ComplianceAccessObservation {
+                    decision: ComplianceAccessDecision::Denied,
+                    linkage,
+                    failure_code: None,
+                    occurred_at: None,
+                    device_key: None,
+                    user_key: None,
+                    resource: None,
+                    matched_evidence: Vec::new(),
+                    evidence: vec![evidence_ref("a1", "access")],
+                }],
+                evidence: vec![evidence_ref("a1", "access")],
+            },
+            ..ComplianceSnapshot::default()
+        }
+    }
+
+    #[test]
+    fn an_uncorrelated_denial_is_never_high_confidence() {
+        let snapshot = snapshot_with_denial(ComplianceAccessLinkage::NoMatchingComplianceEvidence);
+        let findings = derive_findings(&snapshot);
+        let denial = findings
+            .iter()
+            .find(|finding| finding.finding_id == "compliance-access-denied-uncorrelated")
+            .expect("uncorrelated denial finding");
+        assert_eq!(denial.confidence, IntuneFindingConfidence::Low);
+        assert_eq!(denial.severity, IntuneFindingSeverity::Info);
+        assert!(denial.summary.contains("No causal claim is made"));
+    }
+
+    #[test]
+    fn an_access_denial_never_produces_a_local_failure_finding() {
+        let snapshot = snapshot_with_denial(ComplianceAccessLinkage::NoMatchingComplianceEvidence);
+        let findings = derive_findings(&snapshot);
+        assert!(
+            !findings
+                .iter()
+                .any(|finding| finding.finding_id == "compliance-local-setting-noncompliant"),
+            "a sign-in denial must not create a local-noncompliance finding"
+        );
+    }
+
+    #[test]
+    fn every_derived_finding_is_evidence_backed() {
+        let snapshot = snapshot_with_denial(ComplianceAccessLinkage::IdentityMismatch);
+        for finding in derive_findings(&snapshot) {
+            assert!(
+                finding.is_evidence_backed(),
+                "{} cites neither evidence nor a coverage gap",
+                finding.finding_id
+            );
+        }
+    }
+
+    #[test]
+    fn an_empty_snapshot_produces_no_findings() {
+        assert!(derive_findings(&ComplianceSnapshot::default()).is_empty());
+    }
+}

--- a/crates/cmtraceopen-parser/src/intune/device/windows/compliance/sources.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/compliance/sources.rs
@@ -1,0 +1,898 @@
+//! Source classification for compliance evidence.
+//!
+//! Two jobs, both pure:
+//!
+//! 1. decode a supplied evidence bundle into a [`ComplianceInput`], turning any
+//!    decode problem into explicit coverage rather than a silent empty result;
+//! 2. classify one normalized Windows event or setting-report row into a typed
+//!    compliance signal, or decline to classify it.
+//!
+//! Declining matters as much as classifying. A record that names a setting but
+//! states no result yields [`ComplianceSettingState::InsufficientEvidence`], and
+//! a record that names no setting at all yields nothing — epic #356 forbids
+//! creating a correlation from an unknown identifier.
+//!
+//! # Named-data vocabulary
+//!
+//! The native adapter projects platform records into
+//! [`NormalizedWindowsEvent`], carrying the payload in `named_data`. This module
+//! reads the following names, case-insensitively, with the listed aliases:
+//!
+//! | Meaning | Names |
+//! |---|---|
+//! | setting URI | `SettingUri`, `NodeUri`, `Uri` |
+//! | setting id | `SettingId` |
+//! | policy id | `PolicyId`, `CompliancePolicyId` |
+//! | scope | `Scope`, `TargetScope` |
+//! | evaluation result | `EvaluationResult`, `ComplianceResult`, `Result` |
+//! | error code | `ErrorCode`, `ResultCode`, `Hresult` |
+//! | prerequisite | `Prerequisite` (+ `PrerequisiteName`, `PrerequisiteDetail`) |
+//! | report status | `ReportStatus`, `ComplianceReportStatus` |
+//! | report id | `ReportId` |
+//! | policy state | `PolicyState` |
+//! | evaluation time | `EvaluatedAt`, `EvaluationTime` |
+//! | display name | `DisplayName`, `SettingDisplayName` |
+//!
+//! Anything else is carried through untouched.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::models::*;
+use crate::intune::evidence::{
+    IntuneAccessState, IntuneArtifactCoverage, IntuneArtifactStatus, IntuneErrorCode,
+    IntuneNamedValue, IntuneObservationContext, IntuneParseState, IntuneTimestamp,
+};
+use crate::intune::normalized::{
+    NormalizedEventLevel, NormalizedSettingOutcome, NormalizedSettingReport, NormalizedWindowsEvent,
+};
+
+/// Envelope version this build understands.
+pub const COMPLIANCE_INPUT_ENVELOPE_VERSION: u32 = 1;
+
+/// One artifact handed to the analyzer, with what the collector managed to do.
+///
+/// `content` is `None` whenever the artifact was not read. The analyzer never
+/// opens a file: `crate::intune` is wasm32-clean and does no I/O.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComplianceSourceInput {
+    pub artifact_id: String,
+    /// Grouping label reported in coverage, e.g. `mdmEvents`, `mdmReport`.
+    pub family: String,
+    /// What the collector reported. A decode failure can only downgrade this.
+    pub status: IntuneArtifactStatus,
+    pub captured_at_utc: String,
+    pub content: Option<String>,
+}
+
+/// The record kinds a bundle artifact may carry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnvelopeKind {
+    WindowsEvents,
+    SettingReports,
+    CustomCompliance,
+    ServiceResults,
+    AccessDecisions,
+    DeviceContext,
+}
+
+impl EnvelopeKind {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "windowsEvents" => Some(Self::WindowsEvents),
+            "settingReports" => Some(Self::SettingReports),
+            "customCompliance" => Some(Self::CustomCompliance),
+            "serviceResults" => Some(Self::ServiceResults),
+            "accessDecisions" => Some(Self::AccessDecisions),
+            "deviceContext" => Some(Self::DeviceContext),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ComplianceEnvelope {
+    #[serde(default)]
+    compliance_input_version: u32,
+    #[serde(default)]
+    kind: String,
+    #[serde(default)]
+    records: Vec<Value>,
+}
+
+/// Why an artifact could not contribute records.
+struct DecodeProblem {
+    status: IntuneArtifactStatus,
+    detail: String,
+}
+
+/// Decode a supplied bundle into the reducer's input, with coverage for every
+/// artifact including the ones that produced nothing.
+pub fn decode_bundle(sources: &[ComplianceSourceInput], generated_at_utc: &str) -> ComplianceInput {
+    let mut input = ComplianceInput {
+        generated_at_utc: generated_at_utc.to_owned(),
+        ..ComplianceInput::default()
+    };
+
+    for source in sources {
+        let problem = match source.content.as_deref() {
+            Some(text) => absorb_envelope(text, &mut input),
+            None => None,
+        };
+
+        let (status, detail) = match problem {
+            // A decode failure overrides whatever the collector claimed: bytes
+            // that cannot be interpreted are not available evidence.
+            Some(problem) => (problem.status, Some(problem.detail)),
+            None => (source.status.clone(), None),
+        };
+
+        input.coverage.push(IntuneArtifactCoverage {
+            artifact_id: source.artifact_id.clone(),
+            family: source.family.clone(),
+            status,
+            detail,
+            observed_at_utc: source.captured_at_utc.clone(),
+            evidence: Vec::new(),
+        });
+    }
+
+    input.coverage.sort_by(|left, right| {
+        left.artifact_id
+            .cmp(&right.artifact_id)
+            .then_with(|| left.family.cmp(&right.family))
+    });
+    input
+}
+
+/// Parse one artifact's text and append its records, returning a problem when
+/// the text cannot be used.
+fn absorb_envelope(text: &str, input: &mut ComplianceInput) -> Option<DecodeProblem> {
+    let envelope: ComplianceEnvelope = match serde_json::from_str(text) {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            return Some(DecodeProblem {
+                status: IntuneArtifactStatus::ParseFailed,
+                detail: format!("evidence is not a compliance input envelope: {error}"),
+            })
+        }
+    };
+
+    if envelope.compliance_input_version != COMPLIANCE_INPUT_ENVELOPE_VERSION {
+        return Some(DecodeProblem {
+            status: IntuneArtifactStatus::Unsupported,
+            detail: format!(
+                "complianceInputVersion {} is not supported by this build (expected {COMPLIANCE_INPUT_ENVELOPE_VERSION})",
+                envelope.compliance_input_version
+            ),
+        });
+    }
+
+    let Some(kind) = EnvelopeKind::parse(&envelope.kind) else {
+        return Some(DecodeProblem {
+            status: IntuneArtifactStatus::Unsupported,
+            detail: format!("record kind {:?} is not recognized", envelope.kind),
+        });
+    };
+
+    // Decode every record before touching `input`: an envelope contributes all
+    // of its records or none of them, so a failure halfway through cannot leave
+    // a partially absorbed artifact behind while its coverage says `ParseFailed`.
+    let mut staged = StagedRecords::default();
+    for record in envelope.records {
+        if let Err(error) = stage_record(kind, record, &mut staged) {
+            return Some(DecodeProblem {
+                status: IntuneArtifactStatus::ParseFailed,
+                detail: format!("a {} record failed to decode: {error}", envelope.kind),
+            });
+        }
+    }
+    staged.apply(input);
+
+    None
+}
+
+/// Records decoded from one envelope, held until the whole envelope succeeds.
+#[derive(Default)]
+struct StagedRecords {
+    events: Vec<NormalizedWindowsEvent>,
+    setting_reports: Vec<NormalizedSettingReport>,
+    custom_compliance: Vec<ComplianceCustomFact>,
+    service_results: Vec<ComplianceServiceFact>,
+    access_decisions: Vec<ComplianceAccessFact>,
+    device_context: Option<ComplianceDeviceContextFact>,
+}
+
+impl StagedRecords {
+    fn apply(self, input: &mut ComplianceInput) {
+        input.events.extend(self.events);
+        input.setting_reports.extend(self.setting_reports);
+        input.custom_compliance.extend(self.custom_compliance);
+        input.service_results.extend(self.service_results);
+        input.access_decisions.extend(self.access_decisions);
+        // Last one wins; a bundle is expected to declare device context once.
+        if let Some(context) = self.device_context {
+            input.device_context = Some(context);
+        }
+    }
+}
+
+fn stage_record(
+    kind: EnvelopeKind,
+    record: Value,
+    staged: &mut StagedRecords,
+) -> Result<(), serde_json::Error> {
+    match kind {
+        EnvelopeKind::WindowsEvents => staged.events.push(serde_json::from_value(record)?),
+        EnvelopeKind::SettingReports => {
+            staged.setting_reports.push(serde_json::from_value(record)?)
+        }
+        EnvelopeKind::CustomCompliance => staged
+            .custom_compliance
+            .push(serde_json::from_value(record)?),
+        EnvelopeKind::ServiceResults => {
+            staged.service_results.push(serde_json::from_value(record)?)
+        }
+        EnvelopeKind::AccessDecisions => staged
+            .access_decisions
+            .push(serde_json::from_value(record)?),
+        EnvelopeKind::DeviceContext => {
+            staged.device_context = Some(serde_json::from_value(record)?)
+        }
+    }
+    Ok(())
+}
+
+// ── Named-data access ───────────────────────────────────────────────────────
+
+/// First value whose name matches any of `names`, case-insensitively.
+pub(super) fn named_any<'a>(values: &'a [IntuneNamedValue], names: &[&str]) -> Option<&'a str> {
+    values
+        .iter()
+        .find(|value| {
+            names
+                .iter()
+                .any(|name| value.name.eq_ignore_ascii_case(name))
+        })
+        .map(|value| value.value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+/// Lowercase a token and drop everything that is not alphanumeric, so
+/// `Not Compliant`, `not_compliant`, and `NotCompliant` compare equal.
+fn canonical(value: &str) -> String {
+    value
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+const SETTING_URI_NAMES: [&str; 3] = ["SettingUri", "NodeUri", "Uri"];
+const SETTING_ID_NAMES: [&str; 1] = ["SettingId"];
+const POLICY_ID_NAMES: [&str; 2] = ["PolicyId", "CompliancePolicyId"];
+const SCOPE_NAMES: [&str; 2] = ["Scope", "TargetScope"];
+const RESULT_NAMES: [&str; 3] = ["EvaluationResult", "ComplianceResult", "Result"];
+const ERROR_NAMES: [&str; 3] = ["ErrorCode", "ResultCode", "Hresult"];
+const REPORT_STATUS_NAMES: [&str; 2] = ["ReportStatus", "ComplianceReportStatus"];
+const REPORT_ID_NAMES: [&str; 1] = ["ReportId"];
+const POLICY_STATE_NAMES: [&str; 1] = ["PolicyState"];
+const EVALUATED_AT_NAMES: [&str; 2] = ["EvaluatedAt", "EvaluationTime"];
+const DISPLAY_NAME_NAMES: [&str; 2] = ["DisplayName", "SettingDisplayName"];
+const PREREQUISITE_NAMES: [&str; 1] = ["Prerequisite"];
+
+/// Parse a compliance verdict token into a local setting state.
+pub(super) fn parse_setting_result(raw: &str) -> Option<ComplianceSettingState> {
+    match canonical(raw).as_str() {
+        "compliant" | "pass" | "passed" | "true" | "0" => Some(ComplianceSettingState::Compliant),
+        "noncompliant" | "notcompliant" | "fail" | "failed" | "false" => {
+            Some(ComplianceSettingState::Noncompliant)
+        }
+        "error" | "evaluationerror" => Some(ComplianceSettingState::EvaluationError),
+        "notapplicable" | "na" | "unsupported" => Some(ComplianceSettingState::NotApplicable),
+        "notevaluated" | "skipped" | "pending" => Some(ComplianceSettingState::NotEvaluated),
+        "prerequisiteunmet" => Some(ComplianceSettingState::PrerequisiteUnmet),
+        _ => None,
+    }
+}
+
+fn parse_scope(raw: Option<&str>) -> ComplianceScope {
+    match raw.map(canonical).as_deref() {
+        Some("device") | Some("machine") | Some("system") => ComplianceScope::Device,
+        Some("user") => ComplianceScope::User,
+        _ => ComplianceScope::Unknown,
+    }
+}
+
+fn parse_report_status(raw: &str) -> Option<ComplianceReportState> {
+    match canonical(raw).as_str() {
+        "queued" | "pending" => Some(ComplianceReportState::Queued),
+        "submitted" | "sent" | "success" | "succeeded" => Some(ComplianceReportState::Submitted),
+        "failed" | "failure" | "error" => Some(ComplianceReportState::Failed),
+        "stale" => Some(ComplianceReportState::Stale),
+        _ => None,
+    }
+}
+
+fn parse_policy_state(raw: &str) -> Option<CompliancePolicyState> {
+    match canonical(raw).as_str() {
+        "received" | "known" | "present" | "applied" => Some(CompliancePolicyState::Received),
+        "notreceived" | "missing" | "absent" => Some(CompliancePolicyState::NotReceived),
+        _ => None,
+    }
+}
+
+fn parse_prerequisite_state(raw: &str) -> CompliancePrerequisiteState {
+    match canonical(raw).as_str() {
+        "met" | "satisfied" | "true" => CompliancePrerequisiteState::Met,
+        "unmet" | "notmet" | "unsatisfied" | "false" => CompliancePrerequisiteState::Unmet,
+        _ => CompliancePrerequisiteState::Unknown,
+    }
+}
+
+// ── Error codes ─────────────────────────────────────────────────────────────
+
+/// A hexadecimal HRESULT/Win32 token.
+fn hex_code_re() -> &'static Regex {
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    CELL.get_or_init(|| {
+        Regex::new(r"(?i)\b0x[0-9a-f]{1,16}\b").expect("hex error-code regex must compile")
+    })
+}
+
+/// A signed decimal token that is the whole value, not part of an identifier.
+fn decimal_code_re() -> &'static Regex {
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    CELL.get_or_init(|| Regex::new(r"^-?\d{1,19}$").expect("decimal error-code regex must compile"))
+}
+
+/// Build an [`IntuneErrorCode`] from a raw token, keeping the token verbatim.
+///
+/// Both derived forms are best-effort. Intune writes the same failure as a
+/// signed decimal, an unsigned decimal, and a hex HRESULT depending on the
+/// artifact, so neither form is authoritative and the raw token is always kept.
+pub(super) fn parse_error_code(raw: &str) -> Option<IntuneErrorCode> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    if let Some(hex_match) = hex_code_re().find(raw) {
+        let hex = hex_match.as_str();
+        let digits = &hex[2..];
+        let decimal = u64::from_str_radix(digits, 16)
+            .ok()
+            .map(|value| value as i64);
+        // Render the digits that were actually written rather than a 32-bit
+        // truncation of the derived decimal: a 64-bit token such as
+        // `0xFFFFFFFF80070002` must not silently become `0x80070002`.
+        let upper = digits.to_ascii_uppercase();
+        let normalized_hex = if upper.len() <= 8 {
+            format!("0x{upper:0>8}")
+        } else {
+            format!("0x{upper}")
+        };
+        return Some(IntuneErrorCode {
+            raw: raw.to_owned(),
+            decimal,
+            hex: Some(normalized_hex),
+        });
+    }
+
+    if decimal_code_re().is_match(raw) {
+        let decimal = raw.parse::<i64>().ok();
+        return Some(IntuneErrorCode {
+            raw: raw.to_owned(),
+            decimal,
+            hex: decimal.map(|value| format!("0x{:08X}", value as u32)),
+        });
+    }
+
+    // Unrecognized shape: keep it rather than discard it. A token we cannot
+    // interpret is still the only thing a human has to search for.
+    Some(IntuneErrorCode {
+        raw: raw.to_owned(),
+        decimal: None,
+        hex: None,
+    })
+}
+
+// ── Classification ──────────────────────────────────────────────────────────
+
+/// A typed signal extracted from one local observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ComplianceSignal {
+    SettingEvaluation(Box<SettingObservation>),
+    Prerequisite {
+        name: String,
+        state: CompliancePrerequisiteState,
+        detail: Option<String>,
+    },
+    PolicyState {
+        policy_id: String,
+        state: CompliancePolicyState,
+        scope: ComplianceScope,
+    },
+    ReportSubmission {
+        state: ComplianceReportState,
+        report_id: Option<String>,
+        error: Option<IntuneErrorCode>,
+        submitted_at: Option<IntuneTimestamp>,
+    },
+}
+
+/// One local claim about one setting, before merging.
+///
+/// `grouping_token` is non-optional by construction: an observation is only
+/// built once its key yields a token, so the reducer has no unidentified case to
+/// handle and cannot merge on an unknown identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SettingObservation {
+    pub key: ComplianceSettingKey,
+    pub grouping_token: String,
+    pub scope: ComplianceScope,
+    pub state: ComplianceSettingState,
+    pub display_name: Option<String>,
+    pub error: Option<IntuneErrorCode>,
+    pub evaluated_at: Option<IntuneTimestamp>,
+    pub named_data: Vec<IntuneNamedValue>,
+    pub context: IntuneObservationContext,
+}
+
+/// Whether an observation is eligible to produce a compliance signal.
+///
+/// A record that failed to parse, or that the collector could not read, states
+/// nothing about the device. Reading its fields would turn a collection gap into
+/// a fabricated verdict, so such records are declined and left to coverage.
+fn is_usable(context: &IntuneObservationContext) -> bool {
+    context.parse_state == IntuneParseState::Parsed
+        && context.access_state == IntuneAccessState::Available
+}
+
+/// Classify one normalized Windows event.
+///
+/// Returns `None` when the event carries no compliance signal this module can
+/// use. A caller that needs to know an event was seen and not understood should
+/// consult the unkeyed-observation count on the reduced phase instead.
+pub(super) fn classify_event(event: &NormalizedWindowsEvent) -> Option<ComplianceSignal> {
+    if !is_usable(&event.context) {
+        return None;
+    }
+
+    let data = &event.named_data;
+
+    if let Some(raw) = named_any(data, &REPORT_STATUS_NAMES) {
+        let state = parse_report_status(raw).unwrap_or(ComplianceReportState::Unknown);
+        return Some(ComplianceSignal::ReportSubmission {
+            state,
+            report_id: named_any(data, &REPORT_ID_NAMES).map(str::to_owned),
+            error: named_any(data, &ERROR_NAMES).and_then(parse_error_code),
+            submitted_at: event.context.source_timestamp.clone(),
+        });
+    }
+
+    if let Some(raw) = named_any(data, &PREREQUISITE_NAMES) {
+        return Some(ComplianceSignal::Prerequisite {
+            name: named_any(data, &["PrerequisiteName"])
+                .unwrap_or("prerequisite")
+                .to_owned(),
+            state: parse_prerequisite_state(raw),
+            detail: named_any(data, &["PrerequisiteDetail"]).map(str::to_owned),
+        });
+    }
+
+    let key = event_setting_key(event);
+
+    // A policy-level statement is only meaningful with a policy id, and only
+    // when the event is not already describing a specific setting.
+    if let (Some(raw), Some(policy_id)) = (
+        named_any(data, &POLICY_STATE_NAMES),
+        key.policy_id.as_deref(),
+    ) {
+        if key.setting_id.is_none() && key.setting_uri.is_none() {
+            return Some(ComplianceSignal::PolicyState {
+                policy_id: policy_id.to_owned(),
+                state: parse_policy_state(raw).unwrap_or(CompliancePolicyState::Unknown),
+                scope: parse_scope(named_any(data, &SCOPE_NAMES)),
+            });
+        }
+    }
+
+    let grouping_token = key.grouping_token()?;
+
+    let state = match named_any(data, &RESULT_NAMES).and_then(parse_setting_result) {
+        Some(state) => state,
+        // No stated verdict. An error-level event about an identified setting is
+        // an evaluation error; anything else is a mention, not a result.
+        None if event.level == NormalizedEventLevel::Error
+            || event.level == NormalizedEventLevel::Critical =>
+        {
+            ComplianceSettingState::EvaluationError
+        }
+        None => ComplianceSettingState::InsufficientEvidence,
+    };
+
+    Some(ComplianceSignal::SettingEvaluation(Box::new(
+        SettingObservation {
+            key,
+            grouping_token,
+            scope: parse_scope(named_any(data, &SCOPE_NAMES)),
+            state,
+            display_name: named_any(data, &DISPLAY_NAME_NAMES).map(str::to_owned),
+            error: named_any(data, &ERROR_NAMES).and_then(parse_error_code),
+            evaluated_at: named_any(data, &EVALUATED_AT_NAMES)
+                .map(synthetic_timestamp)
+                .or_else(|| event.context.source_timestamp.clone()),
+            named_data: data.clone(),
+            context: event.context.clone(),
+        },
+    )))
+}
+
+fn event_setting_key(event: &NormalizedWindowsEvent) -> ComplianceSettingKey {
+    let data = &event.named_data;
+    ComplianceSettingKey {
+        policy_id: named_any(data, &POLICY_ID_NAMES).map(str::to_owned),
+        setting_id: named_any(data, &SETTING_ID_NAMES).map(str::to_owned),
+        setting_uri: named_any(data, &SETTING_URI_NAMES).map(str::to_owned),
+    }
+}
+
+/// Classify one exported report row.
+///
+/// The outcome mapping is deliberately conservative:
+/// [`NormalizedSettingOutcome::Failed`] becomes
+/// [`ComplianceSettingState::EvaluationError`], **not** `Noncompliant`. A report
+/// row that says the setting failed says the device could not complete it; that
+/// is not the same claim as "the device does not meet the requirement", and
+/// merging the two is exactly the conflation this module refuses to make. An
+/// explicit `EvaluationResult` named value overrides the mapping.
+pub(super) fn classify_setting_report(
+    report: &NormalizedSettingReport,
+) -> Option<SettingObservation> {
+    if !is_usable(&report.context) {
+        return None;
+    }
+
+    let key = ComplianceSettingKey {
+        policy_id: report.policy_id.clone(),
+        setting_id: report.setting_id.clone(),
+        setting_uri: report.setting_uri.clone(),
+    };
+    let grouping_token = key.grouping_token()?;
+
+    let state = named_any(&report.named_data, &RESULT_NAMES)
+        .and_then(parse_setting_result)
+        .unwrap_or(match report.outcome {
+            NormalizedSettingOutcome::Applied => ComplianceSettingState::Compliant,
+            NormalizedSettingOutcome::Failed => ComplianceSettingState::EvaluationError,
+            NormalizedSettingOutcome::Pending => ComplianceSettingState::NotEvaluated,
+            NormalizedSettingOutcome::Conflict => ComplianceSettingState::Contradictory,
+            NormalizedSettingOutcome::Superseded => ComplianceSettingState::NotEvaluated,
+            NormalizedSettingOutcome::NotApplicable => ComplianceSettingState::NotApplicable,
+            NormalizedSettingOutcome::Unknown => ComplianceSettingState::InsufficientEvidence,
+        });
+
+    Some(SettingObservation {
+        key,
+        grouping_token,
+        scope: parse_scope(named_any(&report.named_data, &SCOPE_NAMES)),
+        state,
+        display_name: report.display_name.clone(),
+        error: report.error.clone(),
+        evaluated_at: named_any(&report.named_data, &EVALUATED_AT_NAMES)
+            .map(synthetic_timestamp)
+            .or_else(|| report.context.source_timestamp.clone()),
+        named_data: report.named_data.clone(),
+        context: report.context.clone(),
+    })
+}
+
+/// Wrap a timestamp string carried in named data, keeping the raw text.
+///
+/// The kind reflects what the text actually stated: a trailing `Z` is UTC, any
+/// other RFC 3339 offset is [`IntuneTimestampKind::Offset`]. Labelling an
+/// offset-bearing string as UTC would claim a precision the source never gave.
+fn synthetic_timestamp(raw: &str) -> IntuneTimestamp {
+    use crate::intune::evidence::IntuneTimestampKind;
+
+    let trimmed = raw.trim();
+    let (kind, normalized) = match chrono::DateTime::parse_from_rfc3339(trimmed) {
+        Ok(value) => {
+            let kind = if trimmed.ends_with('Z') || trimmed.ends_with('z') {
+                IntuneTimestampKind::Utc
+            } else {
+                IntuneTimestampKind::Offset
+            };
+            (
+                kind,
+                Some(
+                    value
+                        .with_timezone(&chrono::Utc)
+                        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                ),
+            )
+        }
+        Err(_) => (IntuneTimestampKind::Invalid, None),
+    };
+
+    IntuneTimestamp {
+        raw_text: raw.to_owned(),
+        original_offset: None,
+        kind,
+        normalized_utc: normalized,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intune::evidence::{
+        IntuneAccessState, IntuneEvidenceRef, IntuneParseState, IntuneProvenance,
+        IntuneSensitivity, IntuneSourceKind,
+    };
+
+    fn context(evidence_id: &str) -> IntuneObservationContext {
+        IntuneObservationContext {
+            evidence_ref: IntuneEvidenceRef {
+                evidence_id: evidence_id.to_owned(),
+                source_artifact_id: "artifact".to_owned(),
+            },
+            provenance: IntuneProvenance {
+                source_kind: IntuneSourceKind::EventLog,
+                source_artifact_id: "artifact".to_owned(),
+                file_path: None,
+                line_number: None,
+                record_number: None,
+                registry: None,
+                event: None,
+            },
+            source_timestamp: None,
+            observed_at_utc: "2026-07-31T00:00:00Z".to_owned(),
+            sensitivity: IntuneSensitivity::Public,
+            parse_state: IntuneParseState::Parsed,
+            access_state: IntuneAccessState::Available,
+        }
+    }
+
+    fn event(level: NormalizedEventLevel, data: &[(&str, &str)]) -> NormalizedWindowsEvent {
+        NormalizedWindowsEvent {
+            context: context("e1"),
+            channel: "channel".to_owned(),
+            provider: "provider".to_owned(),
+            event_id: 1,
+            level,
+            task: None,
+            keywords: None,
+            record_id: None,
+            activity_id: None,
+            named_data: data
+                .iter()
+                .map(|(name, value)| IntuneNamedValue {
+                    name: (*name).to_owned(),
+                    value: (*value).to_owned(),
+                })
+                .collect(),
+            message: None,
+        }
+    }
+
+    #[test]
+    fn an_event_with_no_setting_identity_is_not_classified() {
+        assert_eq!(
+            classify_event(&event(
+                NormalizedEventLevel::Error,
+                &[("EvaluationResult", "noncompliant")]
+            )),
+            None,
+            "a verdict with no setting identity must not become a setting evaluation"
+        );
+    }
+
+    #[test]
+    fn an_identified_error_event_without_a_verdict_is_an_evaluation_error() {
+        let signal = classify_event(&event(
+            NormalizedEventLevel::Error,
+            &[("SettingUri", "./Device/X")],
+        ))
+        .expect("classified");
+        match signal {
+            ComplianceSignal::SettingEvaluation(observation) => {
+                assert_eq!(observation.state, ComplianceSettingState::EvaluationError);
+            }
+            other => panic!("unexpected signal {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_identified_informational_event_without_a_verdict_is_insufficient() {
+        let signal = classify_event(&event(
+            NormalizedEventLevel::Information,
+            &[("SettingUri", "./Device/X")],
+        ))
+        .expect("classified");
+        match signal {
+            ComplianceSignal::SettingEvaluation(observation) => {
+                assert_eq!(
+                    observation.state,
+                    ComplianceSettingState::InsufficientEvidence
+                );
+            }
+            other => panic!("unexpected signal {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_failed_report_row_is_an_evaluation_error_not_a_noncompliance() {
+        let report = NormalizedSettingReport {
+            context: context("r1"),
+            setting_uri: Some("./Device/X".to_owned()),
+            setting_id: None,
+            policy_id: None,
+            display_name: None,
+            outcome: NormalizedSettingOutcome::Failed,
+            value: None,
+            error: None,
+            named_data: Vec::new(),
+        };
+        let observation = classify_setting_report(&report).expect("classified");
+        assert_eq!(observation.state, ComplianceSettingState::EvaluationError);
+    }
+
+    #[test]
+    fn result_tokens_are_matched_case_and_punctuation_insensitively() {
+        for raw in ["Not Compliant", "not_compliant", "NONCOMPLIANT"] {
+            assert_eq!(
+                parse_setting_result(raw),
+                Some(ComplianceSettingState::Noncompliant),
+                "{raw} must parse as noncompliant"
+            );
+        }
+    }
+
+    #[test]
+    fn a_hex_error_token_keeps_its_raw_form() {
+        let code = parse_error_code("0x87D1FDE8").expect("parsed");
+        assert_eq!(code.raw, "0x87D1FDE8");
+        assert_eq!(code.hex.as_deref(), Some("0x87D1FDE8"));
+    }
+
+    #[test]
+    fn a_sixty_four_bit_hex_token_is_not_truncated_to_thirty_two_bits() {
+        let code = parse_error_code("0xFFFFFFFF80070002").expect("parsed");
+        assert_eq!(code.hex.as_deref(), Some("0xFFFFFFFF80070002"));
+    }
+
+    #[test]
+    fn an_offset_bearing_evaluation_time_is_not_labelled_utc() {
+        let signal = classify_event(&event(
+            NormalizedEventLevel::Information,
+            &[
+                ("SettingUri", "./Device/X"),
+                ("EvaluationResult", "compliant"),
+                ("EvaluatedAt", "2026-07-31T12:00:00+05:00"),
+            ],
+        ))
+        .expect("classified");
+        match signal {
+            ComplianceSignal::SettingEvaluation(observation) => {
+                let stamp = observation.evaluated_at.expect("evaluated at");
+                assert_eq!(
+                    stamp.kind,
+                    crate::intune::evidence::IntuneTimestampKind::Offset
+                );
+                assert_eq!(
+                    stamp.normalized_utc.as_deref(),
+                    Some("2026-07-31T07:00:00Z")
+                );
+            }
+            other => panic!("unexpected signal {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unparsed_record_states_nothing_about_a_setting() {
+        let mut unusable = event(
+            NormalizedEventLevel::Information,
+            &[
+                ("SettingUri", "./Device/X"),
+                ("EvaluationResult", "noncompliant"),
+            ],
+        );
+        unusable.context.parse_state = IntuneParseState::Malformed;
+        assert_eq!(classify_event(&unusable), None);
+
+        let mut unreadable = event(
+            NormalizedEventLevel::Information,
+            &[
+                ("SettingUri", "./Device/X"),
+                ("EvaluationResult", "noncompliant"),
+            ],
+        );
+        unreadable.context.access_state = IntuneAccessState::PermissionDenied;
+        assert_eq!(classify_event(&unreadable), None);
+    }
+
+    #[test]
+    fn a_record_that_fails_halfway_absorbs_nothing() {
+        let text = format!(
+            r#"{{"complianceInputVersion":{COMPLIANCE_INPUT_ENVELOPE_VERSION},"kind":"windowsEvents","records":[{{"channel":"c"}},7]}}"#
+        );
+        let input = decode_bundle(
+            &[ComplianceSourceInput {
+                artifact_id: "a".to_owned(),
+                family: "mdmEvents".to_owned(),
+                status: IntuneArtifactStatus::Available,
+                captured_at_utc: "2026-07-31T00:00:00Z".to_owned(),
+                content: Some(text),
+            }],
+            "2026-07-31T00:00:00Z",
+        );
+        assert_eq!(input.coverage[0].status, IntuneArtifactStatus::ParseFailed);
+        assert!(
+            input.events.is_empty(),
+            "an envelope that failed to decode must contribute no records"
+        );
+    }
+
+    #[test]
+    fn an_unrecognized_error_token_is_preserved_rather_than_dropped() {
+        let code = parse_error_code("E_SOMETHING").expect("parsed");
+        assert_eq!(code.raw, "E_SOMETHING");
+        assert_eq!(code.decimal, None);
+    }
+
+    #[test]
+    fn malformed_evidence_becomes_parse_failed_coverage() {
+        let input = decode_bundle(
+            &[ComplianceSourceInput {
+                artifact_id: "a".to_owned(),
+                family: "mdmEvents".to_owned(),
+                status: IntuneArtifactStatus::Available,
+                captured_at_utc: "2026-07-31T00:00:00Z".to_owned(),
+                content: Some("{not json".to_owned()),
+            }],
+            "2026-07-31T00:00:00Z",
+        );
+        assert_eq!(input.coverage[0].status, IntuneArtifactStatus::ParseFailed);
+        assert!(input.events.is_empty());
+    }
+
+    #[test]
+    fn an_unknown_envelope_version_becomes_unsupported_coverage() {
+        let input = decode_bundle(
+            &[ComplianceSourceInput {
+                artifact_id: "a".to_owned(),
+                family: "mdmEvents".to_owned(),
+                status: IntuneArtifactStatus::Available,
+                captured_at_utc: "2026-07-31T00:00:00Z".to_owned(),
+                content: Some(r#"{"complianceInputVersion":99,"kind":"windowsEvents"}"#.to_owned()),
+            }],
+            "2026-07-31T00:00:00Z",
+        );
+        assert_eq!(input.coverage[0].status, IntuneArtifactStatus::Unsupported);
+    }
+
+    #[test]
+    fn an_uncollected_artifact_keeps_the_collector_reported_status() {
+        let input = decode_bundle(
+            &[ComplianceSourceInput {
+                artifact_id: "a".to_owned(),
+                family: "mdmReport".to_owned(),
+                status: IntuneArtifactStatus::PermissionDenied,
+                captured_at_utc: "2026-07-31T00:00:00Z".to_owned(),
+                content: None,
+            }],
+            "2026-07-31T00:00:00Z",
+        );
+        assert_eq!(
+            input.coverage[0].status,
+            IntuneArtifactStatus::PermissionDenied
+        );
+    }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/evidence/access-facts/current/access-facts.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/evidence/access-facts/current/access-facts.json
@@ -1,0 +1,49 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "accessDecisions",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "acc-1",
+          "sourceArtifactId": "access-facts"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "access-facts",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T11:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T11:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "restricted",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "decision": "denied",
+      "failureCode": {
+        "raw": "53003",
+        "decimal": 53003,
+        "hex": "0x0000CF0B"
+      },
+      "occurredAt": {
+        "rawText": "2026-07-31T11:00:00Z",
+        "originalOffset": null,
+        "normalizedUtc": "2026-07-31T11:00:00Z",
+        "kind": "utc"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "userKey": "synthetic-user-0001",
+      "resource": "synthetic-resource-0001",
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/evidence/mdm-events/current/mdm-events.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/evidence/mdm-events/current/mdm-events.json
@@ -1,0 +1,60 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "windowsEvents",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-1",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 814,
+      "level": "warning",
+      "task": null,
+      "keywords": null,
+      "recordId": 1,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/FirewallStatus"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "EvaluationResult",
+          "value": "noncompliant"
+        },
+        {
+          "name": "DisplayName",
+          "value": "Firewall status"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/evidence/service-facts/current/service-facts.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/evidence/service-facts/current/service-facts.json
@@ -1,0 +1,45 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "serviceResults",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "svc-1",
+          "sourceArtifactId": "service-facts"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "service-facts",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": null,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:30:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:30:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "policyId": null,
+      "settingId": null,
+      "state": "noncompliant",
+      "reportedAt": {
+        "rawText": "2026-07-31T10:30:00Z",
+        "originalOffset": null,
+        "normalizedUtc": "2026-07-31T10:30:00Z",
+        "kind": "utc"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "userKey": "synthetic-user-0001",
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/expected.json
@@ -1,0 +1,77 @@
+{
+  "scenario": "access-denied-with-matching-state",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "noncompliant",
+    "rationale": "localSettingNoncompliant"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "fresh",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/firewallstatus",
+      "scope": "device",
+      "state": "noncompliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "evt-1"
+      ]
+    }
+  ],
+  "access": [
+    {
+      "decision": "denied",
+      "linkage": "matchedComplianceState",
+      "matchedEvidence": [
+        "svc-1"
+      ]
+    }
+  ],
+  "findings": [
+    {
+      "findingId": "compliance-local-setting-noncompliant",
+      "severity": "error",
+      "confidence": "high",
+      "evidence": [
+        "evt-1"
+      ],
+      "coverageGapIds": []
+    },
+    {
+      "findingId": "compliance-access-denied-correlated",
+      "severity": "warning",
+      "confidence": "medium",
+      "evidence": [
+        "acc-1",
+        "svc-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "a correlated denial never exceeds medium confidence and never becomes a local cause"
+  ],
+  "coverage": [
+    {
+      "artifactId": "access-facts",
+      "status": "available"
+    },
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-events",
+      "status": "available"
+    },
+    {
+      "artifactId": "service-facts",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-with-matching-state/manifest.json
@@ -1,0 +1,74 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "access-denied-with-matching-state",
+  "workload": "device/windows/compliance",
+  "description": "A denial matches a compliance record on device identity and occurred after it was reported. Even so the finding is capped at medium confidence and claims no cause.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-events",
+      "family": "mdmEvents",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-events.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-events/mdm-events.json",
+      "relativePath": "evidence/mdm-events/current/mdm-events.json",
+      "bytesCopied": 1693,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "service-facts",
+      "family": "serviceFacts",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "service-facts.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/service-facts/service-facts.json",
+      "relativePath": "evidence/service-facts/current/service-facts.json",
+      "bytesCopied": 1311,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "access-facts",
+      "family": "accessFacts",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "access-facts.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/access-facts/access-facts.json",
+      "relativePath": "evidence/access-facts/current/access-facts.json",
+      "bytesCopied": 1411,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-without-compliance-evidence/evidence/access-facts/current/access-facts.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-without-compliance-evidence/evidence/access-facts/current/access-facts.json
@@ -1,0 +1,49 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "accessDecisions",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "acc-1",
+          "sourceArtifactId": "access-facts"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "access-facts",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T11:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T11:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "restricted",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "decision": "denied",
+      "failureCode": {
+        "raw": "53003",
+        "decimal": 53003,
+        "hex": "0x0000CF0B"
+      },
+      "occurredAt": {
+        "rawText": "2026-07-31T11:00:00Z",
+        "originalOffset": null,
+        "normalizedUtc": "2026-07-31T11:00:00Z",
+        "kind": "utc"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "userKey": "synthetic-user-0001",
+      "resource": "synthetic-resource-0002",
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-without-compliance-evidence/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-without-compliance-evidence/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-without-compliance-evidence/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-without-compliance-evidence/expected.json
@@ -1,0 +1,46 @@
+{
+  "scenario": "access-denied-without-compliance-evidence",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "insufficientEvidence",
+    "rationale": "noLocalSourceAvailable"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [],
+  "access": [
+    {
+      "decision": "denied",
+      "linkage": "noMatchingComplianceEvidence",
+      "matchedEvidence": []
+    }
+  ],
+  "findings": [
+    {
+      "findingId": "compliance-access-denied-uncorrelated",
+      "severity": "info",
+      "confidence": "low",
+      "evidence": [
+        "acc-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "a sign-in denial alone produces no compliance cause and no local setting state"
+  ],
+  "coverage": [
+    {
+      "artifactId": "access-facts",
+      "status": "available"
+    },
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-without-compliance-evidence/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/access-denied-without-compliance-evidence/manifest.json
@@ -1,0 +1,42 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "access-denied-without-compliance-evidence",
+  "workload": "device/windows/compliance",
+  "description": "A denial with no compliance record to match against. No causal claim, no local state, and the finding is info-severity at low confidence.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "access-facts",
+      "family": "accessFacts",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "access-facts.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/access-facts/access-facts.json",
+      "relativePath": "evidence/access-facts/current/access-facts.json",
+      "bytesCopied": 1411,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/contradictory-ids-and-timestamps/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/contradictory-ids-and-timestamps/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/contradictory-ids-and-timestamps/evidence/mdm-events/current/mdm-events.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/contradictory-ids-and-timestamps/evidence/mdm-events/current/mdm-events.json
@@ -1,0 +1,122 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "windowsEvents",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-1",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 1,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/BitLockerStatus"
+        },
+        {
+          "name": "PolicyId",
+          "value": "synthetic-policy-a"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "EvaluationResult",
+          "value": "compliant"
+        },
+        {
+          "name": "DisplayName",
+          "value": "BitLocker status"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-2",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 2,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:01:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:01:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 2,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/FirewallStatus"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "EvaluationResult",
+          "value": "compliant"
+        },
+        {
+          "name": "EvaluatedAt",
+          "value": "2026-08-01T09:00:00Z"
+        },
+        {
+          "name": "DisplayName",
+          "value": "Firewall status"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/contradictory-ids-and-timestamps/evidence/mdm-report/current/mdm-report.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/contradictory-ids-and-timestamps/evidence/mdm-report/current/mdm-report.json
@@ -1,0 +1,46 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "settingReports",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-1",
+          "sourceArtifactId": "mdm-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:02:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:02:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Result/System/BitLockerStatus",
+      "settingId": null,
+      "policyId": "synthetic-policy-b",
+      "displayName": "BitLocker status",
+      "outcome": "failed",
+      "value": null,
+      "error": null,
+      "namedData": [
+        {
+          "name": "Scope",
+          "value": "device"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/contradictory-ids-and-timestamps/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/contradictory-ids-and-timestamps/expected.json
@@ -1,0 +1,69 @@
+{
+  "scenario": "contradictory-ids-and-timestamps",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "insufficientEvidence",
+    "rationale": "contradictoryLocalEvidence"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/bitlockerstatus",
+      "scope": "device",
+      "state": "contradictory",
+      "timeContradiction": false,
+      "identityContradiction": true,
+      "evidence": [
+        "evt-1",
+        "rpt-1"
+      ]
+    },
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/firewallstatus",
+      "scope": "device",
+      "state": "compliant",
+      "timeContradiction": true,
+      "identityContradiction": false,
+      "evidence": [
+        "evt-2"
+      ]
+    }
+  ],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-contradictory-evidence",
+      "severity": "warning",
+      "confidence": "medium",
+      "evidence": [
+        "evt-1",
+        "evt-2",
+        "rpt-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "two disagreeing definite sources produce no verdict rather than an arbitrary winner",
+    "an evaluation time after the capture is surfaced instead of trusted"
+  ],
+  "coverage": [
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-events",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-report",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/contradictory-ids-and-timestamps/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/contradictory-ids-and-timestamps/manifest.json
@@ -1,0 +1,58 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "contradictory-ids-and-timestamps",
+  "workload": "device/windows/compliance",
+  "description": "Two sources disagree about one setting and declare different policy identifiers for it, and a third claims an evaluation time after the capture.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-events",
+      "family": "mdmEvents",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-events.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-events/mdm-events.json",
+      "relativePath": "evidence/mdm-events/current/mdm-events.json",
+      "bytesCopied": 3396,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-report",
+      "family": "mdmReport",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-report.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-report/mdm-report.json",
+      "relativePath": "evidence/mdm-report/current/mdm-report.json",
+      "bytesCopied": 1300,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-discovery-noncompliant/evidence/custom-compliance/current/custom-compliance.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-discovery-noncompliant/evidence/custom-compliance/current/custom-compliance.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "customCompliance",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "cst-1",
+          "sourceArtifactId": "custom-compliance"
+        },
+        "provenance": {
+          "sourceKind": "imeLog",
+          "sourceArtifactId": "custom-compliance",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "restricted",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "policyId": "synthetic-custom-policy-0001",
+      "runId": "synthetic-run-0001",
+      "settingName": "TpmPresent",
+      "outcome": "discoveryNoncompliant",
+      "error": null,
+      "rawOutput": "{\"TpmPresent\": false}",
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-discovery-noncompliant/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-discovery-noncompliant/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-discovery-noncompliant/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-discovery-noncompliant/expected.json
@@ -1,0 +1,40 @@
+{
+  "scenario": "custom-compliance-discovery-noncompliant",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "noncompliant",
+    "rationale": "customComplianceDiscoveryNoncompliant"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-custom-discovery-noncompliant",
+      "severity": "error",
+      "confidence": "high",
+      "evidence": [
+        "cst-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "a completed discovery run's noncompliant verdict aggregates as a noncompliance"
+  ],
+  "coverage": [
+    {
+      "artifactId": "custom-compliance",
+      "status": "available"
+    },
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-discovery-noncompliant/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-discovery-noncompliant/manifest.json
@@ -1,0 +1,42 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "custom-compliance-discovery-noncompliant",
+  "workload": "device/windows/compliance",
+  "description": "A custom compliance script ran to completion and reported a noncompliant discovery result, which is a real local verdict.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "custom-compliance",
+      "family": "customCompliance",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "custom-compliance.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/custom-compliance/custom-compliance.json",
+      "relativePath": "evidence/custom-compliance/current/custom-compliance.json",
+      "bytesCopied": 1203,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-script-failure/evidence/custom-compliance/current/custom-compliance.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-script-failure/evidence/custom-compliance/current/custom-compliance.json
@@ -1,0 +1,44 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "customCompliance",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "cst-1",
+          "sourceArtifactId": "custom-compliance"
+        },
+        "provenance": {
+          "sourceKind": "imeLog",
+          "sourceArtifactId": "custom-compliance",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "restricted",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "policyId": "synthetic-custom-policy-0001",
+      "runId": "synthetic-run-0002",
+      "settingName": "TpmPresent",
+      "outcome": "scriptFailed",
+      "error": {
+        "raw": "0x80070001",
+        "decimal": 2147942401,
+        "hex": "0x80070001"
+      },
+      "rawOutput": null,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-script-failure/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-script-failure/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-script-failure/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-script-failure/expected.json
@@ -1,0 +1,40 @@
+{
+  "scenario": "custom-compliance-script-failure",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "evaluationError",
+    "rationale": "customComplianceScriptFailed"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-custom-script-failed",
+      "severity": "error",
+      "confidence": "high",
+      "evidence": [
+        "cst-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "a script execution failure is never reported as a noncompliant device"
+  ],
+  "coverage": [
+    {
+      "artifactId": "custom-compliance",
+      "status": "available"
+    },
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-script-failure/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/custom-compliance-script-failure/manifest.json
@@ -1,0 +1,42 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "custom-compliance-script-failure",
+  "workload": "device/windows/compliance",
+  "description": "The custom compliance script never completed, so no verdict exists. The aggregate reports an evaluation error, not a noncompliance.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "custom-compliance",
+      "family": "customCompliance",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "custom-compliance.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/custom-compliance/custom-compliance.json",
+      "relativePath": "evidence/custom-compliance/current/custom-compliance.json",
+      "bytesCopied": 1266,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/evidence/access-facts/current/access-facts.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/evidence/access-facts/current/access-facts.json
@@ -1,0 +1,45 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "accessDecisions",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "acc-1",
+          "sourceArtifactId": "access-facts"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "access-facts",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T11:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T11:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "restricted",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "decision": "granted",
+      "failureCode": null,
+      "occurredAt": {
+        "rawText": "2026-07-31T11:00:00Z",
+        "originalOffset": null,
+        "normalizedUtc": "2026-07-31T11:00:00Z",
+        "kind": "utc"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "userKey": "synthetic-user-0001",
+      "resource": "synthetic-resource-0003",
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/evidence/custom-compliance/current/custom-compliance.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/evidence/custom-compliance/current/custom-compliance.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "customCompliance",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "cst-1",
+          "sourceArtifactId": "custom-compliance"
+        },
+        "provenance": {
+          "sourceKind": "imeLog",
+          "sourceArtifactId": "custom-compliance",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:01:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:01:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "restricted",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "policyId": "synthetic-custom-policy-0002",
+      "runId": "synthetic-run-0003",
+      "settingName": "TpmPresent",
+      "outcome": "discoveryCompliant",
+      "error": null,
+      "rawOutput": "{\"TpmPresent\": true, \"Operator\": \"jane.roe@contoso.invalid\"}",
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/evidence/mdm-report/current/mdm-report.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/evidence/mdm-report/current/mdm-report.json
@@ -1,0 +1,50 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "settingReports",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-1",
+          "sourceArtifactId": "mdm-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Result/System/BitLockerStatus",
+      "settingId": null,
+      "policyId": null,
+      "displayName": "BitLocker status for analyst@contoso.invalid",
+      "outcome": "applied",
+      "value": null,
+      "error": null,
+      "namedData": [
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "PolicyCachePath",
+          "value": "D:\\Users\\Jane Roe\\policy-cache.json"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/expected.json
@@ -1,0 +1,77 @@
+{
+  "scenario": "deterministic-privacy-redaction",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "compliant",
+    "rationale": "allEvaluatedSettingsCompliant"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/bitlockerstatus",
+      "scope": "device",
+      "state": "compliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "rpt-1"
+      ]
+    }
+  ],
+  "access": [
+    {
+      "decision": "granted",
+      "linkage": "noMatchingComplianceEvidence",
+      "matchedEvidence": []
+    }
+  ],
+  "findings": [
+    {
+      "findingId": "compliance-device-compliant",
+      "severity": "info",
+      "confidence": "high",
+      "evidence": [
+        "rpt-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "redaction": {
+    "deviceKey": "[deviceKey:bdc8a4ec488acb6b]",
+    "tenantKey": "[tenantKey:fba19559833dab09]",
+    "enrollmentId": "[enrollmentId:d7a9fc68c2aba0d9]",
+    "activeUserKey": "[userKey:5df91adf9471a500]",
+    "windowsBuild": "10.0.26100.1742",
+    "settingDisplayName": "BitLocker status for [upn:18becf9e0626016f]",
+    "policyCachePath": "D:\\Users\\[user:fcd48b38cec43b13]\\policy-cache.json",
+    "customRawOutput": "[output:c7b8281e700113e1]",
+    "accessResource": "[resource:9d3708a4f60b93bf]"
+  },
+  "assertions": [
+    "the same identity always masks to the same token, so shared evidence stays visible",
+    "states, counts, timestamps, and evidence references survive redaction unchanged"
+  ],
+  "coverage": [
+    {
+      "artifactId": "access-facts",
+      "status": "available"
+    },
+    {
+      "artifactId": "custom-compliance",
+      "status": "available"
+    },
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-report",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/deterministic-privacy-redaction/manifest.json
@@ -1,0 +1,74 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "deterministic-privacy-redaction",
+  "workload": "device/windows/compliance",
+  "description": "The default export projection masks identity, user paths, script output, and access-resource details while preserving every state, timestamp, and evidence reference.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-report",
+      "family": "mdmReport",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-report.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-report/mdm-report.json",
+      "relativePath": "evidence/mdm-report/current/mdm-report.json",
+      "bytesCopied": 1434,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "custom-compliance",
+      "family": "customCompliance",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "custom-compliance.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/custom-compliance/custom-compliance.json",
+      "relativePath": "evidence/custom-compliance/current/custom-compliance.json",
+      "bytesCopied": 1243,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "access-facts",
+      "family": "accessFacts",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "access-facts.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/access-facts/access-facts.json",
+      "relativePath": "evidence/access-facts/current/access-facts.json",
+      "bytesCopied": 1329,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/evaluation-error/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/evaluation-error/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/evaluation-error/evidence/mdm-events/current/mdm-events.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/evaluation-error/evidence/mdm-events/current/mdm-events.json
@@ -1,0 +1,110 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "windowsEvents",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-1",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 404,
+      "level": "error",
+      "task": null,
+      "keywords": null,
+      "recordId": 1,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/BitLockerStatus"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "EvaluationResult",
+          "value": "error"
+        },
+        {
+          "name": "ErrorCode",
+          "value": "0x87D1FDE8"
+        },
+        {
+          "name": "DisplayName",
+          "value": "BitLocker status"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-2",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 2,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:01:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:01:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 404,
+      "level": "error",
+      "task": null,
+      "keywords": null,
+      "recordId": 2,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/FirewallStatus"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/evaluation-error/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/evaluation-error/expected.json
@@ -1,0 +1,62 @@
+{
+  "scenario": "evaluation-error",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "evaluationError",
+    "rationale": "localEvaluationError"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/bitlockerstatus",
+      "scope": "device",
+      "state": "evaluationError",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "evt-1"
+      ]
+    },
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/firewallstatus",
+      "scope": "device",
+      "state": "evaluationError",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "evt-2"
+      ]
+    }
+  ],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-local-evaluation-error",
+      "severity": "error",
+      "confidence": "high",
+      "evidence": [
+        "evt-1",
+        "evt-2"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "an error-level event naming a setting with no verdict is an evaluation error, not a noncompliance"
+  ],
+  "coverage": [
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-events",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/evaluation-error/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/evaluation-error/manifest.json
@@ -1,0 +1,42 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "evaluation-error",
+  "workload": "device/windows/compliance",
+  "description": "The device could not evaluate a setting. An evaluation error is reported as its own state, never as a noncompliant result.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-events",
+      "family": "mdmEvents",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-events.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-events/mdm-events.json",
+      "relativePath": "evidence/mdm-events/current/mdm-events.json",
+      "bytesCopied": 3096,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-service-compliant/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-service-compliant/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-service-compliant/evidence/mdm-events/current/mdm-events.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-service-compliant/evidence/mdm-events/current/mdm-events.json
@@ -1,0 +1,160 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "windowsEvents",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-1",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 1,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/BitLockerStatus"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "EvaluationResult",
+          "value": "compliant"
+        },
+        {
+          "name": "DisplayName",
+          "value": "BitLocker status"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-2",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 2,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:01:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:01:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 2,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/FirewallStatus"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "EvaluationResult",
+          "value": "compliant"
+        },
+        {
+          "name": "DisplayName",
+          "value": "Firewall status"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-3",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 3,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:05:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:05:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 820,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 3,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "ReportStatus",
+          "value": "submitted"
+        },
+        {
+          "name": "ReportId",
+          "value": "synthetic-report-0001"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-service-compliant/evidence/service-facts/current/service-facts.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-service-compliant/evidence/service-facts/current/service-facts.json
@@ -1,0 +1,45 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "serviceResults",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "svc-1",
+          "sourceArtifactId": "service-facts"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "service-facts",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": null,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:10:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:10:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "policyId": null,
+      "settingId": null,
+      "state": "compliant",
+      "reportedAt": {
+        "rawText": "2026-07-31T10:10:00Z",
+        "originalOffset": null,
+        "normalizedUtc": "2026-07-31T10:10:00Z",
+        "kind": "utc"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "userKey": null,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-service-compliant/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-service-compliant/expected.json
@@ -1,0 +1,66 @@
+{
+  "scenario": "local-compliant-service-compliant",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "compliant",
+    "rationale": "allEvaluatedSettingsCompliant"
+  },
+  "reporting": {
+    "state": "submitted",
+    "serviceFreshness": "fresh",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/bitlockerstatus",
+      "scope": "device",
+      "state": "compliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "evt-1"
+      ]
+    },
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/firewallstatus",
+      "scope": "device",
+      "state": "compliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "evt-2"
+      ]
+    }
+  ],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-device-compliant",
+      "severity": "info",
+      "confidence": "high",
+      "evidence": [
+        "evt-1",
+        "evt-2"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "a fresh, agreeing service record adds confidence but is not the source of the local verdict"
+  ],
+  "coverage": [
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-events",
+      "status": "available"
+    },
+    {
+      "artifactId": "service-facts",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-service-compliant/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-service-compliant/manifest.json
@@ -1,0 +1,58 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "local-compliant-service-compliant",
+  "workload": "device/windows/compliance",
+  "description": "Every local setting evaluated compliant, the report submitted, and the service-held state was reported afterwards and agrees.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-events",
+      "family": "mdmEvents",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-events.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-events/mdm-events.json",
+      "relativePath": "evidence/mdm-events/current/mdm-events.json",
+      "bytesCopied": 4514,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "service-facts",
+      "family": "serviceFacts",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "service-facts.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/service-facts/service-facts.json",
+      "relativePath": "evidence/service-facts/current/service-facts.json",
+      "bytesCopied": 1291,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-stale-service-noncompliant/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-stale-service-noncompliant/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-stale-service-noncompliant/evidence/mdm-events/current/mdm-events.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-stale-service-noncompliant/evidence/mdm-events/current/mdm-events.json
@@ -1,0 +1,60 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "windowsEvents",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-1",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 1,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/BitLockerStatus"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "EvaluationResult",
+          "value": "compliant"
+        },
+        {
+          "name": "DisplayName",
+          "value": "BitLocker status"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-stale-service-noncompliant/evidence/service-facts/current/service-facts.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-stale-service-noncompliant/evidence/service-facts/current/service-facts.json
@@ -1,0 +1,45 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "serviceResults",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "svc-1",
+          "sourceArtifactId": "service-facts"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "service-facts",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": null,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-29T08:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-29T08:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "policyId": null,
+      "settingId": null,
+      "state": "noncompliant",
+      "reportedAt": {
+        "rawText": "2026-07-29T08:00:00Z",
+        "originalOffset": null,
+        "normalizedUtc": "2026-07-29T08:00:00Z",
+        "kind": "utc"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "userKey": null,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-stale-service-noncompliant/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-stale-service-noncompliant/expected.json
@@ -1,0 +1,64 @@
+{
+  "scenario": "local-compliant-stale-service-noncompliant",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "compliant",
+    "rationale": "allEvaluatedSettingsCompliant"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "stale",
+    "serviceDisagreesWithLocal": true
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/bitlockerstatus",
+      "scope": "device",
+      "state": "compliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "evt-1"
+      ]
+    }
+  ],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-service-state-stale",
+      "severity": "warning",
+      "confidence": "high",
+      "evidence": [
+        "svc-1"
+      ],
+      "coverageGapIds": []
+    },
+    {
+      "findingId": "compliance-device-compliant",
+      "severity": "info",
+      "confidence": "high",
+      "evidence": [
+        "evt-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "a stale service record produces a reporting-freshness finding, never a local setting state"
+  ],
+  "coverage": [
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-events",
+      "status": "available"
+    },
+    {
+      "artifactId": "service-facts",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-stale-service-noncompliant/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-compliant-stale-service-noncompliant/manifest.json
@@ -1,0 +1,58 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "local-compliant-stale-service-noncompliant",
+  "workload": "device/windows/compliance",
+  "description": "The device evaluates compliant while the service still holds an older noncompliant record. The stale cloud state never becomes a local failure.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-events",
+      "family": "mdmEvents",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-events.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-events/mdm-events.json",
+      "relativePath": "evidence/mdm-events/current/mdm-events.json",
+      "bytesCopied": 1696,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "service-facts",
+      "family": "serviceFacts",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "service-facts.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/service-facts/service-facts.json",
+      "relativePath": "evidence/service-facts/current/service-facts.json",
+      "bytesCopied": 1294,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-setting/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-setting/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-setting/evidence/mdm-events/current/mdm-events.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-setting/evidence/mdm-events/current/mdm-events.json
@@ -1,0 +1,114 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "windowsEvents",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-1",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 1,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/BitLockerStatus"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "EvaluationResult",
+          "value": "compliant"
+        },
+        {
+          "name": "DisplayName",
+          "value": "BitLocker status"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-2",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 2,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:01:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:01:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 814,
+      "level": "warning",
+      "task": null,
+      "keywords": null,
+      "recordId": 2,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/FirewallStatus"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "EvaluationResult",
+          "value": "noncompliant"
+        },
+        {
+          "name": "DisplayName",
+          "value": "Firewall status"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-setting/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-setting/expected.json
@@ -1,0 +1,61 @@
+{
+  "scenario": "local-noncompliant-setting",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "noncompliant",
+    "rationale": "localSettingNoncompliant"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/bitlockerstatus",
+      "scope": "device",
+      "state": "compliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "evt-1"
+      ]
+    },
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/firewallstatus",
+      "scope": "device",
+      "state": "noncompliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "evt-2"
+      ]
+    }
+  ],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-local-setting-noncompliant",
+      "severity": "error",
+      "confidence": "high",
+      "evidence": [
+        "evt-2"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "a local-noncompliance finding cites only local evaluation evidence"
+  ],
+  "coverage": [
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-events",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-setting/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-setting/manifest.json
@@ -1,0 +1,42 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "local-noncompliant-setting",
+  "workload": "device/windows/compliance",
+  "description": "One device-local setting evaluated noncompliant. The finding cites the local evaluation record and nothing else.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-events",
+      "family": "mdmEvents",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-events.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-events/mdm-events.json",
+      "relativePath": "evidence/mdm-events/current/mdm-events.json",
+      "bytesCopied": 3208,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-with-later-service-update/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-with-later-service-update/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-with-later-service-update/evidence/mdm-events/current/mdm-events.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-with-later-service-update/evidence/mdm-events/current/mdm-events.json
@@ -1,0 +1,106 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "windowsEvents",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-1",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 814,
+      "level": "warning",
+      "task": null,
+      "keywords": null,
+      "recordId": 1,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/FirewallStatus"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "EvaluationResult",
+          "value": "noncompliant"
+        },
+        {
+          "name": "DisplayName",
+          "value": "Firewall status"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-2",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 2,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:02:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:02:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 820,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 2,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "ReportStatus",
+          "value": "submitted"
+        },
+        {
+          "name": "ReportId",
+          "value": "synthetic-report-0002"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-with-later-service-update/evidence/service-facts/current/service-facts.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-with-later-service-update/evidence/service-facts/current/service-facts.json
@@ -1,0 +1,45 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "serviceResults",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "svc-1",
+          "sourceArtifactId": "service-facts"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "service-facts",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": null,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:30:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:30:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "policyId": null,
+      "settingId": null,
+      "state": "noncompliant",
+      "reportedAt": {
+        "rawText": "2026-07-31T10:30:00Z",
+        "originalOffset": null,
+        "normalizedUtc": "2026-07-31T10:30:00Z",
+        "kind": "utc"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "userKey": null,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-with-later-service-update/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-with-later-service-update/expected.json
@@ -1,0 +1,55 @@
+{
+  "scenario": "local-noncompliant-with-later-service-update",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "noncompliant",
+    "rationale": "localSettingNoncompliant"
+  },
+  "reporting": {
+    "state": "submitted",
+    "serviceFreshness": "fresh",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/firewallstatus",
+      "scope": "device",
+      "state": "noncompliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "evt-1"
+      ]
+    }
+  ],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-local-setting-noncompliant",
+      "severity": "error",
+      "confidence": "high",
+      "evidence": [
+        "evt-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "a later, agreeing service update leaves the local verdict untouched and raises no staleness finding"
+  ],
+  "coverage": [
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-events",
+      "status": "available"
+    },
+    {
+      "artifactId": "service-facts",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-with-later-service-update/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/local-noncompliant-with-later-service-update/manifest.json
@@ -1,0 +1,58 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "local-noncompliant-with-later-service-update",
+  "workload": "device/windows/compliance",
+  "description": "The service record was written after the local evaluation and agrees with it, so freshness is not questioned and no staleness finding is raised.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-events",
+      "family": "mdmEvents",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-events.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-events/mdm-events.json",
+      "relativePath": "evidence/mdm-events/current/mdm-events.json",
+      "bytesCopied": 2998,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "service-facts",
+      "family": "serviceFacts",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "service-facts.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/service-facts/service-facts.json",
+      "relativePath": "evidence/service-facts/current/service-facts.json",
+      "bytesCopied": 1294,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/malformed-and-unknown-schema/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/malformed-and-unknown-schema/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/malformed-and-unknown-schema/evidence/mdm-events/current/mdm-events.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/malformed-and-unknown-schema/evidence/mdm-events/current/mdm-events.json
@@ -1,0 +1,4 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - deliberately truncated compliance evidence",
+  "complianceInputVersion": 1,
+  "kind": "windowsEvents",
+  "records": [ { "context": { "evidenceRef": { "evidenceId": "evt-1"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/malformed-and-unknown-schema/evidence/mdm-report/current/mdm-report.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/malformed-and-unknown-schema/evidence/mdm-report/current/mdm-report.json
@@ -1,0 +1,5 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - compliance evidence from a future collector",
+  "complianceInputVersion": 99,
+  "kind": "settingReports",
+  "records": []
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/malformed-and-unknown-schema/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/malformed-and-unknown-schema/expected.json
@@ -1,0 +1,45 @@
+{
+  "scenario": "malformed-and-unknown-schema",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "insufficientEvidence",
+    "rationale": "noLocalSourceAvailable"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-source-malformed",
+      "severity": "warning",
+      "confidence": "high",
+      "evidence": [],
+      "coverageGapIds": [
+        "mdm-events",
+        "mdm-report"
+      ]
+    }
+  ],
+  "assertions": [
+    "malformed bytes and an unknown schema version are distinct from an absent source"
+  ],
+  "coverage": [
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-events",
+      "status": "parseFailed"
+    },
+    {
+      "artifactId": "mdm-report",
+      "status": "unsupported"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/malformed-and-unknown-schema/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/malformed-and-unknown-schema/manifest.json
@@ -1,0 +1,58 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "malformed-and-unknown-schema",
+  "workload": "device/windows/compliance",
+  "description": "One source is malformed and one declares a schema version this build does not support. Neither contributes anything and neither is guessed at.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-events",
+      "family": "mdmEvents",
+      "sourceKind": "json",
+      "captureState": "parseFailed",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-events.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-events/mdm-events.json",
+      "relativePath": "evidence/mdm-events/current/mdm-events.json",
+      "bytesCopied": 215,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-report",
+      "family": "mdmReport",
+      "sourceKind": "json",
+      "captureState": "unsupported",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-report.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-report/mdm-report.json",
+      "relativePath": "evidence/mdm-report/current/mdm-report.json",
+      "bytesCopied": 167,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/partial-event-and-report-coverage/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/partial-event-and-report-coverage/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/partial-event-and-report-coverage/evidence/mdm-report/current/mdm-report.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/partial-event-and-report-coverage/evidence/mdm-report/current/mdm-report.json
@@ -1,0 +1,46 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data (truncated capture)",
+  "complianceInputVersion": 1,
+  "kind": "settingReports",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-1",
+          "sourceArtifactId": "mdm-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Result/System/BitLockerStatus",
+      "settingId": null,
+      "policyId": null,
+      "displayName": "BitLocker status",
+      "outcome": "applied",
+      "value": null,
+      "error": null,
+      "namedData": [
+        {
+          "name": "Scope",
+          "value": "device"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/partial-event-and-report-coverage/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/partial-event-and-report-coverage/expected.json
@@ -1,0 +1,76 @@
+{
+  "scenario": "partial-event-and-report-coverage",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "compliant",
+    "rationale": "allEvaluatedSettingsCompliant"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/bitlockerstatus",
+      "scope": "device",
+      "state": "compliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "rpt-1"
+      ]
+    }
+  ],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-source-missing",
+      "severity": "warning",
+      "confidence": "high",
+      "evidence": [],
+      "coverageGapIds": [
+        "custom-compliance",
+        "mdm-events",
+        "mdm-report",
+        "service-facts"
+      ]
+    },
+    {
+      "findingId": "compliance-device-compliant",
+      "severity": "info",
+      "confidence": "medium",
+      "evidence": [
+        "rpt-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "a clean result over incomplete coverage is reported at reduced confidence",
+    "absent, capped, denied, and skipped sources are each their own coverage state"
+  ],
+  "coverage": [
+    {
+      "artifactId": "custom-compliance",
+      "status": "permissionDenied"
+    },
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-events",
+      "status": "missing"
+    },
+    {
+      "artifactId": "mdm-report",
+      "status": "capped"
+    },
+    {
+      "artifactId": "service-facts",
+      "status": "skipped"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/partial-event-and-report-coverage/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/partial-event-and-report-coverage/manifest.json
@@ -1,0 +1,90 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "partial-event-and-report-coverage",
+  "workload": "device/windows/compliance",
+  "description": "Four of five expected sources were absent, truncated, denied, or skipped. The surviving verdict is reported at reduced confidence with an explicit coverage gap.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-events",
+      "family": "mdmEvents",
+      "sourceKind": "json",
+      "captureState": "absent",
+      "encoding": null,
+      "originalBasename": "mdm-events.json",
+      "sanitizedSourcePath": null,
+      "relativePath": null,
+      "bytesCopied": 0,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-report",
+      "family": "mdmReport",
+      "sourceKind": "json",
+      "captureState": "capped",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-report.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-report/mdm-report.json",
+      "relativePath": "evidence/mdm-report/current/mdm-report.json",
+      "bytesCopied": 1305,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "custom-compliance",
+      "family": "customCompliance",
+      "sourceKind": "json",
+      "captureState": "accessDenied",
+      "encoding": null,
+      "originalBasename": "custom-compliance.json",
+      "sanitizedSourcePath": null,
+      "relativePath": null,
+      "bytesCopied": 0,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "service-facts",
+      "family": "serviceFacts",
+      "sourceKind": "json",
+      "captureState": "skipped",
+      "encoding": null,
+      "originalBasename": "service-facts.json",
+      "sanitizedSourcePath": null,
+      "relativePath": null,
+      "bytesCopied": 0,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/report-submission-failure/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/report-submission-failure/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/report-submission-failure/evidence/mdm-events/current/mdm-events.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/report-submission-failure/evidence/mdm-events/current/mdm-events.json
@@ -1,0 +1,110 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "windowsEvents",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-1",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 1,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "SettingUri",
+          "value": "./Device/Vendor/MSFT/Policy/Result/System/BitLockerStatus"
+        },
+        {
+          "name": "Scope",
+          "value": "device"
+        },
+        {
+          "name": "EvaluationResult",
+          "value": "compliant"
+        },
+        {
+          "name": "DisplayName",
+          "value": "BitLocker status"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-2",
+          "sourceArtifactId": "mdm-events"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-events",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 2,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:05:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:05:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 821,
+      "level": "error",
+      "task": null,
+      "keywords": null,
+      "recordId": 2,
+      "activityId": null,
+      "namedData": [
+        {
+          "name": "ReportStatus",
+          "value": "failed"
+        },
+        {
+          "name": "ReportId",
+          "value": "synthetic-report-0003"
+        },
+        {
+          "name": "ErrorCode",
+          "value": "0x80072EE2"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/report-submission-failure/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/report-submission-failure/expected.json
@@ -1,0 +1,60 @@
+{
+  "scenario": "report-submission-failure",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "compliant",
+    "rationale": "allEvaluatedSettingsCompliant"
+  },
+  "reporting": {
+    "state": "failed",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/bitlockerstatus",
+      "scope": "device",
+      "state": "compliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "evt-1"
+      ]
+    }
+  ],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-report-submission-failed",
+      "severity": "error",
+      "confidence": "high",
+      "evidence": [
+        "evt-2"
+      ],
+      "coverageGapIds": []
+    },
+    {
+      "findingId": "compliance-device-compliant",
+      "severity": "info",
+      "confidence": "high",
+      "evidence": [
+        "evt-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "a submission failure is a reporting problem and leaves the local verdict compliant"
+  ],
+  "coverage": [
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-events",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/report-submission-failure/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/report-submission-failure/manifest.json
@@ -1,0 +1,42 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "report-submission-failure",
+  "workload": "device/windows/compliance",
+  "description": "Every local setting passed but the compliance report failed to submit, so the service holds no result from this evaluation.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-events",
+      "family": "mdmEvents",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-events.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-events/mdm-events.json",
+      "relativePath": "evidence/mdm-events/current/mdm-events.json",
+      "bytesCopied": 3076,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/unsupported-not-applicable-setting/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/unsupported-not-applicable-setting/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.19045.4046",
+      "activeUserKey": "synthetic-user-0001",
+      "userSessionPresent": true,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/unsupported-not-applicable-setting/evidence/mdm-report/current/mdm-report.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/unsupported-not-applicable-setting/evidence/mdm-report/current/mdm-report.json
@@ -1,0 +1,86 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "settingReports",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-1",
+          "sourceArtifactId": "mdm-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Result/System/BitLockerStatus",
+      "settingId": null,
+      "policyId": null,
+      "displayName": "BitLocker status",
+      "outcome": "applied",
+      "value": null,
+      "error": null,
+      "namedData": [
+        {
+          "name": "Scope",
+          "value": "device"
+        }
+      ]
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-2",
+          "sourceArtifactId": "mdm-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 2,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:30Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:30Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Result/System/FirewallStatus",
+      "settingId": null,
+      "policyId": null,
+      "displayName": "Firewall status",
+      "outcome": "notApplicable",
+      "value": null,
+      "error": null,
+      "namedData": [
+        {
+          "name": "Scope",
+          "value": "device"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/unsupported-not-applicable-setting/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/unsupported-not-applicable-setting/expected.json
@@ -1,0 +1,70 @@
+{
+  "scenario": "unsupported-not-applicable-setting",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "userPresent",
+  "aggregate": {
+    "state": "compliant",
+    "rationale": "allEvaluatedSettingsCompliant"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/bitlockerstatus",
+      "scope": "device",
+      "state": "compliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "rpt-1"
+      ]
+    },
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/firewallstatus",
+      "scope": "device",
+      "state": "notApplicable",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "rpt-2"
+      ]
+    }
+  ],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-setting-not-applicable",
+      "severity": "info",
+      "confidence": "high",
+      "evidence": [
+        "rpt-2"
+      ],
+      "coverageGapIds": []
+    },
+    {
+      "findingId": "compliance-device-compliant",
+      "severity": "info",
+      "confidence": "high",
+      "evidence": [
+        "rpt-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "a not-applicable setting does not contribute to the aggregate in either direction"
+  ],
+  "coverage": [
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-report",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/unsupported-not-applicable-setting/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/unsupported-not-applicable-setting/manifest.json
@@ -1,0 +1,42 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "unsupported-not-applicable-setting",
+  "workload": "device/windows/compliance",
+  "description": "A setting that does not apply to this device is excluded from the aggregate rather than counted as a pass or a failure.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1228,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-report",
+      "family": "mdmReport",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-report.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-report/mdm-report.json",
+      "relativePath": "evidence/mdm-report/current/mdm-report.json",
+      "bytesCopied": 2392,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/user-targeted-policy-not-evaluated/evidence/device-context/current/device-context.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/user-targeted-policy-not-evaluated/evidence/device-context/current/device-context.json
@@ -1,0 +1,40 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "deviceContext",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "ctx-1",
+          "sourceArtifactId": "device-context"
+        },
+        "provenance": {
+          "sourceKind": "suppliedFact",
+          "sourceArtifactId": "device-context",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T12:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T12:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "deviceKey": "synthetic-device-0001",
+      "tenantKey": "synthetic-tenant-0001",
+      "enrollmentId": "synthetic-enrollment-0001",
+      "windowsBuild": "10.0.26100.1742",
+      "activeUserKey": null,
+      "userSessionPresent": false,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/user-targeted-policy-not-evaluated/evidence/mdm-report/current/mdm-report.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/user-targeted-policy-not-evaluated/evidence/mdm-report/current/mdm-report.json
@@ -1,0 +1,86 @@
+{ "syntheticFixture": "SYNTHETIC FIXTURE - synthetic Intune compliance evidence, no real device data",
+  "complianceInputVersion": 1,
+  "kind": "settingReports",
+  "records": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-1",
+          "sourceArtifactId": "mdm-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Result/System/BitLockerStatus",
+      "settingId": null,
+      "policyId": null,
+      "displayName": "BitLocker status",
+      "outcome": "applied",
+      "value": null,
+      "error": null,
+      "namedData": [
+        {
+          "name": "Scope",
+          "value": "device"
+        }
+      ]
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-2",
+          "sourceArtifactId": "mdm-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 2,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T10:00:10Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T10:00:10Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T12:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./User/Vendor/MSFT/Policy/Result/DeviceLock/MinimumPasswordLength",
+      "settingId": null,
+      "policyId": null,
+      "displayName": "Minimum password length",
+      "outcome": "pending",
+      "value": null,
+      "error": null,
+      "namedData": [
+        {
+          "name": "Scope",
+          "value": "user"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/user-targeted-policy-not-evaluated/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/user-targeted-policy-not-evaluated/expected.json
@@ -1,0 +1,70 @@
+{
+  "scenario": "user-targeted-policy-not-evaluated",
+  "workload": "device/windows/compliance",
+  "userEvaluationContext": "noUserSession",
+  "aggregate": {
+    "state": "compliant",
+    "rationale": "allEvaluatedSettingsCompliant"
+  },
+  "reporting": {
+    "state": "unknown",
+    "serviceFreshness": "unknown",
+    "serviceDisagreesWithLocal": false
+  },
+  "settings": [
+    {
+      "groupingToken": "uri:./device/vendor/msft/policy/result/system/bitlockerstatus",
+      "scope": "device",
+      "state": "compliant",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "rpt-1"
+      ]
+    },
+    {
+      "groupingToken": "uri:./user/vendor/msft/policy/result/devicelock/minimumpasswordlength",
+      "scope": "user",
+      "state": "notEvaluated",
+      "timeContradiction": false,
+      "identityContradiction": false,
+      "evidence": [
+        "rpt-2"
+      ]
+    }
+  ],
+  "access": [],
+  "findings": [
+    {
+      "findingId": "compliance-user-scoped-not-evaluated",
+      "severity": "info",
+      "confidence": "medium",
+      "evidence": [
+        "rpt-2"
+      ],
+      "coverageGapIds": []
+    },
+    {
+      "findingId": "compliance-device-compliant",
+      "severity": "info",
+      "confidence": "high",
+      "evidence": [
+        "rpt-1"
+      ],
+      "coverageGapIds": []
+    }
+  ],
+  "assertions": [
+    "an unevaluated user-scoped setting is info-severity coverage, never an error"
+  ],
+  "coverage": [
+    {
+      "artifactId": "device-context",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-report",
+      "status": "available"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/user-targeted-policy-not-evaluated/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/compliance/user-targeted-policy-not-evaluated/manifest.json
@@ -1,0 +1,42 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "user-targeted-policy-not-evaluated",
+  "workload": "device/windows/compliance",
+  "description": "No user session was present, so a user-targeted setting produced no verdict. That is missing evaluation coverage, not a failed setting.",
+  "generatedAtUtc": "2026-07-31T12:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "device-context",
+      "family": "deviceContext",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "device-context.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/device-context/device-context.json",
+      "relativePath": "evidence/device-context/current/device-context.json",
+      "bytesCopied": 1212,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-report",
+      "family": "mdmReport",
+      "sourceKind": "json",
+      "captureState": "captured",
+      "encoding": "utf-8",
+      "originalBasename": "mdm-report.json",
+      "sanitizedSourcePath": "SYNTHETIC://compliance/mdm-report/mdm-report.json",
+      "relativePath": "evidence/mdm-report/current/mdm-report.json",
+      "bytesCopied": 2401,
+      "capturedUtc": "2026-07-31T12:00:00Z",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/intune_windows_compliance.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_compliance.rs
@@ -1,0 +1,669 @@
+//! Fixture matrix for `intune::device::windows::compliance` (issue #364).
+//!
+//! Every scenario states its expected reduction in `expected.json` rather than
+//! being snapshotted, so a reviewer can read what each case asserts and why. The
+//! shared harness in `tests/support/` validates the parts every Intune corpus
+//! has in common (manifest envelope, byte counts, path safety, evidence closure,
+//! coverage binding, privacy); this file owns the compliance semantics.
+//!
+//! The load-bearing tests are the last four in the "invariants" section. They
+//! encode the correctness constraint the whole module exists for: a Conditional
+//! Access denial, a stale service record, and a missing user evaluation are each
+//! distinct from a failed local setting, and none of them may produce one.
+
+mod support;
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use cmtraceopen_parser::intune::device::windows::compliance::{
+    analyze_compliance_bundle, redacted_export_projection, ComplianceSnapshot,
+    ComplianceSourceInput,
+};
+use cmtraceopen_parser::intune::evidence::IntuneArtifactStatus;
+use serde_json::{json, Value};
+use support::{corpus_root, load_json, mutated, scenario_names, validate_scenario, Failures};
+
+const CORPUS: &str = "device/windows/compliance";
+
+/// The required fixture matrix from issue #364, pinned so a scenario cannot be
+/// dropped or silently renamed. Sorted, because `scenario_names` sorts.
+const SCENARIOS: [&str; 16] = [
+    "access-denied-with-matching-state",
+    "access-denied-without-compliance-evidence",
+    "contradictory-ids-and-timestamps",
+    "custom-compliance-discovery-noncompliant",
+    "custom-compliance-script-failure",
+    "deterministic-privacy-redaction",
+    "evaluation-error",
+    "local-compliant-service-compliant",
+    "local-compliant-stale-service-noncompliant",
+    "local-noncompliant-setting",
+    "local-noncompliant-with-later-service-update",
+    "malformed-and-unknown-schema",
+    "partial-event-and-report-coverage",
+    "report-submission-failure",
+    "unsupported-not-applicable-setting",
+    "user-targeted-policy-not-evaluated",
+];
+
+/// Artifact families whose evidence is a device-local observation.
+///
+/// A finding that claims a local setting failed must cite only these.
+const LOCAL_FAMILIES: [&str; 3] = ["mdmEvents", "mdmReport", "customCompliance"];
+
+/// Findings that assert something about a device-local evaluation.
+const LOCAL_CLAIM_FINDINGS: [&str; 5] = [
+    "compliance-local-setting-noncompliant",
+    "compliance-local-evaluation-error",
+    "compliance-prerequisite-unmet",
+    "compliance-custom-discovery-noncompliant",
+    "compliance-custom-script-failed",
+];
+
+// ── Loading ─────────────────────────────────────────────────────────────────
+
+fn scenario_root(scenario: &str) -> PathBuf {
+    corpus_root(CORPUS).join(scenario)
+}
+
+fn capture_status(capture_state: &str) -> IntuneArtifactStatus {
+    match capture_state {
+        "captured" => IntuneArtifactStatus::Available,
+        "capped" => IntuneArtifactStatus::Capped,
+        "absent" => IntuneArtifactStatus::Missing,
+        "accessDenied" => IntuneArtifactStatus::PermissionDenied,
+        "skipped" => IntuneArtifactStatus::Skipped,
+        "unsupported" => IntuneArtifactStatus::Unsupported,
+        "parseFailed" => IntuneArtifactStatus::ParseFailed,
+        other => panic!("unknown captureState {other:?}"),
+    }
+}
+
+/// Build the analyzer input exactly as a native collector would report it.
+fn sources(root: &Path, manifest: &Value) -> Vec<ComplianceSourceInput> {
+    manifest["artifacts"]
+        .as_array()
+        .expect("manifest artifacts is an array")
+        .iter()
+        .map(|artifact| {
+            let content = artifact["relativePath"].as_str().map(|relative| {
+                std::fs::read_to_string(root.join(relative))
+                    .unwrap_or_else(|error| panic!("{relative} is readable: {error}"))
+            });
+            ComplianceSourceInput {
+                artifact_id: artifact["artifactId"]
+                    .as_str()
+                    .expect("artifactId")
+                    .to_string(),
+                family: artifact["family"].as_str().expect("family").to_string(),
+                status: capture_status(artifact["captureState"].as_str().expect("captureState")),
+                captured_at_utc: artifact["capturedUtc"]
+                    .as_str()
+                    .expect("capturedUtc")
+                    .to_string(),
+                content,
+            }
+        })
+        .collect()
+}
+
+struct Loaded {
+    manifest: Value,
+    expected: Value,
+    snapshot: ComplianceSnapshot,
+    actual: Value,
+}
+
+fn load(scenario: &str) -> Loaded {
+    let root = scenario_root(scenario);
+    let manifest = load_json(&root.join("manifest.json"));
+    let expected = load_json(&root.join("expected.json"));
+    let snapshot = analyze_compliance_bundle(
+        &sources(&root, &manifest),
+        manifest["generatedAtUtc"].as_str().expect("generatedAtUtc"),
+    );
+    let actual = serde_json::to_value(&snapshot).expect("snapshot serializes");
+    Loaded {
+        manifest,
+        expected,
+        snapshot,
+        actual,
+    }
+}
+
+/// artifactId -> family, for deciding whether cited evidence is local.
+fn families(manifest: &Value) -> BTreeMap<String, String> {
+    manifest["artifacts"]
+        .as_array()
+        .expect("artifacts")
+        .iter()
+        .map(|artifact| {
+            (
+                artifact["artifactId"].as_str().expect("id").to_string(),
+                artifact["family"].as_str().expect("family").to_string(),
+            )
+        })
+        .collect()
+}
+
+fn evidence_ids(value: &Value) -> Vec<String> {
+    value
+        .as_array()
+        .map(|items| {
+            let mut ids = items
+                .iter()
+                .map(|item| item["evidenceId"].as_str().unwrap_or_default().to_string())
+                .collect::<Vec<_>>();
+            ids.sort();
+            ids
+        })
+        .unwrap_or_default()
+}
+
+fn artifact_ids(value: &Value) -> Vec<String> {
+    value
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| {
+                    item["sourceArtifactId"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .to_string()
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn strings(value: &Value) -> Vec<String> {
+    value
+        .as_array()
+        .map(|items| {
+            let mut values = items
+                .iter()
+                .map(|item| item.as_str().unwrap_or_default().to_string())
+                .collect::<Vec<_>>();
+            values.sort();
+            values
+        })
+        .unwrap_or_default()
+}
+
+// ── Corpus contract ─────────────────────────────────────────────────────────
+
+#[test]
+fn the_corpus_exposes_exactly_the_required_fixture_matrix() {
+    assert_eq!(
+        scenario_names(&corpus_root(CORPUS)),
+        SCENARIOS.map(str::to_owned).to_vec(),
+        "the scenario matrix in issue #364 is the acceptance criteria, not a suggestion"
+    );
+}
+
+#[test]
+fn every_scenario_satisfies_the_shared_fixture_contract() {
+    let mut failures = Failures::new();
+    for scenario in SCENARIOS {
+        let root = scenario_root(scenario);
+        let manifest = load_json(&root.join("manifest.json"));
+        let expected = load_json(&root.join("expected.json"));
+        failures.absorb(validate_scenario(scenario, &root, &manifest, &expected));
+    }
+    failures.assert_empty("compliance corpus");
+}
+
+// ── Reduction contract ──────────────────────────────────────────────────────
+
+#[test]
+fn every_scenario_matches_its_expected_reduction() {
+    for scenario in SCENARIOS {
+        let loaded = load(scenario);
+        let (actual, expected) = (&loaded.actual, &loaded.expected);
+
+        assert_eq!(
+            actual["deviceContext"]["userEvaluationContext"], expected["userEvaluationContext"],
+            "{scenario}: user evaluation context"
+        );
+        assert_eq!(
+            actual["aggregate"]["state"], expected["aggregate"]["state"],
+            "{scenario}: aggregate state"
+        );
+        assert_eq!(
+            actual["aggregate"]["rationale"], expected["aggregate"]["rationale"],
+            "{scenario}: aggregate rationale"
+        );
+        for field in ["state", "serviceFreshness", "serviceDisagreesWithLocal"] {
+            assert_eq!(
+                actual["reporting"][field], expected["reporting"][field],
+                "{scenario}: reporting.{field}"
+            );
+        }
+
+        assert_settings(scenario, actual, expected);
+        assert_access(scenario, actual, expected);
+        assert_coverage(scenario, actual, expected);
+        assert_findings(scenario, actual, expected);
+    }
+}
+
+fn assert_settings(scenario: &str, actual: &Value, expected: &Value) {
+    let actual_settings = actual["localEvaluation"]["settings"]
+        .as_array()
+        .expect("settings array");
+    let expected_settings = expected["settings"].as_array().expect("expected settings");
+    assert_eq!(
+        actual_settings.len(),
+        expected_settings.len(),
+        "{scenario}: setting count, got tokens {:?}",
+        actual_settings
+            .iter()
+            .map(|setting| &setting["groupingToken"])
+            .collect::<Vec<_>>()
+    );
+    for (index, (got, want)) in actual_settings.iter().zip(expected_settings).enumerate() {
+        for field in [
+            "groupingToken",
+            "scope",
+            "state",
+            "timeContradiction",
+            "identityContradiction",
+        ] {
+            assert_eq!(
+                got[field], want[field],
+                "{scenario}: settings[{index}].{field}"
+            );
+        }
+        assert_eq!(
+            evidence_ids(&got["evidence"]),
+            strings(&want["evidence"]),
+            "{scenario}: settings[{index}].evidence"
+        );
+    }
+}
+
+fn assert_access(scenario: &str, actual: &Value, expected: &Value) {
+    let actual_access = actual["accessImpact"]["decisions"]
+        .as_array()
+        .expect("decisions array");
+    let expected_access = expected["access"].as_array().expect("expected access");
+    assert_eq!(
+        actual_access.len(),
+        expected_access.len(),
+        "{scenario}: access decision count"
+    );
+    for (index, (got, want)) in actual_access.iter().zip(expected_access).enumerate() {
+        for field in ["decision", "linkage"] {
+            assert_eq!(
+                got[field], want[field],
+                "{scenario}: access[{index}].{field}"
+            );
+        }
+        assert_eq!(
+            evidence_ids(&got["matchedEvidence"]),
+            strings(&want["matchedEvidence"]),
+            "{scenario}: access[{index}].matchedEvidence"
+        );
+    }
+}
+
+fn assert_coverage(scenario: &str, actual: &Value, expected: &Value) {
+    let actual_coverage = actual["coverage"].as_array().expect("coverage array");
+    let expected_coverage = expected["coverage"].as_array().expect("expected coverage");
+    assert_eq!(
+        actual_coverage.len(),
+        expected_coverage.len(),
+        "{scenario}: coverage entry count"
+    );
+    for (index, (got, want)) in actual_coverage.iter().zip(expected_coverage).enumerate() {
+        for field in ["artifactId", "status"] {
+            assert_eq!(
+                got[field], want[field],
+                "{scenario}: coverage[{index}].{field}"
+            );
+        }
+    }
+}
+
+fn assert_findings(scenario: &str, actual: &Value, expected: &Value) {
+    let actual_findings = actual["findings"].as_array().expect("findings array");
+    let expected_findings = expected["findings"].as_array().expect("expected findings");
+    assert_eq!(
+        actual_findings.len(),
+        expected_findings.len(),
+        "{scenario}: finding count, got {:?}",
+        actual_findings
+            .iter()
+            .map(|finding| &finding["findingId"])
+            .collect::<Vec<_>>()
+    );
+    for (index, (got, want)) in actual_findings.iter().zip(expected_findings).enumerate() {
+        for field in ["findingId", "severity", "confidence"] {
+            assert_eq!(
+                got[field], want[field],
+                "{scenario}: findings[{index}].{field}"
+            );
+        }
+        assert_eq!(
+            evidence_ids(&got["evidence"]),
+            strings(&want["evidence"]),
+            "{scenario}: findings[{index}].evidence"
+        );
+        assert_eq!(
+            strings(&got["coverageGapIds"]),
+            strings(&want["coverageGapIds"]),
+            "{scenario}: findings[{index}].coverageGapIds"
+        );
+    }
+}
+
+// ── Invariants ──────────────────────────────────────────────────────────────
+
+#[test]
+fn every_finding_cites_evidence_or_a_coverage_gap() {
+    for scenario in SCENARIOS {
+        for finding in load(scenario).snapshot.findings {
+            assert!(
+                finding.is_evidence_backed(),
+                "{scenario}: {} cites neither evidence nor a coverage gap",
+                finding.finding_id
+            );
+        }
+    }
+}
+
+/// The core constraint: a claim about a *local* setting is only ever made from
+/// local evidence. A service record or a sign-in result can never back one.
+#[test]
+fn a_local_failure_claim_cites_only_local_evaluation_evidence() {
+    for scenario in SCENARIOS {
+        let loaded = load(scenario);
+        let families = families(&loaded.manifest);
+        for finding in loaded.actual["findings"].as_array().expect("findings") {
+            let id = finding["findingId"].as_str().unwrap_or_default();
+            if !LOCAL_CLAIM_FINDINGS.contains(&id) {
+                continue;
+            }
+            let cited = artifact_ids(&finding["evidence"]);
+            assert!(
+                !cited.is_empty(),
+                "{scenario}: {id} claims a local failure while citing nothing"
+            );
+            for artifact in cited {
+                let family = families
+                    .get(&artifact)
+                    .unwrap_or_else(|| panic!("{scenario}: unknown artifact {artifact}"));
+                assert!(
+                    LOCAL_FAMILIES.contains(&family.as_str()),
+                    "{scenario}: {id} claims a local failure but cites {artifact} of family {family}"
+                );
+            }
+        }
+    }
+}
+
+/// A finding built only from access evidence must stay Info + Low.
+///
+/// This is the acceptance criterion "no high-confidence compliance cause is
+/// created from a sign-in error alone", enforced across the whole corpus rather
+/// than in the one scenario that exercises it.
+#[test]
+fn a_finding_built_only_from_access_evidence_makes_no_confident_claim() {
+    for scenario in SCENARIOS {
+        let loaded = load(scenario);
+        let families = families(&loaded.manifest);
+        for finding in loaded.actual["findings"].as_array().expect("findings") {
+            let cited = artifact_ids(&finding["evidence"]);
+            if cited.is_empty() {
+                continue;
+            }
+            let access_only = cited
+                .iter()
+                .all(|artifact| families.get(artifact).map(String::as_str) == Some("accessFacts"));
+            if !access_only {
+                continue;
+            }
+            let id = finding["findingId"].as_str().unwrap_or_default();
+            assert_eq!(
+                finding["confidence"],
+                json!("low"),
+                "{scenario}: {id} is built only from access evidence and must stay low confidence"
+            );
+            assert_eq!(
+                finding["severity"],
+                json!("info"),
+                "{scenario}: {id} is built only from access evidence and must stay informational"
+            );
+        }
+    }
+}
+
+#[test]
+fn an_access_denial_alone_produces_no_local_setting_state() {
+    let loaded = load("access-denied-without-compliance-evidence");
+    assert!(
+        loaded.snapshot.local_evaluation.settings.is_empty(),
+        "a sign-in denial must not synthesize a setting evaluation"
+    );
+    assert_eq!(
+        loaded.actual["aggregate"]["state"],
+        json!("insufficientEvidence")
+    );
+    assert_eq!(
+        loaded.actual["accessImpact"]["decisions"][0]["linkage"],
+        json!("noMatchingComplianceEvidence")
+    );
+}
+
+#[test]
+fn a_stale_service_record_leaves_every_local_setting_compliant() {
+    let loaded = load("local-compliant-stale-service-noncompliant");
+    assert_eq!(loaded.actual["aggregate"]["state"], json!("compliant"));
+    assert_eq!(
+        loaded.actual["reporting"]["serviceFreshness"],
+        json!("stale")
+    );
+    assert!(
+        loaded.actual["localEvaluation"]["settings"]
+            .as_array()
+            .expect("settings")
+            .iter()
+            .all(|setting| setting["state"] == json!("compliant")),
+        "a stale cloud record must never rewrite a local setting state"
+    );
+}
+
+#[test]
+fn an_unevaluated_user_setting_is_never_reported_as_a_failure() {
+    let loaded = load("user-targeted-policy-not-evaluated");
+    let user_setting = loaded.actual["localEvaluation"]["settings"]
+        .as_array()
+        .expect("settings")
+        .iter()
+        .find(|setting| setting["scope"] == json!("user"))
+        .expect("a user-scoped setting");
+    assert_eq!(user_setting["state"], json!("notEvaluated"));
+    assert!(
+        !loaded
+            .snapshot
+            .findings
+            .iter()
+            .any(|finding| finding.finding_id == "compliance-local-setting-noncompliant"),
+        "a missing user evaluation must not produce a local-noncompliance finding"
+    );
+}
+
+#[test]
+fn a_custom_script_failure_is_not_a_noncompliant_discovery() {
+    let failure = load("custom-compliance-script-failure");
+    let discovery = load("custom-compliance-discovery-noncompliant");
+    assert_eq!(
+        failure.actual["aggregate"]["state"],
+        json!("evaluationError")
+    );
+    assert_eq!(
+        discovery.actual["aggregate"]["state"],
+        json!("noncompliant")
+    );
+    assert_ne!(
+        failure.actual["aggregate"]["rationale"], discovery.actual["aggregate"]["rationale"],
+        "a crashed script and a noncompliant discovery must not share a rationale"
+    );
+}
+
+#[test]
+fn the_reduction_is_deterministic_across_runs() {
+    for scenario in SCENARIOS {
+        let first = load(scenario).actual;
+        let second = load(scenario).actual;
+        assert_eq!(
+            serde_json::to_string(&first).expect("serializes"),
+            serde_json::to_string(&second).expect("serializes"),
+            "{scenario}: the same bundle must reduce to byte-identical output"
+        );
+    }
+}
+
+// ── Redaction ───────────────────────────────────────────────────────────────
+
+#[test]
+fn the_redacted_projection_matches_its_golden_and_is_idempotent() {
+    let loaded = load("deterministic-privacy-redaction");
+    let projected = redacted_export_projection(&loaded.snapshot);
+    let golden = &loaded.expected["redaction"];
+    let value = serde_json::to_value(&projected).expect("projection serializes");
+
+    for (pointer, key) in [
+        ("/deviceContext/deviceKey", "deviceKey"),
+        ("/deviceContext/tenantKey", "tenantKey"),
+        ("/deviceContext/enrollmentId", "enrollmentId"),
+        ("/deviceContext/activeUserKey", "activeUserKey"),
+        ("/deviceContext/windowsBuild", "windowsBuild"),
+        (
+            "/localEvaluation/settings/0/displayName",
+            "settingDisplayName",
+        ),
+        (
+            "/localEvaluation/customCompliance/0/rawOutput",
+            "customRawOutput",
+        ),
+        ("/accessImpact/decisions/0/resource", "accessResource"),
+    ] {
+        assert_eq!(
+            value.pointer(pointer).unwrap_or(&Value::Null),
+            &golden[key],
+            "redaction golden mismatch at {pointer}"
+        );
+    }
+
+    let cache_path = projected.local_evaluation.settings[0]
+        .named_data
+        .iter()
+        .find(|entry| entry.name == "PolicyCachePath")
+        .expect("PolicyCachePath survives redaction")
+        .value
+        .clone();
+    assert_eq!(cache_path, golden["policyCachePath"].as_str().unwrap());
+
+    let twice = redacted_export_projection(&projected);
+    assert_eq!(
+        serde_json::to_value(&twice).expect("serializes"),
+        value,
+        "the redaction projection must be idempotent"
+    );
+}
+
+#[test]
+fn redaction_preserves_states_coverage_and_evidence() {
+    for scenario in SCENARIOS {
+        let loaded = load(scenario);
+        let projected = redacted_export_projection(&loaded.snapshot);
+        assert_eq!(
+            projected.aggregate, loaded.snapshot.aggregate,
+            "{scenario}: redaction must not touch the aggregate"
+        );
+        assert_eq!(
+            projected.coverage, loaded.snapshot.coverage,
+            "{scenario}: redaction must not drop coverage"
+        );
+        let ids = |snapshot: &ComplianceSnapshot| {
+            snapshot
+                .findings
+                .iter()
+                .map(|finding| (finding.finding_id.clone(), finding.evidence.clone()))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            ids(&projected),
+            ids(&loaded.snapshot),
+            "{scenario}: redaction must not change which evidence a finding cites"
+        );
+    }
+}
+
+// ── Adversarial corpus mutations ────────────────────────────────────────────
+
+fn assert_rejected(scenario: &str, label: &str, manifest: &Value, expected: &Value, needle: &str) {
+    let failures = validate_scenario(scenario, &scenario_root(scenario), manifest, expected);
+    assert!(
+        failures
+            .entries()
+            .iter()
+            .any(|entry| entry.contains(needle)),
+        "{label}: expected a failure mentioning {needle:?}, got {:?}",
+        failures.entries()
+    );
+}
+
+#[test]
+fn a_byte_count_that_disagrees_with_the_evidence_is_rejected() {
+    let scenario = "local-noncompliant-setting";
+    let loaded = load(scenario);
+    assert_rejected(
+        scenario,
+        "byte count",
+        &mutated(&loaded.manifest, "/artifacts/0/bytesCopied", json!(1)),
+        &loaded.expected,
+        "bytesCopied",
+    );
+}
+
+#[test]
+fn coverage_that_contradicts_the_capture_state_is_rejected() {
+    // partial-event-and-report-coverage declares mdm-events absent. Claiming it
+    // was available would let the corpus assert coverage it never had.
+    let scenario = "partial-event-and-report-coverage";
+    let loaded = load(scenario);
+    let coverage = loaded.expected["coverage"]
+        .as_array()
+        .expect("coverage")
+        .iter()
+        .position(|entry| entry["artifactId"] == json!("mdm-events"))
+        .expect("mdm-events coverage entry");
+    assert_rejected(
+        scenario,
+        "coverage drift",
+        &loaded.manifest,
+        &mutated(
+            &loaded.expected,
+            &format!("/coverage/{coverage}/status"),
+            json!("available"),
+        ),
+        "requires coverage status",
+    );
+}
+
+#[test]
+fn a_finding_stripped_of_its_only_citation_is_rejected() {
+    let scenario = "malformed-and-unknown-schema";
+    let loaded = load(scenario);
+    assert_rejected(
+        scenario,
+        "uncited finding",
+        &loaded.manifest,
+        &mutated(&loaded.expected, "/findings/0/coverageGapIds", json!([])),
+        "cites neither evidence nor a coverage gap",
+    );
+}


### PR DESCRIPTION
## Summary

Implements `cmtraceopen_parser::intune::device::windows::compliance` — pure-Rust, wasm32-compatible four-phase analyzer for Intune Windows device compliance evaluation and reporting evidence.

Supersedes the implementation on stale PR #449 (same module + 16-scenario fixture matrix + audit fixes), restacked onto current `main` so CI is not blocked by the unrelated company-portal `std::process` purity failure that failed Check & Test on the old base.

### Module structure

| File | Purpose |
|------|---------|
| `models.rs` | Four-phase typed model: local evaluation → aggregate → reporting → access |
| `sources.rs` | Envelope decoding + event/report classification into typed signals |
| `reducer.rs` | Strict phase-by-phase reduction; findings derived from the finished snapshot only |
| `rules.rs` | Conservative finding derivation; access-only findings capped at Low/Info |
| `redaction.rs` | Deterministic privacy projection via FNV-1a keyed tokens |

### Invariants preserved

- Conditional Access denials never produce local setting verdicts
- Stale cloud state never produces local setting verdicts
- Missing user evaluation is NotEvaluated (coverage gap), not Noncompliant
- Custom script failure ≠ discovery noncompliant
- Report evaluation error ≠ Noncompliant

### Local verification

- `cargo test -p cmtraceopen-parser --test intune_windows_compliance` → **16 passed**
- `cargo test -p cmtraceopen-parser --test intune_skeleton_contract` → **26 passed**
- `cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings` → clean
- No `std::process` / I/O in the compliance leaf

### Relationship to open PRs

| PR | Issue | Decision |
|----|-------|----------|
| #449 | #364 | Stale base (~463 commits behind); residual CI fail unrelated; **ported here** |
| #450 | #362 Autopilot | Larger surface; same stale-base CI fail; left for a dedicated Autopilot restack |

## Test plan

- [x] Fixture matrix (16 scenarios) green locally
- [x] Shared Intune fixture contract green
- [x] Clippy `-D warnings` green on parser crate
- [ ] Full CI Check & Test (Rust) on this PR
- [ ] Human/adversarial review of phase separation and access-confidence caps

Fixes #364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Windows compliance analysis across local evaluation, aggregate status, reporting freshness, and access decisions.
  * Added evidence-backed findings for noncompliance, stale reports, access denials, missing user context, script failures, and evaluation errors.
  * Added deterministic privacy redaction for exported compliance results.

* **Bug Fixes**
  * Improved handling of contradictory evidence, unavailable artifacts, unsupported schemas, invalid timestamps, and partial coverage.

* **Tests**
  * Added coverage for 16 compliance scenarios, including malformed data and privacy-redaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->