### PR TITLE
fix: make Device Inventory framing lossless and bounded

### DIFF
--- a/crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs
@@ -13,6 +13,12 @@ use std::sync::OnceLock;
 
 use crate::models::log_entry::{LogEntry, LogFormat, Severity};
 
+/// Maximum UTF-8 byte length of one in-memory Device Inventory logical record.
+///
+/// Framing force-completes bounded pieces beyond this point without dropping
+/// the remainder. Initial parsing and incremental tailing both use this value.
+pub const MAX_LOGICAL_RECORD_BYTES: usize = 1024 * 1024;
+
 /// The known Windows Device Inventory log dialects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeviceInventoryLogDialect {
@@ -74,6 +80,17 @@ pub struct LogicalRecordFramingResult {
     pub overflow_count: u32,
 }
 
+impl LogicalRecordFramingResult {
+    /// Explicitly complete the newest record at an end-of-input boundary.
+    pub fn flush_pending(mut self) -> Self {
+        if let Some(content) = self.pending_record.take() {
+            self.completed_records
+                .push(FramedLogicalRecord::complete(content));
+        }
+        self
+    }
+}
+
 /// Add complete physical lines to a pending Device Inventory logical record.
 ///
 /// Header recognition intentionally stays in this pure parser module so tailing
@@ -83,13 +100,7 @@ pub fn frame_logical_records(
     dialect: DeviceInventoryLogDialect,
     mut pending_record: Option<String>,
     new_lines: &[&str],
-    max_pending_bytes: usize,
 ) -> LogicalRecordFramingResult {
-    assert!(
-        max_pending_bytes >= 4,
-        "logical record bound must fit one UTF-8 scalar"
-    );
-
     let mut completed_records = Vec::new();
     let mut overflow_count = 0u32;
 
@@ -111,12 +122,12 @@ pub fn frame_logical_records(
 
         while pending_record
             .as_ref()
-            .is_some_and(|record| record.len() > max_pending_bytes)
+            .is_some_and(|record| record.len() > MAX_LOGICAL_RECORD_BYTES)
         {
             let mut record = pending_record
                 .take()
                 .expect("oversized pending record must exist");
-            let split_at = previous_char_boundary(&record, max_pending_bytes);
+            let split_at = previous_char_boundary(&record, MAX_LOGICAL_RECORD_BYTES);
             let remainder = record.split_off(split_at);
             completed_records.push(FramedLogicalRecord::split(record));
             overflow_count = overflow_count.saturating_add(1);
@@ -212,7 +223,8 @@ pub fn parse_content(
     content: &str,
     dialect: DeviceInventoryLogDialect,
 ) -> (Vec<LogEntry>, u32) {
-    parse_records(file_path, content.lines(), dialect)
+    let lines: Vec<&str> = content.lines().collect();
+    parse_lines(file_path, &lines, dialect)
 }
 
 /// Parse already-split Device Inventory physical lines.
@@ -225,22 +237,66 @@ pub fn parse_lines(
     lines: &[&str],
     dialect: DeviceInventoryLogDialect,
 ) -> (Vec<LogEntry>, u32) {
-    parse_records(file_path, lines.iter().copied(), dialect)
+    let framed = frame_logical_records(dialect, None, lines).flush_pending();
+    let (entries, projection_errors) =
+        parse_framed_records(file_path, &framed.completed_records, dialect);
+    (
+        entries,
+        projection_errors.saturating_add(framed.overflow_count),
+    )
 }
 
-/// Every dialect attaches a non-header line to the record above it, so a
-/// Device Inventory record is a logical record for all three dialects. Callers
-/// that frame input themselves must use [`frame_logical_records`] to keep
-/// incremental framing identical to this whole-input reading.
-fn parse_records<'a>(
+/// Project already-bounded logical records into parsed entries.
+///
+/// Framing and projection stay separate so initial parsing and tailing can use
+/// one lossless framing contract without re-framing completed records. Framing
+/// overflow errors belong to the caller because they are produced before this
+/// projection step.
+pub fn parse_framed_records(
     file_path: &str,
-    lines: impl Iterator<Item = &'a str>,
+    framed_records: &[FramedLogicalRecord],
+    dialect: DeviceInventoryLogDialect,
+) -> (Vec<LogEntry>, u32) {
+    let mut entries = Vec::new();
+    let mut parse_errors = 0u32;
+    let mut record_start_line = 1u32;
+
+    for framed_record in framed_records {
+        let (record_entries, record_errors) = project_logical_record(framed_record, dialect);
+        parse_errors = parse_errors.saturating_add(record_errors);
+
+        for mut entry in record_entries {
+            entry.id = entries.len() as u64;
+            entry.line_number =
+                record_start_line.saturating_add(entry.line_number.saturating_sub(1));
+            entry.file_path = file_path.to_string();
+            entries.push(entry);
+        }
+
+        record_start_line = record_start_line.saturating_add(framed_record.physical_lines);
+    }
+
+    (entries, parse_errors)
+}
+
+fn project_logical_record(
+    framed_record: &FramedLogicalRecord,
     dialect: DeviceInventoryLogDialect,
 ) -> (Vec<LogEntry>, u32) {
     let mut records: Vec<LogEntry> = Vec::new();
-    let mut parse_errors = 0;
+    let mut parse_errors = 0u32;
+    let mut lines = framed_record.content.split('\n').collect::<Vec<_>>();
 
-    for (index, raw_line) in lines.enumerate() {
+    // A force-split piece ending at a newline does not own the next empty
+    // physical line. A naturally completed record does, including a genuine
+    // trailing blank continuation.
+    if framed_record.physical_lines == newline_count(&framed_record.content)
+        && framed_record.content.ends_with('\n')
+    {
+        lines.pop();
+    }
+
+    for (index, raw_line) in lines.into_iter().enumerate() {
         let line_number = (index + 1) as u32;
         let line = raw_line.trim_end_matches('\r');
         if line.is_empty() {
@@ -295,17 +351,7 @@ fn parse_records<'a>(
         }
     }
 
-    let entries = records
-        .into_iter()
-        .enumerate()
-        .map(|(id, mut record)| {
-            record.id = id as u64;
-            record.file_path = file_path.to_string();
-            record
-        })
-        .collect();
-
-    (entries, parse_errors)
+    (records, parse_errors)
 }
 
 fn count_headers(content: &str, regex: &Regex) -> usize {
@@ -578,7 +624,6 @@ mod tests {
             DeviceInventoryLogDialect::InventoryAdaptor,
             None,
             &[ADAPTOR_HEADER],
-            1024,
         );
         assert!(first.completed_records.is_empty());
 
@@ -589,7 +634,6 @@ mod tests {
                 r#"{"Status":200,"Data":{"Example":"value"}}"#,
                 NEXT_ADAPTOR_HEADER,
             ],
-            1024,
         );
 
         assert_eq!(
@@ -644,26 +688,24 @@ mod tests {
 
     #[test]
     fn logical_framing_overflow_is_bounded_counted_and_lossless() {
-        let max_pending_bytes = ADAPTOR_HEADER.len() + 8;
-        let continuation = "continuation-0123456789";
+        let continuation = format!("continuation-{}-TAIL", "x".repeat(MAX_LOGICAL_RECORD_BYTES));
         let expected = format!("{ADAPTOR_HEADER}\n{continuation}");
 
         let framed = frame_logical_records(
             DeviceInventoryLogDialect::InventoryAdaptor,
             None,
-            &[ADAPTOR_HEADER, continuation],
-            max_pending_bytes,
+            &[ADAPTOR_HEADER, &continuation],
         );
 
         assert_eq!(framed.overflow_count, 1);
         assert!(framed
             .completed_records
             .iter()
-            .all(|record| record.content.len() <= max_pending_bytes));
+            .all(|record| record.content.len() <= MAX_LOGICAL_RECORD_BYTES));
         assert!(framed
             .pending_record
             .as_ref()
-            .is_none_or(|record| record.len() <= max_pending_bytes));
+            .is_none_or(|record| record.len() <= MAX_LOGICAL_RECORD_BYTES));
 
         // A force-split piece ends mid-line and its remainder continues that
         // same physical line, so the pieces together must still account for

--- a/crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs
@@ -27,6 +27,15 @@ pub enum DeviceInventoryLogDialect {
     RotationFailure,
 }
 
+/// A physical-line segment supplied to the logical-record framer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogicalRecordSegment<'a> {
+    /// The first bytes of a physical line. Header recognition runs here.
+    LineStart(&'a str),
+    /// More bytes from the same physical line, without an inserted newline.
+    LineContinuation(&'a str),
+}
+
 /// A framed Device Inventory logical record and the file span it occupies.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FramedLogicalRecord {
@@ -78,6 +87,8 @@ pub struct LogicalRecordFramingResult {
     pub pending_record: Option<String>,
     /// Number of records force-completed because they reached the size bound.
     pub overflow_count: u32,
+    /// Largest pending record length observed during this framing call.
+    pub max_pending_bytes_observed: usize,
 }
 
 impl LogicalRecordFramingResult {
@@ -94,51 +105,95 @@ impl LogicalRecordFramingResult {
 /// Add complete physical lines to a pending Device Inventory logical record.
 ///
 /// Header recognition intentionally stays in this pure parser module so tailing
-/// and whole-file parsing share the same dialect regexes. The caller owns
-/// time-based flushing of `pending_record`.
+/// and whole-file parsing share the same dialect regexes. The caller explicitly
+/// flushes `pending_record` at a real input boundary.
 pub fn frame_logical_records(
     dialect: DeviceInventoryLogDialect,
     mut pending_record: Option<String>,
-    new_lines: &[&str],
+    segments: &[LogicalRecordSegment<'_>],
 ) -> LogicalRecordFramingResult {
     let mut completed_records = Vec::new();
     let mut overflow_count = 0u32;
+    let mut max_pending_bytes_observed = pending_record.as_ref().map_or(0, String::len);
+    assert!(
+        max_pending_bytes_observed <= MAX_LOGICAL_RECORD_BYTES,
+        "logical-record framing state must already be bounded"
+    );
 
-    for raw_line in new_lines {
-        let line = raw_line.trim_end_matches('\r');
-        if is_record_header(dialect, line) {
-            if let Some(record) = pending_record.take() {
-                completed_records.push(FramedLogicalRecord::complete(record));
+    for segment in segments {
+        let (text, starts_line) = match segment {
+            LogicalRecordSegment::LineStart(raw_line) => {
+                let line = raw_line.trim_end_matches('\r');
+                if is_record_header(dialect, line) {
+                    if let Some(record) = pending_record.take() {
+                        completed_records.push(FramedLogicalRecord::complete(record));
+                    }
+                }
+                (line, true)
             }
-        }
+            LogicalRecordSegment::LineContinuation(text) => (*text, false),
+        };
 
-        match pending_record.as_mut() {
-            Some(record) => {
-                record.push('\n');
-                record.push_str(line);
-            }
-            None => pending_record = Some(line.to_string()),
+        let insert_newline = starts_line && pending_record.is_some();
+        if pending_record.is_none() {
+            pending_record = Some(String::new());
         }
-
-        while pending_record
-            .as_ref()
-            .is_some_and(|record| record.len() > MAX_LOGICAL_RECORD_BYTES)
-        {
-            let mut record = pending_record
-                .take()
-                .expect("oversized pending record must exist");
-            let split_at = previous_char_boundary(&record, MAX_LOGICAL_RECORD_BYTES);
-            let remainder = record.split_off(split_at);
-            completed_records.push(FramedLogicalRecord::split(record));
-            overflow_count = overflow_count.saturating_add(1);
-            pending_record = (!remainder.is_empty()).then_some(remainder);
+        if insert_newline {
+            append_bounded(
+                &mut pending_record,
+                "\n",
+                &mut completed_records,
+                &mut overflow_count,
+                &mut max_pending_bytes_observed,
+            );
         }
+        append_bounded(
+            &mut pending_record,
+            text,
+            &mut completed_records,
+            &mut overflow_count,
+            &mut max_pending_bytes_observed,
+        );
     }
 
     LogicalRecordFramingResult {
         completed_records,
         pending_record,
         overflow_count,
+        max_pending_bytes_observed,
+    }
+}
+
+fn append_bounded(
+    pending_record: &mut Option<String>,
+    mut text: &str,
+    completed_records: &mut Vec<FramedLogicalRecord>,
+    overflow_count: &mut u32,
+    max_pending_bytes_observed: &mut usize,
+) {
+    while !text.is_empty() {
+        let record = pending_record.get_or_insert_with(String::new);
+        let available = MAX_LOGICAL_RECORD_BYTES.saturating_sub(record.len());
+        let split_at = previous_char_boundary(text, available);
+
+        if split_at > 0 {
+            record.push_str(&text[..split_at]);
+            *max_pending_bytes_observed = (*max_pending_bytes_observed).max(record.len());
+            debug_assert!(record.len() <= MAX_LOGICAL_RECORD_BYTES);
+            text = &text[split_at..];
+        }
+
+        if !text.is_empty() {
+            let completed = pending_record
+                .take()
+                .expect("bounded append must have a pending record");
+            completed_records.push(FramedLogicalRecord::split(completed));
+            *overflow_count = overflow_count.saturating_add(1);
+        }
+    }
+
+    if pending_record.is_none() {
+        pending_record.replace(String::new());
     }
 }
 
@@ -237,7 +292,11 @@ pub fn parse_lines(
     lines: &[&str],
     dialect: DeviceInventoryLogDialect,
 ) -> (Vec<LogEntry>, u32) {
-    let framed = frame_logical_records(dialect, None, lines).flush_pending();
+    let segments = lines
+        .iter()
+        .map(|line| LogicalRecordSegment::LineStart(line))
+        .collect::<Vec<_>>();
+    let framed = frame_logical_records(dialect, None, &segments).flush_pending();
     let (entries, projection_errors) =
         parse_framed_records(file_path, &framed.completed_records, dialect);
     (
@@ -623,7 +682,7 @@ mod tests {
         let first = frame_logical_records(
             DeviceInventoryLogDialect::InventoryAdaptor,
             None,
-            &[ADAPTOR_HEADER],
+            &[LogicalRecordSegment::LineStart(ADAPTOR_HEADER)],
         );
         assert!(first.completed_records.is_empty());
 
@@ -631,8 +690,8 @@ mod tests {
             DeviceInventoryLogDialect::InventoryAdaptor,
             first.pending_record,
             &[
-                r#"{"Status":200,"Data":{"Example":"value"}}"#,
-                NEXT_ADAPTOR_HEADER,
+                LogicalRecordSegment::LineStart(r#"{"Status":200,"Data":{"Example":"value"}}"#),
+                LogicalRecordSegment::LineStart(NEXT_ADAPTOR_HEADER),
             ],
         );
 
@@ -694,7 +753,10 @@ mod tests {
         let framed = frame_logical_records(
             DeviceInventoryLogDialect::InventoryAdaptor,
             None,
-            &[ADAPTOR_HEADER, &continuation],
+            &[
+                LogicalRecordSegment::LineStart(ADAPTOR_HEADER),
+                LogicalRecordSegment::LineStart(&continuation),
+            ],
         );
 
         assert_eq!(framed.overflow_count, 1);

--- a/crates/cmtraceopen-parser/tests/intune_device_inventory.rs
+++ b/crates/cmtraceopen-parser/tests/intune_device_inventory.rs
@@ -1,7 +1,7 @@
 use cmtraceopen_parser::{
     intune::device::windows::inventory::{
         detect_dialect, frame_logical_records, parse_content, parse_lines,
-        DeviceInventoryLogDialect, MAX_LOGICAL_RECORD_BYTES,
+        DeviceInventoryLogDialect, LogicalRecordSegment, MAX_LOGICAL_RECORD_BYTES,
     },
     models::log_entry::{
         LogEntry, LogFormat, ParseQuality, ParserImplementation, ParserKind, ParserProvenance,
@@ -394,7 +394,11 @@ fn harvester_continuations_frame_incrementally_the_way_they_parse() {
     let next_header = "7/30/2026 6:00:55 AM [Warning] Second record.";
     let whole_file_content = format!("{header}\n{continuation}\n{next_header}");
 
-    let first = frame_logical_records(DeviceInventoryLogDialect::Harvester, None, &[header]);
+    let first = frame_logical_records(
+        DeviceInventoryLogDialect::Harvester,
+        None,
+        &[LogicalRecordSegment::LineStart(header)],
+    );
     assert!(
         first.completed_records.is_empty(),
         "a harvester header must stay pending until its continuations are known"
@@ -403,7 +407,10 @@ fn harvester_continuations_frame_incrementally_the_way_they_parse() {
     let second = frame_logical_records(
         DeviceInventoryLogDialect::Harvester,
         first.pending_record,
-        &[continuation, next_header],
+        &[
+            LogicalRecordSegment::LineStart(continuation),
+            LogicalRecordSegment::LineStart(next_header),
+        ],
     );
 
     // Each framed record is parsed on its own, exactly as tailing parses it.
@@ -450,7 +457,10 @@ fn logical_record_limit_is_exact_and_lossless() {
     let exact = frame_logical_records(
         DeviceInventoryLogDialect::Harvester,
         None,
-        &[header, &exact_padding],
+        &[
+            LogicalRecordSegment::LineStart(header),
+            LogicalRecordSegment::LineStart(&exact_padding),
+        ],
     );
 
     assert!(exact.completed_records.is_empty());
@@ -466,7 +476,10 @@ fn logical_record_limit_is_exact_and_lossless() {
     let overflow = frame_logical_records(
         DeviceInventoryLogDialect::Harvester,
         None,
-        &[header, &overflow_padding],
+        &[
+            LogicalRecordSegment::LineStart(header),
+            LogicalRecordSegment::LineStart(&overflow_padding),
+        ],
     )
     .flush_pending();
     let chunks: Vec<&str> = overflow
@@ -493,7 +506,10 @@ fn logical_record_split_is_utf8_safe_and_preserves_every_byte() {
     let framed = frame_logical_records(
         DeviceInventoryLogDialect::InventoryAdaptor,
         None,
-        &[header, &continuation],
+        &[
+            LogicalRecordSegment::LineStart(header),
+            LogicalRecordSegment::LineStart(&continuation),
+        ],
     )
     .flush_pending();
     let chunks: Vec<&str> = framed
@@ -567,6 +583,38 @@ fn every_dialect_bounds_oversized_single_lines_and_keeps_parse_entry_points_equa
             .iter()
             .all(|entry| entry.message.len() <= MAX_LOGICAL_RECORD_BYTES));
     }
+}
+
+#[test]
+fn framing_never_builds_an_oversized_pending_record_before_splitting() {
+    let header = "[Thu Jul 30 13:05:01 2026][8604] - PEAK-START";
+    let continuation = format!(
+        "HUGE-LINE-START-{}🧪-HUGE-LINE-TAIL",
+        "x".repeat(MAX_LOGICAL_RECORD_BYTES * 3)
+    );
+    let original = format!("{header}\n{continuation}");
+    let framed = frame_logical_records(
+        DeviceInventoryLogDialect::InventoryAdaptor,
+        None,
+        &[
+            LogicalRecordSegment::LineStart(header),
+            LogicalRecordSegment::LineStart(&continuation),
+        ],
+    )
+    .flush_pending();
+    let reconstructed = framed
+        .completed_records
+        .iter()
+        .map(|record| record.content.as_str())
+        .collect::<String>();
+
+    assert!(framed.max_pending_bytes_observed <= MAX_LOGICAL_RECORD_BYTES);
+    assert!(framed
+        .completed_records
+        .iter()
+        .all(|record| record.content.len() <= MAX_LOGICAL_RECORD_BYTES));
+    assert_eq!(reconstructed.as_bytes(), original.as_bytes());
+    assert!(reconstructed.ends_with("🧪-HUGE-LINE-TAIL"));
 }
 
 /// Compare entries by the fields the parse contract owns.

--- a/crates/cmtraceopen-parser/tests/intune_device_inventory.rs
+++ b/crates/cmtraceopen-parser/tests/intune_device_inventory.rs
@@ -1,7 +1,7 @@
 use cmtraceopen_parser::{
     intune::device::windows::inventory::{
         detect_dialect, frame_logical_records, parse_content, parse_lines,
-        DeviceInventoryLogDialect,
+        DeviceInventoryLogDialect, MAX_LOGICAL_RECORD_BYTES,
     },
     models::log_entry::{
         LogEntry, LogFormat, ParseQuality, ParserImplementation, ParserKind, ParserProvenance,
@@ -394,7 +394,7 @@ fn harvester_continuations_frame_incrementally_the_way_they_parse() {
     let next_header = "7/30/2026 6:00:55 AM [Warning] Second record.";
     let whole_file_content = format!("{header}\n{continuation}\n{next_header}");
 
-    let first = frame_logical_records(DeviceInventoryLogDialect::Harvester, None, &[header], 1024);
+    let first = frame_logical_records(DeviceInventoryLogDialect::Harvester, None, &[header]);
     assert!(
         first.completed_records.is_empty(),
         "a harvester header must stay pending until its continuations are known"
@@ -404,7 +404,6 @@ fn harvester_continuations_frame_incrementally_the_way_they_parse() {
         DeviceInventoryLogDialect::Harvester,
         first.pending_record,
         &[continuation, next_header],
-        1024,
     );
 
     // Each framed record is parsed on its own, exactly as tailing parses it.
@@ -441,6 +440,133 @@ fn harvester_continuations_frame_incrementally_the_way_they_parse() {
         incremental[0].1,
         "First recognized record.\ntrailing continuation"
     );
+}
+
+#[test]
+fn logical_record_limit_is_exact_and_lossless() {
+    let header = "7/30/2026 6:00:54 AM [Information] bounded:";
+    let exact_padding = "x".repeat(MAX_LOGICAL_RECORD_BYTES - header.len() - 1);
+    let exact_text = format!("{header}\n{exact_padding}");
+    let exact = frame_logical_records(
+        DeviceInventoryLogDialect::Harvester,
+        None,
+        &[header, &exact_padding],
+    );
+
+    assert!(exact.completed_records.is_empty());
+    assert_eq!(exact.pending_record.as_deref(), Some(exact_text.as_str()));
+    assert_eq!(
+        exact.pending_record.as_ref().unwrap().len(),
+        MAX_LOGICAL_RECORD_BYTES
+    );
+    assert_eq!(exact.overflow_count, 0);
+
+    let overflow_padding = format!("{exact_padding}Z");
+    let overflow_text = format!("{header}\n{overflow_padding}");
+    let overflow = frame_logical_records(
+        DeviceInventoryLogDialect::Harvester,
+        None,
+        &[header, &overflow_padding],
+    )
+    .flush_pending();
+    let chunks: Vec<&str> = overflow
+        .completed_records
+        .iter()
+        .map(|record| record.content.as_str())
+        .collect();
+
+    assert_eq!(overflow.overflow_count, 1);
+    assert!(chunks
+        .iter()
+        .all(|chunk| chunk.len() <= MAX_LOGICAL_RECORD_BYTES));
+    assert_eq!(chunks.concat(), overflow_text);
+    assert!(chunks.concat().ends_with('Z'));
+}
+
+#[test]
+fn logical_record_split_is_utf8_safe_and_preserves_every_byte() {
+    let header = "[Thu Jul 30 13:05:01 2026][8604] - UTF-8 boundary:";
+    let bytes_before_emoji = MAX_LOGICAL_RECORD_BYTES - 1;
+    let padding = "x".repeat(bytes_before_emoji - header.len() - 1);
+    let continuation = format!("{padding}🧪TAIL-SENTINEL");
+    let original = format!("{header}\n{continuation}");
+    let framed = frame_logical_records(
+        DeviceInventoryLogDialect::InventoryAdaptor,
+        None,
+        &[header, &continuation],
+    )
+    .flush_pending();
+    let chunks: Vec<&str> = framed
+        .completed_records
+        .iter()
+        .map(|record| record.content.as_str())
+        .collect();
+
+    assert_eq!(framed.overflow_count, 1);
+    assert!(chunks
+        .iter()
+        .all(|chunk| chunk.len() <= MAX_LOGICAL_RECORD_BYTES));
+    assert_eq!(chunks.concat().as_bytes(), original.as_bytes());
+    assert!(chunks.concat().ends_with("🧪TAIL-SENTINEL"));
+}
+
+#[test]
+fn every_dialect_bounds_oversized_single_lines_and_keeps_parse_entry_points_equal() {
+    let cases = [
+        (
+            DeviceInventoryLogDialect::Harvester,
+            "7/30/2026 6:00:54 AM [Error] HARVESTER-START",
+            Severity::Error,
+        ),
+        (
+            DeviceInventoryLogDialect::InventoryAdaptor,
+            "[Thu Jul 30 13:05:01 2026][8604] - ADAPTOR-START",
+            Severity::Info,
+        ),
+        (
+            DeviceInventoryLogDialect::RotationFailure,
+            "2026-07-30T13:05:01.1234567-04:00 Failed to rotate ROTATION-START",
+            Severity::Error,
+        ),
+    ];
+
+    for (dialect, header, expected_severity) in cases {
+        let oversized = format!(
+            "MULTILINE-START-{}🧪-{}-TAIL-SENTINEL",
+            "x".repeat(MAX_LOGICAL_RECORD_BYTES),
+            match dialect {
+                DeviceInventoryLogDialect::Harvester => "HARVESTER",
+                DeviceInventoryLogDialect::InventoryAdaptor => "ADAPTOR",
+                DeviceInventoryLogDialect::RotationFailure => "ROTATION",
+            }
+        );
+        let next_header = match dialect {
+            DeviceInventoryLogDialect::Harvester => "7/30/2026 6:00:55 AM [Warning] NEXT-RECORD",
+            DeviceInventoryLogDialect::InventoryAdaptor => {
+                "[Thu Jul 30 13:05:02 2026][8604] - NEXT-RECORD"
+            }
+            DeviceInventoryLogDialect::RotationFailure => {
+                "2026-07-30T13:05:02.1234567-04:00 NEXT-RECORD"
+            }
+        };
+        let content = format!("{header}\n{oversized}\n{next_header}");
+        let lines: Vec<&str> = content.lines().collect();
+        let (from_content, content_errors) = parse_content("Device.log", &content, dialect);
+        let (from_lines, line_errors) = parse_lines("Device.log", &lines, dialect);
+
+        assert_eq!(content_errors, 1, "unexpected error count for {dialect:?}");
+        assert_eq!(content_errors, line_errors);
+        assert_eq!(projection(&from_content), projection(&from_lines));
+        assert_eq!(from_content[0].line_number, 1);
+        assert_eq!(from_content[0].severity, expected_severity);
+        assert_eq!(from_content.last().unwrap().line_number, 3);
+        assert!(from_content
+            .iter()
+            .any(|entry| entry.message.contains("TAIL-SENTINEL")));
+        assert!(from_content
+            .iter()
+            .all(|entry| entry.message.len() <= MAX_LOGICAL_RECORD_BYTES));
+    }
 }
 
 /// Compare entries by the fields the parse contract owns.

--- a/docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md
+++ b/docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md
@@ -467,6 +467,36 @@ Run changed-file `rustfmt --check`, `git diff --check`, the focused watcher suit
 
 Validated on `origin/main` at `e59aed306b4f8f5ee1b862970169a26b24886f4d`: 29 focused watcher tests passed; the full parser and app suites passed, including 658 parser library tests and 572 app library tests; both strict Clippy runs passed; Vitest passed 638 tests across 51 files; TypeScript, changed-file formatting, and diff checks passed.
 
-- [ ] **Step 5: Push a new frozen revision and refresh PR #511**
+- [x] **Step 5: Push a new frozen revision and refresh PR #511**
 
 Commit and push the existing branch, update the PR evidence pack with the new base/head SHAs and terminal-prefix cases, then confirm the PR remains open and unmerged.
+
+### Task 12: Preserve the complete finalized batch through truncation
+
+**Files:**
+- Modify: `src-tauri/src/watcher/tail.rs`
+- Modify: `docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md`
+
+- [x] **Step 1: Replace the incorrect truncation regression with a scalar-width matrix**
+
+For `[0xC2]`, `[0xE2, 0x82]`, `[0xF0, 0x9F, 0xA7]`, and partial BOM `[0xEF, 0xBB]`, buffer the suffix after valid `TERMINAL-CONTENT`, truncate the file to zero, and call `read_new_entries`. Assert the returned batch has `reset == true`, exactly one parse error, and exactly one entry whose message is `TERMINAL-CONTENT` with no replacement character. Assert a second read and explicit finalization return no entries or errors and the carry/framing state remains empty.
+
+- [x] **Step 2: Run the focused test and prove the bad field selection**
+
+Run:
+
+```bash
+CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test --manifest-path src-tauri/Cargo.toml --lib watcher::tail::tests::test_terminal_utf8_prefix_fails_closed_on_truncation
+```
+
+Expected before implementation: FAIL because truncation copies only `finalized.parse_errors` and drops `finalized.entries`.
+
+- [x] **Step 3: Forward terminal finalization atomically**
+
+In the truncation branch, append the complete `TailBatch` returned by `finalize_pending_input` before setting `reset = true`; do not extract individual fields. Audit explicit EOF, parser change, stop, and disconnect call sites to confirm every terminal branch already forwards the complete batch through `TailBatch::append` or the callback helper.
+
+- [ ] **Step 4: Revalidate on current main and refresh PR #511**
+
+Run scoped formatting/diff checks, the 29-test watcher suite, both full Rust suites, both strict all-target Clippy commands, `npm test -- --run`, and `npx tsc --noEmit`. Rebase if `origin/main` advances, push a new frozen SHA, update the evidence pack, and confirm the PR remains open and unmerged.
+
+Validation completed on `origin/main` at `e59aed306b4f8f5ee1b862970169a26b24886f4d`: the 29 focused watcher tests, both full Rust suites, both strict Clippy runs, 638 Vitest tests, TypeScript, scoped formatting, and diff checks passed.

--- a/docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md
+++ b/docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md
@@ -1,0 +1,280 @@
+# Lossless Bounded Device Inventory Framing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make initial Device Inventory parsing and incremental tailing use one parser-owned, UTF-8-safe, lossless logical-record framing contract with a single 1 MiB production limit.
+
+**Architecture:** The Device Inventory module owns `MAX_LOGICAL_RECORD_BYTES`, incremental framing, explicit final flush, and projection of already-framed records. Initial `parse_content`/`parse_lines` frame and flush before projection; the watcher imports the same limit and projects framed records directly, retaining only debounce, file-fragment, identity, and physical-line rebasing concerns.
+
+**Tech Stack:** Rust, `cmtraceopen-parser`, Tauri watcher, Cargo tests/clippy/fmt, TypeScript compiler.
+
+---
+
+## File structure
+
+- Modify `crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs`: define the sole production bound; make framing use it; add explicit flush; replace the unbounded parse path with bounded framing plus framed-record projection.
+- Modify `crates/cmtraceopen-parser/tests/intune_device_inventory.rs`: prove exact limits, lossless UTF-8 splitting, all dialects, line/error semantics, and `parse_content`/`parse_lines` equality.
+- Modify `src-tauri/src/watcher/tail.rs`: import the parser limit, use the shared framer/flush/projector for every tail path, and verify initial-load/tail equality.
+- Modify `library.md`: route issue #507 work to this plan.
+
+### Task 1: Lock the lossless framing contract with parser tests
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/tests/intune_device_inventory.rs`
+
+- [x] **Step 1: Replace caller-selected bounds in existing framing tests**
+
+Import `MAX_LOGICAL_RECORD_BYTES` and update every `frame_logical_records` call to the production signature:
+
+```rust
+use cmtraceopen_parser::intune::device::windows::inventory::{
+    detect_dialect, frame_logical_records, parse_content, parse_lines,
+    DeviceInventoryLogDialect, MAX_LOGICAL_RECORD_BYTES,
+};
+
+let first = frame_logical_records(DeviceInventoryLogDialect::Harvester, None, &[header]);
+```
+
+- [x] **Step 2: Add exact-limit, limit-plus-one, and UTF-8 reconstruction tests**
+
+Build a valid header plus deterministic continuation padding so one record is exactly `MAX_LOGICAL_RECORD_BYTES`, then append one ASCII byte for the overflow case. Assert the exact-limit result has no completed records/errors before flush, while limit-plus-one has one overflow, every emitted/pending chunk is bounded, and concatenating chunk content reproduces every sentinel byte. Repeat with an emoji crossing the cut and assert every chunk remains valid UTF-8 and reconstructs the normalized input exactly.
+
+```rust
+assert_eq!(exact.pending_record.as_ref().unwrap().len(), MAX_LOGICAL_RECORD_BYTES);
+assert_eq!(exact.overflow_count, 0);
+assert_eq!(overflow.overflow_count, 1);
+assert!(all_chunks.iter().all(|chunk| chunk.len() <= MAX_LOGICAL_RECORD_BYTES));
+assert_eq!(all_chunks.concat(), original);
+```
+
+- [x] **Step 3: Add whole-input bounded parsing tests for all dialects**
+
+For Harvester, InventoryAdaptor, and RotationFailure, create a valid header followed by a multiline continuation and an oversized single physical line. Assert `parse_content` and `parse_lines` return equal projected entries, line numbers, severities, and parse-error counts; assert overflow increments parse errors and trailing sentinels remain present across emitted messages.
+
+- [x] **Step 4: Run focused tests and confirm the old API/path fails**
+
+Run:
+
+```bash
+cargo test -p cmtraceopen-parser --test intune_device_inventory -- --nocapture
+```
+
+Expected: FAIL because framing still accepts a caller-provided bound, has no explicit final-flush API, and initial parsing remains unbounded.
+
+### Task 2: Make the parser own framing and projection
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs`
+- Test: `crates/cmtraceopen-parser/tests/intune_device_inventory.rs`
+
+- [x] **Step 1: Add the sole production byte limit and remove the public limit argument**
+
+```rust
+pub const MAX_LOGICAL_RECORD_BYTES: usize = 1024 * 1024;
+
+pub fn frame_logical_records(
+    dialect: DeviceInventoryLogDialect,
+    mut pending_record: Option<String>,
+    new_lines: &[&str],
+) -> LogicalRecordFramingResult {
+    // Split only with String::split_off at previous_char_boundary(...).
+}
+```
+
+Delete `max_pending_bytes` from the contract and compare only against `MAX_LOGICAL_RECORD_BYTES`. Keep `String::split_off`; do not slice, drain, truncate, or discard the remainder.
+
+- [x] **Step 2: Add an explicit final flush**
+
+Add a consuming method that completes the retained record without changing overflow accounting:
+
+```rust
+impl LogicalRecordFramingResult {
+    pub fn flush_pending(mut self) -> Self {
+        if let Some(content) = self.pending_record.take() {
+            self.completed_records
+                .push(FramedLogicalRecord::complete(content));
+        }
+        self
+    }
+}
+```
+
+- [x] **Step 3: Separate bounded framing from projection**
+
+Replace `parse_records(lines: impl Iterator<...>)` with `parse_framed_records(file_path, records, dialect)`. The projector may parse continuations only inside a `FramedLogicalRecord`; it must preserve record-relative physical line positions, then advance the next record start by `physical_lines` (including zero for a mid-line split piece). It returns header-field parse errors only; callers add `overflow_count` once.
+
+```rust
+pub fn parse_framed_records(
+    file_path: &str,
+    records: &[FramedLogicalRecord],
+    dialect: DeviceInventoryLogDialect,
+) -> (Vec<LogEntry>, u32)
+```
+
+- [x] **Step 4: Route both initial entry points through framing and explicit flush**
+
+```rust
+let framed = frame_logical_records(dialect, None, lines).flush_pending();
+let (entries, projection_errors) =
+    parse_framed_records(file_path, &framed.completed_records, dialect);
+(
+    entries,
+    projection_errors.saturating_add(framed.overflow_count),
+)
+```
+
+`parse_content` collects `content.lines()` and delegates to `parse_lines`; there is no unbounded continuation parser or compatibility fallback left.
+
+- [x] **Step 5: Run focused and full parser suites**
+
+Run:
+
+```bash
+cargo test -p cmtraceopen-parser --test intune_device_inventory
+cargo test -p cmtraceopen-parser
+```
+
+Expected: PASS, including #506 rotation-signature tests.
+
+### Task 3: Route the watcher through the same parser contract
+
+**Files:**
+- Modify: `src-tauri/src/watcher/tail.rs`
+
+- [x] **Step 1: Import the parser-owned limit and delete the watcher limit**
+
+```rust
+use cmtraceopen_parser::intune::device::windows::inventory::{
+    self, DeviceInventoryLogDialect, FramedLogicalRecord, MAX_LOGICAL_RECORD_BYTES,
+};
+```
+
+Delete `MAX_PENDING_LOGICAL_RECORD_BYTES`; every completed-line and unterminated-fragment bound check uses `MAX_LOGICAL_RECORD_BYTES`.
+
+- [x] **Step 2: Use the no-argument framer on completed and partial lines**
+
+Update normal reads and `enforce_unterminated_logical_bound` to call:
+
+```rust
+inventory::frame_logical_records(dialect, pending, &lines)
+```
+
+Preserve `pending_fragment` separately until it is a complete physical line or must be split for the bound. Store every returned remainder; never clear it without transferring it to a framed record.
+
+- [x] **Step 3: Use explicit parser flush and direct framed projection**
+
+In `flush_pending_logical_record`, pass the pending record and optional fragment through `frame_logical_records(...).flush_pending()`. In `parse_logical_records`, call `inventory::parse_framed_records`, annotate error-code spans, add framing errors exactly once, rebase entry lines from the current `next_line`, and advance `next_line` by the sum of record `physical_lines`.
+
+```rust
+let physical_lines = records
+    .iter()
+    .fold(0u32, |total, record| total.saturating_add(record.physical_lines));
+let (mut entries, projection_errors) =
+    inventory::parse_framed_records(&path_str, &records, dialect);
+parser::annotate_error_code_spans(&mut entries);
+```
+
+- [x] **Step 4: Delete the recursive per-record dispatcher path**
+
+Remove the loop that calls `parser::parse_content_with_selection` for each framed record. The watcher must never re-enter whole-input framing after it already owns frozen framed records.
+
+### Task 4: Prove tail/open parity and bounded retention
+
+**Files:**
+- Modify: `src-tauri/src/watcher/tail.rs`
+
+- [x] **Step 1: Update existing overflow tests to the parser constant**
+
+Replace watcher-local constant references with `MAX_LOGICAL_RECORD_BYTES`. Assert every live retained buffer and every emitted logical record remains within the production bound.
+
+- [x] **Step 2: Add an initial-load versus tail harness**
+
+For each dialect, write the same input to an initially empty file in multiple appends (splitting continuations and UTF-8 text across read calls without creating invalid file bytes), collect `TailBatch` entries/errors including explicit debounce flush, and compare against `inventory::parse_content` by these owned fields:
+
+```rust
+fn projection(entries: &[LogEntry]) -> Vec<(u32, Severity, String)> {
+    entries.iter().map(|entry| (
+        entry.line_number,
+        entry.severity,
+        entry.message.clone(),
+    )).collect()
+}
+```
+
+- [x] **Step 3: Cover all acceptance scenarios in the parity harness**
+
+Use Harvester, InventoryAdaptor, and RotationFailure cases containing multiline records, exact-limit and limit-plus-one logical records, oversized single physical lines, emoji near the split boundary, leading/trailing sentinels, and a later header. Assert identical entries, line numbers, severity, and aggregate parse errors between initial and tail parses.
+
+- [x] **Step 4: Run watcher and full app tests**
+
+Run:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml watcher::tail
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Expected: PASS with no tail/open drift.
+
+### Task 5: Quality gates and delivery
+
+**Files:**
+- Modify: only files listed above if a gate exposes an issue
+
+- [x] **Step 1: Format only the Rust files in scope**
+
+Run:
+
+```bash
+rustfmt crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs crates/cmtraceopen-parser/tests/intune_device_inventory.rs src-tauri/src/watcher/tail.rs
+git diff --check
+```
+
+Expected: formatting succeeds and `git diff --check` prints nothing.
+
+- [x] **Step 2: Run strict Rust lint gates**
+
+Run:
+
+```bash
+cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings
+cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+```
+
+Expected: PASS with zero warnings.
+
+- [x] **Step 3: Run the required frontend type gate**
+
+Run:
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: PASS. Browser E2E is not applicable because this change has no frontend or IPC behavior.
+
+- [x] **Step 4: Inspect the final scoped diff and rerun focused tests**
+
+Run:
+
+```bash
+git diff --stat main...HEAD
+git diff -- crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs crates/cmtraceopen-parser/tests/intune_device_inventory.rs src-tauri/src/watcher/tail.rs library.md docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md
+cargo test -p cmtraceopen-parser --test intune_device_inventory
+cargo test --manifest-path src-tauri/Cargo.toml watcher::tail
+```
+
+Expected: only the planned files change, #506 behavior remains covered, and focused suites pass.
+
+- [x] **Step 5: Commit, push, and open the unmerged PR**
+
+Run:
+
+```bash
+git add library.md docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs crates/cmtraceopen-parser/tests/intune_device_inventory.rs src-tauri/src/watcher/tail.rs
+git commit -m "fix: bound device inventory logical records"
+git push -u origin codex/issue-507-lossless-device-inventory-framing
+gh pr create --base main --head codex/issue-507-lossless-device-inventory-framing --title "fix: make Device Inventory framing lossless and bounded" --body-file /tmp/issue-507-pr-body.md
+```
+
+The PR body must contain `Closes #507`, frozen commit SHA, base SHA `162f1c2985dfa6fdda0bdcc7717232829316c2f2`, validation commands/results, and an evidence pack: target branch/SHA, test viewing conditions, claims, reproduction commands, and out-of-scope frontend behavior. Do not merge.

--- a/docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md
+++ b/docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md
@@ -336,7 +336,7 @@ Change `frame_logical_records` to consume segments and copy at most `MAX_LOGICAL
 
 Map every `parse_lines` physical line to `LogicalRecordSegment::LineStart`, call the same framer, then explicitly `flush_pending`. Preserve CRLF normalization, blank continuation semantics, physical-line spans, overflow errors, and the framed projector.
 
-- [ ] **Step 4: Run focused and full parser suites**
+- [x] **Step 4: Run focused and full parser suites**
 
 Run:
 
@@ -391,7 +391,7 @@ rustfmt --edition 2021 crates/cmtraceopen-parser/src/intune/device/windows/inven
 git diff --check
 ```
 
-- [ ] **Step 2: Run full Rust and strict lint gates**
+- [x] **Step 2: Run full Rust and strict lint gates**
 
 ```bash
 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p cmtraceopen-parser
@@ -400,7 +400,7 @@ CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo clippy -p cmtraceopen-parser --all-
 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
 ```
 
-- [ ] **Step 3: Run TypeScript gates**
+- [x] **Step 3: Run TypeScript gates**
 
 ```bash
 npm test -- --run
@@ -408,6 +408,8 @@ npx tsc --noEmit
 ```
 
 Expected: PASS. Browser E2E remains out of scope because framing does not change frontend or IPC behavior.
+
+Validated after rebasing onto `origin/main` at `e59aed306b4f8f5ee1b862970169a26b24886f4d`: both full Rust suites passed, both all-target Clippy runs passed with warnings denied, Vitest passed 638 tests across 51 files, and `npx tsc --noEmit` passed.
 
 - [ ] **Step 4: Commit, push, and refresh the frozen evidence pack**
 

--- a/docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md
+++ b/docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md
@@ -411,6 +411,62 @@ Expected: PASS. Browser E2E remains out of scope because framing does not change
 
 Validated after rebasing onto `origin/main` at `e59aed306b4f8f5ee1b862970169a26b24886f4d`: both full Rust suites passed, both all-target Clippy runs passed with warnings denied, Vitest passed 638 tests across 51 files, and `npx tsc --noEmit` passed.
 
-- [ ] **Step 4: Commit, push, and refresh the frozen evidence pack**
+- [x] **Step 4: Commit, push, and refresh the frozen evidence pack**
 
 Commit the rework, push `codex/issue-507-lossless-device-inventory-framing`, and edit PR #511 so its head SHA, validation results, viewing conditions, claims, and reproduction commands describe the critic fixes. Confirm the PR remains open and unmerged.
+
+### Task 10: Surface terminal incomplete UTF-8 as a parse error
+
+**Files:**
+- Modify: `src-tauri/src/watcher/tail.rs`
+- Modify: `docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md`
+
+- [x] **Step 1: Add red finalization tests for every UTF-8 scalar width**
+
+After a valid Device Inventory header, append `[0xC2]`, `[0xE2, 0x82]`, and `[0xF0, 0x9F, 0xA7]` in separate cases. Read each prefix so it enters `pending_utf8_bytes`, then explicitly finalize. Assert the final batch contains the valid header entry, reports exactly one parse error, emits no replacement character or Windows-1252 text, clears the carry, and reports no second error when finalization is repeated. Add `[0xEF, 0xBB]` to prove a partial UTF-8 BOM has the same terminal result.
+
+- [x] **Step 2: Add red tests for parser-change and truncation boundaries**
+
+For parser change, buffer a valid header and incomplete scalar under the Device Inventory selection, switch to plain text, call `read_new_entries` without appending bytes, and assert the old record is emitted with exactly one parse error. For truncation, buffer the same state, truncate the file to zero, call `read_new_entries`, and assert `reset == true`, exactly one parse error, cleared carry/framing state, and no decoded replacement data.
+
+- [x] **Step 3: Add one common stop/disconnect emission test**
+
+Extract the terminal callback emission into one helper used by both watcher-loop exit branches. Drive that helper with a reader containing valid framed text plus an incomplete UTF-8 suffix and assert the callback receives one reportable batch with the valid entry and exactly one parse error. The shared helper makes stop and channel disconnect mechanically identical rather than duplicating terminal semantics.
+
+- [x] **Step 4: Run focused tests and confirm silent-loss failures**
+
+Run:
+
+```bash
+CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test --manifest-path src-tauri/Cargo.toml --lib watcher::tail
+```
+
+Expected before implementation: the explicit, parser-change, truncation, and shared watcher-finalization assertions observe zero parse errors because the carry is silently discarded or retained.
+
+### Task 11: Implement one fail-closed terminal finalizer and revalidate
+
+**Files:**
+- Modify: `src-tauri/src/watcher/tail.rs`
+- Modify: `docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md`
+
+- [x] **Step 1: Track ownership of an incomplete UTF-8 suffix**
+
+Add `pending_utf8_selection: Option<ResolvedParser>`. Set it whenever `decode_tail_bytes` retains an incomplete suffix, clear it when the suffix completes, and restore it with the bytes when an invalid continuation makes the read transactional. Include it in parser-selection boundary detection.
+
+- [x] **Step 2: Add a single consuming terminal-input finalizer**
+
+Rename the semantic boundary operation to `finalize_pending_input`. It first flushes valid logical text, then consumes `pending_utf8_bytes` without decoding and increments `TailBatch.parse_errors` exactly once when the carry was non-empty. Clear the carry owner with it. Repeated finalization must be idempotent.
+
+- [x] **Step 3: Route every terminal boundary through the finalizer**
+
+Use `finalize_pending_input` for explicit end-of-input, parser-selection change, file truncation/rotation, watcher stop, and watcher-channel disconnect. Keep ordinary no-data polling non-terminal so delayed valid continuations still work. Both watcher-loop exits call the same callback-emission helper.
+
+- [x] **Step 4: Run all validation gates on current main**
+
+Run changed-file `rustfmt --check`, `git diff --check`, the focused watcher suite, both full Rust suites, both all-target Clippy commands with `-D warnings`, `npm test -- --run`, and `npx tsc --noEmit`. Rebase on current `origin/main` first if it advances.
+
+Validated on `origin/main` at `e59aed306b4f8f5ee1b862970169a26b24886f4d`: 29 focused watcher tests passed; the full parser and app suites passed, including 658 parser library tests and 572 app library tests; both strict Clippy runs passed; Vitest passed 638 tests across 51 files; TypeScript, changed-file formatting, and diff checks passed.
+
+- [ ] **Step 5: Push a new frozen revision and refresh PR #511**
+
+Commit and push the existing branch, update the PR evidence pack with the new base/head SHAs and terminal-prefix cases, then confirm the PR remains open and unmerged.

--- a/docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md
+++ b/docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make initial Device Inventory parsing and incremental tailing use one parser-owned, UTF-8-safe, lossless logical-record framing contract with a single 1 MiB production limit.
 
-**Architecture:** The Device Inventory module owns `MAX_LOGICAL_RECORD_BYTES`, incremental framing, explicit final flush, and projection of already-framed records. Initial `parse_content`/`parse_lines` frame and flush before projection; the watcher imports the same limit and projects framed records directly, retaining only debounce, file-fragment, identity, and physical-line rebasing concerns.
+**Architecture:** The Device Inventory module owns `MAX_LOGICAL_RECORD_BYTES`, bounded segment framing, explicit final flush, and projection of already-framed records. Initial `parse_content`/`parse_lines` and tailing stream line starts/continuations through that contract; tailing carries incomplete UTF-8 scalars strictly and never uses time as a semantic record boundary.
 
 **Tech Stack:** Rust, `cmtraceopen-parser`, Tauri watcher, Cargo tests/clippy/fmt, TypeScript compiler.
 
@@ -14,7 +14,7 @@
 
 - Modify `crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs`: define the sole production bound; make framing use it; add explicit flush; replace the unbounded parse path with bounded framing plus framed-record projection.
 - Modify `crates/cmtraceopen-parser/tests/intune_device_inventory.rs`: prove exact limits, lossless UTF-8 splitting, all dialects, line/error semantics, and `parse_content`/`parse_lines` equality.
-- Modify `src-tauri/src/watcher/tail.rs`: import the parser limit, use the shared framer/flush/projector for every tail path, and verify initial-load/tail equality.
+- Modify `src-tauri/src/watcher/tail.rs`: import the parser limit, use strict incremental UTF-8 decoding and bounded line segments, remove debounce completion, and verify initial-load/tail equality.
 - Modify `library.md`: route issue #507 work to this plan.
 
 ### Task 1: Lock the lossless framing contract with parser tests
@@ -189,7 +189,7 @@ Replace watcher-local constant references with `MAX_LOGICAL_RECORD_BYTES`. Asser
 
 - [x] **Step 2: Add an initial-load versus tail harness**
 
-For each dialect, write the same input to an initially empty file in multiple appends (splitting continuations and UTF-8 text across read calls without creating invalid file bytes), collect `TailBatch` entries/errors including explicit debounce flush, and compare against `inventory::parse_content` by these owned fields:
+For each dialect, write the same input to an initially empty file in multiple appends (splitting continuations and UTF-8 text across read calls without creating invalid file bytes), collect `TailBatch` entries/errors including an explicit end-of-input flush, and compare against `inventory::parse_content` by these owned fields:
 
 ```rust
 fn projection(entries: &[LogEntry]) -> Vec<(u32, Severity, String)> {
@@ -278,3 +278,137 @@ gh pr create --base main --head codex/issue-507-lossless-device-inventory-framin
 ```
 
 The PR body must contain `Closes #507`, frozen commit SHA, base SHA `162f1c2985dfa6fdda0bdcc7717232829316c2f2`, validation commands/results, and an evidence pack: target branch/SHA, test viewing conditions, claims, reproduction commands, and out-of-scope frontend behavior. Do not merge.
+
+### Task 6: Lock the critic regressions with red tests
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/tests/intune_device_inventory.rs`
+- Modify: `src-tauri/src/watcher/tail.rs`
+
+- [x] **Step 1: Add delayed-continuation parity tests for every dialect**
+
+Write a header, read it into the pending logical record, wait longer than the former 250 ms debounce, append a non-header continuation plus a later header, then read and explicitly flush. For Harvester, InventoryAdaptor, and RotationFailure, compare `(line_number, severity, message)` and aggregate parse errors with `inventory::parse_content`; the first entry must still include the delayed continuation.
+
+- [x] **Step 2: Add strict incremental UTF-8 tests**
+
+For `¢`, `€`, and `🧪`, append every incomplete 2-, 3-, and 4-byte prefix in one read and the remaining bytes in the next. Assert no replacement characters, equal open/tail projections, and a carry of at most three bytes. Append `0xFF` in a separate case and assert `read_new_entries` returns an error without advancing `byte_offset`, mutating logical-record state, or decoding as Windows-1252.
+
+- [x] **Step 3: Add huge-line peak-bound tests**
+
+Feed a terminated physical line and an unterminated line larger than three times `MAX_LOGICAL_RECORD_BYTES`, with UTF-8 near boundaries. Assert every completed/pending parser chunk is bounded, reconstruction is byte-identical, overflow counts match initial parsing, and the watcher test-only peak pending observation never exceeds the parser constant.
+
+- [x] **Step 4: Run focused tests and verify the three regressions fail**
+
+Run:
+
+```bash
+cargo test -p cmtraceopen-parser --test intune_device_inventory
+cargo test --manifest-path src-tauri/Cargo.toml --lib watcher::tail
+```
+
+Expected: delayed continuations orphan after the debounce, split UTF-8 falls into Windows-1252, invalid UTF-8 is accepted, and huge fragments exceed the peak invariant.
+
+### Task 7: Bound parser accumulation before append
+
+**Files:**
+- Modify: `crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs`
+- Test: `crates/cmtraceopen-parser/tests/intune_device_inventory.rs`
+
+- [x] **Step 1: Model physical-line segments explicitly**
+
+Add the shared input contract:
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub enum LogicalRecordSegment<'a> {
+    LineStart(&'a str),
+    LineContinuation(&'a str),
+}
+```
+
+`LineStart` performs dialect header recognition and inserts the logical newline before a prior record; `LineContinuation` concatenates bytes onto the same physical line without inventing a newline.
+
+- [x] **Step 2: Append only within remaining capacity**
+
+Change `frame_logical_records` to consume segments and copy at most `MAX_LOGICAL_RECORD_BYTES - pending.len()` bytes at a UTF-8 character boundary. When no scalar fits, emit the current `FramedLogicalRecord::split` before copying that scalar. Never append the whole source segment and split afterward; assert the pending length after every mutation.
+
+- [x] **Step 3: Route complete initial input through segments**
+
+Map every `parse_lines` physical line to `LogicalRecordSegment::LineStart`, call the same framer, then explicitly `flush_pending`. Preserve CRLF normalization, blank continuation semantics, physical-line spans, overflow errors, and the framed projector.
+
+- [ ] **Step 4: Run focused and full parser suites**
+
+Run:
+
+```bash
+cargo test -p cmtraceopen-parser --test intune_device_inventory
+CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p cmtraceopen-parser
+```
+
+Expected: PASS, including all #506 rotation detection cases and the new peak-bound reconstruction cases.
+
+### Task 8: Make tail decoding and line feeding incremental
+
+**Files:**
+- Modify: `src-tauri/src/watcher/tail.rs`
+
+- [x] **Step 1: Carry incomplete UTF-8 without fallback decoding**
+
+Replace the UTF-16-only `pending_byte` model with a UTF-8 carry of at most three bytes plus the existing UTF-16 odd-byte carry. `String::from_utf8` must distinguish `Utf8Error::error_len() == None` (retain the incomplete suffix) from `Some(_)` (return `AppError` and restore all pre-read state). Do not call the whole-file Windows-1252 fallback from tailing.
+
+- [x] **Step 2: Feed bounded physical-line prefixes into parser segments**
+
+For Device Inventory, avoid `format!("{}{}", pending_fragment, new_text)` and never append an arbitrary slice to `pending_fragment`. Fill the fragment only to `MAX_LOGICAL_RECORD_BYTES`, feed it as `LineStart`, then stream the remainder as `LineContinuation` segments; newline boundaries reset the line-start state. Keep a test-only peak observer updated immediately after every pending mutation.
+
+- [x] **Step 3: Remove wall-clock semantic completion**
+
+Delete `LOGICAL_RECORD_DEBOUNCE`, timestamps from pending state, and time-based calls to `flush_pending_logical_record`. A later header, parser-selection change, stop/disconnect, or explicit flush is a record boundary; elapsed time is not. Keep periodic polling only for discovering bytes.
+
+- [x] **Step 4: Make invalid-byte reads transactional**
+
+On invalid UTF-8, leave `byte_offset`, UTF-8 carry, line-prefix state, pending logical record, entry IDs, and line numbers unchanged. Return a bounded error that identifies invalid UTF-8 without echoing source bytes.
+
+- [x] **Step 5: Run focused watcher tests**
+
+Run:
+
+```bash
+CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test --manifest-path src-tauri/Cargo.toml --lib watcher::tail
+```
+
+Expected: PASS for delayed continuations, every UTF-8 split, invalid input, huge terminated/unterminated lines, all dialect parity, truncation, and parser-change flush behavior.
+
+### Task 9: Revalidate and update PR #511
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md`
+- Modify: only implementation/test files above if a gate exposes a defect
+
+- [x] **Step 1: Run scoped formatting and diff checks**
+
+```bash
+rustfmt --edition 2021 crates/cmtraceopen-parser/src/intune/device/windows/inventory/mod.rs crates/cmtraceopen-parser/tests/intune_device_inventory.rs src-tauri/src/watcher/tail.rs
+git diff --check
+```
+
+- [ ] **Step 2: Run full Rust and strict lint gates**
+
+```bash
+CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p cmtraceopen-parser
+CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test --manifest-path src-tauri/Cargo.toml
+CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings
+CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+```
+
+- [ ] **Step 3: Run TypeScript gates**
+
+```bash
+npm test -- --run
+npx tsc --noEmit
+```
+
+Expected: PASS. Browser E2E remains out of scope because framing does not change frontend or IPC behavior.
+
+- [ ] **Step 4: Commit, push, and refresh the frozen evidence pack**
+
+Commit the rework, push `codex/issue-507-lossless-device-inventory-framing`, and edit PR #511 so its head SHA, validation results, viewing conditions, claims, and reproduction commands describe the critic fixes. Confirm the PR remains open and unmerged.

--- a/library.md
+++ b/library.md
@@ -8,3 +8,4 @@
 - IF repairing PR #490 native SCCM discovery/capture or workspace product path → read [[docs/superpowers/plans/2026-08-04-sccm-native-product-path-rework.md]]
 - IF implementing or reviewing signless CCM/CmtLog timestamp repairs (#410, #414) → read [[docs/superpowers/plans/2026-08-05-signless-ccm-timestamps.md]]
 - IF implementing or reviewing GitHub issue #506 Device Inventory rotation detection narrowing → read [[docs/superpowers/plans/2026-08-05-issue-506-rotation-detection-narrowing.md]]
+- IF implementing or reviewing GitHub issue #507 lossless bounded Device Inventory framing → read [[docs/superpowers/plans/2026-08-05-issue-507-lossless-device-inventory-framing.md]]

--- a/src-tauri/src/watcher/tail.rs
+++ b/src-tauri/src/watcher/tail.rs
@@ -2,10 +2,11 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use cmtraceopen_parser::intune::device::windows::inventory::{
-    self, DeviceInventoryLogDialect, FramedLogicalRecord, MAX_LOGICAL_RECORD_BYTES,
+    self, DeviceInventoryLogDialect, FramedLogicalRecord, LogicalRecordSegment,
+    MAX_LOGICAL_RECORD_BYTES,
 };
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
@@ -14,7 +15,6 @@ use crate::parser::{self, FileEncoding, ResolvedParser};
 
 const IME_RECORD_START: &str = "<![LOG[";
 const IME_RECORD_ATTRS_START: &str = "]LOG]!><";
-const LOGICAL_RECORD_DEBOUNCE: Duration = Duration::from_millis(250);
 
 /// The result of reading new content from a tailed file.
 pub struct TailBatch {
@@ -60,7 +60,6 @@ impl TailBatch {
 
 struct PendingLogicalRecord {
     content: String,
-    last_updated: Instant,
     parser_selection: ResolvedParser,
 }
 
@@ -73,14 +72,20 @@ pub struct TailReader {
     next_line: u32,
     /// Leftover partial record fragment from the previous read.
     pending_fragment: String,
-    /// Selection and activity time for an unterminated Device Inventory line.
-    pending_fragment_selection: Option<(ResolvedParser, Instant)>,
+    /// Selection that owns an unterminated Device Inventory line prefix.
+    pending_fragment_selection: Option<ResolvedParser>,
+    /// True after a bounded prefix of the current physical line was framed.
+    inventory_line_continuation: bool,
     /// Newest Device Inventory logical record held for continuation lines.
     pending_logical_record: Option<PendingLogicalRecord>,
     /// File encoding detected from BOM during initial parse.
     encoding: FileEncoding,
     /// Leftover partial byte from a UTF-16 read boundary split.
     pending_byte: Option<u8>,
+    /// Incomplete UTF-8 scalar suffix retained across append boundaries.
+    pending_utf8_bytes: Vec<u8>,
+    #[cfg(test)]
+    max_pending_bytes_observed: usize,
 }
 
 impl TailReader {
@@ -105,16 +110,19 @@ impl TailReader {
             next_line,
             pending_fragment: String::new(),
             pending_fragment_selection: None,
+            inventory_line_continuation: false,
             pending_logical_record: None,
             encoding,
             pending_byte: None,
+            pending_utf8_bytes: Vec::new(),
+            #[cfg(test)]
+            max_pending_bytes_observed: 0,
         }
     }
 
     /// Read new content from the file since last read, parse into entries.
     /// Returns the new entries plus a `reset` flag and updates internal byte_offset.
     pub fn read_new_entries(&mut self) -> Result<TailBatch, crate::error::AppError> {
-        let now = Instant::now();
         let mut file = std::fs::File::open(&self.path).map_err(crate::error::AppError::Io)?;
         let metadata = file.metadata().map_err(crate::error::AppError::Io)?;
         let file_size = metadata.len();
@@ -128,19 +136,21 @@ impl TailReader {
             self.byte_offset = 0;
             self.pending_fragment.clear();
             self.pending_fragment_selection = None;
+            self.inventory_line_continuation = false;
             self.pending_logical_record = None;
             self.pending_byte = None;
+            self.pending_utf8_bytes.clear();
             self.next_line = 1;
             reset = true;
         }
 
         let mut batch = TailBatch::empty(reset);
-        if !reset && self.pending_logical_record_needs_flush(now) {
-            batch.append(self.flush_pending_logical_record());
-        }
 
         // No new data
         if file_size == self.byte_offset {
+            if !reset && self.pending_parser_selection_changed() {
+                batch.append(self.flush_pending_logical_record());
+            }
             return Ok(batch);
         }
 
@@ -153,30 +163,24 @@ impl TailReader {
         file.read_exact(&mut buffer)
             .map_err(crate::error::AppError::Io)?;
 
-        // For UTF-16, handle partial code unit from previous read
-        let decode_buffer = if let Some(prev_byte) = self.pending_byte.take() {
-            let mut combined = vec![prev_byte];
-            combined.extend_from_slice(&buffer);
-            combined
-        } else {
-            buffer
-        };
-
-        // For UTF-16, save trailing odd byte
-        let (to_decode, leftover) = match self.encoding {
-            FileEncoding::Utf16Le | FileEncoding::Utf16Be if decode_buffer.len() % 2 != 0 => {
-                let split = decode_buffer.len() - 1;
-                self.pending_byte = Some(decode_buffer[split]);
-                (&decode_buffer[..split], true)
-            }
-            _ => (&decode_buffer[..], false),
-        };
-        let _ = leftover; // suppress unused warning
-
-        let new_text = crate::parser::decode_bytes(to_decode, self.encoding).map_err(|e| {
-            crate::error::AppError::Internal(format!("Failed to decode tailed bytes: {}", e))
-        })?;
+        let new_text = self.decode_tail_bytes(buffer)?;
         let received_text = !new_text.is_empty();
+
+        // Parser changes are semantic boundaries, but invalid bytes above fail
+        // before any pending state is flushed or otherwise mutated.
+        if self.pending_parser_selection_changed() {
+            batch.append(self.flush_pending_logical_record());
+        }
+
+        let inventory_dialect = inventory_logical_dialect(&self.parser_selection);
+        if let Some(dialect) = inventory_dialect {
+            let selection = self.parser_selection.clone();
+            if received_text {
+                batch.append(self.process_inventory_text(&new_text, dialect, &selection));
+            }
+            self.byte_offset = file_size;
+            return Ok(batch);
+        }
 
         // Prepend any partial record fragment from the last read.
         let full_text = if self.pending_fragment.is_empty() {
@@ -188,7 +192,6 @@ impl TailReader {
             combined
         };
 
-        let inventory_dialect = inventory_logical_dialect(&self.parser_selection);
         let lines = match self.parser_selection.record_framing {
             RecordFraming::PhysicalLine => {
                 collect_complete_lines(&full_text, &mut self.pending_fragment)
@@ -204,45 +207,6 @@ impl TailReader {
                 }
             }
         };
-
-        if let Some(dialect) = inventory_dialect {
-            let selection = self.parser_selection.clone();
-            if !self.pending_fragment.is_empty() {
-                self.pending_fragment_selection = Some((selection.clone(), now));
-            }
-
-            if received_text {
-                if let Some(pending) = self.pending_logical_record.as_mut() {
-                    pending.last_updated = now;
-                }
-            }
-
-            if !lines.is_empty() {
-                let prior = self
-                    .pending_logical_record
-                    .take()
-                    .map(|pending| pending.content);
-                let framed = inventory::frame_logical_records(dialect, prior, &lines);
-
-                if let Some(content) = framed.pending_record {
-                    self.pending_logical_record = Some(PendingLogicalRecord {
-                        content,
-                        last_updated: now,
-                        parser_selection: selection.clone(),
-                    });
-                }
-
-                batch.append(self.parse_logical_records(
-                    framed.completed_records,
-                    dialect,
-                    framed.overflow_count,
-                ));
-            }
-
-            batch.append(self.enforce_unterminated_logical_bound(dialect, &selection, now));
-            self.byte_offset = file_size;
-            return Ok(batch);
-        }
 
         if lines.is_empty() {
             self.byte_offset = file_size;
@@ -268,32 +232,246 @@ impl TailReader {
         Ok(batch)
     }
 
-    fn pending_logical_record_needs_flush(&self, now: Instant) -> bool {
-        let parser_changed = self
-            .pending_logical_record
+    fn decode_tail_bytes(&mut self, buffer: Vec<u8>) -> Result<String, crate::error::AppError> {
+        if self.encoding != FileEncoding::Utf8 {
+            let decode_buffer = if let Some(previous_byte) = self.pending_byte.take() {
+                let mut combined = Vec::with_capacity(buffer.len().saturating_add(1));
+                combined.push(previous_byte);
+                combined.extend_from_slice(&buffer);
+                combined
+            } else {
+                buffer
+            };
+            let decode_len = if decode_buffer.len() % 2 == 0 {
+                decode_buffer.len()
+            } else {
+                let split = decode_buffer.len() - 1;
+                self.pending_byte = Some(decode_buffer[split]);
+                split
+            };
+            return crate::parser::decode_bytes(&decode_buffer[..decode_len], self.encoding)
+                .map_err(|error| {
+                    crate::error::AppError::Internal(format!(
+                        "Failed to decode tailed bytes: {error}"
+                    ))
+                });
+        }
+
+        let previous_carry = std::mem::take(&mut self.pending_utf8_bytes);
+        let decoded_start_offset = self.byte_offset.saturating_sub(previous_carry.len() as u64);
+        let mut decode_buffer = if previous_carry.is_empty() {
+            buffer
+        } else {
+            let mut combined =
+                Vec::with_capacity(previous_carry.len().saturating_add(buffer.len()));
+            combined.extend_from_slice(&previous_carry);
+            combined.extend_from_slice(&buffer);
+            combined
+        };
+
+        if decoded_start_offset == 0 && decode_buffer.starts_with(&[0xEF, 0xBB, 0xBF]) {
+            decode_buffer.drain(..3);
+        }
+
+        match String::from_utf8(decode_buffer) {
+            Ok(text) => Ok(text),
+            Err(error) => {
+                let utf8_error = error.utf8_error();
+                if utf8_error.error_len().is_some() {
+                    self.pending_utf8_bytes = previous_carry;
+                    return Err(crate::error::AppError::Internal(
+                        "Failed to decode tailed bytes: invalid UTF-8".to_string(),
+                    ));
+                }
+
+                let valid_up_to = utf8_error.valid_up_to();
+                let mut bytes = error.into_bytes();
+                let incomplete = bytes.split_off(valid_up_to);
+                if incomplete.len() > 3 {
+                    self.pending_utf8_bytes = previous_carry;
+                    return Err(crate::error::AppError::Internal(
+                        "Failed to decode tailed bytes: invalid UTF-8".to_string(),
+                    ));
+                }
+                self.pending_utf8_bytes = incomplete;
+                String::from_utf8(bytes).map_err(|_| {
+                    crate::error::AppError::Internal(
+                        "Failed to decode tailed bytes: invalid UTF-8".to_string(),
+                    )
+                })
+            }
+        }
+    }
+
+    fn pending_parser_selection_changed(&self) -> bool {
+        self.pending_logical_record
             .as_ref()
             .is_some_and(|pending| pending.parser_selection != self.parser_selection)
             || self
                 .pending_fragment_selection
                 .as_ref()
-                .is_some_and(|(selection, _)| selection != &self.parser_selection);
+                .is_some_and(|selection| selection != &self.parser_selection)
+    }
 
-        let last_updated = self
+    fn process_inventory_text(
+        &mut self,
+        text: &str,
+        dialect: DeviceInventoryLogDialect,
+        selection: &ResolvedParser,
+    ) -> TailBatch {
+        let mut batch = TailBatch::empty(false);
+        for segment in text.split_inclusive('\n') {
+            let line_complete = segment.ends_with('\n');
+            let content = segment.strip_suffix('\n').unwrap_or(segment);
+            batch.append(self.process_inventory_line_segment(
+                content,
+                line_complete,
+                dialect,
+                selection,
+            ));
+        }
+        batch
+    }
+
+    fn process_inventory_line_segment(
+        &mut self,
+        raw_content: &str,
+        line_complete: bool,
+        dialect: DeviceInventoryLogDialect,
+        selection: &ResolvedParser,
+    ) -> TailBatch {
+        let content = if line_complete {
+            raw_content.trim_end_matches('\r')
+        } else {
+            raw_content
+        };
+
+        if self.inventory_line_continuation {
+            let batch = self.frame_inventory_segments(
+                dialect,
+                selection,
+                &[LogicalRecordSegment::LineContinuation(content)],
+            );
+            if line_complete {
+                self.inventory_line_continuation = false;
+                self.pending_fragment_selection = None;
+            } else {
+                self.pending_fragment_selection = Some(selection.clone());
+            }
+            self.observe_pending_bytes();
+            return batch;
+        }
+
+        if line_complete && self.pending_fragment.is_empty() {
+            let batch = self.frame_inventory_segments(
+                dialect,
+                selection,
+                &[LogicalRecordSegment::LineStart(content)],
+            );
+            self.pending_fragment_selection = None;
+            self.observe_pending_bytes();
+            return batch;
+        }
+
+        let mut batch = TailBatch::empty(false);
+        let mut remaining = content;
+        while !remaining.is_empty() {
+            let logical_bytes = self
+                .pending_logical_record
+                .as_ref()
+                .map_or(0, |record| record.content.len());
+            let separator_bytes = usize::from(self.pending_logical_record.is_some());
+            let available = MAX_LOGICAL_RECORD_BYTES
+                .saturating_sub(logical_bytes)
+                .saturating_sub(separator_bytes)
+                .saturating_sub(self.pending_fragment.len());
+            let take = utf8_prefix_at_most(remaining, available);
+            if take > 0 {
+                self.pending_fragment.push_str(&remaining[..take]);
+                remaining = &remaining[take..];
+                self.pending_fragment_selection = Some(selection.clone());
+                self.observe_pending_bytes();
+            }
+
+            if !remaining.is_empty() {
+                let prefix = std::mem::take(&mut self.pending_fragment);
+                batch.append(self.frame_inventory_segments(
+                    dialect,
+                    selection,
+                    &[LogicalRecordSegment::LineStart(&prefix)],
+                ));
+                self.inventory_line_continuation = true;
+                batch.append(self.frame_inventory_segments(
+                    dialect,
+                    selection,
+                    &[LogicalRecordSegment::LineContinuation(remaining)],
+                ));
+                remaining = "";
+            }
+        }
+
+        if line_complete && !self.inventory_line_continuation {
+            let mut line = std::mem::take(&mut self.pending_fragment);
+            while line.ends_with('\r') {
+                line.pop();
+            }
+            batch.append(self.frame_inventory_segments(
+                dialect,
+                selection,
+                &[LogicalRecordSegment::LineStart(&line)],
+            ));
+        }
+        if line_complete {
+            self.inventory_line_continuation = false;
+            self.pending_fragment_selection = None;
+        } else if !content.is_empty() {
+            self.pending_fragment_selection = Some(selection.clone());
+        }
+
+        self.observe_pending_bytes();
+        batch
+    }
+
+    fn frame_inventory_segments(
+        &mut self,
+        dialect: DeviceInventoryLogDialect,
+        selection: &ResolvedParser,
+        segments: &[LogicalRecordSegment<'_>],
+    ) -> TailBatch {
+        let prior = self
             .pending_logical_record
-            .as_ref()
-            .map(|pending| pending.last_updated)
-            .into_iter()
-            .chain(
-                self.pending_fragment_selection
-                    .as_ref()
-                    .map(|(_, updated)| *updated),
-            )
-            .max();
+            .take()
+            .map(|pending| pending.content);
+        let framed = inventory::frame_logical_records(dialect, prior, segments);
+        #[cfg(test)]
+        {
+            self.max_pending_bytes_observed = self
+                .max_pending_bytes_observed
+                .max(framed.max_pending_bytes_observed);
+        }
+        if let Some(content) = framed.pending_record {
+            self.pending_logical_record = Some(PendingLogicalRecord {
+                content,
+                parser_selection: selection.clone(),
+            });
+        }
+        self.parse_logical_records(framed.completed_records, dialect, framed.overflow_count)
+    }
 
-        parser_changed
-            || last_updated.is_some_and(|updated| {
-                now.saturating_duration_since(updated) >= LOGICAL_RECORD_DEBOUNCE
-            })
+    fn observe_pending_bytes(&mut self) {
+        #[cfg(test)]
+        {
+            let logical_bytes = self
+                .pending_logical_record
+                .as_ref()
+                .map_or(0, |record| record.content.len());
+            let fragment_bytes = self.pending_fragment.len().saturating_add(usize::from(
+                self.pending_logical_record.is_some() && !self.pending_fragment.is_empty(),
+            ));
+            self.max_pending_bytes_observed = self
+                .max_pending_bytes_observed
+                .max(logical_bytes.saturating_add(fragment_bytes));
+        }
     }
 
     fn flush_pending_logical_record(&mut self) -> TailBatch {
@@ -304,7 +482,7 @@ impl TailReader {
         let selection = pending
             .as_ref()
             .map(|record| record.parser_selection.clone())
-            .or_else(|| fragment_selection.map(|(selection, _)| selection));
+            .or(fragment_selection);
         let Some(selection) = selection else {
             return TailBatch::empty(false);
         };
@@ -312,56 +490,30 @@ impl TailReader {
             return TailBatch::empty(false);
         };
 
-        let pending_content = pending.map(|record| record.content);
-        let framed = if fragment.is_empty() {
-            inventory::frame_logical_records(dialect, pending_content, &[]).flush_pending()
-        } else {
-            let fragment_lines = [fragment.as_str()];
-            inventory::frame_logical_records(dialect, pending_content, &fragment_lines)
-                .flush_pending()
-        };
+        let mut pending_content = pending.map(|record| record.content);
+        let mut completed_records = Vec::new();
+        let mut overflow_count = 0u32;
+        if !fragment.is_empty() {
+            let framed = inventory::frame_logical_records(
+                dialect,
+                pending_content,
+                &[LogicalRecordSegment::LineStart(&fragment)],
+            );
+            pending_content = framed.pending_record;
+            completed_records.extend(framed.completed_records);
+            overflow_count = overflow_count.saturating_add(framed.overflow_count);
+        }
+        let framed =
+            inventory::frame_logical_records(dialect, pending_content, &[]).flush_pending();
+        completed_records.extend(framed.completed_records);
+        overflow_count = overflow_count.saturating_add(framed.overflow_count);
+        self.inventory_line_continuation = false;
 
         // An empty record is kept rather than dropped. It parses to no entries
         // either way, but a blank line is still a physical line, and dropping
         // the record here would drop the line it accounts for and shift every
         // later line number down by one.
-        self.parse_logical_records(framed.completed_records, dialect, framed.overflow_count)
-    }
-
-    fn enforce_unterminated_logical_bound(
-        &mut self,
-        dialect: DeviceInventoryLogDialect,
-        selection: &ResolvedParser,
-        now: Instant,
-    ) -> TailBatch {
-        let pending_len = self
-            .pending_logical_record
-            .as_ref()
-            .map_or(0, |record| record.content.len());
-        let pending_bytes = pending_len
-            .saturating_add(self.pending_fragment.len())
-            .saturating_add(usize::from(
-                pending_len > 0 && !self.pending_fragment.is_empty(),
-            ));
-        if pending_bytes <= MAX_LOGICAL_RECORD_BYTES {
-            return TailBatch::empty(false);
-        }
-
-        let pending = self
-            .pending_logical_record
-            .take()
-            .map(|record| record.content);
-        let fragment = std::mem::take(&mut self.pending_fragment);
-        self.pending_fragment_selection = None;
-        let fragment_lines = [fragment.as_str()];
-        let framed = inventory::frame_logical_records(dialect, pending, &fragment_lines);
-
-        self.pending_fragment = framed.pending_record.unwrap_or_default();
-        if !self.pending_fragment.is_empty() {
-            self.pending_fragment_selection = Some((selection.clone(), now));
-        }
-
-        self.parse_logical_records(framed.completed_records, dialect, framed.overflow_count)
+        self.parse_logical_records(completed_records, dialect, overflow_count)
     }
 
     fn parse_logical_records(
@@ -447,6 +599,14 @@ fn collect_complete_lines<'a>(text: &'a str, pending_fragment: &mut String) -> V
     }
 
     lines
+}
+
+fn utf8_prefix_at_most(text: &str, maximum: usize) -> usize {
+    let mut boundary = maximum.min(text.len());
+    while !text.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    boundary
 }
 
 fn collect_complete_ime_lines<'a>(text: &'a str, pending_fragment: &mut String) -> Vec<&'a str> {
@@ -564,11 +724,7 @@ where
 
         // Also do a periodic poll as a fallback (some editors/log writers
         // may not trigger filesystem events reliably)
-        let poll_interval = if inventory_logical_dialect(&tail_reader.parser_selection).is_some() {
-            LOGICAL_RECORD_DEBOUNCE
-        } else {
-            Duration::from_millis(500)
-        };
+        let poll_interval = Duration::from_millis(500);
 
         loop {
             if stop_flag_clone.load(Ordering::Relaxed) {
@@ -763,13 +919,279 @@ mod tests {
                 .collect::<Vec<_>>()
         };
 
-        assert_eq!(tail_errors, opened_errors);
+        assert_eq!(
+            tail_errors, opened_errors,
+            "tail/open parse-error parity failed for {test_name}"
+        );
         assert_eq!(projection(&tailed_entries), projection(&opened_entries));
         assert!(tailed_entries
             .iter()
             .all(|entry| entry.message.len() <= MAX_LOGICAL_RECORD_BYTES));
 
         fs::remove_file(path).expect("should clean up temp file");
+    }
+
+    fn inventory_projection(entries: &[LogEntry]) -> Vec<(u32, Severity, String)> {
+        entries
+            .iter()
+            .map(|entry| (entry.line_number, entry.severity, entry.message.clone()))
+            .collect()
+    }
+
+    fn append_bytes(path: &Path, bytes: &[u8]) {
+        let mut file = OpenOptions::new()
+            .append(true)
+            .open(path)
+            .expect("should reopen tail fixture");
+        file.write_all(bytes)
+            .expect("should append raw fixture bytes");
+    }
+
+    #[test]
+    fn test_delayed_inventory_continuations_match_initial_parse_for_every_dialect() {
+        let cases = [
+            (
+                DeviceInventoryLogDialect::Harvester,
+                "7/30/2026 6:00:54 AM [Information] DELAYED-START",
+                "DELAYED-HARVESTER-CONTINUATION",
+                "7/30/2026 6:00:55 AM [Warning] DELAYED-NEXT",
+            ),
+            (
+                DeviceInventoryLogDialect::InventoryAdaptor,
+                "[Thu Jul 30 13:05:01 2026][8604] - DELAYED-START",
+                "DELAYED-ADAPTOR-CONTINUATION",
+                "[Thu Jul 30 13:05:02 2026][8604] - DELAYED-NEXT",
+            ),
+            (
+                DeviceInventoryLogDialect::RotationFailure,
+                "2026-07-30T13:05:01.1234567-04:00 Failed to rotate DELAYED-START",
+                "System.IO.IOException: DELAYED-ROTATION-CONTINUATION",
+                "2026-07-30T13:05:02.1234567-04:00 DELAYED-NEXT",
+            ),
+        ];
+
+        for (dialect, header, continuation, next_header) in cases {
+            let path = unique_test_path(&format!("inventory-delayed-{dialect:?}"));
+            fs::write(&path, "").expect("should create delayed fixture");
+            let mut reader = TailReader::new(
+                path.clone(),
+                0,
+                ResolvedParser::intune_device_inventory(dialect),
+                0,
+                1,
+            );
+            append_bytes(&path, format!("{header}\n").as_bytes());
+            assert!(reader
+                .read_new_entries()
+                .expect("header read should succeed")
+                .entries
+                .is_empty());
+
+            std::thread::sleep(Duration::from_millis(275));
+            append_bytes(&path, format!("{continuation}\n{next_header}\n").as_bytes());
+            let mut tailed = reader
+                .read_new_entries()
+                .expect("delayed continuation read should succeed");
+            tailed.append(reader.flush_pending_logical_record());
+
+            let content = format!("{header}\n{continuation}\n{next_header}\n");
+            let (opened, opened_errors) =
+                inventory::parse_content(&path.to_string_lossy(), &content, dialect);
+            assert_eq!(tailed.parse_errors, opened_errors);
+            assert_eq!(
+                inventory_projection(&tailed.entries),
+                inventory_projection(&opened)
+            );
+            assert!(tailed.entries[0].message.contains(continuation));
+
+            fs::remove_file(path).expect("should clean up delayed fixture");
+        }
+    }
+
+    #[test]
+    fn test_utf8_scalars_split_across_tail_reads_match_initial_parse() {
+        for scalar in ["¢", "€", "🧪"] {
+            for split in 1..scalar.len() {
+                let path = unique_test_path(&format!("inventory-utf8-{}-{split}", scalar.len()));
+                fs::write(&path, "").expect("should create UTF-8 fixture");
+                let dialect = DeviceInventoryLogDialect::InventoryAdaptor;
+                let mut reader = TailReader::new(
+                    path.clone(),
+                    0,
+                    ResolvedParser::intune_device_inventory(dialect),
+                    0,
+                    1,
+                );
+                let prefix = "[Thu Jul 30 13:05:01 2026][8604] - UTF8-";
+                append_bytes(&path, prefix.as_bytes());
+                append_bytes(&path, &scalar.as_bytes()[..split]);
+                assert!(reader
+                    .read_new_entries()
+                    .expect("incomplete scalar should remain pending")
+                    .entries
+                    .is_empty());
+                assert!(reader.pending_utf8_bytes.len() <= 3);
+
+                let suffix = "-TAIL\n[Thu Jul 30 13:05:02 2026][8604] - NEXT\n";
+                append_bytes(&path, &scalar.as_bytes()[split..]);
+                append_bytes(&path, suffix.as_bytes());
+                let mut tailed = reader
+                    .read_new_entries()
+                    .expect("completed scalar read should succeed");
+                tailed.append(reader.flush_pending_logical_record());
+
+                let content = format!("{prefix}{scalar}{suffix}");
+                let (opened, opened_errors) =
+                    inventory::parse_content(&path.to_string_lossy(), &content, dialect);
+                assert_eq!(tailed.parse_errors, opened_errors);
+                assert_eq!(
+                    inventory_projection(&tailed.entries),
+                    inventory_projection(&opened)
+                );
+                assert!(tailed
+                    .entries
+                    .iter()
+                    .all(|entry| !entry.message.contains('�')));
+
+                fs::remove_file(path).expect("should clean up UTF-8 fixture");
+            }
+        }
+    }
+
+    #[test]
+    fn test_utf8_bom_split_across_tail_reads_is_still_removed() {
+        let path = unique_test_path("inventory-split-utf8-bom");
+        fs::write(&path, []).expect("should create BOM fixture");
+        let dialect = DeviceInventoryLogDialect::Harvester;
+        let mut reader = TailReader::new(
+            path.clone(),
+            0,
+            ResolvedParser::intune_device_inventory(dialect),
+            0,
+            1,
+        );
+
+        for byte in [0xEF, 0xBB] {
+            append_bytes(&path, &[byte]);
+            assert!(reader
+                .read_new_entries()
+                .expect("partial BOM should remain pending")
+                .entries
+                .is_empty());
+        }
+        let content = "7/30/2026 6:00:54 AM [Information] BOM-SPLIT\n";
+        append_bytes(&path, &[0xBF]);
+        append_bytes(&path, content.as_bytes());
+        let mut tailed = reader
+            .read_new_entries()
+            .expect("completed BOM should decode");
+        tailed.append(reader.flush_pending_logical_record());
+
+        let (opened, opened_errors) =
+            inventory::parse_content(&path.to_string_lossy(), content, dialect);
+        assert_eq!(tailed.parse_errors, opened_errors);
+        assert_eq!(
+            inventory_projection(&tailed.entries),
+            inventory_projection(&opened)
+        );
+
+        fs::remove_file(path).expect("should clean up BOM fixture");
+    }
+
+    #[test]
+    fn test_invalid_utf8_tail_read_fails_closed_without_state_changes() {
+        let path = unique_test_path("inventory-invalid-utf8");
+        fs::write(&path, "").expect("should create invalid UTF-8 fixture");
+        let mut reader = TailReader::new(
+            path.clone(),
+            0,
+            ResolvedParser::intune_device_inventory(DeviceInventoryLogDialect::Harvester),
+            0,
+            1,
+        );
+        append_bytes(
+            &path,
+            b"7/30/2026 6:00:54 AM [Information] INVALID-UTF8-\xff\n",
+        );
+
+        let error = match reader.read_new_entries() {
+            Err(error) => error,
+            Ok(_) => panic!("invalid UTF-8 must fail closed"),
+        };
+        assert!(error.to_string().contains("invalid UTF-8"));
+        assert_eq!(reader.byte_offset, 0);
+        assert!(reader.pending_utf8_bytes.is_empty());
+        assert!(reader.pending_fragment.is_empty());
+        assert!(reader.pending_logical_record.is_none());
+        assert_eq!(reader.next_id, 0);
+        assert_eq!(reader.next_line, 1);
+
+        fs::remove_file(path).expect("should clean up invalid UTF-8 fixture");
+
+        let path = unique_test_path("inventory-invalid-utf8-after-carry");
+        fs::write(&path, []).expect("should create split-invalid UTF-8 fixture");
+        let mut reader = TailReader::new(
+            path.clone(),
+            0,
+            ResolvedParser::intune_device_inventory(DeviceInventoryLogDialect::Harvester),
+            0,
+            1,
+        );
+        append_bytes(&path, &[0xE2]);
+        reader
+            .read_new_entries()
+            .expect("an incomplete scalar is not invalid input");
+        append_bytes(&path, b"(");
+
+        let error = match reader.read_new_entries() {
+            Err(error) => error,
+            Ok(_) => panic!("an invalid continuation byte must fail closed"),
+        };
+        assert!(error.to_string().contains("invalid UTF-8"));
+        assert_eq!(reader.byte_offset, 1);
+        assert_eq!(reader.pending_utf8_bytes, vec![0xE2]);
+        assert!(reader.pending_fragment.is_empty());
+        assert!(reader.pending_logical_record.is_none());
+        assert_eq!(reader.next_id, 0);
+        assert_eq!(reader.next_line, 1);
+
+        fs::remove_file(path).expect("should clean up split-invalid UTF-8 fixture");
+    }
+
+    #[test]
+    fn test_huge_terminated_and_unterminated_inventory_lines_never_exceed_pending_peak() {
+        let path = unique_test_path("inventory-pending-peak");
+        fs::write(&path, "").expect("should create peak fixture");
+        let dialect = DeviceInventoryLogDialect::InventoryAdaptor;
+        let mut reader = TailReader::new(
+            path.clone(),
+            0,
+            ResolvedParser::intune_device_inventory(dialect),
+            0,
+            1,
+        );
+        let header = "[Thu Jul 30 13:05:01 2026][8604] - PEAK-START\n";
+        let huge = format!("{}🧪-PEAK-TAIL", "x".repeat(MAX_LOGICAL_RECORD_BYTES * 3));
+        append_bytes(&path, header.as_bytes());
+        append_bytes(&path, huge.as_bytes());
+        let first = reader
+            .read_new_entries()
+            .expect("unterminated huge line should parse incrementally");
+        assert!(first.parse_errors >= 2);
+        assert!(reader.max_pending_bytes_observed <= MAX_LOGICAL_RECORD_BYTES);
+        assert!(reader.pending_fragment.len() <= MAX_LOGICAL_RECORD_BYTES);
+
+        append_bytes(&path, b"\n[Thu Jul 30 13:05:02 2026][8604] - PEAK-NEXT\n");
+        let second = reader
+            .read_new_entries()
+            .expect("terminated huge line should finish");
+        assert!(reader.max_pending_bytes_observed <= MAX_LOGICAL_RECORD_BYTES);
+        assert!(second
+            .entries
+            .iter()
+            .all(|entry| entry.message.len() <= MAX_LOGICAL_RECORD_BYTES));
+
+        fs::remove_file(path).expect("should clean up peak fixture");
     }
 
     #[test]
@@ -1038,7 +1460,7 @@ mod tests {
             .expect("header tail read should succeed");
         assert!(
             header_batch.entries.is_empty(),
-            "the newest logical header must remain pending during the debounce"
+            "the newest logical header must remain pending until a real boundary"
         );
 
         let mut file = OpenOptions::new()
@@ -1057,13 +1479,10 @@ mod tests {
             .expect("continuation tail read should succeed");
         assert!(
             continuation_batch.entries.is_empty(),
-            "continuation before the debounce expires must extend the pending record"
+            "a continuation must extend the pending record"
         );
 
-        std::thread::sleep(std::time::Duration::from_millis(275));
-        let flushed = reader
-            .read_new_entries()
-            .expect("quiescent tail read should flush");
+        let flushed = reader.flush_pending_logical_record();
 
         assert_eq!(flushed.entries.len(), 1);
         assert_eq!(
@@ -1120,10 +1539,7 @@ mod tests {
             .expect("continuation tail read should succeed");
         assert!(continuation_batch.entries.is_empty());
 
-        std::thread::sleep(std::time::Duration::from_millis(275));
-        let flushed = reader
-            .read_new_entries()
-            .expect("quiescent tail read should flush");
+        let flushed = reader.flush_pending_logical_record();
 
         assert_eq!(flushed.entries.len(), 1);
         assert_eq!(
@@ -1208,10 +1624,7 @@ mod tests {
             .expect("blank-line tail read should succeed");
         assert!(blank.entries.is_empty(), "a blank line yields no entry");
 
-        std::thread::sleep(std::time::Duration::from_millis(275));
-        let flushed = reader
-            .read_new_entries()
-            .expect("quiescent tail read should flush the blank record");
+        let flushed = reader.flush_pending_logical_record();
         assert!(flushed.entries.is_empty());
 
         let mut file = OpenOptions::new()
@@ -1227,13 +1640,10 @@ mod tests {
             .expect("header tail read should succeed");
         assert!(
             pending.entries.is_empty(),
-            "the newest record stays pending during the debounce"
+            "the newest record stays pending until a real boundary"
         );
 
-        std::thread::sleep(std::time::Duration::from_millis(275));
-        let after = reader
-            .read_new_entries()
-            .expect("quiescent tail read should flush the header");
+        let after = reader.flush_pending_logical_record();
         assert_eq!(after.entries.len(), 1);
         assert_eq!(
             after.entries[0].line_number, 2,
@@ -1275,13 +1685,10 @@ mod tests {
         assert_eq!(
             batch.entries.len(),
             2,
-            "the newest record stays pending during the debounce"
+            "the newest record stays pending until a real boundary"
         );
 
-        std::thread::sleep(std::time::Duration::from_millis(275));
-        let flushed = reader
-            .read_new_entries()
-            .expect("quiescent tail read should flush");
+        let flushed = reader.flush_pending_logical_record();
         assert_eq!(flushed.entries.len(), 1);
 
         let tailed_lines: Vec<u32> = batch
@@ -1401,7 +1808,7 @@ mod tests {
             .expect("header tail read should succeed");
         assert!(
             header_batch.entries.is_empty(),
-            "the newest harvester record must stay pending during the debounce"
+            "the newest harvester record must stay pending until a real boundary"
         );
 
         let mut file = OpenOptions::new()
@@ -1423,10 +1830,7 @@ mod tests {
         );
         assert_eq!(continuation_batch.entries[0].severity, Severity::Info);
 
-        std::thread::sleep(std::time::Duration::from_millis(275));
-        let flushed = reader
-            .read_new_entries()
-            .expect("quiescent tail read should flush");
+        let flushed = reader.flush_pending_logical_record();
         assert_eq!(flushed.entries.len(), 1);
         assert_eq!(flushed.entries[0].message, "Second record.");
         assert_eq!(flushed.entries[0].severity, Severity::Warning);

--- a/src-tauri/src/watcher/tail.rs
+++ b/src-tauri/src/watcher/tail.rs
@@ -137,8 +137,7 @@ impl TailReader {
         let mut batch = TailBatch::empty(false);
         let mut reset = false;
         if file_size < self.byte_offset {
-            let finalized = self.finalize_pending_input();
-            batch.parse_errors = finalized.parse_errors;
+            batch.append(self.finalize_pending_input());
             self.byte_offset = 0;
             self.pending_fragment.clear();
             self.pending_fragment_selection = None;
@@ -1247,21 +1246,42 @@ mod tests {
 
     #[test]
     fn test_terminal_utf8_prefix_fails_closed_on_truncation() {
-        let (path, mut reader) =
-            reader_with_terminal_utf8_prefix("terminal-truncation", &[0xF0, 0x9F, 0xA7]);
-        fs::write(&path, []).expect("should truncate terminal UTF-8 fixture");
+        for (label, prefix) in [
+            ("two-byte", &[0xC2][..]),
+            ("three-byte", &[0xE2, 0x82][..]),
+            ("four-byte", &[0xF0, 0x9F, 0xA7][..]),
+            ("partial-bom", &[0xEF, 0xBB][..]),
+        ] {
+            let (path, mut reader) =
+                reader_with_terminal_utf8_prefix(&format!("terminal-truncation-{label}"), prefix);
+            fs::write(&path, []).expect("should truncate terminal UTF-8 fixture");
 
-        let finalized = reader
-            .read_new_entries()
-            .expect("truncation should finalize old decoder state");
-        assert!(finalized.reset);
-        assert_eq!(finalized.parse_errors, 1);
-        assert!(finalized.entries.is_empty());
-        assert!(reader.pending_utf8_bytes.is_empty());
-        assert!(reader.pending_fragment.is_empty());
-        assert!(reader.pending_logical_record.is_none());
+            let finalized = reader
+                .read_new_entries()
+                .expect("truncation should finalize old decoder state");
+            assert!(finalized.reset, "{label}");
+            assert_eq!(finalized.parse_errors, 1, "{label}");
+            assert_eq!(finalized.entries.len(), 1, "{label}");
+            assert_eq!(finalized.entries[0].message, "TERMINAL-CONTENT", "{label}");
+            assert!(!finalized.entries[0].message.contains('�'), "{label}");
+            assert!(reader.pending_utf8_bytes.is_empty(), "{label}");
+            assert!(reader.pending_fragment.is_empty(), "{label}");
+            assert!(reader.pending_logical_record.is_none(), "{label}");
+            assert_eq!(reader.next_id, 1, "{label}");
 
-        fs::remove_file(path).expect("should clean up truncation fixture");
+            let repeated_read = reader
+                .read_new_entries()
+                .expect("empty replacement file should stay empty");
+            assert!(!repeated_read.reset, "{label}");
+            assert_eq!(repeated_read.parse_errors, 0, "{label}");
+            assert!(repeated_read.entries.is_empty(), "{label}");
+
+            let repeated_finalization = reader.finalize_pending_input();
+            assert_eq!(repeated_finalization.parse_errors, 0, "{label}");
+            assert!(repeated_finalization.entries.is_empty(), "{label}");
+
+            fs::remove_file(path).expect("should clean up truncation fixture");
+        }
     }
 
     #[test]

--- a/src-tauri/src/watcher/tail.rs
+++ b/src-tauri/src/watcher/tail.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use cmtraceopen_parser::intune::device::windows::inventory::{
-    self, DeviceInventoryLogDialect, FramedLogicalRecord,
+    self, DeviceInventoryLogDialect, FramedLogicalRecord, MAX_LOGICAL_RECORD_BYTES,
 };
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
@@ -15,7 +15,6 @@ use crate::parser::{self, FileEncoding, ResolvedParser};
 const IME_RECORD_START: &str = "<![LOG[";
 const IME_RECORD_ATTRS_START: &str = "]LOG]!><";
 const LOGICAL_RECORD_DEBOUNCE: Duration = Duration::from_millis(250);
-const MAX_PENDING_LOGICAL_RECORD_BYTES: usize = 1024 * 1024;
 
 /// The result of reading new content from a tailed file.
 pub struct TailBatch {
@@ -223,12 +222,7 @@ impl TailReader {
                     .pending_logical_record
                     .take()
                     .map(|pending| pending.content);
-                let framed = inventory::frame_logical_records(
-                    dialect,
-                    prior,
-                    &lines,
-                    MAX_PENDING_LOGICAL_RECORD_BYTES,
-                );
+                let framed = inventory::frame_logical_records(dialect, prior, &lines);
 
                 if let Some(content) = framed.pending_record {
                     self.pending_logical_record = Some(PendingLogicalRecord {
@@ -240,7 +234,7 @@ impl TailReader {
 
                 batch.append(self.parse_logical_records(
                     framed.completed_records,
-                    &selection,
+                    dialect,
                     framed.overflow_count,
                 ));
             }
@@ -318,32 +312,20 @@ impl TailReader {
             return TailBatch::empty(false);
         };
 
-        let mut overflow_count = 0;
-        let records = if fragment.is_empty() {
-            pending
-                .map(|record| vec![FramedLogicalRecord::complete(record.content)])
-                .unwrap_or_default()
+        let pending_content = pending.map(|record| record.content);
+        let framed = if fragment.is_empty() {
+            inventory::frame_logical_records(dialect, pending_content, &[]).flush_pending()
         } else {
             let fragment_lines = [fragment.as_str()];
-            let framed = inventory::frame_logical_records(
-                dialect,
-                pending.map(|record| record.content),
-                &fragment_lines,
-                MAX_PENDING_LOGICAL_RECORD_BYTES,
-            );
-            overflow_count = framed.overflow_count;
-            let mut records = framed.completed_records;
-            // The flush ends the record, so the retained pending text owns its
-            // last physical line the same way a header-terminated record does.
-            records.extend(framed.pending_record.map(FramedLogicalRecord::complete));
-            records
+            inventory::frame_logical_records(dialect, pending_content, &fragment_lines)
+                .flush_pending()
         };
 
         // An empty record is kept rather than dropped. It parses to no entries
         // either way, but a blank line is still a physical line, and dropping
         // the record here would drop the line it accounts for and shift every
         // later line number down by one.
-        self.parse_logical_records(records, &selection, overflow_count)
+        self.parse_logical_records(framed.completed_records, dialect, framed.overflow_count)
     }
 
     fn enforce_unterminated_logical_bound(
@@ -361,7 +343,7 @@ impl TailReader {
             .saturating_add(usize::from(
                 pending_len > 0 && !self.pending_fragment.is_empty(),
             ));
-        if pending_bytes <= MAX_PENDING_LOGICAL_RECORD_BYTES {
+        if pending_bytes <= MAX_LOGICAL_RECORD_BYTES {
             return TailBatch::empty(false);
         }
 
@@ -372,48 +354,39 @@ impl TailReader {
         let fragment = std::mem::take(&mut self.pending_fragment);
         self.pending_fragment_selection = None;
         let fragment_lines = [fragment.as_str()];
-        let framed = inventory::frame_logical_records(
-            dialect,
-            pending,
-            &fragment_lines,
-            MAX_PENDING_LOGICAL_RECORD_BYTES,
-        );
+        let framed = inventory::frame_logical_records(dialect, pending, &fragment_lines);
 
         self.pending_fragment = framed.pending_record.unwrap_or_default();
         if !self.pending_fragment.is_empty() {
             self.pending_fragment_selection = Some((selection.clone(), now));
         }
 
-        self.parse_logical_records(framed.completed_records, selection, framed.overflow_count)
+        self.parse_logical_records(framed.completed_records, dialect, framed.overflow_count)
     }
 
     fn parse_logical_records(
         &mut self,
         records: Vec<FramedLogicalRecord>,
-        selection: &ResolvedParser,
+        dialect: DeviceInventoryLogDialect,
         framing_parse_errors: u32,
     ) -> TailBatch {
         let path_str = self.path.to_string_lossy().to_string();
-        let mut entries = Vec::new();
-        let mut parse_errors = framing_parse_errors;
-
-        for record in records {
-            let parsed =
-                parser::parse_content_with_selection(&record.content, &path_str, selection);
-            let mut record_entries = parsed.entries;
-            self.assign_record_entry_identity(&mut record_entries, record.physical_lines);
-            entries.extend(record_entries);
-            parse_errors = parse_errors.saturating_add(parsed.parse_errors);
-        }
+        let physical_lines = records.iter().fold(0u32, |total, record| {
+            total.saturating_add(record.physical_lines)
+        });
+        let (mut entries, projection_errors) =
+            inventory::parse_framed_records(&path_str, &records, dialect);
+        parser::annotate_error_code_spans(&mut entries);
+        self.assign_framed_entry_identity(&mut entries, physical_lines);
 
         TailBatch {
             entries,
-            parse_errors,
+            parse_errors: framing_parse_errors.saturating_add(projection_errors),
             reset: false,
         }
     }
 
-    /// Number the entries of one logical record, then advance past its lines.
+    /// Number one framed batch's entries, then advance past all of its lines.
     ///
     /// A logical record spans its header plus every continuation beneath it, so
     /// the next record starts at this record's first line plus its physical
@@ -423,7 +396,7 @@ impl TailReader {
     /// and the same file opened. Entries arrive carrying the line they sit on
     /// within the record, which is what the whole-file parse assigns, so they
     /// rebase onto the record's own start line.
-    fn assign_record_entry_identity(&mut self, entries: &mut [LogEntry], physical_lines: u32) {
+    fn assign_framed_entry_identity(&mut self, entries: &mut [LogEntry], physical_lines: u32) {
         let record_start = self.next_line;
         for entry in entries {
             entry.id = self.next_id;
@@ -718,6 +691,85 @@ mod tests {
         assert_eq!(actual.severity, expected.severity);
         assert_eq!(actual.format, expected.format);
         assert_eq!(actual.file_path, expected.file_path);
+    }
+
+    fn inventory_record_with_size(header: &str, total_bytes: usize, suffix: &str) -> String {
+        let fixed_bytes = header.len() + 1 + suffix.len();
+        assert!(fixed_bytes <= total_bytes);
+        format!(
+            "{header}\n{}{suffix}",
+            "x".repeat(total_bytes - fixed_bytes)
+        )
+    }
+
+    fn assert_inventory_tail_matches_initial(
+        test_name: &str,
+        dialect: DeviceInventoryLogDialect,
+        first_record: &str,
+        next_header: &str,
+    ) {
+        let path = unique_test_path(test_name);
+        fs::write(&path, "").expect("should create empty Device Inventory log");
+        let selection = ResolvedParser::intune_device_inventory(dialect);
+        let mut reader = TailReader::new(path.clone(), 0, selection, 0, 1);
+        let split_at = first_record
+            .find('\n')
+            .expect("test record should have a continuation boundary")
+            + 1;
+        let appends = [
+            first_record[..split_at].to_string(),
+            first_record[split_at..].to_string(),
+            format!("\n{next_header}\n"),
+        ];
+        let mut tailed_entries = Vec::new();
+        let mut tail_errors = 0u32;
+
+        for appended in &appends {
+            let mut file = OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .expect("should reopen Device Inventory log");
+            write!(file, "{appended}").expect("should append Device Inventory content");
+            drop(file);
+
+            let batch = reader
+                .read_new_entries()
+                .expect("Device Inventory tail read should succeed");
+            tailed_entries.extend(batch.entries);
+            tail_errors = tail_errors.saturating_add(batch.parse_errors);
+
+            let retained_bytes = reader
+                .pending_logical_record
+                .as_ref()
+                .map_or(0, |record| record.content.len())
+                .saturating_add(reader.pending_fragment.len())
+                .saturating_add(usize::from(
+                    reader.pending_logical_record.is_some() && !reader.pending_fragment.is_empty(),
+                ));
+            assert!(retained_bytes <= MAX_LOGICAL_RECORD_BYTES);
+        }
+
+        let flushed = reader.flush_pending_logical_record();
+        tailed_entries.extend(flushed.entries);
+        tail_errors = tail_errors.saturating_add(flushed.parse_errors);
+
+        let content = format!("{first_record}\n{next_header}\n");
+        let (opened_entries, opened_errors) =
+            inventory::parse_content(&path.to_string_lossy(), &content, dialect);
+        let projection = |entries: &[LogEntry]| {
+            entries
+                .iter()
+                .map(|entry| (entry.line_number, entry.severity, entry.message.clone()))
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(tail_errors, opened_errors);
+        assert_eq!(projection(&tailed_entries), projection(&opened_entries));
+        assert!(tailed_entries
+            .iter()
+            .all(|entry| entry.message.len() <= MAX_LOGICAL_RECORD_BYTES));
+
+        fs::remove_file(path).expect("should clean up temp file");
     }
 
     #[test]
@@ -1260,6 +1312,66 @@ mod tests {
     }
 
     #[test]
+    fn test_device_inventory_initial_and_tail_parity_at_exact_and_overflow_limits() {
+        let cases = [
+            (
+                DeviceInventoryLogDialect::Harvester,
+                "7/30/2026 6:00:54 AM [Error] HARVESTER-START",
+                "7/30/2026 6:00:55 AM [Warning] HARVESTER-NEXT",
+                "-HARVESTER-TAIL-SENTINEL",
+            ),
+            (
+                DeviceInventoryLogDialect::InventoryAdaptor,
+                "[Thu Jul 30 13:05:01 2026][8604] - ADAPTOR-START",
+                "[Thu Jul 30 13:05:02 2026][8604] - ADAPTOR-NEXT",
+                "-ADAPTOR-TAIL-SENTINEL",
+            ),
+            (
+                DeviceInventoryLogDialect::RotationFailure,
+                "2026-07-30T13:05:01.1234567-04:00 Failed to rotate ROTATION-START",
+                "2026-07-30T13:05:02.1234567-04:00 ROTATION-NEXT",
+                "-ROTATION-TAIL-SENTINEL",
+            ),
+        ];
+
+        for (dialect, header, next_header, sentinel) in cases {
+            for (label, total_bytes) in [
+                ("exact", MAX_LOGICAL_RECORD_BYTES),
+                ("overflow", MAX_LOGICAL_RECORD_BYTES + 1),
+            ] {
+                let first_record = inventory_record_with_size(header, total_bytes, sentinel);
+                assert_inventory_tail_matches_initial(
+                    &format!("inventory-{dialect:?}-{label}"),
+                    dialect,
+                    &first_record,
+                    next_header,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_device_inventory_initial_and_tail_parity_at_utf8_split_boundary() {
+        let header = "[Thu Jul 30 13:05:01 2026][8604] - UTF8-START";
+        let fixed_prefix_bytes = header.len() + 1;
+        let first_record = format!(
+            "{header}\n{}🧪-UTF8-TAIL-SENTINEL",
+            "x".repeat(MAX_LOGICAL_RECORD_BYTES - fixed_prefix_bytes - 1)
+        );
+        assert_eq!(
+            first_record[..MAX_LOGICAL_RECORD_BYTES - 1].len(),
+            MAX_LOGICAL_RECORD_BYTES - 1
+        );
+
+        assert_inventory_tail_matches_initial(
+            "inventory-utf8-boundary",
+            DeviceInventoryLogDialect::InventoryAdaptor,
+            &first_record,
+            "[Thu Jul 30 13:05:02 2026][8604] - UTF8-NEXT",
+        );
+    }
+
+    #[test]
     fn test_tail_reader_attaches_split_harvester_continuation() {
         // The harvester dialect reports LogicalRecord framing because the
         // initial parse attaches a non-header line to the record above it.
@@ -1414,7 +1526,7 @@ mod tests {
             cmtraceopen_parser::intune::device::windows::inventory::DeviceInventoryLogDialect::InventoryAdaptor,
         );
         let mut reader = TailReader::new(path.clone(), 0, selection, 0, 1);
-        let continuation = "x".repeat(MAX_PENDING_LOGICAL_RECORD_BYTES);
+        let continuation = "x".repeat(MAX_LOGICAL_RECORD_BYTES);
 
         let mut file = OpenOptions::new()
             .append(true)
@@ -1433,7 +1545,7 @@ mod tests {
         assert_eq!(overflow.entries.len(), 1);
         assert_eq!(overflow.parse_errors, 1);
         assert!(
-            overflow.entries[0].message.len() < MAX_PENDING_LOGICAL_RECORD_BYTES,
+            overflow.entries[0].message.len() < MAX_LOGICAL_RECORD_BYTES,
             "emitted overflow record must honor the pending byte bound"
         );
 
@@ -1466,7 +1578,7 @@ mod tests {
             .entries
             .is_empty());
 
-        let continuation = "x".repeat(MAX_PENDING_LOGICAL_RECORD_BYTES);
+        let continuation = "x".repeat(MAX_LOGICAL_RECORD_BYTES);
         let mut file = OpenOptions::new()
             .append(true)
             .open(&path)
@@ -1485,7 +1597,7 @@ mod tests {
             .as_ref()
             .map_or(0, |record| record.content.len())
             + reader.pending_fragment.len();
-        assert!(pending_bytes <= MAX_PENDING_LOGICAL_RECORD_BYTES);
+        assert!(pending_bytes <= MAX_LOGICAL_RECORD_BYTES);
 
         fs::remove_file(path).expect("should clean up temp file");
     }

--- a/src-tauri/src/watcher/tail.rs
+++ b/src-tauri/src/watcher/tail.rs
@@ -84,6 +84,8 @@ pub struct TailReader {
     pending_byte: Option<u8>,
     /// Incomplete UTF-8 scalar suffix retained across append boundaries.
     pending_utf8_bytes: Vec<u8>,
+    /// Parser selection that owns the incomplete UTF-8 scalar suffix.
+    pending_utf8_selection: Option<ResolvedParser>,
     #[cfg(test)]
     max_pending_bytes_observed: usize,
 }
@@ -115,6 +117,7 @@ impl TailReader {
             encoding,
             pending_byte: None,
             pending_utf8_bytes: Vec::new(),
+            pending_utf8_selection: None,
             #[cfg(test)]
             max_pending_bytes_observed: 0,
         }
@@ -131,8 +134,11 @@ impl TailReader {
         // signal a reset so the frontend replaces (not appends) its stale view.
         // Line numbers restart at 1 to match the new file generation; ids stay
         // monotonic so they remain unique across the reset.
+        let mut batch = TailBatch::empty(false);
         let mut reset = false;
         if file_size < self.byte_offset {
+            let finalized = self.finalize_pending_input();
+            batch.parse_errors = finalized.parse_errors;
             self.byte_offset = 0;
             self.pending_fragment.clear();
             self.pending_fragment_selection = None;
@@ -140,17 +146,19 @@ impl TailReader {
             self.pending_logical_record = None;
             self.pending_byte = None;
             self.pending_utf8_bytes.clear();
+            self.pending_utf8_selection = None;
             self.next_line = 1;
+            batch.reset = true;
             reset = true;
         }
 
-        let mut batch = TailBatch::empty(reset);
+        if !reset && self.pending_parser_selection_changed() {
+            batch.append(self.finalize_pending_input());
+            return Ok(batch);
+        }
 
         // No new data
         if file_size == self.byte_offset {
-            if !reset && self.pending_parser_selection_changed() {
-                batch.append(self.flush_pending_logical_record());
-            }
             return Ok(batch);
         }
 
@@ -165,12 +173,6 @@ impl TailReader {
 
         let new_text = self.decode_tail_bytes(buffer)?;
         let received_text = !new_text.is_empty();
-
-        // Parser changes are semantic boundaries, but invalid bytes above fail
-        // before any pending state is flushed or otherwise mutated.
-        if self.pending_parser_selection_changed() {
-            batch.append(self.flush_pending_logical_record());
-        }
 
         let inventory_dialect = inventory_logical_dialect(&self.parser_selection);
         if let Some(dialect) = inventory_dialect {
@@ -258,6 +260,7 @@ impl TailReader {
         }
 
         let previous_carry = std::mem::take(&mut self.pending_utf8_bytes);
+        let previous_carry_selection = self.pending_utf8_selection.take();
         let decoded_start_offset = self.byte_offset.saturating_sub(previous_carry.len() as u64);
         let mut decode_buffer = if previous_carry.is_empty() {
             buffer
@@ -279,6 +282,7 @@ impl TailReader {
                 let utf8_error = error.utf8_error();
                 if utf8_error.error_len().is_some() {
                     self.pending_utf8_bytes = previous_carry;
+                    self.pending_utf8_selection = previous_carry_selection;
                     return Err(crate::error::AppError::Internal(
                         "Failed to decode tailed bytes: invalid UTF-8".to_string(),
                     ));
@@ -289,11 +293,14 @@ impl TailReader {
                 let incomplete = bytes.split_off(valid_up_to);
                 if incomplete.len() > 3 {
                     self.pending_utf8_bytes = previous_carry;
+                    self.pending_utf8_selection = previous_carry_selection;
                     return Err(crate::error::AppError::Internal(
                         "Failed to decode tailed bytes: invalid UTF-8".to_string(),
                     ));
                 }
                 self.pending_utf8_bytes = incomplete;
+                self.pending_utf8_selection =
+                    previous_carry_selection.or_else(|| Some(self.parser_selection.clone()));
                 String::from_utf8(bytes).map_err(|_| {
                     crate::error::AppError::Internal(
                         "Failed to decode tailed bytes: invalid UTF-8".to_string(),
@@ -309,6 +316,10 @@ impl TailReader {
             .is_some_and(|pending| pending.parser_selection != self.parser_selection)
             || self
                 .pending_fragment_selection
+                .as_ref()
+                .is_some_and(|selection| selection != &self.parser_selection)
+            || self
+                .pending_utf8_selection
                 .as_ref()
                 .is_some_and(|selection| selection != &self.parser_selection)
     }
@@ -474,7 +485,7 @@ impl TailReader {
         }
     }
 
-    fn flush_pending_logical_record(&mut self) -> TailBatch {
+    fn flush_pending_text(&mut self) -> TailBatch {
         let pending = self.pending_logical_record.take();
         let fragment = std::mem::take(&mut self.pending_fragment);
         let fragment_selection = self.pending_fragment_selection.take();
@@ -514,6 +525,20 @@ impl TailReader {
         // the record here would drop the line it accounts for and shift every
         // later line number down by one.
         self.parse_logical_records(completed_records, dialect, overflow_count)
+    }
+
+    /// Complete all input that can still produce text at a real terminal boundary.
+    ///
+    /// An incomplete UTF-8 suffix is not decoded lossily: once no later bytes can
+    /// complete it, consuming it contributes exactly one surfaced parse error.
+    fn finalize_pending_input(&mut self) -> TailBatch {
+        let mut batch = self.flush_pending_text();
+        let incomplete_utf8 = !std::mem::take(&mut self.pending_utf8_bytes).is_empty();
+        self.pending_utf8_selection = None;
+        if incomplete_utf8 {
+            batch.parse_errors = batch.parse_errors.saturating_add(1);
+        }
+        batch
     }
 
     fn parse_logical_records(
@@ -658,6 +683,16 @@ fn complete_unmatched_tail_len(text: &str) -> usize {
     text.rfind('\n').map(|index| index + 1).unwrap_or(0)
 }
 
+fn emit_final_tail_batch<F>(tail_reader: &mut TailReader, on_new_entries: F)
+where
+    F: FnOnce(TailBatch),
+{
+    let batch = tail_reader.finalize_pending_input();
+    if batch.is_reportable() {
+        on_new_entries(batch);
+    }
+}
+
 /// Represents an active tail-watching session
 pub struct TailSession {
     /// Flag to signal the watcher thread to stop
@@ -728,10 +763,7 @@ where
 
         loop {
             if stop_flag_clone.load(Ordering::Relaxed) {
-                let batch = tail_reader.flush_pending_logical_record();
-                if batch.is_reportable() {
-                    on_new_entries(batch);
-                }
+                emit_final_tail_batch(&mut tail_reader, &on_new_entries);
                 log::info!("Tail watcher stopped for {}", watch_path.display());
                 break;
             }
@@ -768,10 +800,7 @@ where
                     }
                 }
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                    let batch = tail_reader.flush_pending_logical_record();
-                    if batch.is_reportable() {
-                        on_new_entries(batch);
-                    }
+                    emit_final_tail_batch(&mut tail_reader, &on_new_entries);
                     log::info!("Watcher channel disconnected");
                     break;
                 }
@@ -905,7 +934,7 @@ mod tests {
             assert!(retained_bytes <= MAX_LOGICAL_RECORD_BYTES);
         }
 
-        let flushed = reader.flush_pending_logical_record();
+        let flushed = reader.finalize_pending_input();
         tailed_entries.extend(flushed.entries);
         tail_errors = tail_errors.saturating_add(flushed.parse_errors);
 
@@ -945,6 +974,30 @@ mod tests {
             .expect("should reopen tail fixture");
         file.write_all(bytes)
             .expect("should append raw fixture bytes");
+    }
+
+    fn reader_with_terminal_utf8_prefix(name: &str, prefix: &[u8]) -> (PathBuf, TailReader) {
+        let path = unique_test_path(name);
+        fs::write(&path, []).expect("should create terminal UTF-8 fixture");
+        let mut reader = TailReader::new(
+            path.clone(),
+            0,
+            ResolvedParser::intune_device_inventory(DeviceInventoryLogDialect::Harvester),
+            0,
+            1,
+        );
+        append_bytes(
+            &path,
+            b"7/30/2026 6:00:54 AM [Information] TERMINAL-CONTENT",
+        );
+        append_bytes(&path, prefix);
+        let batch = reader
+            .read_new_entries()
+            .expect("an incomplete terminal scalar should remain pending");
+        assert!(batch.entries.is_empty());
+        assert_eq!(batch.parse_errors, 0);
+        assert_eq!(reader.pending_utf8_bytes, prefix);
+        (path, reader)
     }
 
     #[test]
@@ -992,7 +1045,7 @@ mod tests {
             let mut tailed = reader
                 .read_new_entries()
                 .expect("delayed continuation read should succeed");
-            tailed.append(reader.flush_pending_logical_record());
+            tailed.append(reader.finalize_pending_input());
 
             let content = format!("{header}\n{continuation}\n{next_header}\n");
             let (opened, opened_errors) =
@@ -1038,7 +1091,7 @@ mod tests {
                 let mut tailed = reader
                     .read_new_entries()
                     .expect("completed scalar read should succeed");
-                tailed.append(reader.flush_pending_logical_record());
+                tailed.append(reader.finalize_pending_input());
 
                 let content = format!("{prefix}{scalar}{suffix}");
                 let (opened, opened_errors) =
@@ -1085,7 +1138,7 @@ mod tests {
         let mut tailed = reader
             .read_new_entries()
             .expect("completed BOM should decode");
-        tailed.append(reader.flush_pending_logical_record());
+        tailed.append(reader.finalize_pending_input());
 
         let (opened, opened_errors) =
             inventory::parse_content(&path.to_string_lossy(), content, dialect);
@@ -1096,6 +1149,135 @@ mod tests {
         );
 
         fs::remove_file(path).expect("should clean up BOM fixture");
+    }
+
+    #[test]
+    fn test_terminal_utf8_prefixes_fail_closed_exactly_once() {
+        for (label, prefix) in [
+            ("two-byte", &[0xC2][..]),
+            ("three-byte", &[0xE2, 0x82][..]),
+            ("four-byte", &[0xF0, 0x9F, 0xA7][..]),
+        ] {
+            let (path, mut reader) =
+                reader_with_terminal_utf8_prefix(&format!("terminal-{label}"), prefix);
+
+            let finalized = reader.finalize_pending_input();
+            assert_eq!(finalized.parse_errors, 1, "{label}");
+            assert_eq!(finalized.entries.len(), 1, "{label}");
+            assert_eq!(finalized.entries[0].message, "TERMINAL-CONTENT", "{label}");
+            assert!(!finalized.entries[0].message.contains('�'), "{label}");
+            assert!(reader.pending_utf8_bytes.is_empty(), "{label}");
+
+            let repeated = reader.finalize_pending_input();
+            assert_eq!(repeated.parse_errors, 0, "{label}");
+            assert!(repeated.entries.is_empty(), "{label}");
+
+            fs::remove_file(path).expect("should clean up terminal UTF-8 fixture");
+        }
+    }
+
+    #[test]
+    fn test_terminal_partial_utf8_bom_fails_closed() {
+        let path = unique_test_path("terminal-partial-bom");
+        fs::write(&path, []).expect("should create terminal BOM fixture");
+        let mut reader = TailReader::new(
+            path.clone(),
+            0,
+            ResolvedParser::intune_device_inventory(DeviceInventoryLogDialect::Harvester),
+            0,
+            1,
+        );
+        append_bytes(&path, &[0xEF, 0xBB]);
+        reader
+            .read_new_entries()
+            .expect("a partial BOM should remain pending");
+
+        let finalized = reader.finalize_pending_input();
+        assert_eq!(finalized.parse_errors, 1);
+        assert!(finalized.entries.is_empty());
+        assert!(reader.pending_utf8_bytes.is_empty());
+
+        fs::remove_file(path).expect("should clean up terminal BOM fixture");
+    }
+
+    #[test]
+    fn test_terminal_utf8_prefix_fails_closed_on_parser_change() {
+        let (path, mut reader) =
+            reader_with_terminal_utf8_prefix("terminal-parser-change", &[0xE2, 0x82]);
+        reader.parser_selection = ResolvedParser::plain_text();
+
+        let finalized = reader
+            .read_new_entries()
+            .expect("parser change should finalize old decoder state");
+        assert_eq!(finalized.parse_errors, 1);
+        assert_eq!(finalized.entries.len(), 1);
+        assert_eq!(finalized.entries[0].message, "TERMINAL-CONTENT");
+        assert!(reader.pending_utf8_bytes.is_empty());
+
+        fs::remove_file(path).expect("should clean up parser-change fixture");
+    }
+
+    #[test]
+    fn test_parser_change_finalizes_utf8_carry_without_pending_text() {
+        let path = unique_test_path("terminal-carry-only-parser-change");
+        fs::write(&path, []).expect("should create carry-only fixture");
+        let mut reader = TailReader::new(path.clone(), 0, ResolvedParser::plain_text(), 0, 1);
+        append_bytes(&path, b"valid content\n");
+        let valid = reader
+            .read_new_entries()
+            .expect("valid content should parse before the terminal prefix");
+        assert_eq!(valid.entries.len(), 1);
+
+        append_bytes(&path, &[0xE2, 0x82]);
+        reader
+            .read_new_entries()
+            .expect("incomplete scalar should remain pending");
+        assert!(reader.pending_fragment.is_empty());
+        reader.parser_selection = ResolvedParser::generic_timestamped(DateOrder::MonthFirst);
+
+        let finalized = reader
+            .read_new_entries()
+            .expect("parser change should finalize carry-only decoder state");
+        assert_eq!(finalized.parse_errors, 1);
+        assert!(finalized.entries.is_empty());
+        assert!(reader.pending_utf8_bytes.is_empty());
+
+        fs::remove_file(path).expect("should clean up carry-only fixture");
+    }
+
+    #[test]
+    fn test_terminal_utf8_prefix_fails_closed_on_truncation() {
+        let (path, mut reader) =
+            reader_with_terminal_utf8_prefix("terminal-truncation", &[0xF0, 0x9F, 0xA7]);
+        fs::write(&path, []).expect("should truncate terminal UTF-8 fixture");
+
+        let finalized = reader
+            .read_new_entries()
+            .expect("truncation should finalize old decoder state");
+        assert!(finalized.reset);
+        assert_eq!(finalized.parse_errors, 1);
+        assert!(finalized.entries.is_empty());
+        assert!(reader.pending_utf8_bytes.is_empty());
+        assert!(reader.pending_fragment.is_empty());
+        assert!(reader.pending_logical_record.is_none());
+
+        fs::remove_file(path).expect("should clean up truncation fixture");
+    }
+
+    #[test]
+    fn test_watcher_terminal_emission_surfaces_incomplete_utf8() {
+        let (path, mut reader) = reader_with_terminal_utf8_prefix("terminal-watcher-exit", &[0xC2]);
+        let mut emitted = None;
+
+        emit_final_tail_batch(&mut reader, |batch| emitted = Some(batch));
+
+        let emitted = emitted.expect("terminal parse error must reach the watcher callback");
+        assert_eq!(emitted.parse_errors, 1);
+        assert_eq!(emitted.entries.len(), 1);
+        assert_eq!(emitted.entries[0].message, "TERMINAL-CONTENT");
+        assert!(reader.pending_utf8_bytes.is_empty());
+
+        fs::remove_file(path).expect("should clean up watcher-exit fixture");
     }
 
     #[test]
@@ -1150,6 +1332,10 @@ mod tests {
         assert!(error.to_string().contains("invalid UTF-8"));
         assert_eq!(reader.byte_offset, 1);
         assert_eq!(reader.pending_utf8_bytes, vec![0xE2]);
+        assert!(reader
+            .pending_utf8_selection
+            .as_ref()
+            .is_some_and(|selection| selection == &reader.parser_selection));
         assert!(reader.pending_fragment.is_empty());
         assert!(reader.pending_logical_record.is_none());
         assert_eq!(reader.next_id, 0);
@@ -1482,7 +1668,7 @@ mod tests {
             "a continuation must extend the pending record"
         );
 
-        let flushed = reader.flush_pending_logical_record();
+        let flushed = reader.finalize_pending_input();
 
         assert_eq!(flushed.entries.len(), 1);
         assert_eq!(
@@ -1539,7 +1725,7 @@ mod tests {
             .expect("continuation tail read should succeed");
         assert!(continuation_batch.entries.is_empty());
 
-        let flushed = reader.flush_pending_logical_record();
+        let flushed = reader.finalize_pending_input();
 
         assert_eq!(flushed.entries.len(), 1);
         assert_eq!(
@@ -1624,7 +1810,7 @@ mod tests {
             .expect("blank-line tail read should succeed");
         assert!(blank.entries.is_empty(), "a blank line yields no entry");
 
-        let flushed = reader.flush_pending_logical_record();
+        let flushed = reader.finalize_pending_input();
         assert!(flushed.entries.is_empty());
 
         let mut file = OpenOptions::new()
@@ -1643,7 +1829,7 @@ mod tests {
             "the newest record stays pending until a real boundary"
         );
 
-        let after = reader.flush_pending_logical_record();
+        let after = reader.finalize_pending_input();
         assert_eq!(after.entries.len(), 1);
         assert_eq!(
             after.entries[0].line_number, 2,
@@ -1688,7 +1874,7 @@ mod tests {
             "the newest record stays pending until a real boundary"
         );
 
-        let flushed = reader.flush_pending_logical_record();
+        let flushed = reader.finalize_pending_input();
         assert_eq!(flushed.entries.len(), 1);
 
         let tailed_lines: Vec<u32> = batch
@@ -1830,7 +2016,7 @@ mod tests {
         );
         assert_eq!(continuation_batch.entries[0].severity, Severity::Info);
 
-        let flushed = reader.flush_pending_logical_record();
+        let flushed = reader.finalize_pending_input();
         assert_eq!(flushed.entries.len(), 1);
         assert_eq!(flushed.entries[0].message, "Second record.");
         assert_eq!(flushed.entries[0].severity, Severity::Warning);
@@ -1877,7 +2063,7 @@ mod tests {
             .entries
             .is_empty());
 
-        let flushed = reader.flush_pending_logical_record();
+        let flushed = reader.finalize_pending_input();
         assert_eq!(flushed.entries.len(), 1);
         assert_eq!(flushed.entries[0].message, "Final action.");
         assert_eq!(flushed.parse_errors, 0);


### PR DESCRIPTION
Closes #507

## Summary

- keep Device Inventory logical-record completion semantic: a later header, parser change, stop/disconnect, or explicit flush ends a pending record; elapsed wall time does not
- decode tailed UTF-8 incrementally, carrying incomplete 2-, 3-, and 4-byte scalars (including a split BOM) and failing closed on actually invalid input without advancing reader state
- finalize an incomplete terminal UTF-8 suffix as exactly one surfaced parse error on explicit EOF, parser change, truncation, watcher stop, or watcher disconnect; never discard or replacement-decode it
- forward terminal finalization atomically: truncation/reset preserves both valid pending entries and UTF-8 parse errors exactly once
- feed physical-line segments through the parser-owned 1 MiB framer without ever over-appending, preserving UTF-8 boundaries, every source byte, physical-line accounting, and initial-load/tail parity
- remove the watcher-local size/debounce paths and keep framing, projection, and tail byte decoding as separate concerns

## Frozen revision

- Base: `e59aed306b4f8f5ee1b862970169a26b24886f4d`
- Head: `3337041eafdec1f2daaedcdabbecd5eb5bfedef8`
- Branch: `codex/issue-507-lossless-device-inventory-framing`

## Validation

- `cargo test -p cmtraceopen-parser --test intune_device_inventory` — 28 passed
- `cargo test --manifest-path src-tauri/Cargo.toml --lib watcher::tail` — 29 passed
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p cmtraceopen-parser` — full parser suite passed, including 658 library tests, all integration targets, and 2 doc tests
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test --manifest-path src-tauri/Cargo.toml` — full app suite passed, including 572 library tests, all integration targets, and doc tests
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings` — passed
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` — passed
- `npm test -- --run` — 51 files / 638 tests passed
- `npx tsc --noEmit` — passed
- scoped `rustfmt --check` and `git diff --check` — passed

All gates above were rerun after rebasing onto the frozen base revision.

## Evidence pack

**Target:** Commit `3337041eafdec1f2daaedcdabbecd5eb5bfedef8` on `codex/issue-507-lossless-device-inventory-framing`.

**Viewing conditions:** Review the parser framer and watcher tail path together. Run the two focused tests above. They exercise Harvester, InventoryAdaptor, and RotationFailure; continuation appends delayed beyond the former debounce; every interior split of 2-, 3-, and 4-byte UTF-8 scalars; split UTF-8 BOM; transactional invalid UTF-8; terminal lone prefixes for every scalar width and a partial BOM; explicit EOF, parser-change, truncation, stop, and disconnect finalization; truncation reset batches that retain valid pending content plus exactly one error without duplicate follow-up emission; exact/overflow limits; and terminated plus unterminated lines over 3 MiB.

**Claims:**

- a delayed continuation is attached identically during initial parsing and tailing, regardless of wall-clock delay
- incomplete UTF-8 suffixes are retained across reads; invalid UTF-8 returns an error without mutating offset, framing, ID, or line state
- once a terminal boundary makes completion impossible, an incomplete UTF-8 suffix is consumed exactly once as a surfaced parse error; valid pending text is preserved and no replacement or Windows-1252 decoding occurs
- every terminal branch forwards the complete finalized batch; truncation never cherry-picks the error count while dropping valid pending entries
- parser and watcher pending observations remain within the parser-owned 1 MiB cap while oversized input is split incrementally at character boundaries
- initial `parse_content`/`parse_lines` and tailing produce equal entries, line numbers, severities, messages, and parse-error counts across all Device Inventory dialects

**Reproduce:** Run the focused parser/watcher commands, then the two full Rust suites and strict Clippy commands listed under Validation.

**Out of scope:** No frontend, IPC, parser detection, or non-Device-Inventory framing behavior changed. Browser E2E is not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device Inventory parsing now supports lossless handling of oversized records with UTF-8-safe splitting and a fixed 1 MB record limit.
  * Initial file loading and live updates now use consistent parsing and framing.
  * Pending records are finalized when input ends, parser settings change, files are truncated, or monitoring stops.

* **Bug Fixes**
  * Improved line numbering and error reporting for split or oversized records.
  * Preserved parsing accuracy across supported formats, delayed continuations, and encoding boundaries.
  * Invalid or incomplete input is handled safely without corrupting parser state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
