### PR TITLE
fix(parser): stop panicking on non-ASCII decimal digits (#413)

### DIFF
--- a/crates/cmtraceopen-parser/src/parser/ccm.rs
+++ b/crates/cmtraceopen-parser/src/parser/ccm.rs
@@ -28,12 +28,14 @@ fn ccm_re() -> &'static Regex {
     CELL.get_or_init(|| {
         Regex::new(concat!(
             r#"<!\[LOG\[(?P<msg>[\s\S]*?)\]LOG\]!>"#,
-            r#"<time="(?P<h>\d{1,2}):(?P<m>\d{1,2}):(?P<s>\d{1,2})\.(?P<time_tail>\d+(?:[+-]\d+)?)""#,
-            r#"\s+date="(?P<mon>\d{1,2})-(?P<day>\d{1,2})-(?P<yr>\d{4})""#,
+            // ASCII digits only: regex \d matches Unicode Nd and feeds byte-indexed
+            // slices that panic on multi-byte digits (issue #413).
+            r#"<time="(?P<h>[0-9]{1,2}):(?P<m>[0-9]{1,2}):(?P<s>[0-9]{1,2})\.(?P<time_tail>[0-9]+(?:[+-][0-9]+)?)""#,
+            r#"\s+date="(?P<mon>[0-9]{1,2})-(?P<day>[0-9]{1,2})-(?P<yr>[0-9]{4})""#,
             r#"\s+component="(?P<comp>[^"]*)""#,
             r#"\s+context="(?P<context>[^"]*)""#,
-            r#"\s+type="(?P<typ>\d)?""#,
-            r#"\s+thread="(?P<thr>\d+)?""#,
+            r#"\s+type="(?P<typ>[0-9])?""#,
+            r#"\s+thread="(?P<thr>[0-9]+)?""#,
             r#"(?:\s+file="(?P<file>[^"]*)")?>"#,
         ))
         .expect("CCM regex must compile")
@@ -167,6 +169,11 @@ impl CcmParsed {
 }
 
 pub(crate) fn truncate_subsecond_to_millis(value: &str) -> Option<u32> {
+    // Byte-indexed slicing is only valid for ASCII digit runs. Unicode Nd
+    // digits (matched by regex \d) are multi-byte and panic on char boundaries.
+    if !value.is_ascii() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
     if value.len() > 3 {
         value[..3].parse().ok()
     } else {
@@ -227,6 +234,11 @@ fn split_ccm_time_tail(value: &str) -> (&str, Option<&str>) {
         return (&value[..index], Some(&value[index..]));
     }
 
+    // Signless splits use fixed byte offsets; refuse non-ASCII digit runs.
+    if !value.is_ascii() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return (value, None);
+    }
+
     // `%03u%d` with a three-digit offset is the only signless shape the
     // legacy grammar can produce that is not also plain fractional text.
     if value.len() == 6 && signless_offset_is_real(&value[3..]) {
@@ -249,6 +261,11 @@ fn split_legacy_public_time_tail(value: &str) -> Option<(&str, &str)> {
         .position(|byte| matches!(byte, b'+' | b'-'))
     {
         return (index > 0).then_some((&value[..index], &value[index..]));
+    }
+
+    // Final-digit split is byte-indexed; non-ASCII digit tails panic otherwise.
+    if !value.is_ascii() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
     }
 
     let split_at = value.len().checked_sub(1)?;
@@ -1476,5 +1493,49 @@ mod tests {
             CcmTimestampParseState::OffsetMissing
         );
         assert_eq!(timestamp.utc_millis, None);
+    }
+
+    /// Non-ASCII Nd digits in a CCM time tail must not panic (issue #413).
+    ///
+    /// `regex` `\d` matches Unicode decimal digits; byte-indexed splits then
+    /// hit mid-character boundaries. ASCII-only patterns + guards reject these
+    /// tails instead of crashing the pure parser crate.
+    #[test]
+    fn non_ascii_decimal_digit_time_tails_do_not_panic() {
+        let tails = ["١٢٣", "123١", "12١٢", "1234١", "٠", "१२३"];
+        for tail in tails {
+            assert!(
+                truncate_subsecond_to_millis(tail).is_none(),
+                "truncate must refuse non-ASCII tail {tail:?}"
+            );
+            let (fraction, offset) = split_ccm_time_tail(tail);
+            assert_eq!(offset, None, "unsigned non-ASCII tail {tail:?}");
+            assert_eq!(fraction, tail);
+            assert!(
+                split_legacy_public_time_tail(tail).is_none(),
+                "legacy split must refuse non-ASCII tail {tail:?}"
+            );
+
+            let text = format!(
+                concat!(
+                    r#"<![LOG[NonASCII {tail}]LOG]!><time="10:00:00.{tail}" date="07-30-2026" "#,
+                    r#"component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+                ),
+                tail = tail
+            );
+            // Must not panic; non-ASCII fractional text is not a CCM match.
+            let records = scan_logical_records(&text, "PolicyAgent.log");
+            assert!(
+                records.iter().all(|record| {
+                    record.timestamp.ordering_state == CcmTimestampParseState::TimestampMissing
+                }),
+                "non-ASCII tail {tail:?} must not produce a CCM-normalized timestamp"
+            );
+            let (entries, _) = parse_content(&text, "PolicyAgent.log", None);
+            assert!(
+                entries.iter().all(|entry| entry.timestamp.is_none()),
+                "non-ASCII tail {tail:?} must not parse as a CCM timestamp entry"
+            );
+        }
     }
 }

--- a/crates/cmtraceopen-parser/src/parser/cmtlog.rs
+++ b/crates/cmtraceopen-parser/src/parser/cmtlog.rs
@@ -37,12 +37,13 @@ fn cmtlog_re() -> &'static Regex {
     CELL.get_or_init(|| {
         Regex::new(concat!(
             r#"<!\[LOG\[(?P<msg>[\s\S]*?)\]LOG\]!>"#,
-            r#"<time="(?P<h>\d{1,2}):(?P<m>\d{1,2}):(?P<s>\d{1,2})\.(?P<ms>\d+)(?P<tz>[+-]*\d+)""#,
-            r#"\s+date="(?P<mon>\d{1,2})-(?P<day>\d{1,2})-(?P<yr>\d{4})""#,
+            // ASCII digits only — same class as CCM issue #413.
+            r#"<time="(?P<h>[0-9]{1,2}):(?P<m>[0-9]{1,2}):(?P<s>[0-9]{1,2})\.(?P<ms>[0-9]+)(?P<tz>[+-]*[0-9]+)""#,
+            r#"\s+date="(?P<mon>[0-9]{1,2})-(?P<day>[0-9]{1,2})-(?P<yr>[0-9]{4})""#,
             r#"\s+component="(?P<comp>[^"]*)""#,
             r#"\s+context="[^"]*""#,
-            r#"\s+type="(?P<typ>\d)""#,
-            r#"\s+thread="(?P<thr>\d+)""#,
+            r#"\s+type="(?P<typ>[0-9])""#,
+            r#"\s+thread="(?P<thr>[0-9]+)""#,
             r#"[^>]*>"#,
         ))
         .expect("CmtLog regex must compile")

--- a/crates/cmtraceopen-parser/src/parser/dns_types.rs
+++ b/crates/cmtraceopen-parser/src/parser/dns_types.rs
@@ -147,8 +147,13 @@ fn decode_wire_format(raw: &str) -> String {
                         // Root label — signals end of name.
                         break;
                     }
-                    // Extract exactly `len` bytes for the label.
+                    // Extract exactly `len` bytes for the label when that end
+                    // is a UTF-8 char boundary; otherwise the log text is
+                    // malformed relative to the claimed wire length (#413).
                     let label_end = len.min(after_paren.len());
+                    if !after_paren.is_char_boundary(label_end) {
+                        break;
+                    }
                     let label = &after_paren[..label_end];
                     if !label.is_empty() {
                         labels.push(label.to_string());
@@ -161,8 +166,12 @@ fn decode_wire_format(raw: &str) -> String {
             break;
         }
 
-        // Unexpected character — advance by one to avoid an infinite loop.
-        remaining = &remaining[1..];
+        // Unexpected character — advance by one Unicode scalar, not one byte.
+        // Byte-stepping panics inside multi-byte characters (#413).
+        match remaining.chars().next() {
+            Some(ch) => remaining = &remaining[ch.len_utf8()..],
+            None => break,
+        }
     }
 
     if labels.is_empty() {
@@ -267,4 +276,13 @@ mod tests {
     fn test_decode_empty() {
         assert_eq!(decode_query_name(""), "");
     }
+
+    #[test]
+    fn non_ascii_wire_labels_do_not_panic() {
+        let _ = decode_query_name("é(1)a");
+        let _ = decode_query_name("(1)é");
+        let _ = decode_query_name("(2)éx");
+        let _ = decode_query_name("é");
+    }
+
 }

--- a/crates/cmtraceopen-parser/src/parser/reporting_events.rs
+++ b/crates/cmtraceopen-parser/src/parser/reporting_events.rs
@@ -18,7 +18,8 @@ fn timestamp_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
         Regex::new(
-            r"^(\d{4})[-/](\d{2})[-/](\d{2})\s+(\d{2}):(\d{2}):(\d{2})(?:(?::|\.)(\d{1,7}))?$",
+            // ASCII digits only — \d is Unicode Nd; fractional ms is byte-sliced (#413).
+            r"^([0-9]{4})[-/]([0-9]{2})[-/]([0-9]{2})\s+([0-9]{2}):([0-9]{2}):([0-9]{2})(?:(?::|\.)([0-9]{1,7}))?$",
         )
         .unwrap()
     })
@@ -181,6 +182,10 @@ fn parse_timestamp(value: &str) -> Option<(i64, String)> {
 fn parse_fractional_millis(value: Option<&str>) -> u32 {
     match value {
         Some(raw) => {
+            // Byte-indexed truncate requires ASCII digits (#413).
+            if !raw.is_ascii() || !raw.bytes().all(|byte| byte.is_ascii_digit()) {
+                return 0;
+            }
             let padded = format!("{:0<3}", raw);
             padded[..3].parse::<u32>().unwrap_or(0)
         }
@@ -412,4 +417,30 @@ mod tests {
         assert_eq!(entries[3].severity, Severity::Warning);
         assert_eq!(entries[3].line_number, 4);
     }
+
+    #[test]
+    fn non_ascii_fractional_timestamp_does_not_panic() {
+        // Detection path: matches_reporting_events_record calls parse_timestamp.
+        let guid = "{11111111-1111-1111-1111-111111111111}";
+        let fields = [
+            guid,
+            "2024-01-15 08:00:00.١٢",
+            "1",
+            "Software Update",
+            "1",
+            "{22222222-2222-2222-2222-222222222222}",
+            "0x00000000",
+            "Windows Update Agent",
+            "Success",
+            "Installation",
+            "detail",
+        ];
+        let line = fields.join("\t");
+        let _ = matches_reporting_events_record(&line);
+        let _ = parse_lines(
+            &[&line],
+            "C:/Windows/SoftwareDistribution/ReportingEvents.log",
+        );
+    }
+
 }

--- a/crates/cmtraceopen-parser/src/parser/simple.rs
+++ b/crates/cmtraceopen-parser/src/parser/simple.rs
@@ -21,8 +21,9 @@ fn meta_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
         Regex::new(concat!(
-            r#"<(\d{1,2})-(\d{1,2})-(\d{4})\s+(\d{1,2}):(\d{1,2}):(\d{1,2})\.(\d+)([+-]?\d+)>"#,
-            r#"(?:<thread=(\d+)(?:\s*\(0x[0-9a-fA-F]+\))?>)?"#,
+            // ASCII digits only — \d is Unicode Nd and byte-sliced ms panics (#413).
+            r#"<([0-9]{1,2})-([0-9]{1,2})-([0-9]{4})\s+([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2})\.([0-9]+)([+-]?[0-9]+)>"#,
+            r#"(?:<thread=([0-9]+)(?:\s*\(0x[0-9a-fA-F]+\))?>)?"#,
         ))
         .expect("Simple metadata regex must compile")
     })
@@ -49,11 +50,7 @@ fn parse_line(line: &str) -> Option<SimpleParsed> {
     let m: u32 = caps.get(5)?.as_str().parse().ok()?;
     let s: u32 = caps.get(6)?.as_str().parse().ok()?;
     let ms_str = caps.get(7)?.as_str();
-    let ms: u32 = if ms_str.len() > 3 {
-        ms_str[..3].parse().ok()?
-    } else {
-        ms_str.parse().ok()?
-    };
+    let ms = super::ccm::truncate_subsecond_to_millis(ms_str)?;
     let tz: i32 = caps.get(8)?.as_str().parse().ok()?;
 
     // Thread is optional (captured by the combined regex)
@@ -245,4 +242,13 @@ mod tests {
         let parsed = parse_line(line).expect("should parse");
         assert_eq!(parsed.severity, Severity::Error);
     }
+
+
+    #[test]
+    fn non_ascii_fractional_digits_do_not_panic() {
+        let line = "message$$<Comp><1-1-2024 1:1:1.١٢+0><thread=1 (0x0001)>";
+        let _ = parse_line(line);
+        let _ = parse_lines(&[line], "simple.log");
+    }
+
 }

--- a/crates/cmtraceopen-parser/src/parser/timestamped.rs
+++ b/crates/cmtraceopen-parser/src/parser/timestamped.rs
@@ -24,7 +24,7 @@ fn iso_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
     Regex::new(
-        r"^(\d{4})-(\d{2})-(\d{2})[T ](\d{1,2}):(\d{2}):(\d{2})([.,]\d+)?(Z|[+-]\d{2}:?\d{2})?\s*(.*)"
+        r"^([0-9]{4})-([0-9]{2})-([0-9]{2})[T ]([0-9]{1,2}):([0-9]{2}):([0-9]{2})([.,][0-9]+)?(Z|[+-][0-9]{2}:?[0-9]{2})?\s*(.*)"
     ).unwrap()
 })
 }
@@ -34,7 +34,7 @@ fn slash_date_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
         Regex::new(
-        r"^(\d{1,2})/(\d{1,2})/(\d{4})\s+(\d{1,2}):(\d{2}):(\d{2})(\.\d+)?(\s*[AaPp][Mm])?\s+(.*)",
+        r"^([0-9]{1,2})/([0-9]{1,2})/([0-9]{4})\s+([0-9]{1,2}):([0-9]{2}):([0-9]{2})(\.[0-9]+)?(\s*[AaPp][Mm])?\s+(.*)",
     )
     .unwrap()
     })
@@ -45,7 +45,7 @@ fn syslog_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
     Regex::new(
-        r"^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+(\d{1,2})\s+(\d{2}):(\d{2}):(\d{2})\s+(.*)"
+        r"^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+([0-9]{1,2})\s+([0-9]{2}):([0-9]{2}):([0-9]{2})\s+(.*)"
     ).unwrap()
 })
 }
@@ -53,7 +53,7 @@ fn syslog_re() -> &'static Regex {
 /// Time-only: 14:30:00.123 message...
 fn time_only_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
-    CELL.get_or_init(|| Regex::new(r"^(\d{2}):(\d{2}):(\d{2})([.,]\d+)?\s+(.*)").unwrap())
+    CELL.get_or_init(|| Regex::new(r"^([0-9]{2}):([0-9]{2}):([0-9]{2})([.,][0-9]+)?\s+(.*)").unwrap())
 }
 
 // ---------------------------------------------------------------------------
@@ -555,6 +555,10 @@ fn parse_fractional_millis(frac: Option<&str>) -> u32 {
         Some(s) => {
             // Strip leading '.' or ','
             let digits = s.trim_start_matches(['.', ',']);
+            // Byte-indexed truncate requires ASCII digits (#413).
+            if !digits.is_ascii() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+                return 0;
+            }
             // Pad or truncate to 3 digits
             let padded = format!("{:0<3}", digits);
             padded[..3].parse::<u32>().unwrap_or(0)
@@ -573,6 +577,10 @@ fn parse_tz_offset(tz: Option<&str>) -> Option<i32> {
             let sign: i32 = if s.starts_with('-') { -1 } else { 1 };
             let digits = s.trim_start_matches(['+', '-']);
             let clean = digits.replace(':', "");
+            // Byte-indexed hour/minute slices require ASCII digits (#413).
+            if !clean.is_ascii() || !clean.bytes().all(|byte| byte.is_ascii_digit()) {
+                return None;
+            }
             if clean.len() >= 4 {
                 let hours: i32 = clean[..2].parse().ok()?;
                 let mins: i32 = clean[2..4].parse().ok()?;
@@ -787,4 +795,24 @@ mod tests {
         // 25:00:00 is not a valid time
         assert!(parse_line("25:00:00 invalid time", DateOrder::MonthFirst).is_none());
     }
+
+    #[test]
+    fn non_ascii_fractional_and_tz_do_not_panic() {
+        // Arabic-Indic fractional seconds and Devanagari timezone digits.
+        let _ = parse_line("14:30:00.١٢ starting", DateOrder::MonthFirst);
+        let _ = parse_line(
+            "2024-01-15T14:30:00.١٢Z Error: connection refused",
+            DateOrder::MonthFirst,
+        );
+        let _ = parse_line(
+            "2024-01-15T14:30:00.123+०१:२३ Error: offset",
+            DateOrder::MonthFirst,
+        );
+        let _ = parse_lines(
+            &["14:30:00.١٢ starting", "2024-01-15T14:30:00.123+०१:२३ x"],
+            "timestamped.log",
+            DateOrder::MonthFirst,
+        );
+    }
+
 }

--- a/crates/cmtraceopen-parser/tests/issue_413_non_ascii_digits.rs
+++ b/crates/cmtraceopen-parser/tests/issue_413_non_ascii_digits.rs
@@ -1,0 +1,48 @@
+//! Regression for https://github.com/adamgell/cmtraceopen/issues/413
+//!
+//! `regex`'s `\d` matches Unicode Nd. Byte-indexed slices of those captures
+//! panic on multi-byte digit characters. This suite pins the public surface:
+//! untrusted input must never crash the pure parser crate.
+
+use cmtraceopen_parser::parser;
+
+#[test]
+fn public_parse_content_survives_non_ascii_ccm_time_tails() {
+    let tails = ["١٢٣", "123١", "12١٢", "1234١"];
+    for tail in tails {
+        let content = format!(
+            r#"<![LOG[NonASCII {tail}]LOG]!><time="10:00:00.{tail}" date="07-30-2026" component="PolicyAgent" context="" type="1" thread="42" file="policyagent.cpp">"#
+        );
+        let (result, _) = parser::parse_content(&content, "PolicyAgent.log", content.len() as u64);
+        // No panic is the contract; a non-match is acceptable.
+        let _ = result.entries;
+    }
+}
+
+#[test]
+fn public_parse_content_survives_non_ascii_timestamped_fraction() {
+    let content = "14:30:00.١٢ starting work\n2024-01-15T14:30:00.123+०१:२३ offset line\n";
+    let (result, _) = parser::parse_content(content, "app.log", content.len() as u64);
+    let _ = result.entries;
+}
+
+#[test]
+fn public_parse_content_survives_non_ascii_reporting_events_detection() {
+    let guid = "{11111111-1111-1111-1111-111111111111}";
+    let line = format!(
+        "{guid}\t2024-01-15 08:00:00.١٢\t1\tSoftware Update\t1\t{{22222222-2222-2222-2222-222222222222}}\t0x00000000\tWindows Update Agent\tSuccess\tInstallation\tdetail"
+    );
+    let (result, _) = parser::parse_content(
+        &line,
+        "C:/Windows/SoftwareDistribution/ReportingEvents.log",
+        line.len() as u64,
+    );
+    let _ = result.entries;
+}
+
+#[test]
+fn public_parse_content_survives_non_ascii_simple_fraction() {
+    let content = "message$$<Comp><1-1-2024 1:1:1.١٢+0><thread=1 (0x0001)>";
+    let (result, _) = parser::parse_content(content, "simple.log", content.len() as u64);
+    let _ = result.entries;
+}


### PR DESCRIPTION
## Summary
- Restrict critical numeric regex captures to ASCII `[0-9]` so Unicode Nd digits cannot enter byte-indexed slicing paths.
- Guard CCM/simple/timestamped/reporting_events fractional helpers with ASCII-digit checks before `value[..n]` slices.
- Make DNS wire-label decoding char-boundary safe (label length + unexpected-character advance).
- Add unit + public-surface regression tests for the panic class documented in #413.

## Why
`regex`'s `\d` matches `\p{Nd}`. Multi-byte digits (e.g. Arabic-Indic `١٢٣`) made:
- `truncate_subsecond_to_millis` / time-tail splits in CCM
- fractional millis / timezone parsing
- reporting-events detection timestamps
- simple-format ms truncation
- DNS label extraction

panic with `byte index N is not a char boundary`. This crate is pure and published; panics on untrusted logs are an availability bug.

## Test plan
- [x] `cargo test --lib` in `crates/cmtraceopen-parser` (656 passed)
- [x] `cargo test --test issue_413_non_ascii_digits`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] Frozen CCM time-tail ambiguity table still green

Fixes #413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log parsing stability for timestamps, fractional seconds, and DNS-style data containing non-ASCII characters.
  * Prevented crashes when malformed or Unicode numeric input is encountered.
  * Invalid timestamp and wire-format values are now rejected safely instead of causing parsing failures.

* **Tests**
  * Added regression coverage for Unicode digits, multibyte characters, malformed lengths, and invalid fractional timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->