### PR TITLE
fix(deps): raise chrono floor to 0.4.35

### DIFF
--- a/crates/cmtraceopen-parser/Cargo.toml
+++ b/crates/cmtraceopen-parser/Cargo.toml
@@ -21,7 +21,7 @@ categories = [
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 regex = "1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.35", features = ["serde"] }
 encoding_rs = "0.8"
 log = "0.4"
 thiserror = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,7 +49,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.23"
 regex = "1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.35", features = ["serde"] }
 encoding_rs = "0.8"
 log = "0.4"
 thiserror = "2"


### PR DESCRIPTION
## Summary
- raise the published `cmtraceopen-parser` chrono requirement to `0.4.35`
- raise the Tauri app chrono requirement to the same accurate floor

## Verification
- `cargo test -p cmtraceopen-parser`
- `cargo check -p cmtrace-open`
- `npx tsc --noEmit`
- temporary floor-resolution check: `cargo update -p chrono --precise 0.4.35 && cargo check -p cmtraceopen-parser -p cmtrace-open`

Closes #417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the date and time handling library to a newer compatible release.
  * Retained support for serializing date and time values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->