### PR TITLE
fix(intune): narrow rotation failure detection

### DIFF
--- a/crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs
@@ -323,11 +323,18 @@ fn count_headers(content: &str, regex: &Regex) -> usize {
 /// happens to contain a generic keyword, so this does not match a bare "error".
 fn rotation_header_states_failure(message: &str) -> bool {
     let lowered = message.trim().to_ascii_lowercase();
-    lowered.contains("failed to rotate")
-        || lowered.contains("rotation failed")
-        || lowered.contains("failed to roll")
-        || lowered.starts_with("failed ")
-        || lowered.starts_with("unhandled ")
+    ["failed to rotate", "rotation failed", "failed to roll"]
+        .iter()
+        .any(|phrase| contains_with_trailing_token_boundary(&lowered, phrase))
+}
+
+fn contains_with_trailing_token_boundary(message: &str, phrase: &str) -> bool {
+    message.match_indices(phrase).any(|(start, matched)| {
+        message[start + matched.len()..]
+            .chars()
+            .next()
+            .is_none_or(|next| !next.is_alphanumeric() && next != '_')
+    })
 }
 
 /// Whether a continuation line is .NET exception evidence: either a namespaced

--- a/crates/cmtraceopen-parser/tests/intune_device_inventory.rs
+++ b/crates/cmtraceopen-parser/tests/intune_device_inventory.rs
@@ -19,6 +19,12 @@ const ADAPTOR: &str = "[Thu Jul 30 13:05:01 2026][8604] - Adapter result:\n{\"St
 
 const ROTATION_FAILURE: &str = "2026-07-30T13:05:01.1234567-04:00 Failed to rotate Device Inventory log.\nSystem.IO.IOException: The process cannot access the file.\n   at Synthetic.Inventory.Rotate()";
 
+const PARTIAL_ROTATION_FAILURE_HEADERS: [&str; 3] = [
+    "2026-07-30T13:05:01.1234567-04:00 Failed to rollback transaction.",
+    "2026-07-30T13:05:01.1234567-04:00 Rotation failedover to backup.",
+    "2026-07-30T13:05:01.1234567-04:00 Failed to rotateCredentials.",
+];
+
 #[test]
 fn parses_harvester_headers_with_direct_severity_mapping() {
     let (entries, parse_errors) = parse_content(
@@ -123,6 +129,59 @@ fn rejects_generic_iso_timestamp_content_as_rotation_failure() {
 }
 
 #[test]
+fn generic_failure_prefixes_do_not_identify_rotation_failures() {
+    let generic_failures = [
+        "2026-07-30T13:05:01.1234567-04:00 Failed to load configuration.",
+        "2026-07-30T13:05:01.1234567-04:00 Unhandled exception in service.",
+    ];
+
+    for path in ["unrelated.log", "IntuneDeviceInventory.log"] {
+        for content in generic_failures {
+            assert_eq!(
+                detect_dialect(path, content),
+                None,
+                "generic failure prefix must not identify rotation for {path}: {content}"
+            );
+        }
+    }
+}
+
+#[test]
+fn partial_rotation_phrases_do_not_identify_rotation_failures() {
+    for path in ["unrelated.log", "IntuneDeviceInventory.log"] {
+        for content in PARTIAL_ROTATION_FAILURE_HEADERS {
+            assert_eq!(
+                detect_dialect(path, content),
+                None,
+                "partial rotation phrase must not identify rotation for {path}: {content}"
+            );
+        }
+    }
+}
+
+#[test]
+fn registered_rotation_failure_phrases_remain_detectable() {
+    let registered_failures = [
+        "2026-07-30T13:05:01.1234567-04:00 Failed to rotate Device Inventory log.",
+        "2026-07-30T13:05:01.1234567-04:00 Device Inventory rotation failed.",
+        "2026-07-30T13:05:01.1234567-04:00 Failed to roll Device Inventory log.",
+        "2026-07-30T13:05:01.1234567-04:00 FAILED TO ROTATE",
+        "2026-07-30T13:05:01.1234567-04:00 Device Inventory RoTaTiOn FaIlEd   ",
+        "2026-07-30T13:05:01.1234567-04:00 FAILED TO ROLL\tbefore archive.",
+    ];
+
+    for path in ["unrelated.log", "IntuneDeviceInventory.log"] {
+        for content in registered_failures {
+            assert_eq!(
+                detect_dialect(path, content),
+                Some(DeviceInventoryLogDialect::RotationFailure),
+                "registered rotation phrase must remain detectable for {path}: {content}"
+            );
+        }
+    }
+}
+
+#[test]
 fn a_device_inventory_selection_without_a_dialect_degrades_instead_of_panicking() {
     // A Device Inventory selection normally carries the dialect detection
     // resolved. One that does not is malformed, not impossible, and the
@@ -151,10 +210,21 @@ fn detects_rotation_failure_from_exception_evidence_without_the_literal_wording(
     // beneath an ISO-8601 header is sufficient evidence on its own.
     let other_wording = "2026-07-30T13:05:01.1234567-04:00 Could not roll the inventory log over.\nSystem.UnauthorizedAccessException: Access to the path is denied.\n   at Synthetic.Inventory.Rotate()";
 
-    assert_eq!(
-        detect_dialect("unrelated.log", other_wording),
-        Some(DeviceInventoryLogDialect::RotationFailure)
-    );
+    for path in ["unrelated.log", "IntuneDeviceInventory.log"] {
+        assert_eq!(
+            detect_dialect(path, other_wording),
+            Some(DeviceInventoryLogDialect::RotationFailure)
+        );
+
+        let (result, selection) =
+            parse_with_dispatcher(other_wording, path, other_wording.len() as u64);
+        assert_eq!(selection.parser, ParserKind::IntuneDeviceInventory);
+        assert_eq!(
+            selection.specialization,
+            Some(ParserSpecialization::IntuneDeviceInventoryRotationFailure)
+        );
+        assert_eq!(result.entries[0].severity, Severity::Error);
+    }
 }
 
 #[test]
@@ -190,6 +260,44 @@ fn rotation_severity_ignores_a_generic_keyword_in_a_continuation() {
 
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].severity, Severity::Info);
+}
+
+#[test]
+fn generic_failure_prefixes_do_not_claim_rotation_severity() {
+    let generic_failures = [
+        "2026-07-30T13:05:01.1234567-04:00 Failed to load configuration.",
+        "2026-07-30T13:05:01.1234567-04:00 Unhandled exception in service.",
+    ];
+
+    for content in generic_failures {
+        let (entries, parse_errors) = parse_content(
+            "IntuneDeviceInventory.log",
+            content,
+            DeviceInventoryLogDialect::RotationFailure,
+        );
+
+        assert_eq!(parse_errors, 0);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].severity, Severity::Info);
+    }
+}
+
+#[test]
+fn partial_rotation_phrases_do_not_claim_rotation_severity() {
+    for path in ["unrelated.log", "IntuneDeviceInventory.log"] {
+        for content in PARTIAL_ROTATION_FAILURE_HEADERS {
+            let (entries, parse_errors) =
+                parse_content(path, content, DeviceInventoryLogDialect::RotationFailure);
+
+            assert_eq!(parse_errors, 0);
+            assert_eq!(entries.len(), 1);
+            assert_eq!(
+                entries[0].severity,
+                Severity::Info,
+                "partial rotation phrase must stay informational for {path}: {content}"
+            );
+        }
+    }
 }
 
 #[test]
@@ -428,4 +536,48 @@ fn dispatcher_keeps_path_only_and_generic_timestamp_collisions_out_of_device_inv
         ParserImplementation::GenericTimestamped
     );
     assert_eq!(timestamped.parser_selection.specialization, None);
+}
+
+#[test]
+fn dispatcher_keeps_generic_failure_prefixes_out_of_device_inventory() {
+    let generic_failures = [
+        "2026-07-30T13:05:01.1234567-04:00 Failed to load configuration.\n2026-07-30T13:05:02.1234567-04:00 Completed an unrelated service operation.",
+        "2026-07-30T13:05:01.1234567-04:00 Unhandled exception in service.\n2026-07-30T13:05:02.1234567-04:00 Completed an unrelated service operation.",
+    ];
+
+    for path in ["unrelated.log", "IntuneDeviceInventory.log"] {
+        for content in generic_failures {
+            let (result, selection) = parse_with_dispatcher(content, path, content.len() as u64);
+
+            assert_eq!(selection.parser, ParserKind::Timestamped);
+            assert_eq!(
+                selection.implementation,
+                ParserImplementation::GenericTimestamped
+            );
+            assert_eq!(selection.specialization, None);
+            assert_eq!(result.parser_selection.specialization, None);
+            assert_eq!(result.entries.len(), 2);
+        }
+    }
+}
+
+#[test]
+fn dispatcher_keeps_partial_rotation_phrases_out_of_device_inventory() {
+    for path in ["unrelated.log", "IntuneDeviceInventory.log"] {
+        for header in PARTIAL_ROTATION_FAILURE_HEADERS {
+            let content = format!(
+                "{header}\n2026-07-30T13:05:02.1234567-04:00 Completed an unrelated service operation."
+            );
+            let (result, selection) = parse_with_dispatcher(&content, path, content.len() as u64);
+
+            assert_eq!(selection.parser, ParserKind::Timestamped);
+            assert_eq!(
+                selection.implementation,
+                ParserImplementation::GenericTimestamped
+            );
+            assert_eq!(selection.specialization, None);
+            assert_eq!(result.parser_selection.specialization, None);
+            assert_eq!(result.entries.len(), 2);
+        }
+    }
 }

--- a/docs/superpowers/plans/2026-08-05-issue-506-rotation-detection-narrowing.md
+++ b/docs/superpowers/plans/2026-08-05-issue-506-rotation-detection-narrowing.md
@@ -1,0 +1,50 @@
+# Device Inventory Rotation Detection Narrowing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent generic ISO-timestamped failures from being classified as Device Inventory rotation failures while preserving registered rotation phrases and .NET exception evidence.
+
+**Architecture:** Keep the existing content-only dialect detector and shared rotation severity predicate. Pin the intended semantics through direct detection, dispatcher, and forced-dialect severity tests, then delete only the generic prefix branches; do not add filename fallback or alter continuation framing.
+
+**Tech Stack:** Rust, Cargo test, Clippy, rustfmt
+
+---
+
+### Task 1: Pin the rotation-detection contract with failing tests
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/tests/intune_device_inventory.rs:118-193`
+- Modify: `crates/cmtraceopen-parser/tests/intune_device_inventory.rs:409-431`
+
+- [x] Add direct-detection cases proving ISO headers beginning with `Failed ` and `Unhandled ` return no Device Inventory dialect for both `unrelated.log` and `IntuneDeviceInventory.log`.
+- [x] Add dispatcher cases proving the same content selects `ParserKind::Timestamped` with `ParserImplementation::GenericTimestamped` and no specialization for both filenames.
+- [x] Add positive cases for `failed to rotate`, `rotation failed`, and `failed to roll`, plus ISO-header records whose only failure evidence is a .NET exception continuation.
+- [x] Add forced-rotation parsing cases proving generic failure prefixes remain `Severity::Info` rather than claiming rotation severity.
+- [x] Run the new negative tests and confirm they fail before the implementation change:
+
+```bash
+cargo test -p cmtraceopen-parser --test intune_device_inventory generic_failure_prefixes
+cargo test -p cmtraceopen-parser --test intune_device_inventory dispatcher_keeps_generic_failure_prefixes
+```
+
+### Task 2: Narrow the shared predicate and validate the parser
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs:319-331`
+- Create: `library.md`
+
+- [x] Remove only `lowered.starts_with("failed ")` and `lowered.starts_with("unhandled ")` from `rotation_header_states_failure`; retain all three registered rotation phrases and exception detection.
+- [x] Add the root library route for this implementation plan.
+- [x] Run focused and full parser validation:
+
+```bash
+cargo test -p cmtraceopen-parser --test intune_device_inventory
+cargo test -p cmtraceopen-parser
+cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings
+rustfmt --edition 2021 --check crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs crates/cmtraceopen-parser/tests/intune_device_inventory.rs
+npx tsc --noEmit
+git diff --check
+git status --short --branch
+```
+
+- [ ] Commit and push the branch, then open a pull request that closes GitHub issue #506 without merging it.

--- a/library.md
+++ b/library.md
@@ -6,3 +6,4 @@
 - IF integrating SCCM Epic #317 with current main for PR #490 → read [[docs/superpowers/plans/2026-08-04-sccm-317-main-integration.md]]
 - IF repairing PR #490 native SCCM discovery/capture or workspace product path → read [[docs/superpowers/plans/2026-08-04-sccm-native-product-path-rework.md]]
 - IF implementing or reviewing signless CCM/CmtLog timestamp repairs (#410, #414) → read [[docs/superpowers/plans/2026-08-05-signless-ccm-timestamps.md]]
+- IF implementing or reviewing GitHub issue #506 Device Inventory rotation detection narrowing → read [[docs/superpowers/plans/2026-08-05-issue-506-rotation-detection-narrowing.md]]


### PR DESCRIPTION
Closes #506

## Summary
- stop treating generic `Failed …` and `Unhandled …` ISO headers as Device Inventory rotation failures
- require a trailing token boundary or end after `failed to rotate`, `rotation failed`, and `failed to roll`
- preserve registered phrase matching across case, punctuation, trailing whitespace, and phrase-at-end inputs
- preserve ISO-header plus .NET exception evidence
- cover direct detection, dispatcher routing, both relevant filename shapes, and severity semantics

## Critic regressions
- `Failed to rollback transaction.`
- `Rotation failedover to backup.`
- `Failed to rotateCredentials.`

All three remain generic timestamped content and informational under forced rotation parsing for both `unrelated.log` and `IntuneDeviceInventory.log`.

## Validation
- `cargo test -p cmtraceopen-parser --test intune_device_inventory` (24 passed)
- `cargo test -p cmtraceopen-parser`
- `cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings`
- scoped `rustfmt --check`
- `npx tsc --noEmit`
- `git diff --check`

## Out of scope
- #507 continuation-size behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rotation-failure detection to recognize only explicit rotation-related messages.
  - Prevented generic failure messages from being incorrectly classified as device inventory rotation failures.
  - Preserved detection for registered rotation phrases and relevant exception messages.
  - Improved parser selection and error severity handling for rotation-related entries.

- **Documentation**
  - Added implementation planning and library references for the updated detection behavior.

- **Tests**
  - Added regression coverage for rotation detection, parser selection, and severity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->