### PR TITLE
feat(sccm): admit hierarchy source contracts

### DIFF
--- a/crates/cmtraceopen-parser/src/sccm/server/windows/catalog.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/catalog.rs
@@ -1,4 +1,113 @@
-use crate::sccm::{classify_artifact_name, SccmArtifactFamily, SccmRole, SccmSourceCatalogEntry};
+use serde::{Deserialize, Serialize};
+
+use crate::sccm::{
+    classify_artifact_name, SccmArtifactFamily, SccmRole, SccmRotation, SccmSourceCatalogEntry,
+};
+
+pub const SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION: u32 = 1;
+pub const SCCM_SERVER_SITE_DATABASE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmServerHierarchyDirection {
+    Origin,
+    Target,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SccmServerHierarchyRotationContract {
+    Current,
+    LoUnderscore,
+}
+
+#[derive(Debug)]
+pub struct SccmServerHierarchySourceContract {
+    pub contract_version: u32,
+    pub source_id: &'static str,
+    pub logical_name: &'static str,
+    pub producer_role: SccmRole,
+    pub expected_component: &'static str,
+    pub(crate) allowed_rotations: &'static [SccmServerHierarchyRotationContract],
+}
+
+impl SccmServerHierarchySourceContract {
+    pub fn allows_rotation(&self, rotation: &SccmRotation) -> bool {
+        let expected = match rotation {
+            SccmRotation::Current => SccmServerHierarchyRotationContract::Current,
+            SccmRotation::LoUnderscore => SccmServerHierarchyRotationContract::LoUnderscore,
+            SccmRotation::Numbered(_) | SccmRotation::Timestamped(_) | SccmRotation::Unknown(_) => {
+                return false
+            }
+        };
+        self.allowed_rotations.contains(&expected)
+    }
+}
+
+const CURRENT_ROTATION: &[SccmServerHierarchyRotationContract] =
+    &[SccmServerHierarchyRotationContract::Current];
+const LO_ROTATION: &[SccmServerHierarchyRotationContract] =
+    &[SccmServerHierarchyRotationContract::LoUnderscore];
+
+const SERVER_HIERARCHY_SOURCE_CONTRACTS: &[SccmServerHierarchySourceContract] = &[
+    SccmServerHierarchySourceContract {
+        contract_version: SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION,
+        source_id: "server-hierarchy-control",
+        logical_name: "replmgr",
+        producer_role: SccmRole::SiteServer,
+        expected_component: "SMS_REPLICATION_MANAGER",
+        allowed_rotations: CURRENT_ROTATION,
+    },
+    SccmServerHierarchySourceContract {
+        contract_version: SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION,
+        source_id: "server-hierarchy-control",
+        logical_name: "rcmctrl",
+        producer_role: SccmRole::SiteServer,
+        expected_component: "SMS_REPLICATION_CONFIGURATION_MONITOR",
+        allowed_rotations: CURRENT_ROTATION,
+    },
+    SccmServerHierarchySourceContract {
+        contract_version: SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION,
+        source_id: "server-hierarchy-control",
+        logical_name: "rcmctrl",
+        producer_role: SccmRole::SiteServer,
+        expected_component: "SMS_REPLICATION_CONFIGURATION_MONITOR",
+        allowed_rotations: LO_ROTATION,
+    },
+    SccmServerHierarchySourceContract {
+        contract_version: SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION,
+        source_id: "server-hierarchy-transfer",
+        logical_name: "sender",
+        producer_role: SccmRole::SiteServer,
+        expected_component: "SMS_LAN_SENDER",
+        allowed_rotations: CURRENT_ROTATION,
+    },
+    SccmServerHierarchySourceContract {
+        contract_version: SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION,
+        source_id: "server-hierarchy-transfer",
+        logical_name: "despool",
+        producer_role: SccmRole::SiteServer,
+        expected_component: "SMS_DESPOOLER",
+        allowed_rotations: CURRENT_ROTATION,
+    },
+];
+
+pub fn declared_hierarchy_source_contracts() -> &'static [SccmServerHierarchySourceContract] {
+    SERVER_HIERARCHY_SOURCE_CONTRACTS
+}
+
+pub(crate) fn classify_declared_hierarchy_source(
+    source_id: &str,
+    producer_role: &SccmRole,
+    logical_name: &str,
+    rotation: &SccmRotation,
+) -> Option<&'static SccmServerHierarchySourceContract> {
+    SERVER_HIERARCHY_SOURCE_CONTRACTS.iter().find(|contract| {
+        contract.source_id == source_id
+            && &contract.producer_role == producer_role
+            && contract.logical_name == logical_name
+            && contract.allows_rotation(rotation)
+    })
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SccmServerSourceKind {
@@ -177,6 +286,16 @@ const SERVER_SOURCE_SPECS: &[SccmServerSourceSpec] = &[
     },
 ];
 
+const SERVER_STRUCTURED_SUPPLEMENT_SPEC: SccmServerSourceSpec = SccmServerSourceSpec {
+    source_id: "server-hierarchy-site-database",
+    producer_role: SccmRole::SiteServer,
+    workflow_subject_role: None,
+    logical_names: &[],
+    explicit_basename: Some("site-database.supplement"),
+    source_kind: SccmServerSourceKind::StructuredSupplement,
+    supplemental: true,
+};
+
 pub fn declared_server_source_catalog() -> &'static [SccmServerSourceSpec] {
     SERVER_SOURCE_SPECS
 }
@@ -191,12 +310,15 @@ pub(crate) fn classify_declared_server_source(
     &'static SccmServerSourceSpec,
     Option<SccmSourceCatalogEntry>,
 )> {
-    let spec = SERVER_SOURCE_SPECS.iter().find(|spec| {
-        spec.source_id == source_id
-            && &spec.producer_role == producer_role
-            && spec.workflow_subject_role.as_ref() == workflow_subject_role
-            && source_kind_matches(spec.source_kind, source_kind)
-    })?;
+    let spec = SERVER_SOURCE_SPECS
+        .iter()
+        .chain(std::iter::once(&SERVER_STRUCTURED_SUPPLEMENT_SPEC))
+        .find(|spec| {
+            spec.source_id == source_id
+                && &spec.producer_role == producer_role
+                && spec.workflow_subject_role.as_ref() == workflow_subject_role
+                && source_kind_matches(spec.source_kind, source_kind)
+        })?;
 
     if spec.source_kind != SccmServerSourceKind::CcmLog {
         if spec
@@ -225,7 +347,9 @@ pub(crate) fn expected_family(source_id: &str) -> Option<SccmArtifactFamily> {
     Some(match source_id {
         "server-sitecomp" => SccmArtifactFamily::SiteComponent,
         "server-status" => SccmArtifactFamily::SiteStatus,
-        "server-hierarchy-control" | "server-hierarchy-transfer" => SccmArtifactFamily::Hierarchy,
+        "server-hierarchy-control"
+        | "server-hierarchy-transfer"
+        | "server-hierarchy-site-database" => SccmArtifactFamily::Hierarchy,
         "server-mp-auth" | "server-mp-policy" | "server-mp-iis" => {
             SccmArtifactFamily::ManagementPoint
         }

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -13,11 +13,15 @@ use thiserror::Error;
 use crate::sccm::rotation::is_canonical_rotation_timestamp;
 use crate::sccm::{
     classify_artifact_name, normalize_ccm_artifact, SccmArtifact, SccmArtifactFamily,
-    SccmArtifactRequest, SccmCoverageState, SccmEvidence, SccmFinding, SccmRole, SccmRotation,
+    SccmArtifactRequest, SccmCoverageState, SccmEvidence, SccmExtractionProfile,
+    SccmExtractionProfileMaturity, SccmFinding, SccmKeyConfidence, SccmRole, SccmRotation,
 };
 
 use super::catalog::{
-    classify_declared_server_source, expected_family, SccmServerSourceKind, SccmServerSourceSpec,
+    classify_declared_hierarchy_source, classify_declared_server_source,
+    declared_hierarchy_source_contracts, expected_family, SccmServerHierarchyDirection,
+    SccmServerHierarchySourceContract, SccmServerSourceKind, SccmServerSourceSpec,
+    SCCM_SERVER_SITE_DATABASE_SCHEMA_VERSION,
 };
 
 /// Keep parser-side work bounded even when the manifest did not come from the
@@ -564,6 +568,19 @@ pub struct SccmServerArtifactAssessment {
     pub source_kind: String,
     pub family: SccmArtifactFamily,
     pub original_basename: Option<String>,
+    pub direction: Option<SccmServerHierarchyDirection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hierarchy_admission: Option<SccmServerHierarchyAdmission>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supplement_schema_version: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supplement_operator_authorized: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supplement_privacy_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supplement_admission: Option<SccmServerSupplementAdmission>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supplement_provenance: Option<String>,
     pub rotation: Option<SccmRotation>,
     pub rotation_lineage_handle: String,
     pub state: SccmCoverageState,
@@ -607,6 +624,46 @@ pub struct SccmServerArtifactAssessment {
         serialize_with = "serialize_opaque_extensions"
     )]
     collection_limit_extensions: Vec<SccmServerOpaqueExtension>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmServerHierarchyAdmission {
+    pub contract_version: u32,
+    pub component: String,
+    pub direction: Option<SccmServerHierarchyDirection>,
+    pub profile_id: Option<String>,
+    pub confidence: SccmKeyConfidence,
+    pub gaps: Vec<SccmServerHierarchyAdmissionGap>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmServerHierarchyAdmissionGap {
+    MissingVersion,
+    UnvalidatedProfile,
+    MissingTopology,
+    UnvalidatedDirection,
+    UnvalidatedKeys,
+    ComponentMismatch,
+    RotationMismatch,
+    UnsupportedContractVersion,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmServerSupplementAdmission {
+    Admitted,
+    CoverageOnly { reason: SccmServerSupplementGap },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmServerSupplementGap {
+    MissingSchemaVersion,
+    UnsupportedSchemaVersion,
+    MissingOperatorAuthorization,
+    PrivacyClassMismatch,
 }
 
 impl SccmServerArtifactAssessment {
@@ -776,6 +833,7 @@ pub fn assess_server_intake(
         let normalized = normalize_artifact(
             artifact,
             manifest.synthetic_fixture,
+            &topology.hierarchy_links,
             &topology.roles_observed,
             &mut relative_paths,
             &mut path_fingerprint_lineages,
@@ -960,11 +1018,9 @@ fn validate_manifest_bounds(
         }
         if let Some(limit) = &artifact.collection_limit {
             if limit.byte_limit > MAX_SCCM_SERVER_ARTIFACT_BYTES
-                || limit
-                    .file_limit
-                    .is_some_and(|value| {
-                        value == 0 || value > MAX_SCCM_SERVER_MANIFEST_ARTIFACTS as u64
-                    })
+                || limit.file_limit.is_some_and(|value| {
+                    value == 0 || value > MAX_SCCM_SERVER_MANIFEST_ARTIFACTS as u64
+                })
             {
                 return Err(SccmServerIntakeError::ManifestLimitExceeded);
             }
@@ -1097,18 +1153,26 @@ fn normalize_hierarchy_link(
     synthetic_fixture: bool,
 ) -> Result<SccmServerHierarchyLinkTopology, SccmServerIntakeError> {
     let _ = RawServerHierarchyLink::KNOWN_FIELDS;
-    if !synthetic_fixture || !link.extensions.is_empty() {
+    if !link.extensions.is_empty() {
         return Err(SccmServerIntakeError::InvalidTopology);
     }
-    let valid = link.origin_site_code == "LAB"
-        && link.origin_host_handle == "synthetic:host:site-01"
-        && matches!(
-            (
-                link.target_site_code.as_str(),
-                link.target_host_handle.as_str()
-            ),
-            ("CHD", "synthetic:host:site-02") | ("SEC", "synthetic:host:site-03")
-        );
+    let valid = if synthetic_fixture {
+        link.origin_site_code == "LAB"
+            && link.origin_host_handle == "synthetic:host:site-01"
+            && matches!(
+                (
+                    link.target_site_code.as_str(),
+                    link.target_host_handle.as_str()
+                ),
+                ("CHD", "synthetic:host:site-02") | ("SEC", "synthetic:host:site-03")
+            )
+    } else {
+        link.origin_site_code != link.target_site_code
+            && opaque_sha256_handle(&link.origin_site_code, "cmtraceopen.site.sha256.v1:")
+            && opaque_sha256_handle(&link.target_site_code, "cmtraceopen.site.sha256.v1:")
+            && opaque_sha256_handle(&link.origin_host_handle, "cmtraceopen.host.sha256.v1:")
+            && opaque_sha256_handle(&link.target_host_handle, "cmtraceopen.host.sha256.v1:")
+    };
     if !valid {
         return Err(SccmServerIntakeError::InvalidTopology);
     }
@@ -1120,9 +1184,67 @@ fn normalize_hierarchy_link(
     })
 }
 
+fn hierarchy_contract_status(
+    source_id: &str,
+    producer_role: &SccmRole,
+    basename: &str,
+    rotation: Option<&SccmRotation>,
+) -> (Option<&'static SccmServerHierarchySourceContract>, bool) {
+    let classified = classify_artifact_name(basename, producer_role.clone());
+    let contract = declared_hierarchy_source_contracts()
+        .iter()
+        .find(|contract| {
+            contract.source_id == source_id
+                && &contract.producer_role == producer_role
+                && contract.logical_name == classified.logical_name
+        });
+    let rotation_matches = rotation.is_some_and(|rotation| {
+        classify_declared_hierarchy_source(
+            source_id,
+            producer_role,
+            &classified.logical_name,
+            rotation,
+        )
+        .is_some()
+    });
+    (contract, rotation_matches)
+}
+
+fn is_hierarchy_log_source(source_id: &str) -> bool {
+    matches!(
+        source_id,
+        "server-hierarchy-control" | "server-hierarchy-transfer"
+    )
+}
+
+fn normalize_supplement_admission(artifact: &RawServerArtifact) -> SccmServerSupplementAdmission {
+    let mut gaps = Vec::new();
+    match artifact.supplement_schema_version {
+        None => gaps.push(SccmServerSupplementGap::MissingSchemaVersion),
+        Some(version) if version != SCCM_SERVER_SITE_DATABASE_SCHEMA_VERSION => {
+            gaps.push(SccmServerSupplementGap::UnsupportedSchemaVersion)
+        }
+        Some(_) => {}
+    }
+    if artifact.supplement_operator_authorized != Some(true) {
+        gaps.push(SccmServerSupplementGap::MissingOperatorAuthorization);
+    }
+    if artifact.supplement_privacy_class.as_deref() != Some("redacted") {
+        gaps.push(SccmServerSupplementGap::PrivacyClassMismatch);
+    }
+    gaps.sort();
+    gaps.dedup();
+    match gaps.into_iter().next() {
+        None => SccmServerSupplementAdmission::Admitted,
+        Some(reason) => SccmServerSupplementAdmission::CoverageOnly { reason },
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn normalize_artifact(
     artifact: RawServerArtifact,
     synthetic_fixture: bool,
+    hierarchy_links: &[SccmServerHierarchyLinkTopology],
     roles_observed: &[SccmRole],
     relative_paths: &mut BTreeSet<String>,
     path_fingerprint_lineages: &mut BTreeMap<PathFingerprintKey, String>,
@@ -1338,6 +1460,16 @@ fn normalize_artifact(
         return Err(SccmServerIntakeError::DuplicateArtifact);
     }
 
+    let direction = artifact.direction;
+    let is_structured_supplement = artifact.source_id == "server-hierarchy-site-database";
+    if (!is_hierarchy_log_source(&artifact.source_id) && direction.is_some())
+        || (!is_structured_supplement
+            && (artifact.supplement_schema_version.is_some()
+                || artifact.supplement_operator_authorized.is_some()
+                || artifact.supplement_privacy_class.is_some()))
+    {
+        return Err(SccmServerIntakeError::InvalidArtifact);
+    }
     let configured_path_state =
         parse_configured_path_state(&artifact.configured_path_provenance.state)?;
     let configured_path_class = match artifact.configured_path_provenance.path_class.as_deref() {
@@ -1360,19 +1492,23 @@ fn normalize_artifact(
     )?;
     let (bytes, capture_provenance) =
         validate_payload_contract(&artifact, relative_path.as_deref(), payload_by_id)?;
-    let collection_limit = artifact.collection_limit.as_ref().map(|limit| {
-        SccmServerCollectionLimit {
-            byte_limit: limit.byte_limit,
-            file_limit: limit.file_limit,
-            limit_applied: limit.limit_applied,
-        }
-    });
+    let collection_limit =
+        artifact
+            .collection_limit
+            .as_ref()
+            .map(|limit| SccmServerCollectionLimit {
+                byte_limit: limit.byte_limit,
+                file_limit: limit.file_limit,
+                limit_applied: limit.limit_applied,
+            });
     let content_sha256 = bytes.map(payload_sha256);
-    let profile_eligible = source_version
+    let mut profile_eligible = source_version
         .as_deref()
         .is_some_and(|version| source_version_is_profile_eligible(version, synthetic_fixture));
 
     let mut evidence = Vec::new();
+    let mut observed_component_matches =
+        synthetic_fixture || artifact.capture_state != SccmCoverageState::Captured;
     let mut state = artifact.capture_state.clone();
     if artifact.capture_state == SccmCoverageState::Captured && parser_eligible {
         let bytes = bytes.ok_or(SccmServerIntakeError::MissingPayload)?;
@@ -1381,6 +1517,18 @@ fn normalize_artifact(
             .as_deref()
             .ok_or(SccmServerIntakeError::InvalidArtifact)?;
         if let Some(content) = decode_server_payload(bytes, encoding)? {
+            if family == SccmArtifactFamily::Hierarchy {
+                observed_component_matches = hierarchy_contract_status(
+                    &artifact.source_id,
+                    &artifact.producer_role,
+                    &artifact.original_basename,
+                    rotation.as_ref(),
+                )
+                .0
+                .is_some_and(|contract| {
+                    content.contains(&format!("$$<{}>", contract.expected_component))
+                });
+            }
             let display_name = original_basename
                 .clone()
                 .ok_or(SccmServerIntakeError::InvalidArtifact)?;
@@ -1429,6 +1577,100 @@ fn normalize_artifact(
         }
     }
 
+    let hierarchy_admission = if is_hierarchy_log_source(&artifact.source_id) {
+        let (contract, rotation_matches) = hierarchy_contract_status(
+            &artifact.source_id,
+            &artifact.producer_role,
+            &artifact.original_basename,
+            rotation.as_ref(),
+        );
+        let contract_version = contract
+            .map(|contract| contract.contract_version)
+            .unwrap_or_default();
+        let component = contract
+            .map(|contract| contract.expected_component.to_owned())
+            .unwrap_or_else(|| "unknown".to_owned());
+        let profile = source_version.as_deref().map(|version| {
+            SccmExtractionProfile::for_artifact_family(
+                Some(version),
+                &SccmArtifactFamily::Hierarchy,
+            )
+        });
+        let mut gaps = Vec::new();
+        if source_version.is_none() {
+            gaps.push(SccmServerHierarchyAdmissionGap::MissingVersion);
+        }
+        if profile
+            .as_ref()
+            .is_none_or(|profile| profile.maturity != SccmExtractionProfileMaturity::Stable)
+        {
+            gaps.push(SccmServerHierarchyAdmissionGap::UnvalidatedProfile);
+        }
+        if !rotation_matches {
+            gaps.push(SccmServerHierarchyAdmissionGap::RotationMismatch);
+        }
+        if !observed_component_matches {
+            gaps.push(SccmServerHierarchyAdmissionGap::ComponentMismatch);
+        }
+        if hierarchy_links.is_empty() {
+            gaps.push(SccmServerHierarchyAdmissionGap::MissingTopology);
+        }
+        match direction {
+            None => gaps.push(SccmServerHierarchyAdmissionGap::UnvalidatedDirection),
+            Some(SccmServerHierarchyDirection::Origin) if !hierarchy_links.is_empty() => {
+                if !hierarchy_links.iter().any(|link| {
+                    link.origin_host_handle
+                        == artifact.producer_host_handle.as_deref().unwrap_or_default()
+                }) {
+                    return Err(SccmServerIntakeError::InvalidArtifact);
+                }
+            }
+            Some(SccmServerHierarchyDirection::Target) if !hierarchy_links.is_empty() => {
+                if !hierarchy_links.iter().any(|link| {
+                    link.target_host_handle
+                        == artifact.producer_host_handle.as_deref().unwrap_or_default()
+                }) {
+                    return Err(SccmServerIntakeError::InvalidArtifact);
+                }
+            }
+            Some(_) => {}
+        }
+        if !synthetic_fixture {
+            gaps.push(SccmServerHierarchyAdmissionGap::UnvalidatedKeys);
+        }
+        gaps.sort();
+        gaps.dedup();
+        let confidence = if gaps.is_empty() {
+            SccmKeyConfidence::Exact
+        } else {
+            SccmKeyConfidence::Low
+        };
+        let profile_id = profile.map(|profile| profile.profile_id);
+        if !synthetic_fixture && !gaps.is_empty() {
+            parser_eligible = false;
+            profile_eligible = false;
+            evidence.clear();
+        }
+        Some(SccmServerHierarchyAdmission {
+            contract_version,
+            component,
+            direction,
+            profile_id,
+            confidence,
+            gaps,
+        })
+    } else {
+        None
+    };
+    let supplement_admission = if is_structured_supplement {
+        Some(normalize_supplement_admission(&artifact))
+    } else {
+        None
+    };
+    let supplement_provenance = supplement_admission
+        .as_ref()
+        .map(|_| "imported supplemental evidence".to_owned());
+
     Ok(PreparedArtifact {
         assessment: SccmServerArtifactAssessment {
             artifact_id: artifact.artifact_id,
@@ -1442,6 +1684,13 @@ fn normalize_artifact(
             source_kind: artifact.source_kind,
             family,
             original_basename,
+            direction,
+            hierarchy_admission,
+            supplement_schema_version: artifact.supplement_schema_version,
+            supplement_operator_authorized: artifact.supplement_operator_authorized,
+            supplement_privacy_class: artifact.supplement_privacy_class,
+            supplement_admission,
+            supplement_provenance,
             rotation,
             rotation_lineage_handle: artifact.rotation.lineage_id,
             state,
@@ -1508,6 +1757,28 @@ fn artifact_family_integrity_key(family: &SccmArtifactFamily) -> &str {
     family.serialized_name()
 }
 
+fn hierarchy_admission_gap_key(gap: &SccmServerHierarchyAdmissionGap) -> &'static str {
+    match gap {
+        SccmServerHierarchyAdmissionGap::MissingVersion => "missingVersion",
+        SccmServerHierarchyAdmissionGap::UnvalidatedProfile => "unvalidatedProfile",
+        SccmServerHierarchyAdmissionGap::MissingTopology => "missingTopology",
+        SccmServerHierarchyAdmissionGap::UnvalidatedDirection => "unvalidatedDirection",
+        SccmServerHierarchyAdmissionGap::UnvalidatedKeys => "unvalidatedKeys",
+        SccmServerHierarchyAdmissionGap::ComponentMismatch => "componentMismatch",
+        SccmServerHierarchyAdmissionGap::RotationMismatch => "rotationMismatch",
+        SccmServerHierarchyAdmissionGap::UnsupportedContractVersion => "unsupportedContractVersion",
+    }
+}
+
+fn supplement_gap_key(gap: &SccmServerSupplementGap) -> &'static str {
+    match gap {
+        SccmServerSupplementGap::MissingSchemaVersion => "missingSchemaVersion",
+        SccmServerSupplementGap::UnsupportedSchemaVersion => "unsupportedSchemaVersion",
+        SccmServerSupplementGap::MissingOperatorAuthorization => "missingOperatorAuthorization",
+        SccmServerSupplementGap::PrivacyClassMismatch => "privacyClassMismatch",
+    }
+}
+
 fn topology_string_bytes(topology: &SccmServerTopologyAssessment) -> Option<usize> {
     let mut total = 0usize;
     checked_add_string_bytes(&mut total, &topology.capture_host_handle)?;
@@ -1534,6 +1805,61 @@ fn artifact_string_bytes(artifacts: &[SccmServerArtifactAssessment]) -> Option<u
         checked_add_string_bytes(&mut total, &artifact.source_kind)?;
         checked_add_string_bytes(&mut total, artifact_family_integrity_key(&artifact.family))?;
         checked_add_optional_string_bytes(&mut total, artifact.original_basename.as_deref())?;
+        if let Some(direction) = artifact.direction {
+            checked_add_string_bytes(
+                &mut total,
+                match direction {
+                    SccmServerHierarchyDirection::Origin => "origin",
+                    SccmServerHierarchyDirection::Target => "target",
+                },
+            )?;
+        }
+        if let Some(admission) = &artifact.hierarchy_admission {
+            checked_add_string_bytes(&mut total, &admission.contract_version.to_string())?;
+            checked_add_string_bytes(&mut total, &admission.component)?;
+            checked_add_optional_string_bytes(&mut total, admission.profile_id.as_deref())?;
+            checked_add_string_bytes(
+                &mut total,
+                match admission.confidence {
+                    SccmKeyConfidence::Low => "low",
+                    SccmKeyConfidence::Strong => "strong",
+                    SccmKeyConfidence::Exact => "exact",
+                },
+            )?;
+            for gap in &admission.gaps {
+                checked_add_string_bytes(&mut total, hierarchy_admission_gap_key(gap))?;
+            }
+        }
+        if let Some(version) = artifact.supplement_schema_version {
+            checked_add_string_bytes(&mut total, &version.to_string())?;
+        }
+        if let Some(authorized) = artifact.supplement_operator_authorized {
+            checked_add_string_bytes(
+                &mut total,
+                if authorized {
+                    "authorized"
+                } else {
+                    "unauthorized"
+                },
+            )?;
+        }
+        checked_add_optional_string_bytes(
+            &mut total,
+            artifact.supplement_privacy_class.as_deref(),
+        )?;
+        if let Some(admission) = &artifact.supplement_admission {
+            checked_add_string_bytes(
+                &mut total,
+                match admission {
+                    SccmServerSupplementAdmission::Admitted => "admitted",
+                    SccmServerSupplementAdmission::CoverageOnly { .. } => "coverageOnly",
+                },
+            )?;
+            if let SccmServerSupplementAdmission::CoverageOnly { reason } = admission {
+                checked_add_string_bytes(&mut total, supplement_gap_key(reason))?;
+            }
+        }
+        checked_add_optional_string_bytes(&mut total, artifact.supplement_provenance.as_deref())?;
         match artifact.rotation.as_ref() {
             None => {}
             Some(SccmRotation::Current) => checked_add_string_bytes(&mut total, "current")?,
@@ -2178,9 +2504,11 @@ fn validate_payload_contract<'a>(
             }
         }
         SccmCoverageState::ParseFailed => {
-            if artifact.collection_limit.as_ref().is_some_and(|limit| {
-                limit.byte_limit == 0 || limit.limit_applied
-            }) {
+            if artifact
+                .collection_limit
+                .as_ref()
+                .is_some_and(|limit| limit.byte_limit == 0 || limit.limit_applied)
+            {
                 return Err(SccmServerIntakeError::InvalidArtifact);
             }
         }
@@ -2309,9 +2637,7 @@ fn validate_relative_path(
 }
 
 fn is_physical_artifact(artifact: &RawServerArtifact) -> bool {
-    artifact.relative_path.is_some()
-        || artifact.bytes_copied > 0
-        || artifact.encoding.is_some()
+    artifact.relative_path.is_some() || artifact.bytes_copied > 0 || artifact.encoding.is_some()
 }
 
 fn safe_encoding(encoding: &str) -> bool {
@@ -2777,6 +3103,7 @@ fn safe_source_id(value: &str, allow_unknown: bool, synthetic_fixture: bool) -> 
             | "server-dp-serve"
             | "server-hierarchy-control"
             | "server-hierarchy-transfer"
+            | "server-hierarchy-site-database"
             | "server-sup-sync"
             | "server-sup-wsus"
             | "server-provider"
@@ -3476,6 +3803,10 @@ define_raw_server_wire! {
         "sourceId" => source_id: String,
         "sourceKind" => source_kind: String,
         "sourceVersion" => source_version: Option<String>,
+        "direction" => direction: Option<SccmServerHierarchyDirection>,
+        "supplementSchemaVersion" => supplement_schema_version: Option<u32>,
+        "operatorAuthorized" => supplement_operator_authorized: Option<bool>,
+        "privacyClass" => supplement_privacy_class: Option<String>,
         "originalPath" => original_path: String,
         "originalBasename" => original_basename: String,
         "configuredPathProvenance" => configured_path_provenance: RawConfiguredPathProvenance,
@@ -3654,6 +3985,10 @@ mod opaque_extension_boundary_tests {
                 "sourceId",
                 "sourceKind",
                 "sourceVersion",
+                "direction",
+                "supplementSchemaVersion",
+                "operatorAuthorized",
+                "privacyClass",
                 "originalPath",
                 "originalBasename",
                 "configuredPathProvenance",
@@ -3796,6 +4131,13 @@ mod opaque_extension_boundary_tests {
             source_kind: "unused".to_owned(),
             family: SccmArtifactFamily::Unknown("unused".to_owned()),
             original_basename: None,
+            direction: None,
+            hierarchy_admission: None,
+            supplement_schema_version: None,
+            supplement_operator_authorized: None,
+            supplement_privacy_class: None,
+            supplement_admission: None,
+            supplement_provenance: None,
             rotation: None,
             rotation_lineage_handle: "unused".to_owned(),
             state: SccmCoverageState::Unsupported,

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -21,7 +21,7 @@ use super::catalog::{
     classify_declared_hierarchy_source, classify_declared_server_source,
     declared_hierarchy_source_contracts, expected_family, SccmServerHierarchyDirection,
     SccmServerHierarchySourceContract, SccmServerSourceKind, SccmServerSourceSpec,
-    SCCM_SERVER_SITE_DATABASE_SCHEMA_VERSION,
+    SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION, SCCM_SERVER_SITE_DATABASE_SCHEMA_VERSION,
 };
 
 /// Keep parser-side work bounded even when the manifest did not come from the
@@ -629,7 +629,7 @@ pub struct SccmServerArtifactAssessment {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SccmServerHierarchyAdmission {
-    pub contract_version: u32,
+    pub contract_version: Option<u32>,
     pub component: String,
     pub direction: Option<SccmServerHierarchyDirection>,
     pub profile_id: Option<String>,
@@ -641,6 +641,7 @@ pub struct SccmServerHierarchyAdmission {
 #[serde(rename_all = "camelCase")]
 pub enum SccmServerHierarchyAdmissionGap {
     MissingVersion,
+    MissingContractVersion,
     UnvalidatedProfile,
     MissingTopology,
     UnvalidatedDirection,
@@ -654,16 +655,30 @@ pub enum SccmServerHierarchyAdmissionGap {
 #[serde(rename_all = "camelCase")]
 pub enum SccmServerSupplementAdmission {
     Admitted,
-    CoverageOnly { reason: SccmServerSupplementGap },
+    CoverageOnly { gaps: Vec<SccmServerSupplementGap> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum SccmServerSupplementGap {
+    MissingContractVersion,
+    UnsupportedContractVersion,
     MissingSchemaVersion,
     UnsupportedSchemaVersion,
     MissingOperatorAuthorization,
     PrivacyClassMismatch,
+    Absent,
+    AccessDenied,
+    Capped,
+    Skipped,
+    Unsupported,
+    ParseFailed,
+    IncompletePayload,
+    MissingPayload,
+    MissingCollectionLimit,
+    MissingDigest,
+    MissingProvenance,
+    MalformedPayload,
 }
 
 impl SccmServerArtifactAssessment {
@@ -833,6 +848,8 @@ pub fn assess_server_intake(
         let normalized = normalize_artifact(
             artifact,
             manifest.synthetic_fixture,
+            manifest.hierarchy_contract_version,
+            &topology.site_handle,
             &topology.hierarchy_links,
             &topology.roles_observed,
             &mut relative_paths,
@@ -1168,6 +1185,7 @@ fn normalize_hierarchy_link(
             )
     } else {
         link.origin_site_code != link.target_site_code
+            && link.origin_host_handle != link.target_host_handle
             && opaque_sha256_handle(&link.origin_site_code, "cmtraceopen.site.sha256.v1:")
             && opaque_sha256_handle(&link.target_site_code, "cmtraceopen.site.sha256.v1:")
             && opaque_sha256_handle(&link.origin_host_handle, "cmtraceopen.host.sha256.v1:")
@@ -1217,8 +1235,25 @@ fn is_hierarchy_log_source(source_id: &str) -> bool {
     )
 }
 
-fn normalize_supplement_admission(artifact: &RawServerArtifact) -> SccmServerSupplementAdmission {
+fn normalize_supplement_admission(
+    artifact: &RawServerArtifact,
+    synthetic_fixture: bool,
+    manifest_contract_version: Option<u32>,
+    payload_error: Option<&SccmServerIntakeError>,
+    payload_present: bool,
+    capture_provenance: Option<&SccmServerCaptureProvenance>,
+    content_digest_present: bool,
+) -> SccmServerSupplementAdmission {
     let mut gaps = Vec::new();
+    if !synthetic_fixture {
+        match manifest_contract_version {
+            None => gaps.push(SccmServerSupplementGap::MissingContractVersion),
+            Some(version) if version != SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION => {
+                gaps.push(SccmServerSupplementGap::UnsupportedContractVersion)
+            }
+            Some(_) => {}
+        }
+    }
     match artifact.supplement_schema_version {
         None => gaps.push(SccmServerSupplementGap::MissingSchemaVersion),
         Some(version) if version != SCCM_SERVER_SITE_DATABASE_SCHEMA_VERSION => {
@@ -1232,11 +1267,49 @@ fn normalize_supplement_admission(artifact: &RawServerArtifact) -> SccmServerSup
     if artifact.supplement_privacy_class.as_deref() != Some("redacted") {
         gaps.push(SccmServerSupplementGap::PrivacyClassMismatch);
     }
+    match artifact.capture_state {
+        SccmCoverageState::Captured => {}
+        SccmCoverageState::Absent => gaps.push(SccmServerSupplementGap::Absent),
+        SccmCoverageState::AccessDenied => gaps.push(SccmServerSupplementGap::AccessDenied),
+        SccmCoverageState::Capped => gaps.push(SccmServerSupplementGap::Capped),
+        SccmCoverageState::Skipped => gaps.push(SccmServerSupplementGap::Skipped),
+        SccmCoverageState::Unsupported => gaps.push(SccmServerSupplementGap::Unsupported),
+        SccmCoverageState::ParseFailed => gaps.push(SccmServerSupplementGap::ParseFailed),
+    }
+    if artifact.capture_state == SccmCoverageState::Captured
+        && (artifact.fragment_complete != Some(true) || artifact.truncated != Some(false))
+    {
+        gaps.push(SccmServerSupplementGap::IncompletePayload);
+    }
+    if artifact.capture_state == SccmCoverageState::Captured && !payload_present {
+        gaps.push(SccmServerSupplementGap::MissingPayload);
+    }
+    if artifact.capture_state == SccmCoverageState::Captured && artifact.collection_limit.is_none()
+    {
+        gaps.push(SccmServerSupplementGap::MissingCollectionLimit);
+    }
+    if artifact.capture_state == SccmCoverageState::Captured
+        && artifact
+            .collection_limit
+            .as_ref()
+            .is_some_and(|limit| limit.limit_applied || artifact.bytes_copied > limit.byte_limit)
+    {
+        gaps.push(SccmServerSupplementGap::Capped);
+    }
+    if artifact.capture_state == SccmCoverageState::Captured && !content_digest_present {
+        gaps.push(SccmServerSupplementGap::MissingDigest);
+    }
+    if artifact.capture_state == SccmCoverageState::Captured && capture_provenance.is_none() {
+        gaps.push(SccmServerSupplementGap::MissingProvenance);
+    }
+    if payload_error.is_some() {
+        gaps.push(SccmServerSupplementGap::MalformedPayload);
+    }
     gaps.sort();
     gaps.dedup();
-    match gaps.into_iter().next() {
-        None => SccmServerSupplementAdmission::Admitted,
-        Some(reason) => SccmServerSupplementAdmission::CoverageOnly { reason },
+    match gaps.is_empty() {
+        true => SccmServerSupplementAdmission::Admitted,
+        false => SccmServerSupplementAdmission::CoverageOnly { gaps },
     }
 }
 
@@ -1244,6 +1317,8 @@ fn normalize_supplement_admission(artifact: &RawServerArtifact) -> SccmServerSup
 fn normalize_artifact(
     artifact: RawServerArtifact,
     synthetic_fixture: bool,
+    manifest_contract_version: Option<u32>,
+    site_handle: &str,
     hierarchy_links: &[SccmServerHierarchyLinkTopology],
     roles_observed: &[SccmRole],
     relative_paths: &mut BTreeSet<String>,
@@ -1490,8 +1565,12 @@ fn normalize_artifact(
         rotation.as_ref(),
         relative_paths,
     )?;
-    let (bytes, capture_provenance) =
-        validate_payload_contract(&artifact, relative_path.as_deref(), payload_by_id)?;
+    let (bytes, capture_provenance, payload_error) =
+        match validate_payload_contract(&artifact, relative_path.as_deref(), payload_by_id) {
+            Ok((bytes, capture_provenance)) => (bytes, capture_provenance, None),
+            Err(error) if is_structured_supplement => (None, None, Some(error)),
+            Err(error) => return Err(error),
+        };
     let collection_limit =
         artifact
             .collection_limit
@@ -1510,6 +1589,10 @@ fn normalize_artifact(
     let mut observed_component_matches =
         synthetic_fixture || artifact.capture_state != SccmCoverageState::Captured;
     let mut state = artifact.capture_state.clone();
+    if is_structured_supplement {
+        parser_eligible = false;
+        profile_eligible = false;
+    }
     if artifact.capture_state == SccmCoverageState::Captured && parser_eligible {
         let bytes = bytes.ok_or(SccmServerIntakeError::MissingPayload)?;
         let encoding = artifact
@@ -1526,7 +1609,11 @@ fn normalize_artifact(
                 )
                 .0
                 .is_some_and(|contract| {
-                    content.contains(&format!("$$<{}>", contract.expected_component))
+                    crate::parser::ccm::scan_logical_records(&content, &artifact.original_basename)
+                        .iter()
+                        .any(|record| {
+                            record.entry.component.as_deref() == Some(contract.expected_component)
+                        })
                 });
             }
             let display_name = original_basename
@@ -1584,9 +1671,13 @@ fn normalize_artifact(
             &artifact.original_basename,
             rotation.as_ref(),
         );
-        let contract_version = contract
-            .map(|contract| contract.contract_version)
-            .unwrap_or_default();
+        let contract_version = if synthetic_fixture {
+            contract.map(|contract| contract.contract_version)
+        } else if manifest_contract_version == Some(SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION) {
+            manifest_contract_version
+        } else {
+            None
+        };
         let component = contract
             .map(|contract| contract.expected_component.to_owned())
             .unwrap_or_else(|| "unknown".to_owned());
@@ -1599,6 +1690,15 @@ fn normalize_artifact(
         let mut gaps = Vec::new();
         if source_version.is_none() {
             gaps.push(SccmServerHierarchyAdmissionGap::MissingVersion);
+        }
+        if !synthetic_fixture {
+            match manifest_contract_version {
+                None => gaps.push(SccmServerHierarchyAdmissionGap::MissingContractVersion),
+                Some(version) if version != SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION => {
+                    gaps.push(SccmServerHierarchyAdmissionGap::UnsupportedContractVersion)
+                }
+                Some(_) => {}
+            }
         }
         if profile
             .as_ref()
@@ -1615,25 +1715,29 @@ fn normalize_artifact(
         if hierarchy_links.is_empty() {
             gaps.push(SccmServerHierarchyAdmissionGap::MissingTopology);
         }
-        match direction {
-            None => gaps.push(SccmServerHierarchyAdmissionGap::UnvalidatedDirection),
-            Some(SccmServerHierarchyDirection::Origin) if !hierarchy_links.is_empty() => {
-                if !hierarchy_links.iter().any(|link| {
-                    link.origin_host_handle
-                        == artifact.producer_host_handle.as_deref().unwrap_or_default()
-                }) {
-                    return Err(SccmServerIntakeError::InvalidArtifact);
-                }
+        let validated_direction = match direction {
+            Some(SccmServerHierarchyDirection::Origin)
+                if hierarchy_links.iter().any(|link| {
+                    link.origin_site_code == site_handle
+                        && link.origin_host_handle
+                            == artifact.producer_host_handle.as_deref().unwrap_or_default()
+                }) =>
+            {
+                Some(SccmServerHierarchyDirection::Origin)
             }
-            Some(SccmServerHierarchyDirection::Target) if !hierarchy_links.is_empty() => {
-                if !hierarchy_links.iter().any(|link| {
-                    link.target_host_handle
-                        == artifact.producer_host_handle.as_deref().unwrap_or_default()
-                }) {
-                    return Err(SccmServerIntakeError::InvalidArtifact);
-                }
+            Some(SccmServerHierarchyDirection::Target)
+                if hierarchy_links.iter().any(|link| {
+                    link.target_site_code == site_handle
+                        && link.target_host_handle
+                            == artifact.producer_host_handle.as_deref().unwrap_or_default()
+                }) =>
+            {
+                Some(SccmServerHierarchyDirection::Target)
             }
-            Some(_) => {}
+            _ => None,
+        };
+        if validated_direction.is_none() {
+            gaps.push(SccmServerHierarchyAdmissionGap::UnvalidatedDirection);
         }
         if !synthetic_fixture {
             gaps.push(SccmServerHierarchyAdmissionGap::UnvalidatedKeys);
@@ -1654,7 +1758,7 @@ fn normalize_artifact(
         Some(SccmServerHierarchyAdmission {
             contract_version,
             component,
-            direction,
+            direction: validated_direction,
             profile_id,
             confidence,
             gaps,
@@ -1663,7 +1767,15 @@ fn normalize_artifact(
         None
     };
     let supplement_admission = if is_structured_supplement {
-        Some(normalize_supplement_admission(&artifact))
+        Some(normalize_supplement_admission(
+            &artifact,
+            synthetic_fixture,
+            manifest_contract_version,
+            payload_error.as_ref(),
+            bytes.is_some(),
+            capture_provenance.as_ref(),
+            content_sha256.is_some(),
+        ))
     } else {
         None
     };
@@ -1684,7 +1796,9 @@ fn normalize_artifact(
             source_kind: artifact.source_kind,
             family,
             original_basename,
-            direction,
+            direction: hierarchy_admission
+                .as_ref()
+                .and_then(|admission| admission.direction),
             hierarchy_admission,
             supplement_schema_version: artifact.supplement_schema_version,
             supplement_operator_authorized: artifact.supplement_operator_authorized,
@@ -1760,6 +1874,7 @@ fn artifact_family_integrity_key(family: &SccmArtifactFamily) -> &str {
 fn hierarchy_admission_gap_key(gap: &SccmServerHierarchyAdmissionGap) -> &'static str {
     match gap {
         SccmServerHierarchyAdmissionGap::MissingVersion => "missingVersion",
+        SccmServerHierarchyAdmissionGap::MissingContractVersion => "missingContractVersion",
         SccmServerHierarchyAdmissionGap::UnvalidatedProfile => "unvalidatedProfile",
         SccmServerHierarchyAdmissionGap::MissingTopology => "missingTopology",
         SccmServerHierarchyAdmissionGap::UnvalidatedDirection => "unvalidatedDirection",
@@ -1772,10 +1887,24 @@ fn hierarchy_admission_gap_key(gap: &SccmServerHierarchyAdmissionGap) -> &'stati
 
 fn supplement_gap_key(gap: &SccmServerSupplementGap) -> &'static str {
     match gap {
+        SccmServerSupplementGap::MissingContractVersion => "missingContractVersion",
+        SccmServerSupplementGap::UnsupportedContractVersion => "unsupportedContractVersion",
         SccmServerSupplementGap::MissingSchemaVersion => "missingSchemaVersion",
         SccmServerSupplementGap::UnsupportedSchemaVersion => "unsupportedSchemaVersion",
         SccmServerSupplementGap::MissingOperatorAuthorization => "missingOperatorAuthorization",
         SccmServerSupplementGap::PrivacyClassMismatch => "privacyClassMismatch",
+        SccmServerSupplementGap::Absent => "absent",
+        SccmServerSupplementGap::AccessDenied => "accessDenied",
+        SccmServerSupplementGap::Capped => "capped",
+        SccmServerSupplementGap::Skipped => "skipped",
+        SccmServerSupplementGap::Unsupported => "unsupported",
+        SccmServerSupplementGap::ParseFailed => "parseFailed",
+        SccmServerSupplementGap::IncompletePayload => "incompletePayload",
+        SccmServerSupplementGap::MissingPayload => "missingPayload",
+        SccmServerSupplementGap::MissingCollectionLimit => "missingCollectionLimit",
+        SccmServerSupplementGap::MissingDigest => "missingDigest",
+        SccmServerSupplementGap::MissingProvenance => "missingProvenance",
+        SccmServerSupplementGap::MalformedPayload => "malformedPayload",
     }
 }
 
@@ -1815,7 +1944,9 @@ fn artifact_string_bytes(artifacts: &[SccmServerArtifactAssessment]) -> Option<u
             )?;
         }
         if let Some(admission) = &artifact.hierarchy_admission {
-            checked_add_string_bytes(&mut total, &admission.contract_version.to_string())?;
+            if let Some(contract_version) = admission.contract_version {
+                checked_add_string_bytes(&mut total, &contract_version.to_string())?;
+            }
             checked_add_string_bytes(&mut total, &admission.component)?;
             checked_add_optional_string_bytes(&mut total, admission.profile_id.as_deref())?;
             checked_add_string_bytes(
@@ -1855,8 +1986,10 @@ fn artifact_string_bytes(artifacts: &[SccmServerArtifactAssessment]) -> Option<u
                     SccmServerSupplementAdmission::CoverageOnly { .. } => "coverageOnly",
                 },
             )?;
-            if let SccmServerSupplementAdmission::CoverageOnly { reason } = admission {
-                checked_add_string_bytes(&mut total, supplement_gap_key(reason))?;
+            if let SccmServerSupplementAdmission::CoverageOnly { gaps } = admission {
+                for gap in gaps {
+                    checked_add_string_bytes(&mut total, supplement_gap_key(gap))?;
+                }
             }
         }
         checked_add_optional_string_bytes(&mut total, artifact.supplement_provenance.as_deref())?;
@@ -2948,6 +3081,7 @@ fn validate_artifact_annotations(
 
     match (artifact.truncated, artifact.fragment_complete) {
         (None, None) => {}
+        (Some(false), Some(true)) if artifact.capture_state == SccmCoverageState::Captured => {}
         (Some(false), Some(false)) if artifact.capture_state == SccmCoverageState::Captured => {}
         (None, Some(false)) if artifact.capture_state == SccmCoverageState::Captured => {}
         (Some(true), Some(false)) if artifact.capture_state == SccmCoverageState::Capped => {}
@@ -3757,6 +3891,7 @@ macro_rules! define_raw_server_wire {
 define_raw_server_wire! {
     struct RawServerManifest {
         "sccmManifestVersion" => sccm_manifest_version: u32,
+        "hierarchyContractVersion" => hierarchy_contract_version: Option<u32>,
         #[serde(default)]
         "syntheticFixture" => synthetic_fixture: bool,
         "proposalOnly" => proposal_only: Option<bool>,
@@ -3936,6 +4071,7 @@ mod opaque_extension_boundary_tests {
             RawServerManifest::KNOWN_FIELDS,
             [
                 "sccmManifestVersion",
+                "hierarchyContractVersion",
                 "syntheticFixture",
                 "proposalOnly",
                 "privacy",

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -1580,7 +1580,9 @@ fn normalize_artifact(
                 file_limit: limit.file_limit,
                 limit_applied: limit.limit_applied,
             });
-    let content_sha256 = bytes.map(payload_sha256);
+    let content_sha256 = bytes
+        .filter(|_| !is_structured_supplement || artifact.encoding.as_deref() != Some("unknown"))
+        .map(payload_sha256);
     let mut profile_eligible = source_version
         .as_deref()
         .is_some_and(|version| source_version_is_profile_eligible(version, synthetic_fixture));

--- a/crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs
@@ -1,0 +1,244 @@
+use cmtraceopen_parser::sccm::server::windows::{
+    assess_server_intake, declared_hierarchy_source_contracts, SccmServerArtifactPayload,
+    SccmServerHierarchySourceContract, SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION,
+};
+use cmtraceopen_parser::sccm::SccmRotation;
+use serde_json::json;
+
+fn contract_rows() -> Vec<(&'static str, &'static str, &'static str)> {
+    declared_hierarchy_source_contracts()
+        .iter()
+        .map(|contract| {
+            (
+                contract.source_id,
+                contract.logical_name,
+                contract.expected_component,
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn catalog_declares_only_observed_hierarchy_source_components() {
+    let contracts = declared_hierarchy_source_contracts();
+    assert_eq!(contracts.len(), 5);
+    assert!(
+        contracts
+            .iter()
+            .all(|contract| contract.contract_version
+                == SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION)
+    );
+    assert_eq!(
+        contract_rows(),
+        vec![
+            (
+                "server-hierarchy-control",
+                "replmgr",
+                "SMS_REPLICATION_MANAGER"
+            ),
+            (
+                "server-hierarchy-control",
+                "rcmctrl",
+                "SMS_REPLICATION_CONFIGURATION_MONITOR"
+            ),
+            (
+                "server-hierarchy-control",
+                "rcmctrl",
+                "SMS_REPLICATION_CONFIGURATION_MONITOR"
+            ),
+            ("server-hierarchy-transfer", "sender", "SMS_LAN_SENDER"),
+            ("server-hierarchy-transfer", "despool", "SMS_DESPOOLER"),
+        ]
+    );
+    assert!(!contracts
+        .iter()
+        .any(|contract| contract.logical_name == "sender.lo_"));
+}
+
+#[test]
+fn catalog_contract_rows_have_distinct_rotation_policies() {
+    let contracts = declared_hierarchy_source_contracts();
+    let rcmctrl = contracts
+        .iter()
+        .filter(|contract| contract.logical_name == "rcmctrl")
+        .collect::<Vec<&SccmServerHierarchySourceContract>>();
+    assert_eq!(rcmctrl.len(), 2);
+    assert_ne!(
+        rcmctrl[0].allows_rotation(&SccmRotation::Current),
+        rcmctrl[1].allows_rotation(&SccmRotation::Current)
+    );
+    assert!(rcmctrl[0].allows_rotation(&SccmRotation::Current));
+    assert!(rcmctrl[1].allows_rotation(&SccmRotation::LoUnderscore));
+}
+
+fn opaque(prefix: &str, value: u8) -> String {
+    format!("{prefix}{value:064x}")
+}
+
+fn live_like_replmgr_manifest(
+    direction: Option<&str>,
+    hierarchy_links: serde_json::Value,
+) -> (String, Vec<SccmServerArtifactPayload>) {
+    let artifact_id = opaque("cmtraceopen.artifact.sha256.v1:", 3);
+    let host = opaque("cmtraceopen.host.sha256.v1:", 1);
+    let site = opaque("cmtraceopen.site.sha256.v1:", 2);
+    let producer_host = opaque("cmtraceopen.host.sha256.v1:", 1);
+    let path = opaque("cmtraceopen.path.sha256.v1:", 4);
+    let lineage = opaque("cmtraceopen.lineage.sha256.v1:", 5);
+    let content = b"SMS_EXECUTIVE started SMS_REPLICATION_MANAGER as thread ID 1 (0x1).  $$<SMS_REPLICATION_MANAGER><08-01-2026 21:50:03.847+240><thread=1 (0x1)>\n";
+    let mut artifact = json!({
+        "artifactId": artifact_id,
+        "producerRole": "siteServer",
+        "producerHostHandle": producer_host,
+        "sourceId": "server-hierarchy-control",
+        "sourceKind": "ccmLog",
+        "sourceVersion": null,
+        "originalPath": "REDACTED",
+        "originalBasename": "replmgr.log",
+        "configuredPathProvenance": {
+            "state": "configured",
+            "pathFingerprint": path,
+        },
+        "rotation": {
+            "kind": "current",
+            "lineageId": lineage,
+        },
+        "captureState": "captured",
+        "encoding": "utf-8",
+        "collectionLimit": {"byteLimit": 4096, "limitApplied": false},
+        "collectedUtc": "2026-08-02T00:00:00Z",
+        "relativePath": "evidence/sccm/server/site-server/server-hierarchy-control/root-00000001/current/replmgr.log",
+        "bytesCopied": content.len(),
+    });
+    if let Some(direction) = direction {
+        artifact["direction"] = json!(direction);
+    }
+    let manifest = json!({
+        "sccmManifestVersion": 1,
+        "syntheticFixture": false,
+        "bundleRole": "server",
+        "topology": {
+            "captureHost": host,
+            "siteCode": site,
+            "rolesObserved": ["siteServer"],
+            "hierarchyLinks": hierarchy_links,
+        },
+        "artifacts": [artifact],
+    });
+    (
+        serde_json::to_string(&manifest).expect("manifest serializes"),
+        vec![SccmServerArtifactPayload {
+            manifest_artifact_id: opaque("cmtraceopen.artifact.sha256.v1:", 3),
+            bytes: content.to_vec(),
+        }],
+    )
+}
+
+#[test]
+fn live_like_manifest_preserves_missing_version_topology_direction_and_keys() {
+    let (manifest, payloads) = live_like_replmgr_manifest(None, json!([]));
+    let assessment = assess_server_intake(&manifest, &payloads).expect("intake succeeds");
+    let artifact = &assessment.artifacts[0];
+    let admission = artifact
+        .hierarchy_admission
+        .as_ref()
+        .expect("hierarchy admission is present");
+    assert_eq!(artifact.source_version, None);
+    assert!(!artifact.profile_eligible);
+    assert!(!artifact.parser_eligible);
+    assert!(assessment.evidence.is_empty());
+    assert!(admission.gaps.contains(
+        &cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyAdmissionGap::MissingVersion
+    ));
+    assert!(admission
+        .gaps
+        .contains(&cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyAdmissionGap::MissingTopology));
+    assert!(admission
+        .gaps
+        .contains(&cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyAdmissionGap::UnvalidatedDirection));
+    assert!(admission
+        .gaps
+        .contains(&cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyAdmissionGap::UnvalidatedKeys));
+}
+
+#[test]
+fn direction_is_validated_against_an_explicit_opaque_link() {
+    let origin_site = opaque("cmtraceopen.site.sha256.v1:", 6);
+    let target_site = opaque("cmtraceopen.site.sha256.v1:", 7);
+    let origin_host = opaque("cmtraceopen.host.sha256.v1:", 1);
+    let target_host = opaque("cmtraceopen.host.sha256.v1:", 8);
+    let links = json!([{
+        "originSiteCode": origin_site,
+        "targetSiteCode": target_site,
+        "originHostHandle": origin_host,
+        "targetHostHandle": target_host,
+    }]);
+    let (manifest, payloads) = live_like_replmgr_manifest(Some("origin"), links);
+    let assessment = assess_server_intake(&manifest, &payloads).expect("intake succeeds");
+    let admission = assessment.artifacts[0]
+        .hierarchy_admission
+        .as_ref()
+        .expect("hierarchy admission is present");
+    assert_eq!(
+        admission.direction,
+        Some(cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyDirection::Origin)
+    );
+    assert!(!admission
+        .gaps
+        .contains(&cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyAdmissionGap::MissingTopology));
+    assert!(!admission
+        .gaps
+        .contains(&cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyAdmissionGap::UnvalidatedDirection));
+}
+
+fn site_database_supplement_manifest(
+    schema_version: u64,
+    authorized: bool,
+    privacy: &str,
+) -> (String, Vec<SccmServerArtifactPayload>) {
+    let (manifest, payloads) = live_like_replmgr_manifest(None, json!([]));
+    let mut manifest = serde_json::from_str::<serde_json::Value>(&manifest).expect("manifest JSON");
+    let artifact = &mut manifest["artifacts"][0];
+    artifact["sourceId"] = json!("server-hierarchy-site-database");
+    artifact["sourceKind"] = json!("structuredSupplement");
+    artifact["originalBasename"] = json!("site-database.supplement");
+    artifact["supplementSchemaVersion"] = json!(schema_version);
+    artifact["operatorAuthorized"] = json!(authorized);
+    artifact["privacyClass"] = json!(privacy);
+    artifact["relativePath"] = json!("evidence/sccm/server/site-server/server-hierarchy-site-database/root-00000001/current/site-database.supplement");
+    (
+        serde_json::to_string(&manifest).expect("manifest serializes"),
+        payloads,
+    )
+}
+
+#[test]
+fn structured_supplement_is_admitted_only_as_redacted_provenance() {
+    let (manifest, payloads) = site_database_supplement_manifest(1, true, "redacted");
+    let assessment = assess_server_intake(&manifest, &payloads).expect("supplement intake");
+    let artifact = &assessment.artifacts[0];
+    assert_eq!(
+        artifact.supplement_admission,
+        Some(cmtraceopen_parser::sccm::server::windows::SccmServerSupplementAdmission::Admitted)
+    );
+    assert_eq!(
+        artifact.supplement_provenance.as_deref(),
+        Some("imported supplemental evidence")
+    );
+    assert!(!artifact.parser_eligible);
+    assert!(assessment.evidence.is_empty());
+}
+
+#[test]
+fn structured_supplement_unknown_schema_remains_coverage_only() {
+    let (manifest, payloads) = site_database_supplement_manifest(2, true, "redacted");
+    let assessment =
+        assess_server_intake(&manifest, &payloads).expect("unknown schema is coverage");
+    assert!(matches!(
+        assessment.artifacts[0].supplement_admission,
+        Some(cmtraceopen_parser::sccm::server::windows::SccmServerSupplementAdmission::CoverageOnly {
+            reason: cmtraceopen_parser::sccm::server::windows::SccmServerSupplementGap::UnsupportedSchemaVersion
+        })
+    ));
+    assert!(assessment.evidence.is_empty());
+}

--- a/crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs
@@ -341,6 +341,29 @@ fn structured_supplement_unknown_schema_remains_coverage_only() {
 }
 
 #[test]
+fn structured_supplement_unknown_encoding_remains_coverage_only_without_digest() {
+    let (manifest, payloads) = site_database_supplement_manifest(1, true, "redacted");
+    let mut manifest = serde_json::from_str::<serde_json::Value>(&manifest).expect("manifest JSON");
+    manifest["artifacts"][0]["encoding"] = json!("unknown");
+
+    let assessment = assess_server_intake(
+        &serde_json::to_string(&manifest).expect("manifest serializes"),
+        &payloads,
+    )
+    .expect("unknown encoding remains coverage");
+    let artifact = &assessment.artifacts[0];
+    assert!(matches!(
+        &artifact.supplement_admission,
+        Some(cmtraceopen_parser::sccm::server::windows::SccmServerSupplementAdmission::CoverageOnly {
+            gaps
+        }) if gaps.contains(&cmtraceopen_parser::sccm::server::windows::SccmServerSupplementGap::MissingDigest)
+    ));
+    assert_eq!(artifact.content_sha256, None);
+    assert!(!artifact.parser_eligible);
+    assert!(assessment.evidence.is_empty());
+}
+
+#[test]
 fn structured_supplement_matrix_stays_coverage_only_without_complete_integrity() {
     type SupplementMutation = fn(&mut serde_json::Value);
     let cases: &[(&str, SupplementMutation)] = &[

--- a/crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs
@@ -79,13 +79,24 @@ fn live_like_replmgr_manifest(
     direction: Option<&str>,
     hierarchy_links: serde_json::Value,
 ) -> (String, Vec<SccmServerArtifactPayload>) {
+    live_like_replmgr_manifest_with_content(
+        direction,
+        hierarchy_links,
+        br#"<![LOG[replication manager record]LOG]!><time="21:50:03.847+240" date="08-01-2026" component="SMS_REPLICATION_MANAGER" context="" type="1" thread="1" file="replmgr.cpp">"#,
+    )
+}
+
+fn live_like_replmgr_manifest_with_content(
+    direction: Option<&str>,
+    hierarchy_links: serde_json::Value,
+    content: &[u8],
+) -> (String, Vec<SccmServerArtifactPayload>) {
     let artifact_id = opaque("cmtraceopen.artifact.sha256.v1:", 3);
     let host = opaque("cmtraceopen.host.sha256.v1:", 1);
     let site = opaque("cmtraceopen.site.sha256.v1:", 2);
     let producer_host = opaque("cmtraceopen.host.sha256.v1:", 1);
     let path = opaque("cmtraceopen.path.sha256.v1:", 4);
     let lineage = opaque("cmtraceopen.lineage.sha256.v1:", 5);
-    let content = b"SMS_EXECUTIVE started SMS_REPLICATION_MANAGER as thread ID 1 (0x1).  $$<SMS_REPLICATION_MANAGER><08-01-2026 21:50:03.847+240><thread=1 (0x1)>\n";
     let mut artifact = json!({
         "artifactId": artifact_id,
         "producerRole": "siteServer",
@@ -115,6 +126,7 @@ fn live_like_replmgr_manifest(
     }
     let manifest = json!({
         "sccmManifestVersion": 1,
+        "hierarchyContractVersion": 1,
         "syntheticFixture": false,
         "bundleRole": "server",
         "topology": {
@@ -136,7 +148,7 @@ fn live_like_replmgr_manifest(
 
 #[test]
 fn live_like_manifest_preserves_missing_version_topology_direction_and_keys() {
-    let (manifest, payloads) = live_like_replmgr_manifest(None, json!([]));
+    let (manifest, payloads) = live_like_replmgr_manifest(Some("origin"), json!([]));
     let assessment = assess_server_intake(&manifest, &payloads).expect("intake succeeds");
     let artifact = &assessment.artifacts[0];
     let admission = artifact
@@ -147,6 +159,7 @@ fn live_like_manifest_preserves_missing_version_topology_direction_and_keys() {
     assert!(!artifact.profile_eligible);
     assert!(!artifact.parser_eligible);
     assert!(assessment.evidence.is_empty());
+    assert_eq!(admission.direction, None);
     assert!(admission.gaps.contains(
         &cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyAdmissionGap::MissingVersion
     ));
@@ -163,7 +176,7 @@ fn live_like_manifest_preserves_missing_version_topology_direction_and_keys() {
 
 #[test]
 fn direction_is_validated_against_an_explicit_opaque_link() {
-    let origin_site = opaque("cmtraceopen.site.sha256.v1:", 6);
+    let origin_site = opaque("cmtraceopen.site.sha256.v1:", 2);
     let target_site = opaque("cmtraceopen.site.sha256.v1:", 7);
     let origin_host = opaque("cmtraceopen.host.sha256.v1:", 1);
     let target_host = opaque("cmtraceopen.host.sha256.v1:", 8);
@@ -191,6 +204,88 @@ fn direction_is_validated_against_an_explicit_opaque_link() {
         .contains(&cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyAdmissionGap::UnvalidatedDirection));
 }
 
+#[test]
+fn direction_is_non_authoritative_when_site_or_host_does_not_match() {
+    let links = json!([{
+        "originSiteCode": opaque("cmtraceopen.site.sha256.v1:", 6),
+        "targetSiteCode": opaque("cmtraceopen.site.sha256.v1:", 7),
+        "originHostHandle": opaque("cmtraceopen.host.sha256.v1:", 8),
+        "targetHostHandle": opaque("cmtraceopen.host.sha256.v1:", 9),
+    }]);
+    let (manifest, payloads) = live_like_replmgr_manifest(Some("origin"), links);
+    let assessment = assess_server_intake(&manifest, &payloads).expect("intake succeeds");
+    let artifact = &assessment.artifacts[0];
+    let admission = artifact
+        .hierarchy_admission
+        .as_ref()
+        .expect("hierarchy admission is present");
+    assert_eq!(artifact.direction, None);
+    assert_eq!(admission.direction, None);
+    assert!(admission
+        .gaps
+        .contains(&cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyAdmissionGap::UnvalidatedDirection));
+}
+
+#[test]
+fn hierarchy_links_reject_equal_site_or_host_handles() {
+    for links in [
+        json!([{
+            "originSiteCode": opaque("cmtraceopen.site.sha256.v1:", 2),
+            "targetSiteCode": opaque("cmtraceopen.site.sha256.v1:", 2),
+            "originHostHandle": opaque("cmtraceopen.host.sha256.v1:", 8),
+            "targetHostHandle": opaque("cmtraceopen.host.sha256.v1:", 9),
+        }]),
+        json!([{
+            "originSiteCode": opaque("cmtraceopen.site.sha256.v1:", 2),
+            "targetSiteCode": opaque("cmtraceopen.site.sha256.v1:", 7),
+            "originHostHandle": opaque("cmtraceopen.host.sha256.v1:", 8),
+            "targetHostHandle": opaque("cmtraceopen.host.sha256.v1:", 8),
+        }]),
+    ] {
+        let (manifest, payloads) = live_like_replmgr_manifest(None, links);
+        assert!(matches!(
+            assess_server_intake(&manifest, &payloads),
+            Err(cmtraceopen_parser::sccm::server::windows::SccmServerIntakeError::InvalidTopology)
+        ));
+    }
+}
+
+#[test]
+fn hierarchy_contract_version_mismatch_is_an_explicit_gap() {
+    let (manifest, payloads) = live_like_replmgr_manifest(None, json!([]));
+    let mut manifest = serde_json::from_str::<serde_json::Value>(&manifest).expect("manifest JSON");
+    manifest["hierarchyContractVersion"] = json!(2);
+    let assessment = assess_server_intake(
+        &serde_json::to_string(&manifest).expect("manifest serializes"),
+        &payloads,
+    )
+    .expect("mismatched contract remains coverage");
+    let admission = assessment.artifacts[0]
+        .hierarchy_admission
+        .as_ref()
+        .expect("hierarchy admission is present");
+    assert_eq!(admission.contract_version, None);
+    assert!(admission
+        .gaps
+        .contains(&cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyAdmissionGap::UnsupportedContractVersion));
+    assert!(assessment.evidence.is_empty());
+}
+
+#[test]
+fn component_token_outside_a_valid_ccm_record_is_not_component_evidence() {
+    let content = b"plain text mentions SMS_REPLICATION_MANAGER but is not a CCM record\n";
+    let (manifest, payloads) = live_like_replmgr_manifest_with_content(None, json!([]), content);
+    let assessment = assess_server_intake(&manifest, &payloads).expect("intake succeeds");
+    let admission = assessment.artifacts[0]
+        .hierarchy_admission
+        .as_ref()
+        .expect("hierarchy admission is present");
+    assert!(admission
+        .gaps
+        .contains(&cmtraceopen_parser::sccm::server::windows::SccmServerHierarchyAdmissionGap::ComponentMismatch));
+    assert!(assessment.evidence.is_empty());
+}
+
 fn site_database_supplement_manifest(
     schema_version: u64,
     authorized: bool,
@@ -205,6 +300,8 @@ fn site_database_supplement_manifest(
     artifact["supplementSchemaVersion"] = json!(schema_version);
     artifact["operatorAuthorized"] = json!(authorized);
     artifact["privacyClass"] = json!(privacy);
+    artifact["fragmentComplete"] = json!(true);
+    artifact["truncated"] = json!(false);
     artifact["relativePath"] = json!("evidence/sccm/server/site-server/server-hierarchy-site-database/root-00000001/current/site-database.supplement");
     (
         serde_json::to_string(&manifest).expect("manifest serializes"),
@@ -235,10 +332,107 @@ fn structured_supplement_unknown_schema_remains_coverage_only() {
     let assessment =
         assess_server_intake(&manifest, &payloads).expect("unknown schema is coverage");
     assert!(matches!(
-        assessment.artifacts[0].supplement_admission,
+        &assessment.artifacts[0].supplement_admission,
         Some(cmtraceopen_parser::sccm::server::windows::SccmServerSupplementAdmission::CoverageOnly {
-            reason: cmtraceopen_parser::sccm::server::windows::SccmServerSupplementGap::UnsupportedSchemaVersion
-        })
+            gaps
+        }) if gaps.contains(&cmtraceopen_parser::sccm::server::windows::SccmServerSupplementGap::UnsupportedSchemaVersion)
     ));
     assert!(assessment.evidence.is_empty());
+}
+
+#[test]
+fn structured_supplement_matrix_stays_coverage_only_without_complete_integrity() {
+    type SupplementMutation = fn(&mut serde_json::Value);
+    let cases: &[(&str, SupplementMutation)] = &[
+        ("unauthorized", |artifact: &mut serde_json::Value| {
+            artifact["operatorAuthorized"] = json!(false);
+        }),
+        ("wrong privacy", |artifact: &mut serde_json::Value| {
+            artifact["privacyClass"] = json!("raw");
+        }),
+        ("capped", |artifact: &mut serde_json::Value| {
+            artifact["captureState"] = json!("capped");
+            artifact["truncated"] = json!(true);
+            artifact["fragmentComplete"] = json!(false);
+            let copied = artifact["bytesCopied"].clone();
+            artifact["collectionLimit"]["byteLimit"] = copied;
+            artifact["collectionLimit"]["limitApplied"] = json!(true);
+        }),
+        ("incomplete", |artifact: &mut serde_json::Value| {
+            artifact["fragmentComplete"] = json!(false);
+            artifact["truncated"] = json!(false);
+        }),
+        ("malformed payload", |artifact: &mut serde_json::Value| {
+            artifact["encoding"] = json!("not-an-encoding");
+        }),
+        ("oversized for cap", |artifact: &mut serde_json::Value| {
+            artifact["collectionLimit"]["byteLimit"] = json!(1);
+        }),
+        (
+            "missing collection limit",
+            |artifact: &mut serde_json::Value| {
+                artifact
+                    .as_object_mut()
+                    .expect("artifact object")
+                    .remove("collectionLimit");
+            },
+        ),
+        ("missing payload", |artifact: &mut serde_json::Value| {
+            artifact["captureState"] = json!("captured");
+        }),
+        ("absent", |artifact: &mut serde_json::Value| {
+            artifact["captureState"] = json!("absent");
+            let object = artifact.as_object_mut().expect("artifact object");
+            object.remove("relativePath");
+            object.remove("encoding");
+            object.remove("collectionLimit");
+            object.remove("fragmentComplete");
+            object.remove("truncated");
+            artifact["bytesCopied"] = json!(0);
+        }),
+        ("denied", |artifact: &mut serde_json::Value| {
+            artifact["captureState"] = json!("accessDenied");
+            artifact["collectionDetail"] =
+                json!(opaque("cmtraceopen.collection-detail.sha256.v1:", 10));
+            let object = artifact.as_object_mut().expect("artifact object");
+            object.remove("relativePath");
+            object.remove("encoding");
+            object.remove("collectionLimit");
+            object.remove("fragmentComplete");
+            object.remove("truncated");
+            artifact["bytesCopied"] = json!(0);
+        }),
+        ("skipped", |artifact: &mut serde_json::Value| {
+            artifact["captureState"] = json!("skipped");
+            artifact["skipReason"] = json!(opaque("cmtraceopen.skip-reason.sha256.v1:", 11));
+            let object = artifact.as_object_mut().expect("artifact object");
+            object.remove("relativePath");
+            object.remove("encoding");
+            object.remove("collectionLimit");
+            object.remove("fragmentComplete");
+            object.remove("truncated");
+            artifact["bytesCopied"] = json!(0);
+        }),
+    ];
+    for (label, mutate) in cases {
+        let (manifest, payloads) = site_database_supplement_manifest(1, true, "redacted");
+        let mut manifest =
+            serde_json::from_str::<serde_json::Value>(&manifest).expect("manifest JSON");
+        mutate(&mut manifest["artifacts"][0]);
+        let payloads = if *label == "missing payload" {
+            Vec::new()
+        } else {
+            payloads
+        };
+        let assessment = assess_server_intake(
+            &serde_json::to_string(&manifest).expect("manifest serializes"),
+            &payloads,
+        )
+        .unwrap_or_else(|error| panic!("{label} must remain coverage: {error}"));
+        assert!(matches!(
+            assessment.artifacts[0].supplement_admission,
+            Some(cmtraceopen_parser::sccm::server::windows::SccmServerSupplementAdmission::CoverageOnly { .. })
+        ), "{label} was admitted");
+        assert!(assessment.evidence.is_empty(), "{label} produced evidence");
+    }
 }

--- a/docs/superpowers/plans/2026-08-04-sccm-481-hierarchy-source-contracts.md
+++ b/docs/superpowers/plans/2026-08-04-sccm-481-hierarchy-source-contracts.md
@@ -1,0 +1,233 @@
+# SCCM #481 Hierarchy Source Contracts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admit only evidence-supported hierarchy source contracts through canonical server intake, preserving missing version, topology, direction, and key authority as explicit gaps.
+
+**Architecture:** Add one typed hierarchy subcontract to the existing server catalog and one optional hierarchy admission projection to existing artifact assessments. Validate exact source/basename/component/rotation tuples from bounded CCM evidence, bind the projection into the existing intake integrity seal, and keep unproven direction, topology, keys, and supplements coverage-only.
+
+**Tech Stack:** Rust, Serde, existing `cmtraceopen-parser` SCCM catalog/intake/evidence modules, Cargo tests, wasm32, Clippy.
+
+**Frozen base:** `8064b5aa1457f72ea8dbb7cb979ec3ea863c524c`
+
+**Observed witness:** ConfigMgr `5.00.9141.1000`, draft tag `sccm-lab-pr490-6fbf1f09`, archive SHA256 `f46df02daeabbe53d73f98ea9782ea53bf7949ef7cca8322a633d9d0ba55e217`.
+
+---
+
+### Task 1: Declare the exact hierarchy source/component/rotation contract
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/src/sccm/server/windows/catalog.rs`
+- Test: `crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs`
+
+- [ ] **Step 1: Write a failing exact-catalog test**
+
+Assert these and only these observed rows:
+
+| Source ID | Basename/rotation | Component |
+|---|---|---|
+| `server-hierarchy-control` | `replmgr.log` current | `SMS_REPLICATION_MANAGER` |
+| `server-hierarchy-control` | `rcmctrl.log` current | `SMS_REPLICATION_CONFIGURATION_MONITOR` |
+| `server-hierarchy-control` | `rcmctrl.lo_` lo_ | `SMS_REPLICATION_CONFIGURATION_MONITOR` |
+| `server-hierarchy-transfer` | `sender.log` current | `SMS_LAN_SENDER` |
+| `server-hierarchy-transfer` | `despool.log` current | `SMS_DESPOOLER` |
+
+Do not declare `sender.lo_`: the lab did not observe it.
+
+- [ ] **Step 2: Run the red test**
+
+```sh
+cargo test --locked -p cmtraceopen-parser --test sccm_server_hierarchy_source_contract
+```
+
+- [ ] **Step 3: Add the minimal typed subcatalog**
+
+```rust
+pub const SCCM_SERVER_HIERARCHY_SOURCE_CONTRACT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmServerHierarchyDirection {
+    Origin,
+    Target,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SccmServerHierarchyRotationContract {
+    Current,
+    LoUnderscore,
+}
+
+#[derive(Debug)]
+pub struct SccmServerHierarchySourceContract {
+    pub contract_version: u32,
+    pub source_id: &'static str,
+    pub logical_name: &'static str,
+    pub producer_role: SccmRole,
+    pub expected_component: &'static str,
+    pub allowed_rotations: &'static [SccmServerHierarchyRotationContract],
+}
+```
+
+Keep this rotation-policy enum crate-private unless a tested public consumer requires it; the public manifest continues to use the existing `SccmRotation` wire contract. Direction is intentionally not inferred by this table. It becomes authoritative only when a manifest declares it and topology validates it.
+
+Add `declared_hierarchy_source_contracts()` and a crate-private exact classifier. Keep the broad catalog as the single discovery registry.
+
+- [ ] **Step 4: Re-run and commit**
+
+```sh
+cargo test --locked -p cmtraceopen-parser --test sccm_server_hierarchy_source_contract
+git add crates/cmtraceopen-parser/src/sccm/server/windows/catalog.rs crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs
+git commit -m "feat(sccm): declare hierarchy source contracts"
+```
+
+### Task 2: Add typed canonical intake admission and gaps
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs`
+- Modify: `crates/cmtraceopen-parser/src/sccm/server/windows/mod.rs`
+- Test: `crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs`
+
+- [ ] **Step 1: Add red intake tests** for exact tuple success, wrong component, wrong rotation, unknown contract version, missing source version, missing direction, missing topology link, direction/topology contradiction, and reverse input order.
+
+- [ ] **Step 2: Run and observe failures.**
+
+- [ ] **Step 3: Add one hierarchy-specific projection, not a generalized parallel admission system.**
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SccmServerHierarchyAdmission {
+    pub contract_version: u32,
+    pub component: String,
+    pub direction: Option<SccmServerHierarchyDirection>,
+    pub profile_id: Option<String>,
+    pub confidence: SccmKeyConfidence,
+    pub gaps: Vec<SccmServerHierarchyAdmissionGap>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SccmServerHierarchyAdmissionGap {
+    MissingVersion,
+    UnvalidatedProfile,
+    MissingTopology,
+    UnvalidatedDirection,
+    UnvalidatedKeys,
+    ComponentMismatch,
+    RotationMismatch,
+    UnsupportedContractVersion,
+}
+```
+
+Add `hierarchy_admission: Option<SccmServerHierarchyAdmission>` to `SccmServerArtifactAssessment` and the intake-integrity identity/projection. Non-hierarchy artifacts remain unchanged.
+
+For a captured hierarchy CCM file, scan bounded logical records using the existing parser, require the exact observed component for source/basename/rotation, and compute a content digest only as parser-computed integrity. Do not claim the collector supplied `contentSha256` when it is null.
+
+Version/profile rules:
+
+- The lab’s `sourceVersion=null` produces `MissingVersion` and `UnvalidatedProfile`.
+- ConfigMgr `5.00.9141.1000` is retained as external capture metadata, not guessed from timestamps or executable paths inside the pure parser.
+- Exact profile confidence is available only when an explicit supported source version/profile is present.
+
+Direction/topology rules:
+
+- Basename and component never imply origin or target.
+- Direction requires an explicit manifest value plus a matching validated hierarchy link.
+- Missing link/direction stays a gap; contradiction fails closed.
+- Extend `normalize_hierarchy_link` to accept production opaque site/host handles, rejecting empty/equal endpoints, unsafe handles, and duplicates. Retain the closed synthetic vocabulary.
+
+- [ ] **Step 4: Re-run, verify order-independent serialization, and commit.**
+
+```sh
+cargo test --locked -p cmtraceopen-parser --test sccm_server_hierarchy_source_contract
+git add crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs crates/cmtraceopen-parser/src/sccm/server/windows/mod.rs crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs
+git commit -m "fix(sccm): bind hierarchy admission to intake"
+```
+
+### Task 3: Keep hierarchy keys profile-bound and source-local
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/src/sccm/keys.rs`
+- Modify: `crates/cmtraceopen-parser/src/sccm/models.rs` only if a genuinely missing key kind is required by observed or committed profile data
+- Test: `crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs`
+- Test: `crates/cmtraceopen-parser/tests/sccm_spine_contract.rs`
+
+- [ ] **Step 1: Add red tests** proving thread IDs, `SiteNumber`, SQL names, and a `pszSiteCode` function token are not correlation keys. Missing version/profile/topology must emit no exact sender/message/link/package/content/flow key.
+- [ ] **Step 2: Run the tests.**
+- [ ] **Step 3: Gate existing hierarchy key extraction on the sealed hierarchy admission’s exact profile and declared field vocabulary.** Do not add labels such as `SenderJobId=` or `ReplicationFlowId=` as live grammar unless a reviewed fixture actually contains them. Keep synthetic grammar isolated to its explicit synthetic profile.
+- [ ] **Step 4: Re-run and commit.**
+
+```sh
+cargo test --locked -p cmtraceopen-parser --test sccm_server_hierarchy_source_contract --test sccm_spine_contract
+git add crates/cmtraceopen-parser/src/sccm/keys.rs crates/cmtraceopen-parser/src/sccm/models.rs crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs crates/cmtraceopen-parser/tests/sccm_spine_contract.rs
+git commit -m "fix(sccm): keep hierarchy keys profile bound"
+```
+
+### Task 4: Define the optional structured supplement boundary
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/src/sccm/server/windows/catalog.rs`
+- Modify: `crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs`
+- Test: `crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs`
+- Create: `crates/cmtraceopen-parser/tests/fixtures/sccm/server/hierarchy_and_replication/supplemental-database/{absent,malformed,oversized,unknown-version}/`
+
+- [ ] **Step 1: Add red tests** for absent, unauthorized, malformed, oversized/capped, and unknown-schema supplements.
+- [ ] **Step 2: Run the red matrix.**
+- [ ] **Step 3: Add an optional manifest extension** with explicit operator authorization, schema version, privacy class, byte/file caps, copied-byte count, content digest, collection timestamp, and payload reference. Normalize it through the same intake and integrity seal. Public provenance is exactly `imported supplemental evidence`; query text, table names, connection strings, credentials, raw database/server/site values, and raw identifiers are forbidden.
+
+The current raw lab does not prove this contract. Consequently, no production schema/profile is admitted yet: absent is valid optional coverage; unknown version is coverage-only; unauthorized/malformed data fails closed; capped data preserves the cap gap and is not interpreted. `rcmctrl.lo_` is a rotated CCM log, never a database supplement.
+
+- [ ] **Step 4: Re-run and commit.**
+
+```sh
+cargo test --locked -p cmtraceopen-parser --test sccm_server_hierarchy_source_contract
+git add crates/cmtraceopen-parser/src/sccm/server/windows/catalog.rs crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs crates/cmtraceopen-parser/tests/fixtures/sccm/server/hierarchy_and_replication/supplemental-database
+git commit -m "feat(sccm): define hierarchy supplement boundary"
+```
+
+### Task 5: Add the sanitized observed fixture and full verification
+
+**Files:**
+- Create: `crates/cmtraceopen-parser/tests/fixtures/sccm/server/hierarchy_and_replication/live-lab-5.00.9141.1000/`
+- Modify: `crates/cmtraceopen-parser/tests/sccm_server_hierarchy_source_contract.rs`
+- Modify: `crates/cmtraceopen-parser/tests/sccm_server_intake.rs`
+
+- [ ] **Step 1: Add a sanitized observed fixture** containing only safe source IDs, basenames, roles, rotations, exact component tags, byte counts, opaque lineage/digest handles, and safe generic CCM envelopes. Do not copy raw lab payloads, host/site values, SQL/database values, paths, or thread IDs.
+- [ ] **Step 2: Assert** all five rows classify exactly; `rcmctrl.lo_` is the only observed rotation; null source version yields profile gaps; null path class is not guessed; empty hierarchy links yield direction/topology gaps; no exact hierarchy keys are emitted; and public output contains no raw identifiers.
+- [ ] **Step 3: Assert deterministic ordering for identical inputs**, not byte identity between the two captures; live `rcmctrl.log` changed between captures.
+- [ ] **Step 4: Run every gate.**
+
+```sh
+cargo test --locked -p cmtraceopen-parser --test sccm_server_hierarchy_source_contract
+cargo test --locked -p cmtraceopen-parser --test sccm_server_intake
+cargo test --locked -p cmtraceopen-parser --test sccm_server_intake_fixture_contract
+cargo test --locked -p cmtraceopen-parser --test sccm_spine_contract
+cargo test --locked -p cmtraceopen-parser
+cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown
+cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings
+cargo fmt --check --all
+git diff --check
+```
+
+Expected: every command exits `0`; no `src-tauri` or `server/windows/hierarchy.rs` change exists.
+
+- [ ] **Step 5: Commit and deliver the evidence pack.**
+
+```sh
+git add crates/cmtraceopen-parser docs/superpowers/plans/2026-08-04-sccm-481-hierarchy-source-contracts.md
+git commit -m "test(sccm): pin observed hierarchy source coverage"
+git diff --name-only 8064b5aa1457f72ea8dbb7cb979ec3ea863c524c..HEAD
+git show --check --oneline HEAD
+git status --porcelain
+```
+
+The handoff must name exact SHA, changed files, test counts/results, wasm32/Clippy/fmt/diff results, fixture provenance, and every still-unproven semantic. Do not merge; independent review follows.
+
+## Self-review
+
+- Spec coverage: catalog, version/profile admission, topology, direction, provenance, keys, rotation, coverage states, supplement boundary, privacy, and determinism map to Tasks 1–5.
+- Evidence fidelity: the plan declares only `rcmctrl.lo_`, makes direction/topology/keys explicit gaps for the single-site lab, and never treats SQL/thread metadata as keys.
+- Placeholder scan: every error/privacy/boundary state has a test and implementation step.
+- Type consistency: one hierarchy subcatalog and one optional hierarchy admission projection extend the existing canonical intake; no parallel manifest or reducer is added.
+- Scope: no native discovery, database collection, semantic transactions, causal joins, or compatibility fallback.


### PR DESCRIPTION
Closes #481.

Adds the bounded hierarchy and replication source admission contract, fail-closed supplement provenance, topology-bound direction, and exact logical-record component validation. Unknown encodings remain CoverageOnly with MissingDigest and cannot produce semantic evidence.

Independent critic verdict: ACCEPT at edb37e7e5372ba4030709df25aaa6bb07e62e5f2.

Local gates: focused hierarchy, reducer, intake, fixture, and spine suites; full parser suite and docs; wasm32 check; strict Clippy; scoped rustfmt; diff check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validated SCCM server hierarchy source contracts, including direction, rotation, topology, component, and profile checks.
  * Added structured supplement metadata for schema version, authorization, privacy, provenance, and admission status.
  * Added detailed admission results that identify validation gaps and support coverage-only supplement intake.

* **Bug Fixes**
  * Invalid hierarchy links, mismatched contracts, unsupported schemas, and incomplete integrity data are now rejected or clearly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->