### PR TITLE
fix: redact bare unspecified IPv6 in macOS exports

### DIFF
--- a/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/logs/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/logs/redaction.rs
@@ -104,31 +104,15 @@ fn mac_address_re() -> &'static Regex {
     })
 }
 
-/// Fully-expanded eight-group IPv6 or any `::`-compressed form, in group 1.
+/// Fully-expanded eight-group IPv6 or any `::`-compressed form.
 ///
-/// The address is **not** wrapped in `\b`. `\b` is a word-boundary assertion and
-/// `:` is not a word character, so it cannot anchor an address that begins or
-/// ends with a colon, which every `::`-compressed form does at one end or both.
-/// With `\b` on both sides `fd12:3456:789a::` matched nothing at all and exported
-/// verbatim, and `::1` was missed the same way.
-///
-/// This engine has no look-around, so the left edge is a *consumed* guard group
-/// and the right edge has no assertion at all. That asymmetry is deliberate:
-///
-/// * Consuming only the left delimiter keeps two addresses separated by a single
-///   character both matchable. A guard on both sides would eat the delimiter that
-///   the following address needs, and `^` cannot stand in for it because it
-///   anchors to the start of the text, not to where scanning resumed.
-/// * No right-edge assertion is needed because the alternatives are already
-///   self-limiting: they consume only hex and colons, and each requires either
-///   eight groups or a `::` run. A MAC (`00:11:22:33:44:55`) and a house-grammar
-///   timestamp (`08:18:00:104`) have neither, so neither can be claimed.
-///
+/// Deliberately unanchored: [`Redactor::replace_ipv6_addresses`] checks both
+/// Unicode-aware token boundaries without consuming either delimiter.
 fn ipv6_address_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
         Regex::new(
-            r"(?i)(?:^|[^0-9A-Za-z:])((?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|(?:[0-9a-f]{1,4}:)+:(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?|::(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?)",
+            r"(?i)(?:(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|(?:[0-9a-f]{1,4}:)+:(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?|::(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?)",
         )
         .expect("ipv6 address pattern must compile")
     })
@@ -221,6 +205,26 @@ impl Redactor {
         out
     }
 
+    fn replace_ipv6_addresses(&mut self, text: &str) -> String {
+        let mut out = String::with_capacity(text.len());
+        let mut last = 0usize;
+
+        for target in ipv6_address_re().find_iter(text) {
+            out.push_str(&text[last..target.start()]);
+            let before = text[..target.start()].chars().next_back();
+            let after = text[target.end()..].chars().next();
+            if before.is_some_and(binds_to_identifier) || after.is_some_and(binds_to_identifier) {
+                out.push_str(target.as_str());
+            } else {
+                out.push_str(&self.token_for(PortalRedactionKind::Ip, target.as_str()));
+            }
+            last = target.end();
+        }
+
+        out.push_str(&text[last..]);
+        out
+    }
+
     /// Apply every redaction rule, in a fixed order.
     ///
     /// Certificate subjects go first and are deliberately over-broad (`CN=` to
@@ -245,15 +249,17 @@ impl Redactor {
         let text = self.replace_group(&text, guid_re(), PortalRedactionKind::Guid, 0);
         let text = self.replace_group(&text, ipv4_address_re(), PortalRedactionKind::Ip, 0);
         let text = self.replace_group(&text, mac_address_re(), PortalRedactionKind::Mac, 0);
-        // Group 1: the IPv6 pattern consumes a leading delimiter that must be
-        // written back out, so the address is captured rather than whole-matched.
-        let text = self.replace_group(&text, ipv6_address_re(), PortalRedactionKind::Ip, 1);
+        let text = self.replace_ipv6_addresses(&text);
         self.replace_user_paths(&text)
     }
 
     fn into_placeholders(self) -> Vec<PortalPlaceholder> {
         self.placeholders.into_values().collect()
     }
+}
+
+fn binds_to_identifier(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_'
 }
 
 /// Build the deterministic, redacted export projection of a parse.

--- a/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/logs/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/logs/redaction.rs
@@ -124,14 +124,11 @@ fn mac_address_re() -> &'static Regex {
 ///   eight groups or a `::` run. A MAC (`00:11:22:33:44:55`) and a house-grammar
 ///   timestamp (`08:18:00:104`) have neither, so neither can be claimed.
 ///
-/// A bare `::` carrying no group is excluded on purpose. It is the all-zeros
-/// address, it identifies nothing, and matching it would redact the path
-/// separator in ordinary prose such as `std::process`.
 fn ipv6_address_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
         Regex::new(
-            r"(?i)(?:^|[^0-9A-Za-z:])((?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|(?:[0-9a-f]{1,4}:)+:(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?|::[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)",
+            r"(?i)(?:^|[^0-9A-Za-z:])((?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|(?:[0-9a-f]{1,4}:)+:(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?|::(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?)",
         )
         .expect("ipv6 address pattern must compile")
     })
@@ -448,9 +445,8 @@ mod tests {
         );
         assert!(redacted.ends_with(" up"));
 
-        // A bare `::` identifies nothing and appears in ordinary prose. Keep
-        // the runtime sample intact while avoiding a raw forbidden-token
-        // self-match in the module purity scan.
+        // C++ scope syntax is not an address because the consumed left guard
+        // rejects a preceding word character.
         let no_address = concat!("called std::", "process::exit");
         let redacted = redact(no_address);
         assert_eq!(

--- a/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/unified_log/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/unified_log/redaction.rs
@@ -137,13 +137,11 @@ fn mac_address_pattern() -> &'static Regex {
 ///   eight groups or a `::` run. A MAC (`00:11:22:33:44:55`) and a wall-clock
 ///   timestamp (`08:18:00:104`) have neither, so neither can be claimed.
 ///
-/// A bare `::` carrying no group is excluded on purpose: it is the all-zeros
-/// address, it identifies nothing, and matching it damages prose.
 fn ipv6_address_pattern() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     compiled(
         &CELL,
-        r"(?i)(^|[^0-9A-Za-z:])(?:(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|(?:[0-9a-f]{1,4}:)+:(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?|::[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)",
+        r"(?i)(^|[^0-9A-Za-z:])(?:(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|(?:[0-9a-f]{1,4}:)+:(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?|::(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?)",
     )
 }
 

--- a/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/unified_log/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/portal/macos/company_portal/unified_log/redaction.rs
@@ -115,34 +115,40 @@ fn mac_address_pattern() -> &'static Regex {
     compiled(&CELL, r"(?i)\b(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}\b")
 }
 
-/// Fully expanded eight-group IPv6 or any `::`-compressed form, preceded by a
-/// captured delimiter in group 1 that the replacement must write back out.
+/// Fully expanded eight-group IPv6 or any `::`-compressed form.
 ///
-/// The address is **not** wrapped in `\b`. `\b` is a word-boundary assertion and
-/// `:` is not a word character, so it fails in both directions here: it cannot
-/// anchor an address that begins or ends with a colon, which every
-/// `::`-compressed form does at one end or both, and it happily anchors a bare
-/// `::` sitting between two word characters, which turned `std::process::exit`
-/// in prose into two host placeholders.
-///
-/// This engine has no look-around, so the left edge is a *consumed* guard group
-/// and the right edge has no assertion at all. That asymmetry is deliberate:
-///
-/// * Consuming only the left delimiter keeps two addresses separated by a single
-///   character both matchable. A guard on both sides would eat the delimiter the
-///   following address needs, and `^` cannot stand in for it because it anchors
-///   to the start of the text, not to where scanning resumed.
-/// * No right-edge assertion is needed because the alternatives are already
-///   self-limiting: they consume only hex and colons, and each requires either
-///   eight groups or a `::` run. A MAC (`00:11:22:33:44:55`) and a wall-clock
-///   timestamp (`08:18:00:104`) have neither, so neither can be claimed.
-///
+/// Deliberately unanchored: [`redact_ipv6_addresses`] checks both Unicode-aware
+/// token boundaries without consuming either delimiter.
 fn ipv6_address_pattern() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     compiled(
         &CELL,
-        r"(?i)(^|[^0-9A-Za-z:])(?:(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|(?:[0-9a-f]{1,4}:)+:(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?|::(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?)",
+        r"(?i)(?:(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|(?:[0-9a-f]{1,4}:)+:(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?|::(?:[0-9a-f]{1,4}(?::[0-9a-f]{1,4})*)?)",
     )
+}
+
+fn redact_ipv6_addresses(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut cursor = 0usize;
+
+    for matched in ipv6_address_pattern().find_iter(value) {
+        output.push_str(&value[cursor..matched.start()]);
+        let before = value[..matched.start()].chars().next_back();
+        let after = value[matched.end()..].chars().next();
+        if before.is_some_and(binds_to_identifier) || after.is_some_and(binds_to_identifier) {
+            output.push_str(matched.as_str());
+        } else {
+            output.push_str(HOST);
+        }
+        cursor = matched.end();
+    }
+
+    output.push_str(&value[cursor..]);
+    output
+}
+
+fn binds_to_identifier(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_'
 }
 
 fn labeled_certificate_pattern() -> &'static Regex {
@@ -240,11 +246,7 @@ pub fn redact_text(input: &str) -> String {
     // MAC between the two so it is not mistaken for a compressed IPv6 run.
     let step12 = ipv4_address_pattern().replace_all(&step11, HOST);
     let step13 = mac_address_pattern().replace_all(&step12, HOST);
-    // `${1}` is the delimiter the IPv6 pattern had to consume on the left; it is
-    // evidence framing, not part of the address, so it is written back out.
-    ipv6_address_pattern()
-        .replace_all(&step13, format!("${{1}}{HOST}"))
-        .into_owned()
+    redact_ipv6_addresses(&step13)
 }
 
 fn redact_classified(value: &PortalClassifiedString) -> PortalClassifiedString {

--- a/crates/cmtraceopen-parser/tests/company_portal_macos_logs.rs
+++ b/crates/cmtraceopen-parser/tests/company_portal_macos_logs.rs
@@ -224,6 +224,30 @@ fn advanced_logging_certificate_and_network_records_are_redacted() {
     }
 }
 
+#[test]
+fn bare_unspecified_ipv6_is_redacted_in_direct_log_export() {
+    let parse = parse_scenario(
+        "2026-05-12 08:14:22:007 | CompanyPortal | I | 7 | NetworkService | peer :: connected; std::process::exit; ratio 3:2; mode:key\n",
+        "bare-unspecified-ipv6",
+        "CompanyPortal.log",
+    );
+
+    let export = redacted_export_projection(&parse);
+    let json = serde_json::to_string(&export).expect("export must serialize");
+
+    assert!(
+        !json.contains("peer :: connected"),
+        "bare IPv6 leaked: {json}"
+    );
+    assert!(
+        json.contains("peer [redacted:ip:001] connected"),
+        "redaction must retain delimiters: {json}"
+    );
+    for safe_text in ["std::process::exit", "ratio 3:2", "mode:key"] {
+        assert!(json.contains(safe_text), "non-address text changed: {json}");
+    }
+}
+
 /// A version banner, a timestamp, and a GUID all look address-shaped to a lazy
 /// matcher. Redacting them as network addresses would corrupt evidence the
 /// module promises to preserve losslessly.

--- a/crates/cmtraceopen-parser/tests/company_portal_macos_logs.rs
+++ b/crates/cmtraceopen-parser/tests/company_portal_macos_logs.rs
@@ -225,27 +225,59 @@ fn advanced_logging_certificate_and_network_records_are_redacted() {
 }
 
 #[test]
-fn bare_unspecified_ipv6_is_redacted_in_direct_log_export() {
+fn direct_log_export_enforces_ipv6_token_boundaries() {
     let parse = parse_scenario(
-        "2026-05-12 08:14:22:007 | CompanyPortal | I | 7 | NetworkService | peer :: connected; std::process::exit; ratio 3:2; mode:key\n",
+        concat!(
+            "2026-05-12 08:14:22:001 | CompanyPortal | I | 7 | NetworkService | :: start\n",
+            "2026-05-12 08:14:22:002 | CompanyPortal | I | 7 | NetworkService | middle :: value\n",
+            "2026-05-12 08:14:22:003 | CompanyPortal | I | 7 | NetworkService | end ::\n",
+            "2026-05-12 08:14:22:004 | CompanyPortal | I | 7 | NetworkService | bracket [::]\n",
+            "2026-05-12 08:14:22:005 | CompanyPortal | I | 7 | NetworkService | peers ::,2001:db8:0:0:0:0:0:1;fd12:3456:789a:: done\n",
+            "2026-05-12 08:14:22:006 | CompanyPortal | I | 7 | NetworkService | mapped ::ffff:192.0.2.128 done\n",
+            "2026-05-12 08:14:22:007 | CompanyPortal | I | 7 | NetworkService | safe std::__1::basic_string std::process café::babe ::1β _::1 at 08:18:00:104 ratio 3:2 mode:key version 5.2504.0 guid 4b2f9d61-1c53-4c58-8f1a-b0d3e1b5aa77 mac 00:11:22:33:44:55\n",
+        ),
         "bare-unspecified-ipv6",
         "CompanyPortal.log",
     );
 
     let export = redacted_export_projection(&parse);
-    let json = serde_json::to_string(&export).expect("export must serialize");
+    let messages: Vec<&str> = export
+        .records
+        .iter()
+        .map(|record| record.message.as_str())
+        .collect();
 
-    assert!(
-        !json.contains("peer :: connected"),
-        "bare IPv6 leaked: {json}"
+    assert_eq!(messages[0], "[redacted:ip:001] start");
+    assert_eq!(messages[1], "middle [redacted:ip:001] value");
+    assert_eq!(messages[2], "end [redacted:ip:001]");
+    assert_eq!(messages[3], "bracket [[redacted:ip:001]]");
+    assert_eq!(
+        messages[4],
+        "peers [redacted:ip:001],[redacted:ip:002];[redacted:ip:003] done"
     );
-    assert!(
-        json.contains("peer [redacted:ip:001] connected"),
-        "redaction must retain delimiters: {json}"
-    );
-    for safe_text in ["std::process::exit", "ratio 3:2", "mode:key"] {
-        assert!(json.contains(safe_text), "non-address text changed: {json}");
+    for leaked in ["2001:db8:0:0:0:0:0:1", "fd12:3456:789a::", "192.0.2.128"] {
+        assert!(
+            !messages[4..=5].join(" ").contains(leaked),
+            "{leaked} leaked"
+        );
     }
+
+    let safe = messages[6];
+    for text in [
+        "std::__1::basic_string",
+        "std::process",
+        "café::babe",
+        "::1β",
+        "_::1",
+        "08:18:00:104",
+        "ratio 3:2",
+        "mode:key",
+        "version 5.2504.0",
+    ] {
+        assert!(safe.contains(text), "non-address text changed: {safe}");
+    }
+    assert!(safe.contains("guid [redacted:guid:001]"));
+    assert!(safe.contains("mac [redacted:mac:001]"));
 }
 
 /// A version banner, a timestamp, and a GUID all look address-shaped to a lazy

--- a/crates/cmtraceopen-parser/tests/company_portal_macos_unified_log.rs
+++ b/crates/cmtraceopen-parser/tests/company_portal_macos_unified_log.rs
@@ -1228,7 +1228,8 @@ fn ipv6_redaction_does_not_claim_timestamps_macs_or_prose() {
         "a timestamp is not an address: {redacted}"
     );
 
-    // A bare `::` identifies nothing and appears in ordinary prose.
+    // C++ scope syntax is not an address because the consumed left guard
+    // rejects a preceding word character.
     let redacted = redact_text("called std::process::exit");
     assert_eq!(redacted, "called std::process::exit");
 
@@ -1254,6 +1255,30 @@ fn network_addresses_are_redacted() {
         "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
     ] {
         assert!(!redacted.contains(secret), "{secret} leaked: {redacted}");
+    }
+}
+
+#[test]
+fn bare_unspecified_ipv6_is_redacted_in_unified_log_export() {
+    let header = format!(
+        r#"{{"captureId":"c","schemaId":"{PORTAL_UNIFIED_LOG_SCHEMA_ID}","schemaVersion":{PORTAL_UNIFIED_LOG_SCHEMA_VERSION}}}"#
+    );
+    let record = r#"{"category":"Network","eventMessage":"peer :: connected; std::process::exit; ratio 3:2; mode:key","messageType":"Default","process":"CompanyPortal","sourceSequence":0,"subsystem":"com.microsoft.CompanyPortalMac","timestamp":"2026-07-15 07:02:00.000000-0500"}"#;
+    let capture = parse_capture(&format!("{header}\n{record}\n"));
+
+    let export = redacted_capture_projection(&capture);
+    let json = serde_json::to_string(&export).expect("export must serialize");
+
+    assert!(
+        !json.contains("peer :: connected"),
+        "bare IPv6 leaked: {json}"
+    );
+    assert!(
+        json.contains("peer [redacted:host] connected"),
+        "redaction must retain delimiters: {json}"
+    );
+    for safe_text in ["std::process::exit", "ratio 3:2", "mode:key"] {
+        assert!(json.contains(safe_text), "non-address text changed: {json}");
     }
 }
 

--- a/crates/cmtraceopen-parser/tests/company_portal_macos_unified_log.rs
+++ b/crates/cmtraceopen-parser/tests/company_portal_macos_unified_log.rs
@@ -1259,27 +1259,76 @@ fn network_addresses_are_redacted() {
 }
 
 #[test]
-fn bare_unspecified_ipv6_is_redacted_in_unified_log_export() {
+fn unified_log_export_enforces_ipv6_token_boundaries() {
     let header = format!(
         r#"{{"captureId":"c","schemaId":"{PORTAL_UNIFIED_LOG_SCHEMA_ID}","schemaVersion":{PORTAL_UNIFIED_LOG_SCHEMA_VERSION}}}"#
     );
-    let record = r#"{"category":"Network","eventMessage":"peer :: connected; std::process::exit; ratio 3:2; mode:key","messageType":"Default","process":"CompanyPortal","sourceSequence":0,"subsystem":"com.microsoft.CompanyPortalMac","timestamp":"2026-07-15 07:02:00.000000-0500"}"#;
-    let capture = parse_capture(&format!("{header}\n{record}\n"));
+    let messages = [
+        ":: start",
+        "middle :: value",
+        "end ::",
+        "bracket [::]",
+        "peers ::,2001:db8:0:0:0:0:0:1;fd12:3456:789a:: done",
+        "mapped ::ffff:192.0.2.128 done",
+        "safe std::__1::basic_string std::process café::babe ::1β _::1 at 08:18:00:104 ratio 3:2 mode:key version 5.2504.0 guid 4b2f9d61-1c53-4c58-8f1a-b0d3e1b5aa77 mac 00:11:22:33:44:55",
+    ];
+    let records = messages
+        .iter()
+        .enumerate()
+        .map(|(source_sequence, message)| {
+            serde_json::json!({
+                "category": "Network",
+                "eventMessage": message,
+                "messageType": "Default",
+                "process": "CompanyPortal",
+                "sourceSequence": source_sequence,
+                "subsystem": "com.microsoft.CompanyPortalMac",
+                "timestamp": "2026-07-15 07:02:00.000000-0500",
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let capture = parse_capture(&format!("{header}\n{records}\n"));
 
     let export = redacted_capture_projection(&capture);
-    let json = serde_json::to_string(&export).expect("export must serialize");
+    let messages: Vec<&str> = export
+        .records
+        .iter()
+        .map(|record| record.event_message.value.as_str())
+        .collect();
 
-    assert!(
-        !json.contains("peer :: connected"),
-        "bare IPv6 leaked: {json}"
+    assert_eq!(messages[0], "[redacted:host] start");
+    assert_eq!(messages[1], "middle [redacted:host] value");
+    assert_eq!(messages[2], "end [redacted:host]");
+    assert_eq!(messages[3], "bracket [[redacted:host]]");
+    assert_eq!(
+        messages[4],
+        "peers [redacted:host],[redacted:host];[redacted:host] done"
     );
-    assert!(
-        json.contains("peer [redacted:host] connected"),
-        "redaction must retain delimiters: {json}"
-    );
-    for safe_text in ["std::process::exit", "ratio 3:2", "mode:key"] {
-        assert!(json.contains(safe_text), "non-address text changed: {json}");
+    for leaked in ["2001:db8:0:0:0:0:0:1", "fd12:3456:789a::", "192.0.2.128"] {
+        assert!(
+            !messages[4..=5].join(" ").contains(leaked),
+            "{leaked} leaked"
+        );
     }
+
+    let safe = messages[6];
+    for text in [
+        "std::__1::basic_string",
+        "std::process",
+        "café::babe",
+        "::1β",
+        "_::1",
+        "08:18:00:104",
+        "ratio 3:2",
+        "mode:key",
+        "version 5.2504.0",
+    ] {
+        assert!(safe.contains(text), "non-address text changed: {safe}");
+    }
+    assert!(safe.contains("guid [redacted:guid]"));
+    assert!(safe.contains("mac [redacted:host]"));
 }
 
 /// Address matchers must not eat evidence that merely looks address-shaped.


### PR DESCRIPTION
## Summary
- redact the bare unspecified IPv6 address `::` in macOS Company Portal direct-log and unified-log exports
- use Unicode-aware identifier boundaries so C++ symbols, underscore continuations, and non-ASCII identifier-adjacent text remain intact
- preserve delimiters between adjacent bare, full, compressed, and IPv4-mapped addresses
- cover both public export surfaces, including timestamps, MAC categories, ratios, `key:value`, versions, and GUID categories

## Validation
- `cargo test -p cmtraceopen-parser --test company_portal_macos_logs`
- `cargo test -p cmtraceopen-parser --test company_portal_macos_unified_log`
- `cargo test -p cmtraceopen-parser`
- `cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings`
- `rustfmt --edition 2021 --check` on the four changed Rust files
- `git diff --check origin/main...HEAD`

Closes #416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 redaction now handles bare, compressed, bracketed, peer-list, and IPv4-mapped addresses in macOS Company Portal and unified logs.
  * Improved boundary detection prevents identifiers, timestamps, versions, GUIDs, MAC addresses, ratios, and C++ scope syntax from being misidentified as IPv6 addresses.
  * Redacted addresses embedded in supported text are handled without altering surrounding content.

* **Tests**
  * Added regression coverage for IPv6 formats, token boundaries, delimiters, and unrelated text preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->