### PR TITLE
test: tighten deployment fixture expectations

### DIFF
--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/bits-transfer-failure/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/bits-transfer-failure/expected.json
@@ -4,7 +4,7 @@
   "scenario":"bits-transfer-failure",
   "stateChain":["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract":{"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile":{"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","packageId","requestId"],"validatedArtifactFamilies":["client-app-intent","client-content"]},
+  "extractionProfile":{"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","packageId","requestId"],"validatedArtifactFamilies":["client-app-intent","client-content"]},
   "reorderedInputDeterministic":true,
   "coverage":[{"logicalArtifactId":"client-app-intent","state":"captured"},{"logicalArtifactId":"client-content","state":"captured"}],
   "artifactProvenance":[

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/cache-failure/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/cache-failure/expected.json
@@ -4,7 +4,7 @@
   "scenario":"cache-failure",
   "stateChain":["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract":{"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile":{"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","packageId","requestId"],"validatedArtifactFamilies":["client-app-intent","client-content"]},
+  "extractionProfile":{"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","packageId","requestId"],"validatedArtifactFamilies":["client-app-intent","client-content"]},
   "reorderedInputDeterministic":true,
   "coverage":[{"logicalArtifactId":"client-app-intent","state":"captured"},{"logicalArtifactId":"client-content","state":"captured"}],
   "artifactProvenance":[

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/dependency-failure/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/dependency-failure/expected.json
@@ -4,7 +4,7 @@
   "scenario":"dependency-failure",
   "stateChain":["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract":{"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile":{"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content","client-policy-state"]},
+  "extractionProfile":{"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content","client-policy-state"]},
   "reorderedInputDeterministic":true,
   "coverage":[{"logicalArtifactId":"client-app-intent","state":"captured"}],
   "artifactProvenance":[{"artifactId":"deployment-dependency-failure-intent-current","bytesCopied":859,"encoding":"utf-8","byteLimit":4096,"limitApplied":false}],

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/detection-false-negative/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/detection-false-negative/expected.json
@@ -4,7 +4,7 @@
   "scenario":"detection-false-negative",
   "stateChain":["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract":{"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile":{"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content"]},
+  "extractionProfile":{"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content"]},
   "reorderedInputDeterministic":true,
   "coverage":[{"logicalArtifactId":"client-app-enforce","state":"captured"},{"logicalArtifactId":"client-app-intent","state":"captured"},{"logicalArtifactId":"client-content","state":"captured"}],
   "artifactProvenance":[

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/dp-content-missing/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/dp-content-missing/expected.json
@@ -4,7 +4,7 @@
   "scenario": "dp-content-missing",
   "stateChain": ["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract": {"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile": {"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","ciId","contentId","contentVersion","distributionPointHostHandle","packageId","requestId"],"validatedArtifactFamilies":["client-app-intent","client-content"]},
+  "extractionProfile": {"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","ciId","contentId","contentVersion","distributionPointHostHandle","packageId","requestId"],"validatedArtifactFamilies":["client-app-intent","client-content"]},
   "reorderedInputDeterministic": true,
   "coverage": [{"logicalArtifactId":"client-app-intent","state":"captured"},{"logicalArtifactId":"client-content","state":"captured"}],
   "artifactProvenance": [

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/enforcement-exit/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/enforcement-exit/expected.json
@@ -4,7 +4,7 @@
   "scenario":"enforcement-exit",
   "stateChain":["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract":{"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile":{"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content"]},
+  "extractionProfile":{"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content"]},
   "reorderedInputDeterministic":true,
   "coverage":[{"logicalArtifactId":"client-app-enforce","state":"captured"},{"logicalArtifactId":"client-app-intent","state":"captured"},{"logicalArtifactId":"client-content","state":"captured"}],
   "artifactProvenance":[

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/incomplete/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/incomplete/expected.json
@@ -4,7 +4,7 @@
   "scenario":"incomplete",
   "stateChain":["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract":{"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile":{"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","ciId"],"validatedArtifactFamilies":["client-app-intent"]},
+  "extractionProfile":{"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","ciId"],"validatedArtifactFamilies":["client-app-intent"]},
   "reorderedInputDeterministic":true,
   "coverage":[{"logicalArtifactId":"client-app-enforce","state":"capped"},{"logicalArtifactId":"client-app-intent","state":"captured"},{"logicalArtifactId":"client-content","state":"accessDenied"}],
   "artifactProvenance":[

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/location-missing/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/location-missing/expected.json
@@ -4,7 +4,7 @@
   "scenario":"location-missing",
   "stateChain":["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract":{"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile":{"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content","client-policy-state"]},
+  "extractionProfile":{"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content","client-policy-state"]},
   "reorderedInputDeterministic":true,
   "coverage":[{"logicalArtifactId":"client-app-intent","state":"captured"},{"logicalArtifactId":"client-content","state":"absent"}],
   "artifactProvenance":[{"artifactId":"deployment-location-missing-intent-current","bytesCopied":532,"encoding":"utf-8","byteLimit":4096,"limitApplied":false}],

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/not-targeted/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/not-targeted/expected.json
@@ -4,7 +4,7 @@
   "scenario":"not-targeted",
   "stateChain":["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract":{"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile":{"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content","client-policy-state"]},
+  "extractionProfile":{"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content","client-policy-state"]},
   "reorderedInputDeterministic":true,
   "coverage":[{"logicalArtifactId":"client-app-intent","state":"captured"}],
   "artifactProvenance":[{"artifactId":"deployment-not-targeted-intent-current","bytesCopied":315,"encoding":"utf-8","byteLimit":4096,"limitApplied":false}],

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/requirements-failure/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/requirements-failure/expected.json
@@ -4,7 +4,7 @@
   "scenario":"requirements-failure",
   "stateChain":["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract":{"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile":{"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content","client-policy-state"]},
+  "extractionProfile":{"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content","client-policy-state"]},
   "reorderedInputDeterministic":true,
   "coverage":[{"logicalArtifactId":"client-app-intent","state":"captured"}],
   "artifactProvenance":[{"artifactId":"deployment-requirements-failure-intent-current","bytesCopied":580,"encoding":"utf-8","byteLimit":4096,"limitApplied":false}],

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/rotation-boundary/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/rotation-boundary/expected.json
@@ -4,7 +4,7 @@
   "scenario":"rotation-boundary",
   "stateChain":["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract":{"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile":{"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","ciId"],"validatedArtifactFamilies":["client-app-intent"]},
+  "extractionProfile":{"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","ciId"],"validatedArtifactFamilies":["client-app-intent"]},
   "reorderedInputDeterministic":true,
   "coverage":[{"logicalArtifactId":"client-app-intent","state":"captured"},{"logicalArtifactId":"client-content","state":"captured","artifactIds":["deployment-rotation-boundary-content-current","deployment-rotation-boundary-content-lo"]}],
   "artifactProvenance":[

--- a/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/success/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/sccm/client/deployment/success/expected.json
@@ -4,7 +4,7 @@
   "scenario": "success",
   "stateChain": ["intent","requirements","locateContent","transfer","cache","enforce","detect","report"],
   "analysisContract": {"independentReducer":true,"consumesPolicyReducerOutput":false,"policyCoverageRequired":false,"crossSideCorrelationPerformed":false},
-  "extractionProfile": {"selectionState":"selected","profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content","client-policy-state"]},
+  "extractionProfile": {"profileId":"deployment-client-5.00.test-v1","sourceVersionPrefix":"5.00.TEST.","contentVersionRequired":true,"keyKinds":["assignmentId","bitsJobId","ciId","contentId","contentVersion","distributionPointHostHandle","exitCode","packageId","productCode","requestId"],"validatedArtifactFamilies":["client-app-enforce","client-app-intent","client-content","client-policy-state"]},
   "reorderedInputDeterministic": true,
   "coverage": [{"logicalArtifactId":"client-app-enforce","state":"captured"},{"logicalArtifactId":"client-app-intent","state":"captured"},{"logicalArtifactId":"client-content","state":"captured"},{"logicalArtifactId":"client-policy-agent","state":"absent"},{"logicalArtifactId":"client-policy-state","state":"captured"}],
   "artifactProvenance": [

--- a/crates/cmtraceopen-parser/tests/sccm_client_deployment.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_deployment.rs
@@ -6,7 +6,7 @@
 //! and compares the reducer output against the declared expectations.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
 };
 
@@ -16,9 +16,8 @@ use cmtraceopen_parser::sccm::{
     SccmClientAdmittedEvidence, SccmClientCapturedPayload, SccmClientIntakeArtifact,
     SccmClientIntakeBundle, SccmConfidence, SccmCoverageState, SccmDeploymentClassification,
     SccmDeploymentConfidence, SccmDeploymentKeyConfidence, SccmDeploymentKeyProfileKind,
-    SccmDeploymentObservationKeyConfidence, SccmDeploymentPhase,
-    SccmDeploymentProfileSelectionState, SccmDeploymentState, SccmFindingClass, SccmRole,
-    SccmRotation, SCCM_DEPLOYMENT_PROFILE_ID,
+    SccmDeploymentObservationKeyConfidence, SccmDeploymentPhase, SccmDeploymentState,
+    SccmFindingClass, SccmRole, SccmRotation, SCCM_DEPLOYMENT_PROFILE_ID,
 };
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -104,6 +103,7 @@ fn expected(scenario: &str) -> Value {
     let root = deployment_root().join(scenario);
     let manifest = load_json(&root.join("manifest.json"));
     let mut value = load_json(&root.join("expected.json"));
+    assert_expected_extraction_profile_contract(scenario, &value);
     let artifact_ids = manifest["artifacts"]
         .as_array()
         .expect("manifest artifacts")
@@ -121,6 +121,27 @@ fn expected(scenario: &str) -> Value {
         .collect::<BTreeMap<_, _>>();
     translate_artifact_ids(&mut value, &artifact_ids);
     value
+}
+
+fn assert_expected_extraction_profile_contract(scenario: &str, expected: &Value) {
+    let profile = expected["extractionProfile"]
+        .as_object()
+        .unwrap_or_else(|| panic!("{scenario}: extractionProfile is an object"));
+    let declared_fields = profile.keys().cloned().collect::<BTreeSet<_>>();
+    let consumed_fields = [
+        "profileId",
+        "sourceVersionPrefix",
+        "contentVersionRequired",
+        "keyKinds",
+        "validatedArtifactFamilies",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect::<BTreeSet<_>>();
+    assert_eq!(
+        declared_fields, consumed_fields,
+        "{scenario}: extractionProfile declares only consumed contract fields"
+    );
 }
 
 fn translate_artifact_ids(value: &mut Value, artifact_ids: &BTreeMap<String, String>) {
@@ -1551,8 +1572,6 @@ fn collect_object_keys(value: &Value, keys: &mut Vec<String>) {
     }
 }
 
-/// Scenarios whose declared `extractionProfile` states what the bundle
-/// actually produced rather than the profile's full capability list.
 const OBSERVED_KEY_KIND_SCENARIOS: [&str; 8] = [
     "bits-transfer-failure",
     "cache-failure",
@@ -2232,35 +2251,6 @@ fn every_equally_terminal_record_is_cited_rather_than_one_elected() {
             "{label}: two conflicting exit codes cannot key the transaction"
         );
     }
-}
-
-fn selection_state_name(state: SccmDeploymentProfileSelectionState) -> &'static str {
-    match state {
-        SccmDeploymentProfileSelectionState::Selected => "selected",
-        SccmDeploymentProfileSelectionState::Unselected => "unselected",
-    }
-}
-
-#[test]
-fn the_extraction_profile_reports_its_selection_state() {
-    for scenario in SCENARIOS {
-        let analysis = analyze_scenario(scenario);
-        let expected = expected(scenario);
-        assert_eq!(
-            selection_state_name(analysis.extraction_profile.selection_state),
-            expected["extractionProfile"]["selectionState"]
-                .as_str()
-                .expect("declared selection state"),
-            "{scenario}: extraction profile selection state"
-        );
-    }
-
-    let mut unprofiled = client_artifact("synthetic-intent", "AppIntentEval.log");
-    unprofiled.configmgr_version = Some("5.00.PROD.9128".to_owned());
-    assert!(
-        try_bundle_from(vec![(unprofiled, intent_content())]).is_err(),
-        "an unregistered profile cannot create deployment analysis authority"
-    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- remove unconsumed `extractionProfile.selectionState` from all twelve deployment expectations
- reject unowned extraction-profile expectation fields in the corpus harness
- retain the rotation-boundary claim for only `client-app-intent`, because its content fragments do not produce a logical record

## Verification
- `cargo test -p cmtraceopen-parser --test sccm_client_deployment`
- `cargo test -p cmtraceopen-parser`
- `cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings`
- `rustfmt --check crates/cmtraceopen-parser/tests/sccm_client_deployment.rs`
- `jq -e .` across all deployment expected JSON fixtures

Closes #411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated deployment test fixtures to remove obsolete extraction profile selection-state data.
  * Added validation ensuring extraction profiles contain only the fields required by deployment tests.
  * Continued validating profile identifiers, version requirements, key types, and artifact families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->