### PR TITLE
fix(graph): make WAM authentication non-blocking and cancellable

### DIFF
--- a/docs/superpowers/plans/2026-08-05-graph-auth-critic-rework.md
+++ b/docs/superpowers/plans/2026-08-05-graph-auth-critic-rework.md
@@ -1,0 +1,214 @@
+# Graph Authentication Critic Rework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove every passive WAM path, use one organizations-only scope request for all interactive Graph consent, and make cancellation target a native-issued non-reusable attempt.
+
+**Architecture:** Reading the in-memory connection snapshot remains passive and broker-free. An explicit sign-in or permission click first reserves an opaque native UUID ticket, then the matching command consumes that ticket exactly once and runs capability discovery plus WAM under the same lease and absolute deadline. Initial sign-in and permission upgrade share one scope-based organizations request; the legacy resource and compatibility paths are deleted.
+
+**Tech Stack:** Rust 1.88, Tauri 2, Windows WebAuthenticationCoreManager, UUID v4, React 19, TypeScript, Zustand, Vitest.
+
+---
+
+## File map
+
+- `src-tauri/src/graph_api/models.rs`: one WAM scope contract and serialized native attempt ticket.
+- `src-tauri/src/graph_api.rs`: native reservation/claim registry, generation-safe cancellation, shared WAM acquisition, and adversarial registry tests.
+- `src-tauri/src/commands/graph_api.rs`: reserve, authenticate, permission, and cancel IPC commands; no passive probe command.
+- `src-tauri/src/lib.rs`: command registration and IPC contract coverage.
+- `src-tauri/src/ipc_bridge.rs`: debug-command rejection list after deleting passive probe IPC.
+- `src-tauri/tests/graph_esp_diagnostics.rs`: source and serialization contracts for the single WAM path and native attempt ownership.
+- `src/lib/commands.ts`: validated reserve-ticket wrapper and attempt-ID-bearing interactive wrappers; no probe wrapper.
+- `src/lib/commands.test.ts`: valid and malformed native ticket and replay-safe IPC tests.
+- `src/components/dialogs/settings/GraphApiTab.tsx`: passive status-only mount and native-ticket interactive state machine.
+- `src/components/dialogs/settings/GraphApiTab.test.tsx`: literal no-WAM passive contract plus late, replay, remount, timeout, retry, and concurrency cases.
+- `src/stores/ui-store.ts`: remove the obsolete passive capability-check phase.
+- `src/stores/ui-store.test.ts`: restart remains disconnected with no transient operation.
+- `src/components/layout/StatusBar.tsx`: remove the obsolete capability-check indicator.
+
+### Task 1: Make mount, opt-in, restart, and remount broker-free
+
+**Files:**
+
+- Modify: `src/components/dialogs/settings/GraphApiTab.tsx`
+- Modify: `src/components/dialogs/settings/GraphApiTab.test.tsx`
+- Modify: `src/stores/ui-store.ts`
+- Modify: `src/components/layout/StatusBar.tsx`
+- Modify: `src/lib/commands.ts`
+- Modify: `src-tauri/src/commands/graph_api.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src-tauri/src/ipc_bridge.rs`
+
+- [ ] **Step 1: Write the literal passive-boundary test**
+
+Add one table-driven settings test that covers initial opt-in, persisted restart, mount, unmount/remount, and StrictMode initialization. For every scenario assert:
+
+```typescript
+expect(graphGetAuthStatus).toHaveBeenCalled();
+expect(graphReserveInteractiveOperation).not.toHaveBeenCalled();
+expect(graphAuthenticate).not.toHaveBeenCalled();
+expect(graphRequestMissingPermissions).not.toHaveBeenCalled();
+```
+
+The test must not mock or call a capability-probe wrapper because that wrapper is deleted.
+
+- [ ] **Step 2: Run the settings test and confirm failure**
+
+```bash
+npx vitest run src/components/dialogs/settings/GraphApiTab.test.tsx
+```
+
+Expected: the current mount effect calls `graphProbeCapability`.
+
+- [ ] **Step 3: Delete passive capability IPC and state**
+
+Delete `graphProbeCapability`, `graph_probe_capability`, standalone `probe_host_capability`, and `checkingCapability`. Replace the mount refresh body with only:
+
+```typescript
+const status = await graphGetAuthStatus();
+if (!isCurrentRefresh()) return;
+setAuthStatus(status);
+useUiStore.getState().setGraphApiStatus(graphApiPhaseFromStatus(status));
+```
+
+Capability discovery remains inside `authenticate` after the explicit click and shares its 120-second deadline.
+
+- [ ] **Step 4: Run focused frontend and IPC tests**
+
+```bash
+npx vitest run src/components/dialogs/settings/GraphApiTab.test.tsx src/lib/commands.test.ts src/stores/ui-store.test.ts
+npx tsc --noEmit
+```
+
+Expected: passive scenarios invoke only the in-memory status command.
+
+### Task 2: Collapse WAM onto one organizations-only scope request
+
+**Files:**
+
+- Modify: `src-tauri/src/graph_api/models.rs`
+- Modify: `src-tauri/src/graph_api.rs`
+- Modify: `src-tauri/tests/graph_esp_diagnostics.rs`
+
+- [ ] **Step 1: Replace compatibility tests with a single-contract test**
+
+Assert one contract with the five delegated scopes plus `openid profile offline_access`, no `resource`, no `wam_compat`, no request mode, and one native constructor path used by both authentication and permission upgrade.
+
+- [ ] **Step 2: Run the contract test and confirm failure**
+
+```bash
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked --test graph_esp_diagnostics graph_wam -- --nocapture
+```
+
+Expected: legacy resource and `wam_compat=2.0` assertions still exist.
+
+- [ ] **Step 3: Implement the one-path request**
+
+Keep one platform-neutral contract:
+
+```rust
+pub const GRAPH_WAM_SCOPE_REQUEST: &str = concat!(
+    "DeviceManagementManagedDevices.Read.All ",
+    "DeviceManagementServiceConfig.Read.All ",
+    "DeviceManagementApps.Read.All ",
+    "DeviceManagementConfiguration.Read.All ",
+    "DeviceManagementScripts.Read.All ",
+    "openid profile offline_access"
+);
+```
+
+Delete `GRAPH_SCOPE_REQUEST`, `GRAPH_WAM_PERMISSION_SCOPE_REQUEST`, both old request structs, `WamRequestMode`, the resource property branch, and the compatibility property branch. `authenticate` and `request_missing_permissions` must both call the same `wam::acquire_token`.
+
+- [ ] **Step 4: Run Graph model and integration tests**
+
+```bash
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_wam -- --nocapture
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked --all-features --test graph_esp_diagnostics
+```
+
+Expected: one organizations provider and one scope constructor are proven.
+
+### Task 3: Issue and consume native-owned attempt tickets
+
+**Files:**
+
+- Modify: `src-tauri/src/graph_api/models.rs`
+- Modify: `src-tauri/src/graph_api.rs`
+- Modify: `src-tauri/src/commands/graph_api.rs`
+- Modify: `src/lib/commands.ts`
+- Modify: `src/lib/commands.test.ts`
+- Modify: `src/components/dialogs/settings/GraphApiTab.tsx`
+- Modify: `src/components/dialogs/settings/GraphApiTab.test.tsx`
+
+- [ ] **Step 1: Write failing native ownership tests**
+
+Cover reserve/claim once, wrong-kind claim, duplicate claim, replayed cancel after drop, old cancel after a new reservation, cancel-before-claim, cancel plus restart, rapid retry, late publication, and a timeout-boundary cancellation. The registry shape is:
+
+```rust
+struct GraphInteractiveOperationEntry {
+    attempt_id: uuid::Uuid,
+    kind: GraphInteractiveOperationKind,
+    claimed: bool,
+    cancelled: Arc<AtomicBool>,
+    accepts_cancellation: bool,
+}
+```
+
+- [ ] **Step 2: Implement reserve then claim**
+
+Add a synchronous `graph_reserve_interactive_operation(kind)` command returning:
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct GraphInteractiveOperationTicket {
+    pub attempt_id: String,
+}
+```
+
+`reserve` creates `Uuid::new_v4()` inside native state. `claim` must match ticket plus operation kind and flip `claimed` exactly once. Cancel accepts only the native ticket. Drop removes only the matching UUID. Replayed or delayed old tickets return `false` and cannot affect a later entry.
+
+- [ ] **Step 3: Move the frontend to native tickets**
+
+Remove `crypto.randomUUID()` from Graph authentication. After `beginSharedGraphAction`, await the reserve wrapper, attach its validated UUID to the current action, then call authenticate or permission consent. If the action was retired, disabled, or superseded before reservation resolves, immediately send cancel for that ticket and never call WAM.
+
+- [ ] **Step 4: Add adversarial frontend and IPC tests**
+
+Cover duplicate/replayed native ticket responses, cancel then retry with a distinct ticket, late success after disable/re-enable, controlled timeout result, rapid clicks, unmount/remount, and simultaneous authentication/permission attempts. Malformed or reused reserve payloads must reject before interactive IPC.
+
+- [ ] **Step 5: Run focused native and frontend suites**
+
+```bash
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_interactive_operation -- --nocapture
+npx vitest run src/components/dialogs/settings/GraphApiTab.test.tsx src/lib/commands.test.ts
+npx tsc --noEmit
+```
+
+Expected: every cancel is bound to one native UUID generation.
+
+### Task 4: Freeze and verify the reworked PR
+
+**Files:**
+
+- Modify: `docs/superpowers/plans/2026-08-05-graph-auth-critic-rework.md`
+- Modify: `library.md`
+
+- [ ] **Step 1: Run local gates**
+
+```bash
+npm test -- --run
+npm run frontend:build
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked --workspace --all-features
+cargo +1.88 --manifest-path src-tauri/Cargo.toml clippy --locked --workspace --all-targets --all-features -- -D warnings
+```
+
+- [ ] **Step 2: Rebase current main and rerun affected gates**
+
+Fetch and rebase only if `origin/main` is not an ancestor. Record the frozen SHA after the final commit.
+
+- [ ] **Step 3: Push and hold for hosted evidence**
+
+Require green TypeScript, E2E, Rust, both MSRV lanes, Windows Graph/ESP/full-workspace/Clippy, CodeQL, and Windows/Linux/macOS packages. Do not merge and do not begin live WAM validation.
+
+- [ ] **Step 4: Update the PR evidence pack**
+
+Record target SHA, CI run, claims, reproduce commands, viewing conditions, and the explicit out-of-scope statement: live WAM validation was not started during this rework.

--- a/docs/superpowers/plans/2026-08-05-graph-auth-nonblocking.md
+++ b/docs/superpowers/plans/2026-08-05-graph-auth-nonblocking.md
@@ -1,0 +1,300 @@
+# Graph API Non-Blocking WAM Authentication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Graph authentication responsive, cancellable, capability-aware, and deterministic on Windows while preserving explicit opt-in and the existing delegated-permission workflow.
+
+**Architecture:** Keep one organizations-only Windows WAM path. Separate the persistent connection snapshot from the last interactive attempt, execute every WAM operation on a blocking worker behind an async Tauri command, and give the backend sole ownership of one request-ID-scoped interactive operation at a time. The frontend persists only the opt-in preference; runtime capability, action, and attempt state reset on process restart and never launch WAM automatically.
+
+**Tech Stack:** Rust 1.88, Tauri 2, Windows WebAuthenticationCoreManager/WAM, React 19, TypeScript, Zustand, Vitest.
+
+---
+
+## File map
+
+- `src-tauri/src/graph_api/models.rs`: serialized capability, connection, and attempt contracts.
+- `src-tauri/src/graph_api.rs`: capability classification, one-operation ownership, cancellation, deadline handling, token-generation safety, and Windows WAM execution.
+- `src-tauri/src/commands/graph_api.rs`: async/off-thread IPC entry points and HWND lifetime handling.
+- `src-tauri/src/lib.rs`: command registration and IPC coverage.
+- `src/lib/commands.ts`: exact TypeScript mirrors and request-ID-bearing command wrappers.
+- `src/stores/ui-store.ts`: non-persisted deterministic Graph runtime phase, capability, and last-attempt state; only `graphApiEnabled` remains persisted.
+- `src/stores/ui-store.test.ts`: persistence/restart contract.
+- `src/components/dialogs/settings/GraphApiTab.tsx`: explicit consent, capability check, sign-in/cancel controls, and typed outcome rendering.
+- `src/components/dialogs/settings/GraphApiTab.test.tsx`: frontend state-machine, remount, cancellation, and stale-completion behavior.
+- `src-tauri/tests/graph_esp_diagnostics.rs`: serialized Graph status contract adjustments after removing attempt errors from connection state.
+- `e2e/graph-api-settings.spec.ts`: running-app settings smoke coverage proving opt-in does not launch Windows WAM.
+
+### Task 1: Define typed capability and authentication-attempt contracts
+
+**Files:**
+- Modify: `src-tauri/src/graph_api/models.rs`
+- Modify: `src/lib/commands.ts`
+- Test: `src-tauri/src/graph_api/models.rs`
+- Test: `src-tauri/tests/graph_esp_diagnostics.rs`
+
+- [ ] **Step 1: Write failing Rust serialization tests**
+
+Cover the exact camel-case JSON contract for:
+
+```rust
+pub enum GraphHostCapabilityKind {
+    Available,
+    PersonalAccountOnly,
+    NoOrganizationalAccount,
+    ProviderUnavailable,
+    Unknown,
+}
+
+pub struct GraphHostCapability {
+    pub kind: GraphHostCapabilityKind,
+}
+
+pub enum GraphAuthAttemptOutcome {
+    Connected,
+    Cancelled,
+    TimedOut,
+    Unavailable,
+    Failed,
+    Stale,
+}
+
+pub struct GraphAuthAttemptResult {
+    pub outcome: GraphAuthAttemptOutcome,
+    pub status: GraphAuthStatus,
+    pub capability: GraphHostCapability,
+    pub message: Option<String>,
+}
+```
+
+Verify that `GraphAuthStatus` contains connection and delegated-capability data only; remove its obsolete `error` field and make `GraphAuthStatus::disconnected()` argument-free.
+
+- [ ] **Step 2: Run the contract tests and confirm they fail**
+
+Run from `src-tauri/`:
+
+```bash
+cargo +1.88 test --locked graph_auth_attempt_contract -- --nocapture
+```
+
+Expected: compilation or assertion failure because the new types do not exist yet.
+
+- [ ] **Step 3: Implement the minimal Rust and TypeScript contracts**
+
+Mirror the Rust shapes exactly in `src/lib/commands.ts`; do not add permissive optional fields or string aliases. Replace `graphAuthenticate()` with `graphAuthenticate(requestId)` returning `GraphAuthAttemptResult`, add `graphProbeCapability()`, and add `graphCancelAuthentication(requestId)`.
+
+- [ ] **Step 4: Update status fixtures and run contract tests**
+
+Run:
+
+```bash
+cargo +1.88 test --locked graph_auth -- --nocapture
+npx vitest run src/components/dialogs/settings/GraphApiTab.test.tsx
+```
+
+Expected: Rust contract tests pass; frontend tests may still fail where they expect the old command signature or error-bearing status.
+
+- [ ] **Step 5: Commit the contract package**
+
+```bash
+git add src-tauri/src/graph_api/models.rs src-tauri/tests/graph_esp_diagnostics.rs src/lib/commands.ts
+git commit -m "refactor(graph): type authentication attempts"
+```
+
+### Task 2: Add native capability probing, ownership, cancellation, and deadline safety
+
+**Files:**
+- Modify: `src-tauri/src/graph_api.rs`
+
+- [ ] **Step 1: Write failing platform-neutral operation tests**
+
+Add tests proving:
+
+- only one interactive request ID owns the native slot;
+- a mismatched request ID cannot cancel it;
+- a matching request ID sets cancellation exactly once;
+- dropping the lease releases ownership;
+- late token set/clear operations cannot cross an auth generation;
+- cancelled and timed-out waits are distinct;
+- one absolute deadline is reused across provider lookup, account enumeration, and token acquisition.
+
+- [ ] **Step 2: Write failing capability-classification tests**
+
+Use pure inputs rather than WinRT objects:
+
+```rust
+fn classify_graph_host_capability(
+    organizational_accounts: AccountEnumeration,
+    personal_accounts: AccountEnumeration,
+) -> GraphHostCapabilityKind
+```
+
+Cover organizational account available, personal-only, no accounts, provider unavailable, enumeration denied/not supported, and unknown provider failure.
+
+- [ ] **Step 3: Run the focused tests and confirm failure**
+
+```bash
+cargo +1.88 test --locked graph_interactive_operation -- --nocapture
+cargo +1.88 test --locked graph_host_capability -- --nocapture
+```
+
+- [ ] **Step 4: Implement the single-owner operation lease**
+
+Store one active `{ request_id, cancelled }` entry under `GraphAuthState`. Return a lease that owns the cancellation flag and releases only its matching request on drop. Do not log request-adjacent identity data, tokens, tenant IDs, or UPNs.
+
+- [ ] **Step 5: Make WAM waiting cooperative**
+
+Replace the single 120-second `recv_timeout` with a bounded polling loop that checks the matching lease cancellation flag and the same absolute deadline. On cancellation or timeout, call `IAsyncOperation::Cancel()` and return a typed acquisition failure. Never use a second timeout budget for later WAM stages.
+
+- [ ] **Step 6: Implement organizations-only capability discovery**
+
+On the initialized WinRT worker, use the existing Microsoft provider ID with the `organizations` authority and `FindAllAccountsAsync`. Query `consumers` only to distinguish a proven personal-only host after organizations returns zero accounts. Do not authenticate against `consumers` or `common`. Treat enumeration-denied/not-supported results as `Unknown`, not as proof that no organizational account exists.
+
+- [ ] **Step 7: Gate authentication and preserve token safety**
+
+Before interactive token acquisition, perform capability discovery under the operation's absolute deadline. Return `Unavailable` without showing WAM for proven personal-only, no-organizational-account, or unavailable-provider states. Re-check cancellation after WAM returns and before installing a token. A cancelled, timed-out, failed, unavailable, or stale operation must not publish a token.
+
+- [ ] **Step 8: Put permission upgrade under the same owner**
+
+Pass a request-scoped lease to the existing permission-upgrade WAM operation. Preserve current cancellation/denial/unchanged/upgraded semantics and original-token retention, while preventing it from overlapping initial sign-in.
+
+- [ ] **Step 9: Run native unit tests and commit**
+
+```bash
+cargo +1.88 test --locked graph_interactive_operation -- --nocapture
+cargo +1.88 test --locked graph_host_capability -- --nocapture
+cargo +1.88 test --locked graph_permission_upgrade -- --nocapture
+git add src-tauri/src/graph_api.rs
+git commit -m "fix(graph): own and cancel WAM operations"
+```
+
+### Task 3: Move Graph authentication behind async Tauri commands
+
+**Files:**
+- Modify: `src-tauri/src/commands/graph_api.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Add IPC coverage for the new command names and request ID**
+
+Assert that the handler exposes `graph_probe_capability`, async `graph_authenticate`, and `graph_cancel_authentication`; initial authentication and permission upgrade both require `requestId`.
+
+- [ ] **Step 2: Replace the synchronous authentication command**
+
+Make `graph_authenticate` async, acquire the main HWND/always-on-top guard, clone managed state, claim the request lease, and run WinRT work through `tauri::async_runtime::spawn_blocking`. Remove the old direct synchronous path rather than retaining an alias or fallback.
+
+- [ ] **Step 3: Add capability and cancellation commands**
+
+Run capability probing on `spawn_blocking`. Keep cancellation lightweight and synchronous: it may set only the matching native flag and returns whether a request was cancelled.
+
+- [ ] **Step 4: Apply the same request-ID ownership to permission upgrades**
+
+Change the permission command signature rather than adding a compatibility overload.
+
+- [ ] **Step 5: Run Rust checks and commit**
+
+```bash
+cargo +1.88 check --locked
+cargo +1.88 test --locked graph_auth -- --nocapture
+git add src-tauri/src/commands/graph_api.rs src-tauri/src/lib.rs
+git commit -m "fix(graph): run WAM authentication off thread"
+```
+
+### Task 4: Implement deterministic frontend states and cancellation UX
+
+**Files:**
+- Modify: `src/stores/ui-store.ts`
+- Modify: `src/stores/ui-store.test.ts`
+- Modify: `src/components/dialogs/settings/GraphApiTab.tsx`
+- Modify: `src/components/dialogs/settings/GraphApiTab.test.tsx`
+
+- [ ] **Step 1: Write failing store persistence tests**
+
+Replace the old four-phase status with:
+
+```typescript
+type GraphApiPhase =
+  | "checkingCapability"
+  | "disconnected"
+  | "signingIn"
+  | "cancelling"
+  | "connected"
+  | "unsupported"
+  | "error";
+```
+
+Add non-persisted `graphApiCapability` and `graphApiLastAttempt`. Verify that rehydration restores only `graphApiEnabled`, resets runtime state to `disconnected`, and never marks an operation active.
+
+- [ ] **Step 2: Write failing Graph settings tests**
+
+Cover explicit opt-in without automatic WAM, capability checking, available/personal-only/no-organizational/provider-unavailable/unknown rendering, request-ID forwarding, sign-in cancellation, cancellation during disable, timeout Retry, remount, StrictMode, stale completion, concurrent-click suppression, and restart without automatic interactive authentication.
+
+- [ ] **Step 3: Implement the runtime state transitions**
+
+On opt-in or restart, refresh the in-memory connection snapshot, then run only the non-interactive capability probe when disconnected. Never call `graphAuthenticate` from an effect. Store typed capability and attempt results separately from `GraphAuthStatus`.
+
+- [ ] **Step 4: Implement sign-in and cancellation controls**
+
+Generate one request ID per interactive action. Show `Cancel sign-in` during initial authentication and a cancelling state after the matching cancel command is sent. Do not release the shared frontend action until the native promise settles. Disable/re-enable must not allow a second request while cancellation is pending.
+
+- [ ] **Step 5: Preserve explicit permission consent**
+
+Give permission upgrade its own request ID, place it under the same shared busy/cancel ownership, and keep existing upgraded/unchanged/cancelled/denied/failed/stale copy and token-retention behavior.
+
+- [ ] **Step 6: Render deterministic capability-aware copy**
+
+Tell personal-only users that Intune Graph requires a work or school account. Tell no-organizational-account users to add a work or school account in Windows Settings. Keep unknown capability retryable without claiming the host lacks Entra. Do not display raw provider responses.
+
+- [ ] **Step 7: Run frontend tests and commit**
+
+```bash
+npx vitest run src/components/dialogs/settings/GraphApiTab.test.tsx src/stores/ui-store.test.ts
+npx tsc --noEmit
+git add src/stores/ui-store.ts src/stores/ui-store.test.ts src/components/dialogs/settings/GraphApiTab.tsx src/components/dialogs/settings/GraphApiTab.test.tsx
+git commit -m "fix(graph): make sign-in cancellable and deterministic"
+```
+
+### Task 5: Integration verification and evidence handoff
+
+**Files:**
+- Create: `e2e/graph-api-settings.spec.ts`
+- Modify: `docs/superpowers/plans/2026-08-05-graph-auth-nonblocking.md`
+
+- [ ] **Step 1: Run focused verification**
+
+```bash
+npx vitest run src/components/dialogs/settings/GraphApiTab.test.tsx src/stores/ui-store.test.ts
+cargo +1.88 test --locked graph_auth -- --nocapture
+cargo +1.88 test --locked graph_permission_upgrade -- --nocapture
+```
+
+- [ ] **Step 2: Run full repository gates**
+
+```bash
+npx tsc --noEmit
+npm test -- --run
+npm run frontend:build
+cargo +1.88 test --locked --workspace
+cargo +1.88 clippy --locked --workspace --all-targets --all-features -- -D warnings
+```
+
+- [ ] **Step 3: Run available platform checks**
+
+On macOS, verify non-Windows configuration and compile Windows-target code if the MSVC target/link-independent check is available. Do not claim WAM runtime acceptance from compilation.
+
+- [ ] **Step 4: Integrate current main and rerun affected gates**
+
+Fetch `origin/main`, rebase the branch, record the new frozen SHA, and rerun focused Rust/TypeScript tests plus strict clippy/typecheck.
+
+- [ ] **Step 5: Prepare the Windows evidence pack**
+
+Require an exact Windows full-build SHA and six inspectable scenarios: organizational happy path, broker cancel, provider error, controlled 120-second timeout, personal/no-Entra host, and restart during sign-in. Each record includes viewing conditions, monotonic timestamps, typed outcome, reproduce steps, and out-of-scope statement. Redact identity and token material.
+
+- [ ] **Step 6: Commit documentation, push, and open the PR**
+
+```bash
+git add docs/superpowers/plans/2026-08-05-graph-auth-nonblocking.md library.md e2e/graph-api-settings.spec.ts
+git commit -m "docs(graph): record issue 441 verification"
+git push -u origin codex/issue-441-nonblocking-graph-auth
+gh pr create --base main --head codex/issue-441-nonblocking-graph-auth
+```
+
+The PR body must contain `Closes #441`, the final frozen SHA, commands/results, the Windows evidence matrix, and an explicit statement that Windows-only runtime acceptance remains required before merge.

--- a/docs/superpowers/plans/2026-08-05-graph-auth-nonblocking.md
+++ b/docs/superpowers/plans/2026-08-05-graph-auth-nonblocking.md
@@ -27,6 +27,7 @@
 ### Task 1: Define typed capability and authentication-attempt contracts
 
 **Files:**
+
 - Modify: `src-tauri/src/graph_api/models.rs`
 - Modify: `src/lib/commands.ts`
 - Test: `src-tauri/src/graph_api/models.rs`
@@ -73,7 +74,7 @@ Verify that `GraphAuthStatus` contains connection and delegated-capability data 
 Run from `src-tauri/`:
 
 ```bash
-cargo +1.88 test --locked graph_auth_attempt_contract -- --nocapture
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_auth_attempt_contract -- --nocapture
 ```
 
 Expected: compilation or assertion failure because the new types do not exist yet.
@@ -87,7 +88,7 @@ Mirror the Rust shapes exactly in `src/lib/commands.ts`; do not add permissive o
 Run:
 
 ```bash
-cargo +1.88 test --locked graph_auth -- --nocapture
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_auth -- --nocapture
 npx vitest run src/components/dialogs/settings/GraphApiTab.test.tsx
 ```
 
@@ -103,6 +104,7 @@ git commit -m "refactor(graph): type authentication attempts"
 ### Task 2: Add native capability probing, ownership, cancellation, and deadline safety
 
 **Files:**
+
 - Modify: `src-tauri/src/graph_api.rs`
 
 - [ ] **Step 1: Write failing platform-neutral operation tests**
@@ -133,8 +135,8 @@ Cover organizational account available, personal-only, no accounts, provider una
 - [ ] **Step 3: Run the focused tests and confirm failure**
 
 ```bash
-cargo +1.88 test --locked graph_interactive_operation -- --nocapture
-cargo +1.88 test --locked graph_host_capability -- --nocapture
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_interactive_operation -- --nocapture
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_host_capability -- --nocapture
 ```
 
 - [ ] **Step 4: Implement the single-owner operation lease**
@@ -160,9 +162,9 @@ Pass a request-scoped lease to the existing permission-upgrade WAM operation. Pr
 - [ ] **Step 9: Run native unit tests and commit**
 
 ```bash
-cargo +1.88 test --locked graph_interactive_operation -- --nocapture
-cargo +1.88 test --locked graph_host_capability -- --nocapture
-cargo +1.88 test --locked graph_permission_upgrade -- --nocapture
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_interactive_operation -- --nocapture
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_host_capability -- --nocapture
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_permission_upgrade -- --nocapture
 git add src-tauri/src/graph_api.rs
 git commit -m "fix(graph): own and cancel WAM operations"
 ```
@@ -170,6 +172,7 @@ git commit -m "fix(graph): own and cancel WAM operations"
 ### Task 3: Move Graph authentication behind async Tauri commands
 
 **Files:**
+
 - Modify: `src-tauri/src/commands/graph_api.rs`
 - Modify: `src-tauri/src/lib.rs`
 
@@ -192,8 +195,8 @@ Change the permission command signature rather than adding a compatibility overl
 - [ ] **Step 5: Run Rust checks and commit**
 
 ```bash
-cargo +1.88 check --locked
-cargo +1.88 test --locked graph_auth -- --nocapture
+cargo +1.88 --manifest-path src-tauri/Cargo.toml check --locked
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_auth -- --nocapture
 git add src-tauri/src/commands/graph_api.rs src-tauri/src/lib.rs
 git commit -m "fix(graph): run WAM authentication off thread"
 ```
@@ -201,6 +204,7 @@ git commit -m "fix(graph): run WAM authentication off thread"
 ### Task 4: Implement deterministic frontend states and cancellation UX
 
 **Files:**
+
 - Modify: `src/stores/ui-store.ts`
 - Modify: `src/stores/ui-store.test.ts`
 - Modify: `src/components/dialogs/settings/GraphApiTab.tsx`
@@ -255,6 +259,7 @@ git commit -m "fix(graph): make sign-in cancellable and deterministic"
 ### Task 5: Integration verification and evidence handoff
 
 **Files:**
+
 - Create: `e2e/graph-api-settings.spec.ts`
 - Modify: `docs/superpowers/plans/2026-08-05-graph-auth-nonblocking.md`
 
@@ -262,8 +267,8 @@ git commit -m "fix(graph): make sign-in cancellable and deterministic"
 
 ```bash
 npx vitest run src/components/dialogs/settings/GraphApiTab.test.tsx src/stores/ui-store.test.ts
-cargo +1.88 test --locked graph_auth -- --nocapture
-cargo +1.88 test --locked graph_permission_upgrade -- --nocapture
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_auth -- --nocapture
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked graph_permission_upgrade -- --nocapture
 ```
 
 - [ ] **Step 2: Run full repository gates**
@@ -272,8 +277,8 @@ cargo +1.88 test --locked graph_permission_upgrade -- --nocapture
 npx tsc --noEmit
 npm test -- --run
 npm run frontend:build
-cargo +1.88 test --locked --workspace
-cargo +1.88 clippy --locked --workspace --all-targets --all-features -- -D warnings
+cargo +1.88 --manifest-path src-tauri/Cargo.toml test --locked --workspace
+cargo +1.88 --manifest-path src-tauri/Cargo.toml clippy --locked --workspace --all-targets --all-features -- -D warnings
 ```
 
 - [ ] **Step 3: Run available platform checks**

--- a/library.md
+++ b/library.md
@@ -1,6 +1,7 @@
 # CMTrace Open — Workspace Library
 
 - IF implementing or reviewing SCCM issue #409 server intake synthetic identity grammar → read [[docs/superpowers/plans/2026-08-05-sccm-409-server-intake-identity-grammar.md]]
+- IF implementing or reviewing Graph API non-blocking WAM authentication for issue #441 → read [[docs/superpowers/plans/2026-08-05-graph-auth-nonblocking.md]]
 - IF implementing or reviewing SCCM issue #321 client policy production analysis → read [[docs/superpowers/plans/2026-08-04-sccm-321-policy-production.md]]
 - IF implementing or reviewing SCCM issue #333 client/server production correlation → read [[docs/superpowers/plans/2026-08-04-sccm-333-production-correlation.md]]
 - IF reviewing SCCM issue #333 executable correlation fixture oracles → read [[crates/cmtraceopen-parser/tests/fixtures/sccm/correlation/README.md]]

--- a/library.md
+++ b/library.md
@@ -2,6 +2,7 @@
 
 - IF implementing or reviewing SCCM issue #409 server intake synthetic identity grammar → read [[docs/superpowers/plans/2026-08-05-sccm-409-server-intake-identity-grammar.md]]
 - IF implementing or reviewing Graph API non-blocking WAM authentication for issue #441 → read [[docs/superpowers/plans/2026-08-05-graph-auth-nonblocking.md]]
+- IF reworking Graph API authentication after the PR #512 critic gate → read [[docs/superpowers/plans/2026-08-05-graph-auth-critic-rework.md]]
 - IF implementing or reviewing SCCM issue #321 client policy production analysis → read [[docs/superpowers/plans/2026-08-04-sccm-321-policy-production.md]]
 - IF implementing or reviewing SCCM issue #333 client/server production correlation → read [[docs/superpowers/plans/2026-08-04-sccm-333-production-correlation.md]]
 - IF reviewing SCCM issue #333 executable correlation fixture oracles → read [[crates/cmtraceopen-parser/tests/fixtures/sccm/correlation/README.md]]

--- a/src-tauri/src/commands/graph_api.rs
+++ b/src-tauri/src/commands/graph_api.rs
@@ -9,7 +9,7 @@ use crate::graph_api::models::GraphPermissionUpgradeResult;
 #[cfg(target_os = "windows")]
 use crate::graph_api::{
     self, GraphAppInfo, GraphAuthAttemptResult, GraphAuthState, GraphAuthStatus,
-    GraphHostCapability, GraphResolutionResult,
+    GraphResolutionResult,
 };
 #[cfg(feature = "esp-diagnostics")]
 use cmtraceopen_parser::esp::EspGraphOverlay;
@@ -87,13 +87,25 @@ impl Drop for InteractiveAuthWindow {
 
 #[tauri::command]
 #[cfg(target_os = "windows")]
+pub fn graph_reserve_interactive_operation(
+    kind: graph_api::GraphInteractiveOperationKind,
+    state: tauri::State<'_, GraphAuthState>,
+) -> CmdResult<graph_api::GraphInteractiveOperationTicket> {
+    state.reserve_interactive_operation(kind)
+}
+
+#[tauri::command]
+#[cfg(target_os = "windows")]
 pub async fn graph_authenticate(
-    request_id: String,
+    attempt_id: String,
     app: tauri::AppHandle,
     state: tauri::State<'_, GraphAuthState>,
 ) -> CmdResult<GraphAuthAttemptResult> {
     let state = state.inner().clone();
-    let lease = state.begin_interactive_operation(request_id)?;
+    let lease = state.claim_interactive_operation(
+        &attempt_id,
+        graph_api::GraphInteractiveOperationKind::Authentication,
+    )?;
     let window = InteractiveAuthWindow::acquire(&app)?;
     let hwnd = window.hwnd();
     tauri::async_runtime::spawn_blocking(move || graph_api::authenticate(&state, hwnd, &lease))
@@ -103,30 +115,25 @@ pub async fn graph_authenticate(
 
 #[tauri::command]
 #[cfg(target_os = "windows")]
-pub async fn graph_probe_capability() -> CmdResult<GraphHostCapability> {
-    tauri::async_runtime::spawn_blocking(graph_api::probe_host_capability)
-        .await
-        .map_err(|error| AppError::Internal(format!("GraphCapabilityTaskFailed: {error}")))
-}
-
-#[tauri::command]
-#[cfg(target_os = "windows")]
 pub fn graph_cancel_authentication(
-    request_id: String,
+    attempt_id: String,
     state: tauri::State<'_, GraphAuthState>,
 ) -> bool {
-    state.cancel_interactive_operation(&request_id)
+    state.cancel_interactive_operation(&attempt_id)
 }
 
 #[tauri::command]
 #[cfg(target_os = "windows")]
 pub async fn graph_request_missing_permissions(
-    request_id: String,
+    attempt_id: String,
     app: tauri::AppHandle,
     state: tauri::State<'_, GraphAuthState>,
 ) -> CmdResult<GraphPermissionUpgradeResult> {
     let state = state.inner().clone();
-    let lease = state.begin_interactive_operation(request_id)?;
+    let lease = state.claim_interactive_operation(
+        &attempt_id,
+        graph_api::GraphInteractiveOperationKind::PermissionConsent,
+    )?;
     // The guard is held across the await and restores the pin on scope exit,
     // including the `?` early return below.
     let window = InteractiveAuthWindow::acquire(&app)?;

--- a/src-tauri/src/commands/graph_api.rs
+++ b/src-tauri/src/commands/graph_api.rs
@@ -8,7 +8,8 @@ use crate::graph_api::esp::EspGraphRequest;
 use crate::graph_api::models::GraphPermissionUpgradeResult;
 #[cfg(target_os = "windows")]
 use crate::graph_api::{
-    self, GraphAppInfo, GraphAuthState, GraphAuthStatus, GraphResolutionResult,
+    self, GraphAppInfo, GraphAuthAttemptResult, GraphAuthState, GraphAuthStatus,
+    GraphHostCapability, GraphResolutionResult,
 };
 #[cfg(feature = "esp-diagnostics")]
 use cmtraceopen_parser::esp::EspGraphOverlay;
@@ -86,27 +87,52 @@ impl Drop for InteractiveAuthWindow {
 
 #[tauri::command]
 #[cfg(target_os = "windows")]
-pub fn graph_authenticate(
+pub async fn graph_authenticate(
+    request_id: String,
     app: tauri::AppHandle,
     state: tauri::State<'_, GraphAuthState>,
-) -> CmdResult<GraphAuthStatus> {
+) -> CmdResult<GraphAuthAttemptResult> {
+    let state = state.inner().clone();
+    let lease = state.begin_interactive_operation(request_id)?;
     let window = InteractiveAuthWindow::acquire(&app)?;
-    graph_api::authenticate(&state, window.hwnd())
+    let hwnd = window.hwnd();
+    tauri::async_runtime::spawn_blocking(move || graph_api::authenticate(&state, hwnd, &lease))
+        .await
+        .map_err(|error| AppError::Internal(format!("GraphAuthenticationTaskFailed: {error}")))
+}
+
+#[tauri::command]
+#[cfg(target_os = "windows")]
+pub async fn graph_probe_capability() -> CmdResult<GraphHostCapability> {
+    tauri::async_runtime::spawn_blocking(graph_api::probe_host_capability)
+        .await
+        .map_err(|error| AppError::Internal(format!("GraphCapabilityTaskFailed: {error}")))
+}
+
+#[tauri::command]
+#[cfg(target_os = "windows")]
+pub fn graph_cancel_authentication(
+    request_id: String,
+    state: tauri::State<'_, GraphAuthState>,
+) -> bool {
+    state.cancel_interactive_operation(&request_id)
 }
 
 #[tauri::command]
 #[cfg(target_os = "windows")]
 pub async fn graph_request_missing_permissions(
+    request_id: String,
     app: tauri::AppHandle,
     state: tauri::State<'_, GraphAuthState>,
 ) -> CmdResult<GraphPermissionUpgradeResult> {
+    let state = state.inner().clone();
+    let lease = state.begin_interactive_operation(request_id)?;
     // The guard is held across the await and restores the pin on scope exit,
     // including the `?` early return below.
     let window = InteractiveAuthWindow::acquire(&app)?;
     let hwnd = window.hwnd();
-    let state = state.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        graph_api::request_missing_permissions_on_initialized_worker(&state, hwnd)
+        graph_api::request_missing_permissions(&state, hwnd, &lease)
     })
     .await
     .map_err(|error| AppError::Internal(format!("GraphPermissionTaskFailed: {error}")))?

--- a/src-tauri/src/graph_api.rs
+++ b/src-tauri/src/graph_api.rs
@@ -250,31 +250,6 @@ impl Drop for GraphInteractiveOperationLease {
 }
 
 #[cfg(any(target_os = "windows", test))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DeadlineReceiveError {
-    Timeout,
-    Disconnected,
-}
-
-#[cfg(any(target_os = "windows", test))]
-fn receive_before_deadline<T>(
-    receiver: &std::sync::mpsc::Receiver<T>,
-    deadline: std::time::Instant,
-) -> Result<T, DeadlineReceiveError> {
-    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-    if remaining.is_zero() {
-        return Err(DeadlineReceiveError::Timeout);
-    }
-    match receiver.recv_timeout(remaining) {
-        Ok(value) => Ok(value),
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(DeadlineReceiveError::Timeout),
-        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            Err(DeadlineReceiveError::Disconnected)
-        }
-    }
-}
-
-#[cfg(any(target_os = "windows", test))]
 fn invalid_graph_app_response(required_scope: &str) -> client::GraphClientError {
     client::GraphClientError::new(
         client::GraphClientErrorKind::InvalidResponse,
@@ -2416,15 +2391,12 @@ pub use windows_impl::*;
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::sync::mpsc;
-    use std::time::{Duration, Instant};
-
     use super::client::GraphClientErrorKind;
     use super::{
         parse_graph_app_json, parse_graph_app_values, GraphAppInfo, VersionedAuthSlot,
         VersionedGuidCache,
     };
+    use std::collections::HashMap;
 
     const APP_A: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     const APP_B: &str = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
@@ -2545,35 +2517,6 @@ mod tests {
                 "near miss was classified as a denial: {error_code:?} {message:?}"
             );
         }
-    }
-
-    #[test]
-    fn deadline_receiver_distinguishes_ready_timeout_and_disconnect() {
-        let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
-        ready_sender.send(7_u8).expect("ready value");
-        assert_eq!(
-            super::receive_before_deadline(
-                &ready_receiver,
-                Instant::now() + Duration::from_secs(1)
-            ),
-            Ok(7)
-        );
-
-        let (_pending_sender, pending_receiver) = mpsc::sync_channel::<u8>(1);
-        assert_eq!(
-            super::receive_before_deadline(&pending_receiver, Instant::now()),
-            Err(super::DeadlineReceiveError::Timeout)
-        );
-
-        let (disconnected_sender, disconnected_receiver) = mpsc::sync_channel::<u8>(1);
-        drop(disconnected_sender);
-        assert_eq!(
-            super::receive_before_deadline(
-                &disconnected_receiver,
-                Instant::now() + Duration::from_secs(1)
-            ),
-            Err(super::DeadlineReceiveError::Disconnected)
-        );
     }
 
     fn app(id: &str, name: &str) -> GraphAppInfo {

--- a/src-tauri/src/graph_api.rs
+++ b/src-tauri/src/graph_api.rs
@@ -371,6 +371,7 @@ mod windows_impl {
         status: GraphAuthStatus,
     }
 
+    #[derive(Debug)]
     enum WamAcquisitionFailure {
         Cancelled,
         TimedOut,
@@ -666,7 +667,12 @@ mod windows_impl {
                     &HSTRING::from(authority),
                 ) {
                     Ok(operation) => operation,
-                    Err(_) => return Ok(GraphAccountEnumeration::ProviderUnavailable),
+                    Err(error) => {
+                        log::debug!(
+                            "event=graph_capability_provider_lookup_failed authority={authority} error={error}"
+                        );
+                        return Ok(GraphAccountEnumeration::ProviderUnavailable);
+                    }
                 };
             let provider = match wait_for_operation(&provider_operation, deadline, cancelled) {
                 Ok(provider) => provider,
@@ -676,16 +682,25 @@ mod windows_impl {
                 Err(WamAcquisitionFailure::TimedOut) => {
                     return Err(WamAcquisitionFailure::TimedOut)
                 }
-                Err(WamAcquisitionFailure::Denied | WamAcquisitionFailure::Failed) => {
-                    return Ok(GraphAccountEnumeration::ProviderUnavailable)
+                Err(failure @ (WamAcquisitionFailure::Denied | WamAcquisitionFailure::Failed)) => {
+                    log::debug!(
+                        "event=graph_capability_provider_lookup_wait_failed authority={authority} failure={failure:?}"
+                    );
+                    return Ok(GraphAccountEnumeration::ProviderUnavailable);
                 }
             };
 
-            let accounts_operation =
-                match WebAuthenticationCoreManager::FindAllAccountsAsync(&provider) {
-                    Ok(operation) => operation,
-                    Err(_) => return Ok(GraphAccountEnumeration::Unknown),
-                };
+            let accounts_operation = match WebAuthenticationCoreManager::FindAllAccountsAsync(
+                &provider,
+            ) {
+                Ok(operation) => operation,
+                Err(error) => {
+                    log::debug!(
+                            "event=graph_capability_account_discovery_failed authority={authority} error={error}"
+                        );
+                    return Ok(GraphAccountEnumeration::Unknown);
+                }
+            };
             let result = match wait_for_operation(&accounts_operation, deadline, cancelled) {
                 Ok(result) => result,
                 Err(WamAcquisitionFailure::Cancelled) => {
@@ -694,8 +709,11 @@ mod windows_impl {
                 Err(WamAcquisitionFailure::TimedOut) => {
                     return Err(WamAcquisitionFailure::TimedOut)
                 }
-                Err(WamAcquisitionFailure::Denied | WamAcquisitionFailure::Failed) => {
-                    return Ok(GraphAccountEnumeration::Unknown)
+                Err(failure @ (WamAcquisitionFailure::Denied | WamAcquisitionFailure::Failed)) => {
+                    log::debug!(
+                        "event=graph_capability_account_discovery_wait_failed authority={authority} failure={failure:?}"
+                    );
+                    return Ok(GraphAccountEnumeration::Unknown);
                 }
             };
 
@@ -1213,7 +1231,7 @@ mod windows_impl {
 
     fn request_missing_permissions_with<F>(
         state: &GraphAuthState,
-        lease: Option<&GraphInteractiveOperationLease>,
+        lease: &GraphInteractiveOperationLease,
         acquire: F,
     ) -> Result<GraphPermissionUpgradeResult, AppError>
     where
@@ -1267,11 +1285,8 @@ mod windows_impl {
         match classify_graph_permission_candidate(&current.status, &candidate.status) {
             GraphPermissionCandidateDecision::Upgrade => {
                 let status = candidate.status.clone();
-                let published = match lease {
-                    Some(lease) => lease
-                        .publish_if_active(|| state.set_token_if_generation(generation, candidate)),
-                    None => Some(state.set_token_if_generation(generation, candidate)),
-                };
+                let published = lease
+                    .publish_if_active(|| state.set_token_if_generation(generation, candidate));
                 if published == Some(true) {
                     Ok(GraphPermissionUpgradeResult {
                         outcome: GraphPermissionUpgradeOutcome::Upgraded,
@@ -1480,7 +1495,7 @@ mod windows_impl {
         lease: &GraphInteractiveOperationLease,
     ) -> Result<GraphPermissionUpgradeResult, AppError> {
         let deadline = wam::authentication_deadline();
-        request_missing_permissions_with(state, Some(lease), || {
+        request_missing_permissions_with(state, lease, || {
             wam::acquire_permission_consent_token(hwnd_raw, deadline, lease)
         })
     }
@@ -1821,6 +1836,20 @@ mod windows_impl {
             state
         }
 
+        fn request_missing_permissions_for_test<F>(
+            state: &GraphAuthState,
+            acquire: F,
+        ) -> Result<GraphPermissionUpgradeResult, AppError>
+        where
+            F: FnOnce() -> Result<CachedToken, WamAcquisitionFailure>,
+        {
+            let registry = Arc::new(GraphInteractiveOperationRegistry::default());
+            let lease = registry
+                .begin("permission-test-request".to_string())
+                .expect("test operation lease");
+            request_missing_permissions_with(state, &lease, acquire)
+        }
+
         fn stored_token_and_generation(state: &GraphAuthState) -> (String, u64) {
             let guard = state.inner.access_token.lock().unwrap();
             let cached = guard.value.as_ref().expect("cached token");
@@ -1831,7 +1860,7 @@ mod windows_impl {
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
 
-            let result = request_missing_permissions_with(&state, None, || Ok(candidate))
+            let result = request_missing_permissions_for_test(&state, || Ok(candidate))
                 .expect("candidate rejection is a structured outcome");
 
             assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Failed);
@@ -1849,7 +1878,7 @@ mod windows_impl {
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
 
-            let result = request_missing_permissions_with(&state, None, || Err(failure))
+            let result = request_missing_permissions_for_test(&state, || Err(failure))
                 .expect("acquisition failure is a structured outcome");
 
             assert_eq!(result.outcome, expected_outcome);
@@ -1863,7 +1892,7 @@ mod windows_impl {
             let state = GraphAuthState::new();
             let calls = Cell::new(0);
 
-            let result = request_missing_permissions_with(&state, None, || {
+            let result = request_missing_permissions_for_test(&state, || {
                 calls.set(calls.get() + 1);
                 unreachable!("disconnected precondition must stop before WAM")
             });
@@ -1886,7 +1915,7 @@ mod windows_impl {
             ));
             let calls = Cell::new(0);
 
-            let result = request_missing_permissions_with(&state, None, || {
+            let result = request_missing_permissions_for_test(&state, || {
                 calls.set(calls.get() + 1);
                 unreachable!("complete precondition must stop before WAM")
             });
@@ -1912,7 +1941,7 @@ mod windows_impl {
             let expected_status = candidate.status.clone();
             let calls = Cell::new(0);
 
-            let result = request_missing_permissions_with(&state, None, || {
+            let result = request_missing_permissions_for_test(&state, || {
                 calls.set(calls.get() + 1);
                 Ok(candidate)
             })
@@ -1936,6 +1965,31 @@ mod windows_impl {
         }
 
         #[test]
+        fn graph_permission_upgrade_cancelled_lease_blocks_candidate_publication() {
+            let state = seed_partial_state();
+            let before = stored_token_and_generation(&state);
+            let registry = Arc::new(GraphInteractiveOperationRegistry::default());
+            let request_id = "cancelled-permission-request";
+            let lease = registry
+                .begin(request_id.to_string())
+                .expect("test operation lease");
+            assert!(registry.cancel(request_id));
+            let candidate = token(
+                CANDIDATE_TOKEN,
+                "user@contoso.example",
+                "tenant-a",
+                &[GRAPH_DELEGATED_SCOPES[0], GRAPH_DELEGATED_SCOPES[1]],
+            );
+
+            let result = request_missing_permissions_with(&state, &lease, || Ok(candidate))
+                .expect("cancelled publication is a structured outcome");
+
+            assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Cancelled);
+            assert_eq!(result.status, current_auth_status(&state));
+            assert_eq!(stored_token_and_generation(&state), before);
+        }
+
+        #[test]
         fn graph_permission_upgrade_equal_scopes_retain_original_token_and_generation() {
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
@@ -1946,7 +2000,7 @@ mod windows_impl {
                 &[GRAPH_DELEGATED_SCOPES[0]],
             );
 
-            let result = request_missing_permissions_with(&state, None, || Ok(candidate))
+            let result = request_missing_permissions_for_test(&state, || Ok(candidate))
                 .expect("equal scopes are unchanged");
 
             assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Unchanged);
@@ -1975,7 +2029,7 @@ mod windows_impl {
                 &[GRAPH_DELEGATED_SCOPES[0]],
             );
 
-            let result = request_missing_permissions_with(&state, None, || Ok(candidate))
+            let result = request_missing_permissions_for_test(&state, || Ok(candidate))
                 .expect("scope regression is a structured failure");
 
             assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Failed);
@@ -2039,10 +2093,9 @@ mod windows_impl {
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
 
-            let result = request_missing_permissions_with(&state, None, || {
-                Err(WamAcquisitionFailure::Denied)
-            })
-            .expect("provider denial is a structured outcome");
+            let result =
+                request_missing_permissions_for_test(&state, || Err(WamAcquisitionFailure::Denied))
+                    .expect("provider denial is a structured outcome");
 
             assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Denied);
             assert!(result.message.is_some());
@@ -2055,10 +2108,9 @@ mod windows_impl {
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
 
-            let result = request_missing_permissions_with(&state, None, || {
-                Err(WamAcquisitionFailure::Failed)
-            })
-            .expect("provider failure is a structured outcome");
+            let result =
+                request_missing_permissions_for_test(&state, || Err(WamAcquisitionFailure::Failed))
+                    .expect("provider failure is a structured outcome");
 
             assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Failed);
             assert!(result.message.is_some());
@@ -2093,7 +2145,7 @@ mod windows_impl {
                 &[GRAPH_DELEGATED_SCOPES[0], GRAPH_DELEGATED_SCOPES[1]],
             );
 
-            let result = request_missing_permissions_with(&state, None, || {
+            let result = request_missing_permissions_for_test(&state, || {
                 state.clear_token();
                 Ok(candidate)
             })
@@ -2124,7 +2176,7 @@ mod windows_impl {
             );
             let newer_status = newer.status.clone();
 
-            let result = request_missing_permissions_with(&state, None, || {
+            let result = request_missing_permissions_for_test(&state, || {
                 assert!(state.set_token_if_generation(1, newer));
                 Ok(candidate)
             })
@@ -2149,7 +2201,7 @@ mod windows_impl {
             );
             let newer_status = newer.status.clone();
 
-            let result = request_missing_permissions_with(&state, None, || {
+            let result = request_missing_permissions_for_test(&state, || {
                 assert!(state.set_token_if_generation(1, newer));
                 Err(WamAcquisitionFailure::Failed)
             })
@@ -2183,7 +2235,7 @@ mod windows_impl {
                 .expect("ESP operation");
             assert!(!operation.is_cancelled());
 
-            let result = request_missing_permissions_with(&state, None, || {
+            let result = request_missing_permissions_for_test(&state, || {
                 Ok(token(
                     CANDIDATE_TOKEN,
                     "user@contoso.example",

--- a/src-tauri/src/graph_api.rs
+++ b/src-tauri/src/graph_api.rs
@@ -13,10 +13,10 @@ pub mod models;
 pub use models::{
     normalize_graph_guid, project_graph_auth_status, GraphAppInfo, GraphAuthAttemptOutcome,
     GraphAuthAttemptResult, GraphAuthCapabilities, GraphAuthStatus, GraphHostCapability,
-    GraphHostCapabilityKind, GraphHttpMethod, GraphResolutionResult, GraphTransportRequest,
-    GraphTransportResponse, GraphWamPermissionRequestContract, GraphWamRequestContract,
-    GRAPH_DELEGATED_SCOPES, GRAPH_SCOPE_REQUEST, GRAPH_WAM_PERMISSION_REQUEST,
-    GRAPH_WAM_PERMISSION_SCOPE_REQUEST, GRAPH_WAM_REQUEST,
+    GraphHostCapabilityKind, GraphHttpMethod, GraphInteractiveOperationKind,
+    GraphInteractiveOperationTicket, GraphResolutionResult, GraphTransportRequest,
+    GraphTransportResponse, GraphWamRequestContract, GRAPH_DELEGATED_SCOPES, GRAPH_WAM_REQUEST,
+    GRAPH_WAM_SCOPE_REQUEST,
 };
 
 #[cfg(any(target_os = "windows", test))]
@@ -151,7 +151,9 @@ fn classify_graph_host_capability(
 
 #[cfg(any(target_os = "windows", test))]
 struct GraphInteractiveOperationEntry {
-    request_id: String,
+    attempt_id: uuid::Uuid,
+    kind: GraphInteractiveOperationKind,
+    claimed: bool,
     cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>,
     accepts_cancellation: bool,
 }
@@ -166,47 +168,76 @@ struct GraphInteractiveOperationRegistry {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GraphInteractiveOperationError {
     Busy,
+    InvalidTicket,
 }
 
 #[cfg(any(target_os = "windows", test))]
 pub(crate) struct GraphInteractiveOperationLease {
     registry: std::sync::Arc<GraphInteractiveOperationRegistry>,
-    request_id: String,
+    attempt_id: uuid::Uuid,
     cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 #[cfg(any(target_os = "windows", test))]
 impl GraphInteractiveOperationRegistry {
-    fn begin(
-        self: &std::sync::Arc<Self>,
-        request_id: String,
-    ) -> Result<GraphInteractiveOperationLease, GraphInteractiveOperationError> {
+    fn reserve(
+        &self,
+        kind: GraphInteractiveOperationKind,
+    ) -> Result<GraphInteractiveOperationTicket, GraphInteractiveOperationError> {
         let mut active = self.active.lock().unwrap();
         if active.is_some() {
             return Err(GraphInteractiveOperationError::Busy);
         }
+        let attempt_id = uuid::Uuid::new_v4();
         let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         *active = Some(GraphInteractiveOperationEntry {
-            request_id: request_id.clone(),
-            cancelled: cancelled.clone(),
+            attempt_id,
+            kind,
+            claimed: false,
+            cancelled,
             accepts_cancellation: true,
         });
-        Ok(GraphInteractiveOperationLease {
-            registry: self.clone(),
-            request_id,
-            cancelled,
+        Ok(GraphInteractiveOperationTicket {
+            attempt_id: attempt_id.hyphenated().to_string(),
         })
     }
 
-    fn cancel(&self, request_id: &str) -> bool {
-        let active = self.active.lock().unwrap();
-        let Some(active) = active
+    fn claim(
+        self: &std::sync::Arc<Self>,
+        attempt_id: &str,
+        kind: GraphInteractiveOperationKind,
+    ) -> Result<GraphInteractiveOperationLease, GraphInteractiveOperationError> {
+        let attempt_id = uuid::Uuid::parse_str(attempt_id)
+            .map_err(|_| GraphInteractiveOperationError::InvalidTicket)?;
+        let mut active = self.active.lock().unwrap();
+        let entry = active
+            .as_mut()
+            .filter(|entry| entry.attempt_id == attempt_id && entry.kind == kind && !entry.claimed)
+            .ok_or(GraphInteractiveOperationError::InvalidTicket)?;
+        entry.claimed = true;
+        Ok(GraphInteractiveOperationLease {
+            registry: self.clone(),
+            attempt_id,
+            cancelled: entry.cancelled.clone(),
+        })
+    }
+
+    fn cancel(&self, attempt_id: &str) -> bool {
+        let Ok(attempt_id) = uuid::Uuid::parse_str(attempt_id) else {
+            return false;
+        };
+        let mut active = self.active.lock().unwrap();
+        let Some(entry) = active
             .as_ref()
-            .filter(|active| active.request_id == request_id && active.accepts_cancellation)
+            .filter(|active| active.attempt_id == attempt_id && active.accepts_cancellation)
         else {
             return false;
         };
-        !active
+        if !entry.claimed {
+            *active = None;
+            return true;
+        }
+        !entry
             .cancelled
             .swap(true, std::sync::atomic::Ordering::AcqRel)
     }
@@ -227,7 +258,7 @@ impl GraphInteractiveOperationLease {
         let mut active = self.registry.active.lock().unwrap();
         let entry = active
             .as_mut()
-            .filter(|active| active.request_id == self.request_id)?;
+            .filter(|active| active.attempt_id == self.attempt_id)?;
         if entry.cancelled.load(std::sync::atomic::Ordering::Acquire) {
             return None;
         }
@@ -242,7 +273,7 @@ impl Drop for GraphInteractiveOperationLease {
         let mut active = self.registry.active.lock().unwrap();
         if active
             .as_ref()
-            .is_some_and(|active| active.request_id == self.request_id)
+            .is_some_and(|active| active.attempt_id == self.attempt_id)
         {
             *active = None;
         }
@@ -338,10 +369,10 @@ mod windows_impl {
         classify_graph_host_capability, normalize_graph_guid, parse_graph_app_json,
         parse_graph_app_values, project_graph_auth_status, GraphAccountEnumeration, GraphAppInfo,
         GraphAuthAttemptOutcome, GraphAuthAttemptResult, GraphAuthStatus, GraphHostCapability,
-        GraphHostCapabilityKind, GraphHttpMethod, GraphInteractiveOperationLease,
-        GraphInteractiveOperationRegistry, GraphResolutionResult, GraphTransportRequest,
-        GraphTransportResponse, VersionedAuthSlot, VersionedGuidCache,
-        GRAPH_WAM_PERMISSION_REQUEST, GRAPH_WAM_REQUEST,
+        GraphHostCapabilityKind, GraphHttpMethod, GraphInteractiveOperationKind,
+        GraphInteractiveOperationLease, GraphInteractiveOperationRegistry,
+        GraphInteractiveOperationTicket, GraphResolutionResult, GraphTransportRequest,
+        GraphTransportResponse, VersionedAuthSlot, VersionedGuidCache, GRAPH_WAM_REQUEST,
     };
     use crate::error::AppError;
 
@@ -409,23 +440,39 @@ mod windows_impl {
             Self::default()
         }
 
-        pub(crate) fn begin_interactive_operation(
+        pub(crate) fn reserve_interactive_operation(
             &self,
-            request_id: String,
-        ) -> Result<GraphInteractiveOperationLease, AppError> {
+            kind: GraphInteractiveOperationKind,
+        ) -> Result<GraphInteractiveOperationTicket, AppError> {
             self.inner
                 .interactive_operations
-                .begin(request_id)
-                .map_err(|_| {
-                    AppError::InvalidInput(
+                .reserve(kind)
+                .map_err(|error| match error {
+                    GraphInteractiveOperationError::Busy => AppError::InvalidInput(
                         "Another Microsoft Graph sign-in action is already in progress."
                             .to_string(),
-                    )
+                    ),
+                    GraphInteractiveOperationError::InvalidTicket => AppError::InvalidInput(
+                        "Invalid Microsoft Graph operation ticket.".to_string(),
+                    ),
                 })
         }
 
-        pub(crate) fn cancel_interactive_operation(&self, request_id: &str) -> bool {
-            self.inner.interactive_operations.cancel(request_id)
+        pub(crate) fn claim_interactive_operation(
+            &self,
+            attempt_id: &str,
+            kind: GraphInteractiveOperationKind,
+        ) -> Result<GraphInteractiveOperationLease, AppError> {
+            self.inner
+                .interactive_operations
+                .claim(attempt_id, kind)
+                .map_err(|_| {
+                    AppError::InvalidInput("Invalid Microsoft Graph operation ticket.".to_string())
+                })
+        }
+
+        pub(crate) fn cancel_interactive_operation(&self, attempt_id: &str) -> bool {
+            self.inner.interactive_operations.cancel(attempt_id)
         }
 
         fn get_valid_token_snapshot(&self) -> (Option<CachedToken>, u64) {
@@ -588,15 +635,7 @@ mod windows_impl {
 
         const GRAPH_WAM_ACQUISITION_TIMEOUT: std::time::Duration =
             std::time::Duration::from_secs(120);
-        const GRAPH_WAM_CAPABILITY_TIMEOUT: std::time::Duration =
-            std::time::Duration::from_secs(15);
         const GRAPH_WAM_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
-
-        #[derive(Clone, Copy)]
-        enum WamRequestMode {
-            InitialConnect,
-            PermissionConsent,
-        }
 
         struct WinRtApartment;
 
@@ -749,17 +788,6 @@ mod windows_impl {
             )))
         }
 
-        pub fn probe_host_capability() -> GraphHostCapability {
-            let Ok(_apartment) = WinRtApartment::initialize() else {
-                return GraphHostCapability::new(GraphHostCapabilityKind::ProviderUnavailable);
-            };
-            probe_host_capability_with_deadline(
-                std::time::Instant::now() + GRAPH_WAM_CAPABILITY_TIMEOUT,
-                None,
-            )
-            .unwrap_or_else(|_| GraphHostCapability::new(GraphHostCapabilityKind::Unknown))
-        }
-
         pub fn authentication_deadline() -> std::time::Instant {
             std::time::Instant::now() + GRAPH_WAM_ACQUISITION_TIMEOUT
         }
@@ -777,30 +805,12 @@ mod windows_impl {
         /// Desktop (Win32) apps don't have a CoreWindow, so we must use
         /// `IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync`
         /// with an explicit HWND instead of the UWP `RequestTokenAsync`.
-        pub fn acquire_permission_consent_token(
-            hwnd_raw: isize,
-            deadline: std::time::Instant,
-            lease: &GraphInteractiveOperationLease,
-        ) -> Result<CachedToken, WamAcquisitionFailure> {
-            let _apartment = WinRtApartment::initialize()?;
-            acquire_token_with_request(hwnd_raw, WamRequestMode::PermissionConsent, deadline, lease)
-        }
-
         pub fn acquire_token(
             hwnd_raw: isize,
             deadline: std::time::Instant,
             lease: &GraphInteractiveOperationLease,
         ) -> Result<CachedToken, WamAcquisitionFailure> {
             let _apartment = WinRtApartment::initialize()?;
-            acquire_token_with_request(hwnd_raw, WamRequestMode::InitialConnect, deadline, lease)
-        }
-
-        fn acquire_token_with_request(
-            hwnd_raw: isize,
-            request_mode: WamRequestMode,
-            deadline: std::time::Instant,
-            lease: &GraphInteractiveOperationLease,
-        ) -> Result<CachedToken, WamAcquisitionFailure> {
             let hwnd = HWND(hwnd_raw as *mut _);
 
             // Provider lookup doesn't need a window
@@ -818,55 +828,14 @@ mod windows_impl {
             )?;
 
             let client_id = HSTRING::from(GRAPH_POWERSHELL_CLIENT_ID);
-            let request = match request_mode {
-                WamRequestMode::PermissionConsent => {
-                    let scope = HSTRING::from(GRAPH_WAM_PERMISSION_REQUEST.scope);
-                    if GRAPH_WAM_PERMISSION_REQUEST.force_authentication {
-                        WebTokenRequest::CreateWithPromptType(
-                            &provider,
-                            &scope,
-                            &client_id,
-                            WebTokenRequestPromptType::ForceAuthentication,
-                        )
-                    } else {
-                        WebTokenRequest::Create(&provider, &scope, &client_id)
-                    }
-                }
-                WamRequestMode::InitialConnect => {
-                    let scope = HSTRING::from(GRAPH_WAM_REQUEST.scope);
-                    WebTokenRequest::Create(&provider, &scope, &client_id)
-                }
-            }
+            let scope = HSTRING::from(GRAPH_WAM_REQUEST.scope);
+            let request = WebTokenRequest::CreateWithPromptType(
+                &provider,
+                &scope,
+                &client_id,
+                WebTokenRequestPromptType::ForceAuthentication,
+            )
             .map_err(|e| AppError::Internal(format!("WAM request creation failed: {e}")))?;
-
-            let properties = request
-                .Properties()
-                .map_err(|e| AppError::Internal(format!("WAM properties failed: {e}")))?;
-            match request_mode {
-                WamRequestMode::PermissionConsent => {
-                    // The explicit permission action mirrors MSAL's Entra WAM
-                    // v2 consent shape. In particular, it must not attach the
-                    // v1 `resource` property or WAM may reuse the cached token.
-                    for &(name, value) in GRAPH_WAM_PERMISSION_REQUEST.properties {
-                        properties
-                            .Insert(&HSTRING::from(name), &HSTRING::from(value))
-                            .map_err(|e| {
-                                AppError::Internal(format!("WAM set consent property failed: {e}"))
-                            })?;
-                    }
-                }
-                WamRequestMode::InitialConnect => {
-                    // Preserve the established initial-connect contract.
-                    // Without this resource property the legacy/default request
-                    // can report Success while returning an empty token.
-                    properties
-                        .Insert(
-                            &HSTRING::from(GRAPH_WAM_REQUEST.resource_property),
-                            &HSTRING::from(GRAPH_WAM_REQUEST.resource),
-                        )
-                        .map_err(|e| AppError::Internal(format!("WAM set resource failed: {e}")))?;
-                }
-            }
 
             // Use the COM interop interface to pass our HWND
             let interop: IWebAuthenticationCoreManagerInterop =
@@ -1379,10 +1348,6 @@ mod windows_impl {
         }
     }
 
-    pub fn probe_host_capability() -> GraphHostCapability {
-        wam::probe_host_capability()
-    }
-
     /// Authenticate with Graph API via WAM on an off-thread worker.
     pub(crate) fn authenticate(
         state: &GraphAuthState,
@@ -1496,7 +1461,7 @@ mod windows_impl {
     ) -> Result<GraphPermissionUpgradeResult, AppError> {
         let deadline = wam::authentication_deadline();
         request_missing_permissions_with(state, lease, || {
-            wam::acquire_permission_consent_token(hwnd_raw, deadline, lease)
+            wam::acquire_token(hwnd_raw, deadline, lease)
         })
     }
 
@@ -1844,8 +1809,14 @@ mod windows_impl {
             F: FnOnce() -> Result<CachedToken, WamAcquisitionFailure>,
         {
             let registry = Arc::new(GraphInteractiveOperationRegistry::default());
+            let ticket = registry
+                .reserve(GraphInteractiveOperationKind::PermissionConsent)
+                .expect("test operation ticket");
             let lease = registry
-                .begin("permission-test-request".to_string())
+                .claim(
+                    &ticket.attempt_id,
+                    GraphInteractiveOperationKind::PermissionConsent,
+                )
                 .expect("test operation lease");
             request_missing_permissions_with(state, &lease, acquire)
         }
@@ -1969,11 +1940,16 @@ mod windows_impl {
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
             let registry = Arc::new(GraphInteractiveOperationRegistry::default());
-            let request_id = "cancelled-permission-request";
+            let ticket = registry
+                .reserve(GraphInteractiveOperationKind::PermissionConsent)
+                .unwrap();
             let lease = registry
-                .begin(request_id.to_string())
+                .claim(
+                    &ticket.attempt_id,
+                    GraphInteractiveOperationKind::PermissionConsent,
+                )
                 .expect("test operation lease");
-            assert!(registry.cancel(request_id));
+            assert!(registry.cancel(&ticket.attempt_id));
             let candidate = token(
                 CANDIDATE_TOKEN,
                 "user@contoso.example",
@@ -2395,40 +2371,111 @@ mod tests {
     }
 
     #[test]
-    fn graph_interactive_operation_owns_and_cancels_only_the_matching_request() {
+    fn graph_interactive_operation_issues_single_use_kind_bound_tickets() {
         let registry = std::sync::Arc::new(super::GraphInteractiveOperationRegistry::default());
-        let first = registry
-            .begin("request-a".to_string())
-            .expect("first operation should own the slot");
+        let first_ticket = registry
+            .reserve(super::GraphInteractiveOperationKind::Authentication)
+            .expect("first reservation should own the slot");
         assert_eq!(
-            registry.begin("request-b".to_string()).err(),
+            registry
+                .reserve(super::GraphInteractiveOperationKind::PermissionConsent)
+                .err(),
             Some(super::GraphInteractiveOperationError::Busy)
         );
-        assert!(!registry.cancel("request-b"));
-        assert!(registry.cancel("request-a"));
+        assert_eq!(
+            registry
+                .claim(
+                    &first_ticket.attempt_id,
+                    super::GraphInteractiveOperationKind::PermissionConsent,
+                )
+                .err(),
+            Some(super::GraphInteractiveOperationError::InvalidTicket)
+        );
+        let first = registry
+            .claim(
+                &first_ticket.attempt_id,
+                super::GraphInteractiveOperationKind::Authentication,
+            )
+            .expect("matching operation should claim its ticket");
+        assert_eq!(
+            registry
+                .claim(
+                    &first_ticket.attempt_id,
+                    super::GraphInteractiveOperationKind::Authentication,
+                )
+                .err(),
+            Some(super::GraphInteractiveOperationError::InvalidTicket)
+        );
+        assert!(!registry.cancel("22d12752-4b6e-45e0-aac4-0bc351e91118"));
+        assert!(registry.cancel(&first_ticket.attempt_id));
         assert!(first.is_cancelled());
-        assert!(!registry.cancel("request-a"));
+        assert!(!registry.cancel(&first_ticket.attempt_id));
 
         drop(first);
-        let second = registry
-            .begin("request-b".to_string())
+        let second_ticket = registry
+            .reserve(super::GraphInteractiveOperationKind::PermissionConsent)
             .expect("dropping the lease should release ownership");
+        assert_ne!(first_ticket.attempt_id, second_ticket.attempt_id);
+        assert!(!registry.cancel(&first_ticket.attempt_id));
+        let second = registry
+            .claim(
+                &second_ticket.attempt_id,
+                super::GraphInteractiveOperationKind::PermissionConsent,
+            )
+            .unwrap();
         assert!(!second.is_cancelled());
     }
 
     #[test]
     fn graph_interactive_operation_never_publishes_after_matching_cancellation() {
         let registry = std::sync::Arc::new(super::GraphInteractiveOperationRegistry::default());
-        let cancelled = registry.begin("cancelled".to_string()).unwrap();
-        assert!(registry.cancel("cancelled"));
+        let cancelled_ticket = registry
+            .reserve(super::GraphInteractiveOperationKind::Authentication)
+            .unwrap();
+        let cancelled = registry
+            .claim(
+                &cancelled_ticket.attempt_id,
+                super::GraphInteractiveOperationKind::Authentication,
+            )
+            .unwrap();
+        assert!(registry.cancel(&cancelled_ticket.attempt_id));
         let mut published = false;
         assert_eq!(cancelled.publish_if_active(|| published = true), None,);
         assert!(!published);
 
         drop(cancelled);
-        let completed = registry.begin("completed".to_string()).unwrap();
+        let completed_ticket = registry
+            .reserve(super::GraphInteractiveOperationKind::Authentication)
+            .unwrap();
+        let completed = registry
+            .claim(
+                &completed_ticket.attempt_id,
+                super::GraphInteractiveOperationKind::Authentication,
+            )
+            .unwrap();
         assert_eq!(completed.publish_if_active(|| 42), Some(42));
-        assert!(!registry.cancel("completed"));
+        assert!(!registry.cancel(&completed_ticket.attempt_id));
+    }
+
+    #[test]
+    fn graph_interactive_operation_cancellation_retires_an_unclaimed_ticket() {
+        let registry = std::sync::Arc::new(super::GraphInteractiveOperationRegistry::default());
+        let retired = registry
+            .reserve(super::GraphInteractiveOperationKind::Authentication)
+            .unwrap();
+        assert!(registry.cancel(&retired.attempt_id));
+        assert_eq!(
+            registry
+                .claim(
+                    &retired.attempt_id,
+                    super::GraphInteractiveOperationKind::Authentication,
+                )
+                .err(),
+            Some(super::GraphInteractiveOperationError::InvalidTicket)
+        );
+        assert!(registry
+            .reserve(super::GraphInteractiveOperationKind::Authentication)
+            .is_ok());
     }
 
     #[test]

--- a/src-tauri/src/graph_api.rs
+++ b/src-tauri/src/graph_api.rs
@@ -11,8 +11,9 @@ pub mod esp;
 pub mod models;
 
 pub use models::{
-    normalize_graph_guid, project_graph_auth_status, GraphAppInfo, GraphAuthCapabilities,
-    GraphAuthStatus, GraphHttpMethod, GraphResolutionResult, GraphTransportRequest,
+    normalize_graph_guid, project_graph_auth_status, GraphAppInfo, GraphAuthAttemptOutcome,
+    GraphAuthAttemptResult, GraphAuthCapabilities, GraphAuthStatus, GraphHostCapability,
+    GraphHostCapabilityKind, GraphHttpMethod, GraphResolutionResult, GraphTransportRequest,
     GraphTransportResponse, GraphWamPermissionRequestContract, GraphWamRequestContract,
     GRAPH_DELEGATED_SCOPES, GRAPH_SCOPE_REQUEST, GRAPH_WAM_PERMISSION_REQUEST,
     GRAPH_WAM_PERMISSION_SCOPE_REQUEST, GRAPH_WAM_REQUEST,
@@ -114,6 +115,137 @@ impl<T> VersionedAuthSlot<T> {
             return None;
         }
         Some(self.replace(value))
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GraphAccountEnumeration {
+    Accounts(usize),
+    ProviderUnavailable,
+    Unknown,
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn classify_graph_host_capability(
+    organizational: GraphAccountEnumeration,
+    personal: GraphAccountEnumeration,
+) -> GraphHostCapabilityKind {
+    match organizational {
+        GraphAccountEnumeration::Accounts(count) if count > 0 => GraphHostCapabilityKind::Available,
+        GraphAccountEnumeration::ProviderUnavailable => {
+            GraphHostCapabilityKind::ProviderUnavailable
+        }
+        GraphAccountEnumeration::Unknown => GraphHostCapabilityKind::Unknown,
+        GraphAccountEnumeration::Accounts(_) => match personal {
+            GraphAccountEnumeration::Accounts(count) if count > 0 => {
+                GraphHostCapabilityKind::PersonalAccountOnly
+            }
+            GraphAccountEnumeration::Unknown => GraphHostCapabilityKind::Unknown,
+            GraphAccountEnumeration::Accounts(_) | GraphAccountEnumeration::ProviderUnavailable => {
+                GraphHostCapabilityKind::NoOrganizationalAccount
+            }
+        },
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+struct GraphInteractiveOperationEntry {
+    request_id: String,
+    cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    accepts_cancellation: bool,
+}
+
+#[cfg(any(target_os = "windows", test))]
+#[derive(Default)]
+struct GraphInteractiveOperationRegistry {
+    active: std::sync::Mutex<Option<GraphInteractiveOperationEntry>>,
+}
+
+#[cfg(any(target_os = "windows", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GraphInteractiveOperationError {
+    Busy,
+}
+
+#[cfg(any(target_os = "windows", test))]
+pub(crate) struct GraphInteractiveOperationLease {
+    registry: std::sync::Arc<GraphInteractiveOperationRegistry>,
+    request_id: String,
+    cancelled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[cfg(any(target_os = "windows", test))]
+impl GraphInteractiveOperationRegistry {
+    fn begin(
+        self: &std::sync::Arc<Self>,
+        request_id: String,
+    ) -> Result<GraphInteractiveOperationLease, GraphInteractiveOperationError> {
+        let mut active = self.active.lock().unwrap();
+        if active.is_some() {
+            return Err(GraphInteractiveOperationError::Busy);
+        }
+        let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        *active = Some(GraphInteractiveOperationEntry {
+            request_id: request_id.clone(),
+            cancelled: cancelled.clone(),
+            accepts_cancellation: true,
+        });
+        Ok(GraphInteractiveOperationLease {
+            registry: self.clone(),
+            request_id,
+            cancelled,
+        })
+    }
+
+    fn cancel(&self, request_id: &str) -> bool {
+        let active = self.active.lock().unwrap();
+        let Some(active) = active
+            .as_ref()
+            .filter(|active| active.request_id == request_id && active.accepts_cancellation)
+        else {
+            return false;
+        };
+        !active
+            .cancelled
+            .swap(true, std::sync::atomic::Ordering::AcqRel)
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+impl GraphInteractiveOperationLease {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.cancelled.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    #[cfg(target_os = "windows")]
+    fn cancellation_flag(&self) -> &std::sync::atomic::AtomicBool {
+        self.cancelled.as_ref()
+    }
+
+    fn publish_if_active<T>(&self, publish: impl FnOnce() -> T) -> Option<T> {
+        let mut active = self.registry.active.lock().unwrap();
+        let entry = active
+            .as_mut()
+            .filter(|active| active.request_id == self.request_id)?;
+        if entry.cancelled.load(std::sync::atomic::Ordering::Acquire) {
+            return None;
+        }
+        entry.accepts_cancellation = false;
+        Some(publish())
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+impl Drop for GraphInteractiveOperationLease {
+    fn drop(&mut self) {
+        let mut active = self.registry.active.lock().unwrap();
+        if active
+            .as_ref()
+            .is_some_and(|active| active.request_id == self.request_id)
+        {
+            *active = None;
+        }
     }
 }
 
@@ -228,9 +360,11 @@ mod windows_impl {
         GraphPermissionUpgradeOutcome, GraphPermissionUpgradeResult,
     };
     use super::{
-        normalize_graph_guid, parse_graph_app_json, parse_graph_app_values,
-        project_graph_auth_status, receive_before_deadline, DeadlineReceiveError, GraphAppInfo,
-        GraphAuthStatus, GraphHttpMethod, GraphResolutionResult, GraphTransportRequest,
+        classify_graph_host_capability, normalize_graph_guid, parse_graph_app_json,
+        parse_graph_app_values, project_graph_auth_status, GraphAccountEnumeration, GraphAppInfo,
+        GraphAuthAttemptOutcome, GraphAuthAttemptResult, GraphAuthStatus, GraphHostCapability,
+        GraphHostCapabilityKind, GraphHttpMethod, GraphInteractiveOperationLease,
+        GraphInteractiveOperationRegistry, GraphResolutionResult, GraphTransportRequest,
         GraphTransportResponse, VersionedAuthSlot, VersionedGuidCache,
         GRAPH_WAM_PERMISSION_REQUEST, GRAPH_WAM_REQUEST,
     };
@@ -244,6 +378,7 @@ mod windows_impl {
     struct GraphAuthStateInner {
         access_token: Mutex<VersionedAuthSlot<CachedToken>>,
         guid_cache: Mutex<VersionedGuidCache>,
+        interactive_operations: Arc<GraphInteractiveOperationRegistry>,
         #[cfg(feature = "esp-diagnostics")]
         esp_operations: EspGraphOperationRegistry,
         #[cfg(test)]
@@ -263,6 +398,7 @@ mod windows_impl {
 
     enum WamAcquisitionFailure {
         Cancelled,
+        TimedOut,
         Denied(AppError),
         Failed(AppError),
     }
@@ -282,6 +418,7 @@ mod windows_impl {
                 Self::Cancelled => {
                     AppError::Internal("Authentication was cancelled by user.".into())
                 }
+                Self::TimedOut => AppError::Internal("Authentication timed out.".into()),
                 Self::Denied(error) | Self::Failed(error) => error,
             }
         }
@@ -315,6 +452,25 @@ mod windows_impl {
     impl GraphAuthState {
         pub fn new() -> Self {
             Self::default()
+        }
+
+        pub(crate) fn begin_interactive_operation(
+            &self,
+            request_id: String,
+        ) -> Result<GraphInteractiveOperationLease, AppError> {
+            self.inner
+                .interactive_operations
+                .begin(request_id)
+                .map_err(|_| {
+                    AppError::InvalidInput(
+                        "Another Microsoft Graph sign-in action is already in progress."
+                            .to_string(),
+                    )
+                })
+        }
+
+        pub(crate) fn cancel_interactive_operation(&self, request_id: &str) -> bool {
+            self.inner.interactive_operations.cancel(request_id)
         }
 
         fn get_valid_token_snapshot(&self) -> (Option<CachedToken>, u64) {
@@ -465,8 +621,8 @@ mod windows_impl {
 
         use windows::core::{factory, RuntimeType, HSTRING};
         use windows::Security::Authentication::Web::Core::{
-            WebAuthenticationCoreManager, WebTokenRequest, WebTokenRequestPromptType,
-            WebTokenRequestResult, WebTokenRequestStatus,
+            FindAllWebAccountsStatus, WebAuthenticationCoreManager, WebTokenRequest,
+            WebTokenRequestPromptType, WebTokenRequestResult, WebTokenRequestStatus,
         };
         use windows::Win32::Foundation::HWND;
         use windows::Win32::System::WinRT::{
@@ -477,6 +633,9 @@ mod windows_impl {
 
         const GRAPH_WAM_ACQUISITION_TIMEOUT: std::time::Duration =
             std::time::Duration::from_secs(120);
+        const GRAPH_WAM_CAPABILITY_TIMEOUT: std::time::Duration =
+            std::time::Duration::from_secs(15);
+        const GRAPH_WAM_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 
         #[derive(Clone, Copy)]
         enum WamRequestMode {
@@ -505,7 +664,8 @@ mod windows_impl {
             operation: &IAsyncOperation<T>,
             deadline: std::time::Instant,
             stage: &str,
-        ) -> Result<T, AppError>
+            cancelled: Option<&std::sync::atomic::AtomicBool>,
+        ) -> Result<T, WamAcquisitionFailure>
         where
             T: RuntimeType + Send + 'static,
         {
@@ -522,20 +682,143 @@ mod windows_impl {
                     ))
                 })?;
 
-            match receive_before_deadline(&receiver, deadline) {
-                Ok(result) => result
-                    .map_err(|error| AppError::Internal(format!("WAM {stage} failed: {error}"))),
-                Err(DeadlineReceiveError::Timeout) => {
+            loop {
+                if cancelled.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Acquire)) {
                     let _ = operation.Cancel();
-                    Err(AppError::Internal(format!(
-                        "WAM authentication timed out during {stage} after {} seconds.",
-                        GRAPH_WAM_ACQUISITION_TIMEOUT.as_secs()
-                    )))
+                    return Err(WamAcquisitionFailure::Cancelled);
                 }
-                Err(DeadlineReceiveError::Disconnected) => Err(AppError::Internal(format!(
-                    "WAM {stage} completion channel disconnected."
-                ))),
+
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                if remaining.is_zero() {
+                    let _ = operation.Cancel();
+                    return Err(WamAcquisitionFailure::TimedOut);
+                }
+
+                match receiver.recv_timeout(remaining.min(GRAPH_WAM_POLL_INTERVAL)) {
+                    Ok(result) => {
+                        return result.map_err(|error| {
+                            WamAcquisitionFailure::Failed(AppError::Internal(format!(
+                                "WAM {stage} failed: {error}"
+                            )))
+                        });
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                        return Err(WamAcquisitionFailure::Failed(AppError::Internal(format!(
+                            "WAM {stage} completion channel disconnected."
+                        ))));
+                    }
+                }
             }
+        }
+
+        fn enumerate_accounts(
+            authority: &str,
+            deadline: std::time::Instant,
+            cancelled: Option<&std::sync::atomic::AtomicBool>,
+        ) -> Result<GraphAccountEnumeration, WamAcquisitionFailure> {
+            let provider_operation =
+                match WebAuthenticationCoreManager::FindAccountProviderWithAuthorityAsync(
+                    &HSTRING::from("https://login.microsoft.com"),
+                    &HSTRING::from(authority),
+                ) {
+                    Ok(operation) => operation,
+                    Err(_) => return Ok(GraphAccountEnumeration::ProviderUnavailable),
+                };
+            let provider = match wait_for_operation(
+                &provider_operation,
+                deadline,
+                "provider lookup",
+                cancelled,
+            ) {
+                Ok(provider) => provider,
+                Err(WamAcquisitionFailure::Cancelled) => {
+                    return Err(WamAcquisitionFailure::Cancelled)
+                }
+                Err(WamAcquisitionFailure::TimedOut) => {
+                    return Err(WamAcquisitionFailure::TimedOut)
+                }
+                Err(WamAcquisitionFailure::Denied(_) | WamAcquisitionFailure::Failed(_)) => {
+                    return Ok(GraphAccountEnumeration::ProviderUnavailable)
+                }
+            };
+
+            let accounts_operation =
+                match WebAuthenticationCoreManager::FindAllAccountsAsync(&provider) {
+                    Ok(operation) => operation,
+                    Err(_) => return Ok(GraphAccountEnumeration::Unknown),
+                };
+            let result = match wait_for_operation(
+                &accounts_operation,
+                deadline,
+                "account discovery",
+                cancelled,
+            ) {
+                Ok(result) => result,
+                Err(WamAcquisitionFailure::Cancelled) => {
+                    return Err(WamAcquisitionFailure::Cancelled)
+                }
+                Err(WamAcquisitionFailure::TimedOut) => {
+                    return Err(WamAcquisitionFailure::TimedOut)
+                }
+                Err(WamAcquisitionFailure::Denied(_) | WamAcquisitionFailure::Failed(_)) => {
+                    return Ok(GraphAccountEnumeration::Unknown)
+                }
+            };
+
+            let Ok(status) = result.Status() else {
+                return Ok(GraphAccountEnumeration::Unknown);
+            };
+            if status != FindAllWebAccountsStatus::Success {
+                return Ok(GraphAccountEnumeration::Unknown);
+            }
+            let count = result
+                .Accounts()
+                .ok()
+                .and_then(|accounts| accounts.Size().ok())
+                .map(|count| count as usize);
+            Ok(count
+                .map(GraphAccountEnumeration::Accounts)
+                .unwrap_or(GraphAccountEnumeration::Unknown))
+        }
+
+        fn probe_host_capability_with_deadline(
+            deadline: std::time::Instant,
+            cancelled: Option<&std::sync::atomic::AtomicBool>,
+        ) -> Result<GraphHostCapability, WamAcquisitionFailure> {
+            let organizational = enumerate_accounts("organizations", deadline, cancelled)?;
+            let personal = if organizational == GraphAccountEnumeration::Accounts(0) {
+                enumerate_accounts("consumers", deadline, cancelled)?
+            } else {
+                GraphAccountEnumeration::Accounts(0)
+            };
+            Ok(GraphHostCapability::new(classify_graph_host_capability(
+                organizational,
+                personal,
+            )))
+        }
+
+        pub fn probe_host_capability() -> GraphHostCapability {
+            let Ok(_apartment) = WinRtApartment::initialize() else {
+                return GraphHostCapability::new(GraphHostCapabilityKind::ProviderUnavailable);
+            };
+            probe_host_capability_with_deadline(
+                std::time::Instant::now() + GRAPH_WAM_CAPABILITY_TIMEOUT,
+                None,
+            )
+            .unwrap_or_else(|_| GraphHostCapability::new(GraphHostCapabilityKind::Unknown))
+        }
+
+        pub fn authentication_deadline() -> std::time::Instant {
+            std::time::Instant::now() + GRAPH_WAM_ACQUISITION_TIMEOUT
+        }
+
+        pub fn probe_host_capability_for_authentication(
+            deadline: std::time::Instant,
+            lease: &GraphInteractiveOperationLease,
+        ) -> Result<GraphHostCapability, WamAcquisitionFailure> {
+            let _apartment = WinRtApartment::initialize()?;
+            probe_host_capability_with_deadline(deadline, Some(lease.cancellation_flag()))
         }
 
         /// Acquire a token via WAM using the Win32 interop path.
@@ -543,23 +826,31 @@ mod windows_impl {
         /// Desktop (Win32) apps don't have a CoreWindow, so we must use
         /// `IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync`
         /// with an explicit HWND instead of the UWP `RequestTokenAsync`.
-        pub fn acquire_permission_consent_token_on_initialized_worker(
+        pub fn acquire_permission_consent_token(
             hwnd_raw: isize,
+            deadline: std::time::Instant,
+            lease: &GraphInteractiveOperationLease,
         ) -> Result<CachedToken, WamAcquisitionFailure> {
             let _apartment = WinRtApartment::initialize()?;
-            acquire_token_with_request(hwnd_raw, WamRequestMode::PermissionConsent)
+            acquire_token_with_request(hwnd_raw, WamRequestMode::PermissionConsent, deadline, lease)
         }
 
-        pub fn acquire_token(hwnd_raw: isize) -> Result<CachedToken, WamAcquisitionFailure> {
-            acquire_token_with_request(hwnd_raw, WamRequestMode::InitialConnect)
+        pub fn acquire_token(
+            hwnd_raw: isize,
+            deadline: std::time::Instant,
+            lease: &GraphInteractiveOperationLease,
+        ) -> Result<CachedToken, WamAcquisitionFailure> {
+            let _apartment = WinRtApartment::initialize()?;
+            acquire_token_with_request(hwnd_raw, WamRequestMode::InitialConnect, deadline, lease)
         }
 
         fn acquire_token_with_request(
             hwnd_raw: isize,
             request_mode: WamRequestMode,
+            deadline: std::time::Instant,
+            lease: &GraphInteractiveOperationLease,
         ) -> Result<CachedToken, WamAcquisitionFailure> {
             let hwnd = HWND(hwnd_raw as *mut _);
-            let deadline = std::time::Instant::now() + GRAPH_WAM_ACQUISITION_TIMEOUT;
 
             // Provider lookup doesn't need a window
             let authority = HSTRING::from("organizations");
@@ -569,7 +860,12 @@ mod windows_impl {
                     &authority,
                 )
                 .map_err(|e| AppError::Internal(format!("WAM provider lookup failed: {e}")))?;
-            let provider = wait_for_operation(&provider_operation, deadline, "provider lookup")?;
+            let provider = wait_for_operation(
+                &provider_operation,
+                deadline,
+                "provider lookup",
+                Some(lease.cancellation_flag()),
+            )?;
 
             let client_id = HSTRING::from(GRAPH_POWERSHELL_CLIENT_ID);
             let request = match request_mode {
@@ -631,7 +927,12 @@ mod windows_impl {
                 unsafe { interop.RequestTokenForWindowAsync(hwnd, &request) }
                     .map_err(|e| AppError::Internal(format!("WAM token request failed: {e}")))?;
 
-            let result = wait_for_operation(&operation, deadline, "token request")?;
+            let result = wait_for_operation(
+                &operation,
+                deadline,
+                "token request",
+                Some(lease.cancellation_flag()),
+            )?;
 
             let status = result
                 .ResponseStatus()
@@ -677,15 +978,11 @@ mod windows_impl {
                         upn.as_deref(),
                         tenant.as_deref(),
                         unix_now(),
-                    );
-                    if !status.is_authenticated {
-                        return Err(AppError::Internal(
-                            status
-                                .error
-                                .clone()
-                                .unwrap_or_else(|| "InvalidWamToken".to_string()),
-                        )
-                        .into());
+                    )
+                    .map_err(|error| AppError::Internal(error.to_string()))?;
+
+                    if lease.is_cancelled() {
+                        return Err(WamAcquisitionFailure::Cancelled);
                     }
 
                     Ok(CachedToken { token, status })
@@ -961,13 +1258,15 @@ mod windows_impl {
         state
             .get_valid_token()
             .map(|(cached, _)| cached.status)
-            .unwrap_or_else(|| GraphAuthStatus::disconnected(None))
+            .unwrap_or_else(GraphAuthStatus::disconnected)
     }
 
     const GRAPH_PERMISSION_DENIED_MESSAGE: &str =
         "Consent was not granted. Your existing Graph permissions remain available. A tenant administrator may need to approve the missing permissions.";
     const GRAPH_PERMISSION_FAILED_MESSAGE: &str =
         "Windows could not complete the permission request. Your existing Graph permissions remain available.";
+    const GRAPH_PERMISSION_TIMED_OUT_MESSAGE: &str =
+        "The Windows permission request timed out. Your existing Graph permissions remain available.";
     const GRAPH_PERMISSION_STALE_MESSAGE: &str =
         "The permission request was superseded by a newer Graph connection change.";
 
@@ -980,7 +1279,7 @@ mod windows_impl {
         let (token, generation) = state.get_valid_token_snapshot();
         let status = token
             .map(|cached| cached.status)
-            .unwrap_or_else(|| GraphAuthStatus::disconnected(None));
+            .unwrap_or_else(GraphAuthStatus::disconnected);
         if generation == expected_generation {
             GraphPermissionUpgradeResult {
                 outcome,
@@ -998,6 +1297,7 @@ mod windows_impl {
 
     fn request_missing_permissions_with<F>(
         state: &GraphAuthState,
+        lease: Option<&GraphInteractiveOperationLease>,
         acquire: F,
     ) -> Result<GraphPermissionUpgradeResult, AppError>
     where
@@ -1022,6 +1322,14 @@ mod windows_impl {
                     None,
                 ));
             }
+            Err(WamAcquisitionFailure::TimedOut) => {
+                return Ok(retained_permission_upgrade_result(
+                    state,
+                    generation,
+                    GraphPermissionUpgradeOutcome::TimedOut,
+                    Some(GRAPH_PERMISSION_TIMED_OUT_MESSAGE),
+                ));
+            }
             Err(WamAcquisitionFailure::Denied(_)) => {
                 return Ok(retained_permission_upgrade_result(
                     state,
@@ -1043,12 +1351,24 @@ mod windows_impl {
         match classify_graph_permission_candidate(&current.status, &candidate.status) {
             GraphPermissionCandidateDecision::Upgrade => {
                 let status = candidate.status.clone();
-                if state.set_token_if_generation(generation, candidate) {
+                let published = match lease {
+                    Some(lease) => lease
+                        .publish_if_active(|| state.set_token_if_generation(generation, candidate)),
+                    None => Some(state.set_token_if_generation(generation, candidate)),
+                };
+                if published == Some(true) {
                     Ok(GraphPermissionUpgradeResult {
                         outcome: GraphPermissionUpgradeOutcome::Upgraded,
                         status,
                         message: None,
                     })
+                } else if published.is_none() {
+                    Ok(retained_permission_upgrade_result(
+                        state,
+                        generation,
+                        GraphPermissionUpgradeOutcome::Cancelled,
+                        None,
+                    ))
                 } else {
                     Ok(retained_permission_upgrade_result(
                         state,
@@ -1078,43 +1398,174 @@ mod windows_impl {
         }
     }
 
-    /// Authenticate with Graph API via WAM. Returns current auth status.
-    /// `hwnd_raw` is the native window handle for the WAM dialog.
-    pub fn authenticate(
-        state: &GraphAuthState,
-        hwnd_raw: isize,
-    ) -> Result<GraphAuthStatus, AppError> {
-        let expected_generation = match state.claim_authentication() {
-            Ok(cached) => return Ok(cached.status),
-            Err(generation) => generation,
-        };
+    const GRAPH_AUTH_CANCELLED_MESSAGE: &str = "Microsoft Graph sign-in was cancelled.";
+    const GRAPH_AUTH_TIMED_OUT_MESSAGE: &str =
+        "Microsoft Graph sign-in timed out after 120 seconds.";
+    const GRAPH_AUTH_FAILED_MESSAGE: &str = "Windows could not complete Microsoft Graph sign-in.";
+    const GRAPH_AUTH_STALE_MESSAGE: &str =
+        "The sign-in result was superseded by a newer Graph connection change.";
 
-        match wam::acquire_token(hwnd_raw) {
-            Ok(token) => {
-                let status = token.status.clone();
-                if state.set_token_if_generation(expected_generation, token) {
-                    Ok(status)
-                } else {
-                    Ok(current_auth_status(state))
-                }
+    fn retained_auth_attempt(
+        state: &GraphAuthState,
+        expected_generation: u64,
+        outcome: GraphAuthAttemptOutcome,
+        capability: GraphHostCapability,
+        message: Option<&'static str>,
+    ) -> GraphAuthAttemptResult {
+        let (token, generation) = state.get_valid_token_snapshot();
+        let status = token
+            .map(|cached| cached.status)
+            .unwrap_or_else(GraphAuthStatus::disconnected);
+        if generation == expected_generation {
+            GraphAuthAttemptResult {
+                outcome,
+                status,
+                capability,
+                message: message.map(str::to_string),
             }
-            Err(failure) => {
-                let error = failure.into_initial_auth_error();
-                if state.clear_token_if_generation(expected_generation) {
-                    Ok(GraphAuthStatus::disconnected(Some(error.to_string())))
-                } else {
-                    Ok(current_auth_status(state))
-                }
+        } else {
+            GraphAuthAttemptResult {
+                outcome: GraphAuthAttemptOutcome::Stale,
+                status,
+                capability,
+                message: Some(GRAPH_AUTH_STALE_MESSAGE.to_string()),
             }
         }
     }
 
-    pub fn request_missing_permissions_on_initialized_worker(
+    fn unavailable_message(kind: GraphHostCapabilityKind) -> Option<&'static str> {
+        match kind {
+            GraphHostCapabilityKind::PersonalAccountOnly => Some(
+                "Only a personal Microsoft account is available. Connect a Windows work or school account to use Microsoft Graph.",
+            ),
+            GraphHostCapabilityKind::NoOrganizationalAccount => Some(
+                "No Windows work or school account is available for Microsoft Graph.",
+            ),
+            GraphHostCapabilityKind::ProviderUnavailable => Some(
+                "Windows Web Account Manager is unavailable on this host.",
+            ),
+            GraphHostCapabilityKind::Available | GraphHostCapabilityKind::Unknown => None,
+        }
+    }
+
+    pub fn probe_host_capability() -> GraphHostCapability {
+        wam::probe_host_capability()
+    }
+
+    /// Authenticate with Graph API via WAM on an off-thread worker.
+    pub fn authenticate(
         state: &GraphAuthState,
         hwnd_raw: isize,
+        lease: &GraphInteractiveOperationLease,
+    ) -> GraphAuthAttemptResult {
+        let expected_generation = match state.claim_authentication() {
+            Ok(cached) => {
+                return GraphAuthAttemptResult {
+                    outcome: GraphAuthAttemptOutcome::Connected,
+                    status: cached.status,
+                    capability: GraphHostCapability::new(GraphHostCapabilityKind::Available),
+                    message: None,
+                }
+            }
+            Err(generation) => generation,
+        };
+        let deadline = wam::authentication_deadline();
+        let capability = match wam::probe_host_capability_for_authentication(deadline, lease) {
+            Ok(capability) => capability,
+            Err(WamAcquisitionFailure::Cancelled) => {
+                return retained_auth_attempt(
+                    state,
+                    expected_generation,
+                    GraphAuthAttemptOutcome::Cancelled,
+                    GraphHostCapability::new(GraphHostCapabilityKind::Unknown),
+                    Some(GRAPH_AUTH_CANCELLED_MESSAGE),
+                )
+            }
+            Err(WamAcquisitionFailure::TimedOut) => {
+                return retained_auth_attempt(
+                    state,
+                    expected_generation,
+                    GraphAuthAttemptOutcome::TimedOut,
+                    GraphHostCapability::new(GraphHostCapabilityKind::Unknown),
+                    Some(GRAPH_AUTH_TIMED_OUT_MESSAGE),
+                )
+            }
+            Err(WamAcquisitionFailure::Denied(_) | WamAcquisitionFailure::Failed(_)) => {
+                GraphHostCapability::new(GraphHostCapabilityKind::Unknown)
+            }
+        };
+        if let Some(message) = unavailable_message(capability.kind) {
+            return retained_auth_attempt(
+                state,
+                expected_generation,
+                GraphAuthAttemptOutcome::Unavailable,
+                capability,
+                Some(message),
+            );
+        }
+
+        match wam::acquire_token(hwnd_raw, deadline, lease) {
+            Ok(token) => {
+                let status = token.status.clone();
+                match lease
+                    .publish_if_active(|| state.set_token_if_generation(expected_generation, token))
+                {
+                    Some(true) => GraphAuthAttemptResult {
+                        outcome: GraphAuthAttemptOutcome::Connected,
+                        status,
+                        capability,
+                        message: None,
+                    },
+                    None => retained_auth_attempt(
+                        state,
+                        expected_generation,
+                        GraphAuthAttemptOutcome::Cancelled,
+                        capability,
+                        Some(GRAPH_AUTH_CANCELLED_MESSAGE),
+                    ),
+                    Some(false) => retained_auth_attempt(
+                        state,
+                        expected_generation,
+                        GraphAuthAttemptOutcome::Stale,
+                        capability,
+                        Some(GRAPH_AUTH_STALE_MESSAGE),
+                    ),
+                }
+            }
+            Err(WamAcquisitionFailure::Cancelled) => retained_auth_attempt(
+                state,
+                expected_generation,
+                GraphAuthAttemptOutcome::Cancelled,
+                capability,
+                Some(GRAPH_AUTH_CANCELLED_MESSAGE),
+            ),
+            Err(WamAcquisitionFailure::TimedOut) => retained_auth_attempt(
+                state,
+                expected_generation,
+                GraphAuthAttemptOutcome::TimedOut,
+                capability,
+                Some(GRAPH_AUTH_TIMED_OUT_MESSAGE),
+            ),
+            Err(WamAcquisitionFailure::Denied(_) | WamAcquisitionFailure::Failed(_)) => {
+                retained_auth_attempt(
+                    state,
+                    expected_generation,
+                    GraphAuthAttemptOutcome::Failed,
+                    capability,
+                    Some(GRAPH_AUTH_FAILED_MESSAGE),
+                )
+            }
+        }
+    }
+
+    pub fn request_missing_permissions(
+        state: &GraphAuthState,
+        hwnd_raw: isize,
+        lease: &GraphInteractiveOperationLease,
     ) -> Result<GraphPermissionUpgradeResult, AppError> {
-        request_missing_permissions_with(state, || {
-            wam::acquire_permission_consent_token_on_initialized_worker(hwnd_raw)
+        let deadline = wam::authentication_deadline();
+        request_missing_permissions_with(state, Some(lease), || {
+            wam::acquire_permission_consent_token(hwnd_raw, deadline, lease)
         })
     }
 
@@ -1430,7 +1881,6 @@ mod windows_impl {
                     .collect(),
                 expires_at: Some(unix_now() + 3_600),
                 capabilities: GraphAuthCapabilities::default(),
-                error: None,
             }
         }
 
@@ -1465,7 +1915,7 @@ mod windows_impl {
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
 
-            let result = request_missing_permissions_with(&state, || Ok(candidate))
+            let result = request_missing_permissions_with(&state, None, || Ok(candidate))
                 .expect("candidate rejection is a structured outcome");
 
             assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Failed);
@@ -1483,7 +1933,7 @@ mod windows_impl {
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
 
-            let result = request_missing_permissions_with(&state, || Err(failure))
+            let result = request_missing_permissions_with(&state, None, || Err(failure))
                 .expect("acquisition failure is a structured outcome");
 
             assert_eq!(result.outcome, expected_outcome);
@@ -1497,7 +1947,7 @@ mod windows_impl {
             let state = GraphAuthState::new();
             let calls = Cell::new(0);
 
-            let result = request_missing_permissions_with(&state, || {
+            let result = request_missing_permissions_with(&state, None, || {
                 calls.set(calls.get() + 1);
                 unreachable!("disconnected precondition must stop before WAM")
             });
@@ -1520,7 +1970,7 @@ mod windows_impl {
             ));
             let calls = Cell::new(0);
 
-            let result = request_missing_permissions_with(&state, || {
+            let result = request_missing_permissions_with(&state, None, || {
                 calls.set(calls.get() + 1);
                 unreachable!("complete precondition must stop before WAM")
             });
@@ -1546,7 +1996,7 @@ mod windows_impl {
             let expected_status = candidate.status.clone();
             let calls = Cell::new(0);
 
-            let result = request_missing_permissions_with(&state, || {
+            let result = request_missing_permissions_with(&state, None, || {
                 calls.set(calls.get() + 1);
                 Ok(candidate)
             })
@@ -1580,7 +2030,7 @@ mod windows_impl {
                 &[GRAPH_DELEGATED_SCOPES[0]],
             );
 
-            let result = request_missing_permissions_with(&state, || Ok(candidate))
+            let result = request_missing_permissions_with(&state, None, || Ok(candidate))
                 .expect("equal scopes are unchanged");
 
             assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Unchanged);
@@ -1609,7 +2059,7 @@ mod windows_impl {
                 &[GRAPH_DELEGATED_SCOPES[0]],
             );
 
-            let result = request_missing_permissions_with(&state, || Ok(candidate))
+            let result = request_missing_permissions_with(&state, None, || Ok(candidate))
                 .expect("scope regression is a structured failure");
 
             assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Failed);
@@ -1660,12 +2110,21 @@ mod windows_impl {
         }
 
         #[test]
+        fn graph_permission_upgrade_timeout_retains_original_token() {
+            assert_acquisition_failure_retains_current(
+                WamAcquisitionFailure::TimedOut,
+                GraphPermissionUpgradeOutcome::TimedOut,
+                true,
+            );
+        }
+
+        #[test]
         fn graph_permission_upgrade_denial_retains_original_token_and_sanitizes_provider_text() {
             let raw_provider_text = "AADSTS65004: UserDeclinedConsent access_denied";
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
 
-            let result = request_missing_permissions_with(&state, || {
+            let result = request_missing_permissions_with(&state, None, || {
                 Err(WamAcquisitionFailure::Denied(AppError::Internal(
                     raw_provider_text.to_string(),
                 )))
@@ -1686,7 +2145,7 @@ mod windows_impl {
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
 
-            let result = request_missing_permissions_with(&state, || {
+            let result = request_missing_permissions_with(&state, None, || {
                 Err(WamAcquisitionFailure::Failed(AppError::Internal(
                     raw_provider_text.to_string(),
                 )))
@@ -1762,7 +2221,7 @@ mod windows_impl {
                 &[GRAPH_DELEGATED_SCOPES[0], GRAPH_DELEGATED_SCOPES[1]],
             );
 
-            let result = request_missing_permissions_with(&state, || {
+            let result = request_missing_permissions_with(&state, None, || {
                 state.clear_token();
                 Ok(candidate)
             })
@@ -1793,7 +2252,7 @@ mod windows_impl {
             );
             let newer_status = newer.status.clone();
 
-            let result = request_missing_permissions_with(&state, || {
+            let result = request_missing_permissions_with(&state, None, || {
                 assert!(state.set_token_if_generation(1, newer));
                 Ok(candidate)
             })
@@ -1818,7 +2277,7 @@ mod windows_impl {
             );
             let newer_status = newer.status.clone();
 
-            let result = request_missing_permissions_with(&state, || {
+            let result = request_missing_permissions_with(&state, None, || {
                 assert!(state.set_token_if_generation(1, newer));
                 Err(WamAcquisitionFailure::Failed(AppError::Internal(
                     "raw-provider-sensitive-text".to_string(),
@@ -1855,7 +2314,7 @@ mod windows_impl {
                 .expect("ESP operation");
             assert!(!operation.is_cancelled());
 
-            let result = request_missing_permissions_with(&state, || {
+            let result = request_missing_permissions_with(&state, None, || {
                 Ok(token(
                     CANDIDATE_TOKEN,
                     "user@contoso.example",
@@ -1915,7 +2374,6 @@ mod windows_impl {
                     missing_scopes: Vec::new(),
                     expires_at: Some(unix_now() + 3_600),
                     capabilities: super::super::GraphAuthCapabilities::all(),
-                    error: None,
                 },
             }
         }
@@ -1971,6 +2429,89 @@ mod tests {
     const APP_A: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     const APP_B: &str = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
     const APP_SCOPE: &str = "DeviceManagementApps.Read.All";
+
+    #[test]
+    fn graph_host_capability_distinguishes_organizational_and_personal_hosts() {
+        use super::{
+            classify_graph_host_capability, GraphAccountEnumeration as Accounts,
+            GraphHostCapabilityKind as Capability,
+        };
+
+        for (organizational, personal, expected) in [
+            (
+                Accounts::Accounts(1),
+                Accounts::Accounts(0),
+                Capability::Available,
+            ),
+            (
+                Accounts::Accounts(0),
+                Accounts::Accounts(1),
+                Capability::PersonalAccountOnly,
+            ),
+            (
+                Accounts::Accounts(0),
+                Accounts::Accounts(0),
+                Capability::NoOrganizationalAccount,
+            ),
+            (
+                Accounts::ProviderUnavailable,
+                Accounts::Accounts(0),
+                Capability::ProviderUnavailable,
+            ),
+            (
+                Accounts::Unknown,
+                Accounts::Accounts(0),
+                Capability::Unknown,
+            ),
+            (
+                Accounts::Accounts(0),
+                Accounts::Unknown,
+                Capability::Unknown,
+            ),
+        ] {
+            assert_eq!(
+                classify_graph_host_capability(organizational, personal),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn graph_interactive_operation_owns_and_cancels_only_the_matching_request() {
+        let registry = std::sync::Arc::new(super::GraphInteractiveOperationRegistry::default());
+        let first = registry
+            .begin("request-a".to_string())
+            .expect("first operation should own the slot");
+        assert_eq!(
+            registry.begin("request-b".to_string()).err(),
+            Some(super::GraphInteractiveOperationError::Busy)
+        );
+        assert!(!registry.cancel("request-b"));
+        assert!(registry.cancel("request-a"));
+        assert!(first.is_cancelled());
+        assert!(!registry.cancel("request-a"));
+
+        drop(first);
+        let second = registry
+            .begin("request-b".to_string())
+            .expect("dropping the lease should release ownership");
+        assert!(!second.is_cancelled());
+    }
+
+    #[test]
+    fn graph_interactive_operation_never_publishes_after_matching_cancellation() {
+        let registry = std::sync::Arc::new(super::GraphInteractiveOperationRegistry::default());
+        let cancelled = registry.begin("cancelled".to_string()).unwrap();
+        assert!(registry.cancel("cancelled"));
+        let mut published = false;
+        assert_eq!(cancelled.publish_if_active(|| published = true), None,);
+        assert!(!published);
+
+        drop(cancelled);
+        let completed = registry.begin("completed".to_string()).unwrap();
+        assert_eq!(completed.publish_if_active(|| 42), Some(42));
+        assert!(!registry.cancel("completed"));
+    }
 
     #[test]
     fn graph_permission_upgrade_recognizes_documented_consent_denial_markers() {

--- a/src-tauri/src/graph_api.rs
+++ b/src-tauri/src/graph_api.rs
@@ -374,34 +374,14 @@ mod windows_impl {
     enum WamAcquisitionFailure {
         Cancelled,
         TimedOut,
-        Denied(AppError),
-        Failed(AppError),
+        Denied,
+        Failed,
     }
-
-    const WAM_USER_INTERACTION_REQUIRED_MESSAGE: &str =
-        "Interactive authentication required. Please sign in to Windows with your Entra ID account first.";
 
     impl From<AppError> for WamAcquisitionFailure {
-        fn from(error: AppError) -> Self {
-            Self::Failed(error)
+        fn from(_error: AppError) -> Self {
+            Self::Failed
         }
-    }
-
-    impl WamAcquisitionFailure {
-        fn into_initial_auth_error(self) -> AppError {
-            match self {
-                Self::Cancelled => {
-                    AppError::Internal("Authentication was cancelled by user.".into())
-                }
-                Self::TimedOut => AppError::Internal("Authentication timed out.".into()),
-                Self::Denied(error) | Self::Failed(error) => error,
-            }
-        }
-    }
-
-    fn wam_provider_legacy_error(error_message: Option<String>) -> AppError {
-        let error_message = error_message.unwrap_or_else(|| "Unknown WAM error".to_string());
-        AppError::Internal(format!("WAM authentication failed: {error_message}"))
     }
 
     fn wam_provider_status_failure(
@@ -409,11 +389,10 @@ mod windows_impl {
         error_message: Option<String>,
     ) -> WamAcquisitionFailure {
         let denied = super::is_wam_consent_denial(error_code, error_message.as_deref());
-        let legacy_error = wam_provider_legacy_error(error_message);
         if denied {
-            WamAcquisitionFailure::Denied(legacy_error)
+            WamAcquisitionFailure::Denied
         } else {
-            WamAcquisitionFailure::Failed(legacy_error)
+            WamAcquisitionFailure::Failed
         }
     }
 
@@ -638,7 +617,6 @@ mod windows_impl {
         fn wait_for_operation<T>(
             operation: &IAsyncOperation<T>,
             deadline: std::time::Instant,
-            stage: &str,
             cancelled: Option<&std::sync::atomic::AtomicBool>,
         ) -> Result<T, WamAcquisitionFailure>
         where
@@ -651,11 +629,7 @@ mod windows_impl {
                     let _ = sender.send(result);
                     Ok(())
                 }))
-                .map_err(|error| {
-                    AppError::Internal(format!(
-                        "WAM {stage} completion registration failed: {error}"
-                    ))
-                })?;
+                .map_err(|_| WamAcquisitionFailure::Failed)?;
 
             loop {
                 if cancelled.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Acquire)) {
@@ -671,17 +645,11 @@ mod windows_impl {
 
                 match receiver.recv_timeout(remaining.min(GRAPH_WAM_POLL_INTERVAL)) {
                     Ok(result) => {
-                        return result.map_err(|error| {
-                            WamAcquisitionFailure::Failed(AppError::Internal(format!(
-                                "WAM {stage} failed: {error}"
-                            )))
-                        });
+                        return result.map_err(|_| WamAcquisitionFailure::Failed);
                     }
                     Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
                     Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                        return Err(WamAcquisitionFailure::Failed(AppError::Internal(format!(
-                            "WAM {stage} completion channel disconnected."
-                        ))));
+                        return Err(WamAcquisitionFailure::Failed);
                     }
                 }
             }
@@ -700,12 +668,7 @@ mod windows_impl {
                     Ok(operation) => operation,
                     Err(_) => return Ok(GraphAccountEnumeration::ProviderUnavailable),
                 };
-            let provider = match wait_for_operation(
-                &provider_operation,
-                deadline,
-                "provider lookup",
-                cancelled,
-            ) {
+            let provider = match wait_for_operation(&provider_operation, deadline, cancelled) {
                 Ok(provider) => provider,
                 Err(WamAcquisitionFailure::Cancelled) => {
                     return Err(WamAcquisitionFailure::Cancelled)
@@ -713,7 +676,7 @@ mod windows_impl {
                 Err(WamAcquisitionFailure::TimedOut) => {
                     return Err(WamAcquisitionFailure::TimedOut)
                 }
-                Err(WamAcquisitionFailure::Denied(_) | WamAcquisitionFailure::Failed(_)) => {
+                Err(WamAcquisitionFailure::Denied | WamAcquisitionFailure::Failed) => {
                     return Ok(GraphAccountEnumeration::ProviderUnavailable)
                 }
             };
@@ -723,12 +686,7 @@ mod windows_impl {
                     Ok(operation) => operation,
                     Err(_) => return Ok(GraphAccountEnumeration::Unknown),
                 };
-            let result = match wait_for_operation(
-                &accounts_operation,
-                deadline,
-                "account discovery",
-                cancelled,
-            ) {
+            let result = match wait_for_operation(&accounts_operation, deadline, cancelled) {
                 Ok(result) => result,
                 Err(WamAcquisitionFailure::Cancelled) => {
                     return Err(WamAcquisitionFailure::Cancelled)
@@ -736,7 +694,7 @@ mod windows_impl {
                 Err(WamAcquisitionFailure::TimedOut) => {
                     return Err(WamAcquisitionFailure::TimedOut)
                 }
-                Err(WamAcquisitionFailure::Denied(_) | WamAcquisitionFailure::Failed(_)) => {
+                Err(WamAcquisitionFailure::Denied | WamAcquisitionFailure::Failed) => {
                     return Ok(GraphAccountEnumeration::Unknown)
                 }
             };
@@ -838,7 +796,6 @@ mod windows_impl {
             let provider = wait_for_operation(
                 &provider_operation,
                 deadline,
-                "provider lookup",
                 Some(lease.cancellation_flag()),
             )?;
 
@@ -902,12 +859,7 @@ mod windows_impl {
                 unsafe { interop.RequestTokenForWindowAsync(hwnd, &request) }
                     .map_err(|e| AppError::Internal(format!("WAM token request failed: {e}")))?;
 
-            let result = wait_for_operation(
-                &operation,
-                deadline,
-                "token request",
-                Some(lease.cancellation_flag()),
-            )?;
+            let result = wait_for_operation(&operation, deadline, Some(lease.cancellation_flag()))?;
 
             let status = result
                 .ResponseStatus()
@@ -964,9 +916,7 @@ mod windows_impl {
                 }
                 WebTokenRequestStatus::UserCancel => Err(WamAcquisitionFailure::Cancelled),
                 WebTokenRequestStatus::UserInteractionRequired => {
-                    Err(WamAcquisitionFailure::Denied(AppError::Internal(
-                        WAM_USER_INTERACTION_REQUIRED_MESSAGE.into(),
-                    )))
+                    Err(WamAcquisitionFailure::Denied)
                 }
                 WebTokenRequestStatus::ProviderError => {
                     let provider_error = result.ResponseError().ok();
@@ -978,16 +928,7 @@ mod windows_impl {
                         .map(|message| message.to_string());
                     Err(wam_provider_status_failure(error_code, error_message))
                 }
-                _ => {
-                    let error_message = result
-                        .ResponseError()
-                        .ok()
-                        .and_then(|error| error.ErrorMessage().ok())
-                        .map(|message| message.to_string());
-                    Err(WamAcquisitionFailure::Failed(wam_provider_legacy_error(
-                        error_message,
-                    )))
-                }
+                _ => Err(WamAcquisitionFailure::Failed),
             }
         }
     }
@@ -1305,7 +1246,7 @@ mod windows_impl {
                     Some(GRAPH_PERMISSION_TIMED_OUT_MESSAGE),
                 ));
             }
-            Err(WamAcquisitionFailure::Denied(_)) => {
+            Err(WamAcquisitionFailure::Denied) => {
                 return Ok(retained_permission_upgrade_result(
                     state,
                     generation,
@@ -1313,7 +1254,7 @@ mod windows_impl {
                     Some(GRAPH_PERMISSION_DENIED_MESSAGE),
                 ));
             }
-            Err(WamAcquisitionFailure::Failed(_)) => {
+            Err(WamAcquisitionFailure::Failed) => {
                 return Ok(retained_permission_upgrade_result(
                     state,
                     generation,
@@ -1428,7 +1369,7 @@ mod windows_impl {
     }
 
     /// Authenticate with Graph API via WAM on an off-thread worker.
-    pub fn authenticate(
+    pub(crate) fn authenticate(
         state: &GraphAuthState,
         hwnd_raw: isize,
         lease: &GraphInteractiveOperationLease,
@@ -1465,7 +1406,7 @@ mod windows_impl {
                     Some(GRAPH_AUTH_TIMED_OUT_MESSAGE),
                 )
             }
-            Err(WamAcquisitionFailure::Denied(_) | WamAcquisitionFailure::Failed(_)) => {
+            Err(WamAcquisitionFailure::Denied | WamAcquisitionFailure::Failed) => {
                 GraphHostCapability::new(GraphHostCapabilityKind::Unknown)
             }
         };
@@ -1521,7 +1462,7 @@ mod windows_impl {
                 capability,
                 Some(GRAPH_AUTH_TIMED_OUT_MESSAGE),
             ),
-            Err(WamAcquisitionFailure::Denied(_) | WamAcquisitionFailure::Failed(_)) => {
+            Err(WamAcquisitionFailure::Denied | WamAcquisitionFailure::Failed) => {
                 retained_auth_attempt(
                     state,
                     expected_generation,
@@ -1533,7 +1474,7 @@ mod windows_impl {
         }
     }
 
-    pub fn request_missing_permissions(
+    pub(crate) fn request_missing_permissions(
         state: &GraphAuthState,
         hwnd_raw: isize,
         lease: &GraphInteractiveOperationLease,
@@ -2094,87 +2035,43 @@ mod windows_impl {
         }
 
         #[test]
-        fn graph_permission_upgrade_denial_retains_original_token_and_sanitizes_provider_text() {
-            let raw_provider_text = "AADSTS65004: UserDeclinedConsent access_denied";
+        fn graph_permission_upgrade_denial_retains_original_token() {
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
 
             let result = request_missing_permissions_with(&state, None, || {
-                Err(WamAcquisitionFailure::Denied(AppError::Internal(
-                    raw_provider_text.to_string(),
-                )))
+                Err(WamAcquisitionFailure::Denied)
             })
             .expect("provider denial is a structured outcome");
 
             assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Denied);
             assert!(result.message.is_some());
-            assert!(!format!("{result:?}").contains(raw_provider_text));
             assert_eq!(result.status, current_auth_status(&state));
             assert_eq!(stored_token_and_generation(&state), before);
         }
 
         #[test]
-        fn graph_permission_upgrade_provider_failure_retains_original_token_and_sanitizes_message()
-        {
-            let raw_provider_text = "raw-provider-sensitive-text";
+        fn graph_permission_upgrade_provider_failure_retains_original_token() {
             let state = seed_partial_state();
             let before = stored_token_and_generation(&state);
 
             let result = request_missing_permissions_with(&state, None, || {
-                Err(WamAcquisitionFailure::Failed(AppError::Internal(
-                    raw_provider_text.to_string(),
-                )))
+                Err(WamAcquisitionFailure::Failed)
             })
             .expect("provider failure is a structured outcome");
 
             assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Failed);
             assert!(result.message.is_some());
-            assert!(!format!("{result:?}").contains(raw_provider_text));
             assert_eq!(result.status, current_auth_status(&state));
             assert_eq!(stored_token_and_generation(&state), before);
         }
 
         #[test]
-        fn graph_permission_upgrade_provider_status_failure_preserves_legacy_initial_auth_detail() {
-            let raw_provider_text = "provider-specific failure";
-            let error = wam_provider_status_failure(None, Some(raw_provider_text.to_string()))
-                .into_initial_auth_error();
-            assert_eq!(
-                error.to_string(),
-                format!("WAM authentication failed: {raw_provider_text}")
-            );
-
-            let fallback = wam_provider_status_failure(None, None).into_initial_auth_error();
-            assert_eq!(
-                fallback.to_string(),
-                "WAM authentication failed: Unknown WAM error"
-            );
-        }
-
-        #[test]
-        fn graph_permission_upgrade_provider_denial_is_reachable_and_preserves_legacy_detail() {
+        fn graph_permission_upgrade_provider_denial_is_classified_without_exposing_detail() {
             let raw_provider_text = "AADSTS65004: UserDeclinedConsent; OAuth error=access_denied";
             let failure =
                 wam_provider_status_failure(Some(65_004), Some(raw_provider_text.to_string()));
-            assert!(matches!(&failure, WamAcquisitionFailure::Denied(_)));
-
-            let error = failure.into_initial_auth_error();
-            assert_eq!(
-                error.to_string(),
-                format!("WAM authentication failed: {raw_provider_text}")
-            );
-        }
-
-        #[test]
-        fn graph_permission_upgrade_user_interaction_required_preserves_legacy_guidance() {
-            let failure = WamAcquisitionFailure::Denied(AppError::Internal(
-                WAM_USER_INTERACTION_REQUIRED_MESSAGE.into(),
-            ));
-
-            assert_eq!(
-                failure.into_initial_auth_error().to_string(),
-                "Interactive authentication required. Please sign in to Windows with your Entra ID account first."
-            );
+            assert!(matches!(failure, WamAcquisitionFailure::Denied));
         }
 
         #[test]
@@ -2183,7 +2080,7 @@ mod windows_impl {
                 Some(65_005),
                 Some("AADSTS65005: MisconfiguredApplication".to_string()),
             );
-            assert!(matches!(failure, WamAcquisitionFailure::Failed(_)));
+            assert!(matches!(failure, WamAcquisitionFailure::Failed));
         }
 
         #[test]
@@ -2254,15 +2151,12 @@ mod windows_impl {
 
             let result = request_missing_permissions_with(&state, None, || {
                 assert!(state.set_token_if_generation(1, newer));
-                Err(WamAcquisitionFailure::Failed(AppError::Internal(
-                    "raw-provider-sensitive-text".to_string(),
-                )))
+                Err(WamAcquisitionFailure::Failed)
             })
             .expect("stale failure is a structured outcome");
 
             assert_eq!(result.outcome, GraphPermissionUpgradeOutcome::Stale);
             assert_eq!(result.status, newer_status);
-            assert!(!format!("{result:?}").contains("raw-provider-sensitive-text"));
         }
 
         #[cfg(feature = "esp-diagnostics")]

--- a/src-tauri/src/graph_api.rs
+++ b/src-tauri/src/graph_api.rs
@@ -447,14 +447,11 @@ mod windows_impl {
             self.inner
                 .interactive_operations
                 .reserve(kind)
-                .map_err(|error| match error {
-                    GraphInteractiveOperationError::Busy => AppError::InvalidInput(
+                .map_err(|_| {
+                    AppError::InvalidInput(
                         "Another Microsoft Graph sign-in action is already in progress."
                             .to_string(),
-                    ),
-                    GraphInteractiveOperationError::InvalidTicket => AppError::InvalidInput(
-                        "Invalid Microsoft Graph operation ticket.".to_string(),
-                    ),
+                    )
                 })
         }
 

--- a/src-tauri/src/graph_api/models.rs
+++ b/src-tauri/src/graph_api/models.rs
@@ -70,7 +70,10 @@ pub const GRAPH_WAM_PERMISSION_REQUEST: GraphWamPermissionRequestContract =
         properties: &[
             ("wam_compat", "2.0"),
             ("prompt", "consent"),
-            ("authority", "https://login.microsoftonline.com/common/"),
+            (
+                "authority",
+                "https://login.microsoftonline.com/organizations/",
+            ),
             ("validateAuthority", "yes"),
         ],
     };
@@ -145,7 +148,48 @@ pub struct GraphAuthStatus {
     pub missing_scopes: Vec<String>,
     pub expires_at: Option<u64>,
     pub capabilities: GraphAuthCapabilities,
-    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum GraphHostCapabilityKind {
+    Available,
+    PersonalAccountOnly,
+    NoOrganizationalAccount,
+    ProviderUnavailable,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphHostCapability {
+    pub kind: GraphHostCapabilityKind,
+}
+
+impl GraphHostCapability {
+    pub const fn new(kind: GraphHostCapabilityKind) -> Self {
+        Self { kind }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum GraphAuthAttemptOutcome {
+    Connected,
+    Cancelled,
+    TimedOut,
+    Unavailable,
+    Failed,
+    Stale,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphAuthAttemptResult {
+    pub outcome: GraphAuthAttemptOutcome,
+    pub status: GraphAuthStatus,
+    pub capability: GraphHostCapability,
+    pub message: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -154,6 +198,7 @@ pub enum GraphPermissionUpgradeOutcome {
     Upgraded,
     Unchanged,
     Cancelled,
+    TimedOut,
     Denied,
     Failed,
     Stale,
@@ -242,7 +287,7 @@ pub fn classify_graph_permission_candidate(
 }
 
 impl GraphAuthStatus {
-    pub fn disconnected(error: Option<String>) -> Self {
+    pub fn disconnected() -> Self {
         Self {
             is_authenticated: false,
             user_principal_name: None,
@@ -255,8 +300,34 @@ impl GraphAuthStatus {
                 .collect(),
             expires_at: None,
             capabilities: GraphAuthCapabilities::default(),
-            error,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphTokenProjectionError {
+    MalformedToken,
+    MissingAudience,
+    InvalidAudience,
+    MissingExpiry,
+    ExpiredToken,
+    MissingTenant,
+    TenantMismatch,
+    MissingScopeClaim,
+}
+
+impl fmt::Display for GraphTokenProjectionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::MalformedToken => "MalformedToken",
+            Self::MissingAudience => "MissingAudience",
+            Self::InvalidAudience => "InvalidAudience",
+            Self::MissingExpiry => "MissingExpiry",
+            Self::ExpiredToken => "ExpiredToken",
+            Self::MissingTenant => "MissingTenant",
+            Self::TenantMismatch => "TenantMismatch",
+            Self::MissingScopeClaim => "MissingScopeClaim",
+        })
     }
 }
 
@@ -270,49 +341,47 @@ pub fn project_graph_auth_status(
     user_principal_name: Option<&str>,
     wam_tenant_id: Option<&str>,
     now_unix: u64,
-) -> GraphAuthStatus {
-    let reject = |code: &str| GraphAuthStatus::disconnected(Some(code.to_string()));
-
+) -> Result<GraphAuthStatus, GraphTokenProjectionError> {
     if access_token.is_empty() || access_token.len() > MAX_ACCESS_TOKEN_BYTES {
-        return reject("MalformedToken");
+        return Err(GraphTokenProjectionError::MalformedToken);
     }
 
     let mut segments = access_token.split('.');
     let Some(header) = segments.next() else {
-        return reject("MalformedToken");
+        return Err(GraphTokenProjectionError::MalformedToken);
     };
     let Some(payload) = segments.next() else {
-        return reject("MalformedToken");
+        return Err(GraphTokenProjectionError::MalformedToken);
     };
     let Some(signature) = segments.next() else {
-        return reject("MalformedToken");
+        return Err(GraphTokenProjectionError::MalformedToken);
     };
     if header.is_empty() || payload.is_empty() || signature.is_empty() || segments.next().is_some()
     {
-        return reject("MalformedToken");
+        return Err(GraphTokenProjectionError::MalformedToken);
     }
 
     let Ok(payload) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload) else {
-        return reject("MalformedToken");
+        return Err(GraphTokenProjectionError::MalformedToken);
     };
     let Ok(claims) = serde_json::from_slice::<serde_json::Value>(&payload) else {
-        return reject("MalformedToken");
+        return Err(GraphTokenProjectionError::MalformedToken);
     };
 
     let Some(audience) = claims.get("aud").and_then(serde_json::Value::as_str) else {
-        return reject("MissingAudience");
+        return Err(GraphTokenProjectionError::MissingAudience);
     };
     if audience.trim_end_matches('/') != GRAPH_URL_AUDIENCE
         && !audience.eq_ignore_ascii_case(GRAPH_APP_ID_AUDIENCE)
     {
-        return reject("InvalidAudience");
+        return Err(GraphTokenProjectionError::InvalidAudience);
     }
 
     let Some(expires_at) = claims.get("exp").and_then(serde_json::Value::as_u64) else {
-        return reject("MissingExpiry");
+        return Err(GraphTokenProjectionError::MissingExpiry);
     };
     if expires_at <= now_unix {
-        return reject("ExpiredToken");
+        return Err(GraphTokenProjectionError::ExpiredToken);
     }
 
     let Some(token_tenant_id) = claims
@@ -320,13 +389,13 @@ pub fn project_graph_auth_status(
         .and_then(serde_json::Value::as_str)
         .filter(|tenant| !tenant.is_empty())
     else {
-        return reject("MissingTenant");
+        return Err(GraphTokenProjectionError::MissingTenant);
     };
     if wam_tenant_id
         .filter(|tenant| !tenant.is_empty())
         .is_some_and(|tenant| !tenant.eq_ignore_ascii_case(token_tenant_id))
     {
-        return reject("TenantMismatch");
+        return Err(GraphTokenProjectionError::TenantMismatch);
     }
 
     // Authoritative account identity. Present in every authenticated Entra
@@ -340,7 +409,7 @@ pub fn project_graph_auth_status(
         .map(str::to_string);
 
     let Some(scope_claim) = claims.get("scp").and_then(serde_json::Value::as_str) else {
-        return reject("MissingScopeClaim");
+        return Err(GraphTokenProjectionError::MissingScopeClaim);
     };
     let token_scopes: Vec<&str> = scope_claim.split_whitespace().collect();
     let granted_scopes: Vec<String> = GRAPH_DELEGATED_SCOPES
@@ -363,7 +432,7 @@ pub fn project_graph_auth_status(
         .collect();
     let capabilities = GraphAuthCapabilities::from_granted_scopes(&granted_scopes);
 
-    GraphAuthStatus {
+    Ok(GraphAuthStatus {
         is_authenticated: true,
         user_principal_name: user_principal_name.map(str::to_string),
         object_id,
@@ -372,8 +441,7 @@ pub fn project_graph_auth_status(
         missing_scopes,
         expires_at: Some(expires_at),
         capabilities,
-        error: None,
-    }
+    })
 }
 
 /// A resolved app from Graph API.

--- a/src-tauri/src/graph_api/models.rs
+++ b/src-tauri/src/graph_api/models.rs
@@ -17,18 +17,9 @@ pub const GRAPH_DELEGATED_SCOPES: [&str; 5] = [
     "DeviceManagementScripts.Read.All",
 ];
 
-pub const GRAPH_SCOPE_REQUEST: &str = concat!(
-    "DeviceManagementManagedDevices.Read.All ",
-    "DeviceManagementServiceConfig.Read.All ",
-    "DeviceManagementApps.Read.All ",
-    "DeviceManagementConfiguration.Read.All ",
-    "DeviceManagementScripts.Read.All"
-);
-
-/// Interactive Entra WAM v2 scope string. The five declared Intune data
-/// permissions remain fixed; these three standard OpenID Connect scopes are
-/// the identity/session scopes MSAL adds to interactive public-client calls.
-pub const GRAPH_WAM_PERMISSION_SCOPE_REQUEST: &str = concat!(
+/// Organizations-only interactive scope request shared by initial sign-in and
+/// explicit missing-permission consent.
+pub const GRAPH_WAM_SCOPE_REQUEST: &str = concat!(
     "DeviceManagementManagedDevices.Read.All ",
     "DeviceManagementServiceConfig.Read.All ",
     "DeviceManagementApps.Read.All ",
@@ -40,45 +31,13 @@ pub const GRAPH_WAM_PERMISSION_SCOPE_REQUEST: &str = concat!(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GraphWamRequestContract {
     pub scope: &'static str,
-    pub resource_property: &'static str,
-    pub resource: &'static str,
 }
 
 pub const GRAPH_WAM_REQUEST: GraphWamRequestContract = GraphWamRequestContract {
-    scope: GRAPH_SCOPE_REQUEST,
-    resource_property: "resource",
-    resource: "https://graph.microsoft.com",
+    scope: GRAPH_WAM_SCOPE_REQUEST,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct GraphWamPermissionRequestContract {
-    pub scope: &'static str,
-    pub force_authentication: bool,
-    pub properties: &'static [(&'static str, &'static str)],
-}
-
-/// Provider contract for the explicit permission-upgrade action.
-///
-/// The Entra WAM provider's v2 compatibility mode interprets `scope` as a
-/// dynamic delegated-permission request. `prompt=consent` requests an explicit
-/// approval/denial surface instead of allowing the button to reuse the
-/// established default/resource request that returned a cached partial token.
-pub const GRAPH_WAM_PERMISSION_REQUEST: GraphWamPermissionRequestContract =
-    GraphWamPermissionRequestContract {
-        scope: GRAPH_WAM_PERMISSION_SCOPE_REQUEST,
-        force_authentication: true,
-        properties: &[
-            ("wam_compat", "2.0"),
-            ("prompt", "consent"),
-            (
-                "authority",
-                "https://login.microsoftonline.com/organizations/",
-            ),
-            ("validateAuthority", "yes"),
-        ],
-    };
-
-const GRAPH_URL_AUDIENCE: &str = GRAPH_WAM_REQUEST.resource;
+const GRAPH_URL_AUDIENCE: &str = "https://graph.microsoft.com";
 const GRAPH_APP_ID_AUDIENCE: &str = "00000003-0000-0000-c000-000000000000";
 const MAX_ACCESS_TOKEN_BYTES: usize = 64 * 1024;
 
@@ -170,6 +129,19 @@ impl GraphHostCapability {
     pub const fn new(kind: GraphHostCapabilityKind) -> Self {
         Self { kind }
     }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum GraphInteractiveOperationKind {
+    Authentication,
+    PermissionConsent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphInteractiveOperationTicket {
+    pub attempt_id: String,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/src-tauri/src/ipc_bridge.rs
+++ b/src-tauri/src/ipc_bridge.rs
@@ -183,8 +183,11 @@ fn dispatch(body: &str, state: &Arc<BridgeState>) -> String {
             err_json("ESP Graph commands are unavailable through the debug IPC bridge")
         }
 
-        "graph_request_missing_permissions" => {
-            err_json("Graph permission upgrade is unavailable through the debug IPC bridge")
+        "graph_authenticate"
+        | "graph_probe_capability"
+        | "graph_cancel_authentication"
+        | "graph_request_missing_permissions" => {
+            err_json("Microsoft Graph sign-in is unavailable through the debug IPC bridge")
         }
 
         #[cfg(feature = "esp-diagnostics")]
@@ -333,7 +336,7 @@ mod tests {
             let value: serde_json::Value = serde_json::from_str(&response).unwrap();
             assert_eq!(
                 value["error"],
-                "Graph permission upgrade is unavailable through the debug IPC bridge"
+                "Microsoft Graph sign-in is unavailable through the debug IPC bridge"
             );
             assert!(value.get("result").is_none());
         }

--- a/src-tauri/src/ipc_bridge.rs
+++ b/src-tauri/src/ipc_bridge.rs
@@ -184,7 +184,7 @@ fn dispatch(body: &str, state: &Arc<BridgeState>) -> String {
         }
 
         "graph_authenticate"
-        | "graph_probe_capability"
+        | "graph_reserve_interactive_operation"
         | "graph_cancel_authentication"
         | "graph_request_missing_permissions" => {
             err_json("Microsoft Graph sign-in is unavailable through the debug IPC bridge")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -350,7 +350,7 @@ pub fn run() {
             #[cfg(target_os = "windows")]
             commands::graph_api::graph_authenticate,
             #[cfg(target_os = "windows")]
-            commands::graph_api::graph_probe_capability,
+            commands::graph_api::graph_reserve_interactive_operation,
             #[cfg(target_os = "windows")]
             commands::graph_api::graph_cancel_authentication,
             #[cfg(target_os = "windows")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -350,6 +350,10 @@ pub fn run() {
             #[cfg(target_os = "windows")]
             commands::graph_api::graph_authenticate,
             #[cfg(target_os = "windows")]
+            commands::graph_api::graph_probe_capability,
+            #[cfg(target_os = "windows")]
+            commands::graph_api::graph_cancel_authentication,
+            #[cfg(target_os = "windows")]
             commands::graph_api::graph_request_missing_permissions,
             #[cfg(target_os = "windows")]
             commands::graph_api::graph_get_auth_status,

--- a/src-tauri/tests/graph_esp_diagnostics.rs
+++ b/src-tauri/tests/graph_esp_diagnostics.rs
@@ -191,7 +191,7 @@ fn graph_permission_upgrade_command_runs_owned_wam_on_a_blocking_worker() {
     let graph_source = include_str!("../src/graph_api.rs");
     let permission_entry = source_section(
         graph_source,
-        "pub fn request_missing_permissions(",
+        "pub(crate) fn request_missing_permissions(",
         "/// Get current auth status",
     );
     assert!(permission_entry
@@ -278,8 +278,8 @@ fn graph_permission_upgrade_command_runs_owned_wam_on_a_blocking_worker() {
 
     let authenticate = source_section(
         graph_source,
-        "pub fn authenticate(",
-        "pub fn request_missing_permissions(",
+        "pub(crate) fn authenticate(",
+        "pub(crate) fn request_missing_permissions(",
     );
     assert!(authenticate.contains("match wam::acquire_token(hwnd_raw, deadline, lease)"));
     assert!(authenticate.contains("probe_host_capability_for_authentication(deadline, lease)"));

--- a/src-tauri/tests/graph_esp_diagnostics.rs
+++ b/src-tauri/tests/graph_esp_diagnostics.rs
@@ -12,7 +12,8 @@ use app_lib::graph_api::client::{
 };
 use app_lib::graph_api::models::{
     classify_graph_permission_candidate, normalize_graph_guid, project_graph_auth_status,
-    GraphAppInfo, GraphAuthCapabilities, GraphAuthStatus, GraphHttpMethod,
+    GraphAppInfo, GraphAuthAttemptOutcome, GraphAuthAttemptResult, GraphAuthCapabilities,
+    GraphAuthStatus, GraphHostCapability, GraphHostCapabilityKind, GraphHttpMethod,
     GraphPermissionCandidateDecision, GraphPermissionUpgradeOutcome, GraphPermissionUpgradeResult,
     GraphResolutionResult, GraphTransportRequest, GraphTransportResponse, GRAPH_DELEGATED_SCOPES,
     GRAPH_SCOPE_REQUEST, GRAPH_WAM_PERMISSION_REQUEST, GRAPH_WAM_PERMISSION_SCOPE_REQUEST,
@@ -88,7 +89,6 @@ fn graph_permission_status_with_oid(
             .collect(),
         expires_at: Some(2_000_000_000),
         capabilities: GraphAuthCapabilities::default(),
-        error: None,
     }
 }
 
@@ -98,6 +98,7 @@ fn graph_permission_upgrade_outcomes_serialize_to_camel_case_wire_values() {
         (GraphPermissionUpgradeOutcome::Upgraded, "\"upgraded\""),
         (GraphPermissionUpgradeOutcome::Unchanged, "\"unchanged\""),
         (GraphPermissionUpgradeOutcome::Cancelled, "\"cancelled\""),
+        (GraphPermissionUpgradeOutcome::TimedOut, "\"timedOut\""),
         (GraphPermissionUpgradeOutcome::Denied, "\"denied\""),
         (GraphPermissionUpgradeOutcome::Failed, "\"failed\""),
         (GraphPermissionUpgradeOutcome::Stale, "\"stale\""),
@@ -106,6 +107,40 @@ fn graph_permission_upgrade_outcomes_serialize_to_camel_case_wire_values() {
             serde_json::to_string(&outcome).expect("outcome should serialize"),
             expected
         );
+    }
+}
+
+#[test]
+fn graph_auth_attempt_contract_serializes_typed_outcomes_without_credentials() {
+    for (outcome, expected) in [
+        (GraphAuthAttemptOutcome::Connected, "\"connected\""),
+        (GraphAuthAttemptOutcome::Cancelled, "\"cancelled\""),
+        (GraphAuthAttemptOutcome::TimedOut, "\"timedOut\""),
+        (GraphAuthAttemptOutcome::Unavailable, "\"unavailable\""),
+        (GraphAuthAttemptOutcome::Failed, "\"failed\""),
+        (GraphAuthAttemptOutcome::Stale, "\"stale\""),
+    ] {
+        assert_eq!(
+            serde_json::to_string(&outcome).expect("outcome should serialize"),
+            expected
+        );
+    }
+
+    let result = GraphAuthAttemptResult {
+        outcome: GraphAuthAttemptOutcome::Unavailable,
+        status: GraphAuthStatus::disconnected(),
+        capability: GraphHostCapability {
+            kind: GraphHostCapabilityKind::PersonalAccountOnly,
+        },
+        message: Some("Microsoft Graph requires a Windows work or school account.".to_string()),
+    };
+    let json = serde_json::to_value(&result).expect("attempt should serialize");
+    assert_eq!(json["outcome"], "unavailable");
+    assert_eq!(json["capability"]["kind"], "personalAccountOnly");
+    assert_eq!(json.as_object().expect("attempt object").len(), 4);
+    let rendered = format!("{json} {result:?}");
+    for forbidden in ["accessToken", "access_token", "Bearer"] {
+        assert!(!rendered.contains(forbidden), "attempt leaked {forbidden}");
     }
 }
 
@@ -138,7 +173,7 @@ fn graph_permission_upgrade_result_is_a_token_free_three_field_contract() {
 }
 
 #[test]
-fn graph_permission_upgrade_command_runs_wam_on_an_initialized_blocking_worker() {
+fn graph_permission_upgrade_command_runs_owned_wam_on_a_blocking_worker() {
     let command_source = include_str!("../src/commands/graph_api.rs");
     let command_start = command_source
         .find("pub async fn graph_request_missing_permissions")
@@ -151,21 +186,21 @@ fn graph_permission_upgrade_command_runs_wam_on_an_initialized_blocking_worker()
 
     assert!(command.contains("state.inner().clone()"));
     assert!(command.contains("tauri::async_runtime::spawn_blocking"));
-    assert!(command.contains("graph_api::request_missing_permissions_on_initialized_worker"));
+    assert!(command.contains("graph_api::request_missing_permissions(&state, hwnd, &lease)"));
 
     let graph_source = include_str!("../src/graph_api.rs");
     let permission_entry = source_section(
         graph_source,
-        "pub fn request_missing_permissions_on_initialized_worker(",
+        "pub fn request_missing_permissions(",
         "/// Get current auth status",
     );
     assert!(permission_entry
-        .contains("wam::acquire_permission_consent_token_on_initialized_worker(hwnd_raw)"));
-    assert!(!permission_entry.contains("wam::acquire_token(hwnd_raw)"));
+        .contains("wam::acquire_permission_consent_token(hwnd_raw, deadline, lease)"));
+    assert!(!permission_entry.contains("wam::acquire_token("));
 
     let permission_worker = source_section(
         graph_source,
-        "pub fn acquire_permission_consent_token_on_initialized_worker(",
+        "pub fn acquire_permission_consent_token(",
         "pub fn acquire_token(",
     );
     assert!(permission_worker.contains("WinRtApartment::initialize()"));
@@ -244,9 +279,10 @@ fn graph_permission_upgrade_command_runs_wam_on_an_initialized_blocking_worker()
     let authenticate = source_section(
         graph_source,
         "pub fn authenticate(",
-        "pub fn request_missing_permissions_on_initialized_worker(",
+        "pub fn request_missing_permissions(",
     );
-    assert!(authenticate.contains("match wam::acquire_token(hwnd_raw)"));
+    assert!(authenticate.contains("match wam::acquire_token(hwnd_raw, deadline, lease)"));
+    assert!(authenticate.contains("probe_host_capability_for_authentication(deadline, lease)"));
     assert!(!authenticate.contains("acquire_permission_consent_token"));
 }
 
@@ -412,7 +448,8 @@ fn graph_auth_status_projects_object_id_from_oid_claim() {
         Some("alice@contoso.example"),
         Some("tenant-a"),
         1_900_000_000,
-    );
+    )
+    .expect("valid Graph token");
     assert!(status.is_authenticated);
     assert_eq!(status.object_id.as_deref(), Some("OID-ALICE"));
 }
@@ -562,7 +599,6 @@ fn platform_boundary_transport_dtos_round_trip_off_windows() {
         missing_scopes: Vec::new(),
         expires_at: Some(2_000_000_000),
         capabilities: GraphAuthCapabilities::all(),
-        error: None,
     };
     let status_json = serde_json::to_string(&status).expect("status should serialize");
     let decoded_status: GraphAuthStatus =
@@ -628,7 +664,10 @@ fn graph_wam_permission_request_requires_explicit_v2_consent() {
         &[
             ("wam_compat", "2.0"),
             ("prompt", "consent"),
-            ("authority", "https://login.microsoftonline.com/common/"),
+            (
+                "authority",
+                "https://login.microsoftonline.com/organizations/",
+            ),
             ("validateAuthority", "yes")
         ]
     );
@@ -654,15 +693,14 @@ fn graph_auth_status_reports_full_and_app_only_capabilities() {
         Some("user@contoso.example"),
         Some("tenant-a"),
         1_900_000_000,
-    );
+    )
+    .expect("valid full Graph token");
     assert!(status.is_authenticated);
     assert_eq!(status.tenant_id.as_deref(), Some("tenant-a"));
     assert_eq!(status.expires_at, Some(2_000_000_000));
     assert_eq!(status.granted_scopes.len(), 5);
     assert!(status.missing_scopes.is_empty());
     assert_eq!(status.capabilities, GraphAuthCapabilities::all());
-    assert_eq!(status.error, None);
-
     let app_only = unsigned_token(serde_json::json!({
         "aud": "00000003-0000-0000-c000-000000000000",
         "tid": "tenant-a",
@@ -674,7 +712,8 @@ fn graph_auth_status_reports_full_and_app_only_capabilities() {
         Some("user@contoso.example"),
         Some("tenant-a"),
         1_900_000_000,
-    );
+    )
+    .expect("valid app-only Graph token");
     assert!(status.is_authenticated);
     assert!(status.capabilities.apps);
     assert!(!status.capabilities.managed_devices);
@@ -688,23 +727,14 @@ fn graph_auth_status_reports_full_and_app_only_capabilities() {
 #[test]
 fn graph_auth_status_rejects_expired_malformed_audience_and_tenant_claims() {
     let assert_rejected = |token: &str, wam_tenant: Option<&str>, expected: &str| {
-        let status = project_graph_auth_status(
+        let error = project_graph_auth_status(
             token,
             Some("user@contoso.example"),
             wam_tenant,
             1_900_000_000,
-        );
-        assert!(!status.is_authenticated);
-        assert!(
-            status
-                .error
-                .as_deref()
-                .is_some_and(|error| error.contains(expected)),
-            "unexpected status: {status:?}"
-        );
-        assert!(status.granted_scopes.is_empty());
-        assert_eq!(status.missing_scopes.len(), 5);
-        assert_eq!(status.capabilities, GraphAuthCapabilities::default());
+        )
+        .expect_err("invalid Graph token should be rejected");
+        assert_eq!(error.to_string(), expected);
     };
 
     assert_rejected("not-a-jwt", Some("tenant-a"), "MalformedToken");

--- a/src-tauri/tests/graph_esp_diagnostics.rs
+++ b/src-tauri/tests/graph_esp_diagnostics.rs
@@ -16,8 +16,7 @@ use app_lib::graph_api::models::{
     GraphAuthStatus, GraphHostCapability, GraphHostCapabilityKind, GraphHttpMethod,
     GraphPermissionCandidateDecision, GraphPermissionUpgradeOutcome, GraphPermissionUpgradeResult,
     GraphResolutionResult, GraphTransportRequest, GraphTransportResponse, GRAPH_DELEGATED_SCOPES,
-    GRAPH_SCOPE_REQUEST, GRAPH_WAM_PERMISSION_REQUEST, GRAPH_WAM_PERMISSION_SCOPE_REQUEST,
-    GRAPH_WAM_REQUEST,
+    GRAPH_WAM_REQUEST, GRAPH_WAM_SCOPE_REQUEST,
 };
 use base64::Engine;
 use serde::Deserialize;
@@ -194,17 +193,7 @@ fn graph_permission_upgrade_command_runs_owned_wam_on_a_blocking_worker() {
         "pub(crate) fn request_missing_permissions(",
         "/// Get current auth status",
     );
-    assert!(permission_entry
-        .contains("wam::acquire_permission_consent_token(hwnd_raw, deadline, lease)"));
-    assert!(!permission_entry.contains("wam::acquire_token("));
-
-    let permission_worker = source_section(
-        graph_source,
-        "pub fn acquire_permission_consent_token(",
-        "pub fn acquire_token(",
-    );
-    assert!(permission_worker.contains("WinRtApartment::initialize()"));
-    assert!(permission_worker.contains("WamRequestMode::PermissionConsent"));
+    assert!(permission_entry.contains("wam::acquire_token(hwnd_raw, deadline, lease)"));
 
     let apartment_init = source_section(
         graph_source,
@@ -219,71 +208,62 @@ fn graph_permission_upgrade_command_runs_owned_wam_on_a_blocking_worker() {
     );
     assert!(apartment_drop.contains("RoUninitialize()"));
 
-    let initial_entry = source_section(
-        graph_source,
-        "pub fn acquire_token(",
-        "fn acquire_token_with_request(",
-    );
-    assert!(initial_entry.contains("WamRequestMode::InitialConnect"));
-    assert!(!initial_entry.contains("WamRequestMode::PermissionConsent"));
-
     let request_builder = source_section(
         graph_source,
-        "fn acquire_token_with_request(",
+        "pub fn acquire_token(",
         "// Use the COM interop interface to pass our HWND",
     );
-    let constructor_match = source_section(
-        request_builder,
-        "let request = match request_mode {",
-        ".map_err(|e| AppError::Internal(format!(\"WAM request creation failed: {e}\")))?;",
-    );
-    let permission_constructor = source_section(
-        constructor_match,
-        "WamRequestMode::PermissionConsent =>",
-        "WamRequestMode::InitialConnect =>",
-    );
-    assert!(permission_constructor.contains("GRAPH_WAM_PERMISSION_REQUEST.scope"));
-    assert!(permission_constructor.contains("WebTokenRequest::CreateWithPromptType"));
-    assert!(permission_constructor.contains("WebTokenRequestPromptType::ForceAuthentication"));
-    assert!(!permission_constructor.contains("GRAPH_WAM_REQUEST"));
-
-    let initial_constructor_start = constructor_match
-        .find("WamRequestMode::InitialConnect =>")
-        .expect("initial constructor arm must exist");
-    let initial_constructor = &constructor_match[initial_constructor_start..];
-    assert!(initial_constructor.contains("GRAPH_WAM_REQUEST.scope"));
-    assert!(initial_constructor.contains("WebTokenRequest::Create(&provider"));
-    assert!(!initial_constructor.contains("CreateWithPromptType"));
-    assert!(!initial_constructor.contains("GRAPH_WAM_PERMISSION_REQUEST"));
-
-    let property_start = request_builder
-        .find("let properties = request")
-        .expect("request properties must be configured");
-    let property_match = &request_builder[property_start..];
-    let permission_properties = source_section(
-        property_match,
-        "WamRequestMode::PermissionConsent =>",
-        "WamRequestMode::InitialConnect =>",
-    );
-    assert!(permission_properties.contains("GRAPH_WAM_PERMISSION_REQUEST.properties"));
-    assert!(!permission_properties.contains("GRAPH_WAM_REQUEST.resource"));
-
-    let initial_properties_start = property_match
-        .find("WamRequestMode::InitialConnect =>")
-        .expect("initial property arm must exist");
-    let initial_properties = &property_match[initial_properties_start..];
-    assert!(initial_properties.contains("GRAPH_WAM_REQUEST.resource_property"));
-    assert!(initial_properties.contains("GRAPH_WAM_REQUEST.resource"));
-    assert!(!initial_properties.contains("GRAPH_WAM_PERMISSION_REQUEST"));
+    assert!(request_builder.contains("WinRtApartment::initialize()"));
+    assert!(request_builder.contains("HSTRING::from(\"organizations\")"));
+    assert!(request_builder.contains("HSTRING::from(GRAPH_WAM_REQUEST.scope)"));
+    assert!(request_builder.contains("WebTokenRequest::CreateWithPromptType"));
+    assert!(request_builder.contains("WebTokenRequestPromptType::ForceAuthentication"));
+    assert!(!request_builder.contains("WamRequestMode"));
+    assert!(!request_builder.contains("wam_compat"));
+    assert!(!request_builder.contains("resource_property"));
+    assert!(!request_builder.contains(".Properties()"));
 
     let authenticate = source_section(
         graph_source,
         "pub(crate) fn authenticate(",
         "pub(crate) fn request_missing_permissions(",
     );
+    assert_eq!(authenticate.matches("wam::authentication_deadline()").count(), 1);
     assert!(authenticate.contains("match wam::acquire_token(hwnd_raw, deadline, lease)"));
     assert!(authenticate.contains("probe_host_capability_for_authentication(deadline, lease)"));
-    assert!(!authenticate.contains("acquire_permission_consent_token"));
+    assert!(graph_source.contains("std::time::Duration::from_secs(120)"));
+    assert!(!graph_source.contains("acquire_permission_consent_token"));
+}
+
+#[test]
+fn graph_interactive_commands_require_native_single_use_tickets() {
+    let command_source = include_str!("../src/commands/graph_api.rs");
+    let reserve = source_section(
+        command_source,
+        "pub fn graph_reserve_interactive_operation(",
+        "pub async fn graph_authenticate(",
+    );
+    assert!(reserve.contains("kind: graph_api::GraphInteractiveOperationKind"));
+    assert!(reserve.contains("state.reserve_interactive_operation(kind)"));
+
+    let authenticate = source_section(
+        command_source,
+        "pub async fn graph_authenticate(",
+        "pub fn graph_cancel_authentication(",
+    );
+    assert!(authenticate.contains("attempt_id: String"));
+    assert!(authenticate.contains("claim_interactive_operation"));
+    assert!(authenticate.contains("GraphInteractiveOperationKind::Authentication"));
+
+    let permission = source_section(
+        command_source,
+        "pub async fn graph_request_missing_permissions(",
+        "pub fn graph_get_auth_status(",
+    );
+    assert!(permission.contains("attempt_id: String"));
+    assert!(permission.contains("claim_interactive_operation"));
+    assert!(permission.contains("GraphInteractiveOperationKind::PermissionConsent"));
+    assert!(!command_source.contains("begin_interactive_operation"));
 }
 
 #[test]
@@ -623,31 +603,9 @@ fn platform_boundary_transport_dtos_round_trip_off_windows() {
 }
 
 #[test]
-fn graph_wam_scope_request_uses_short_delegated_permissions() {
-    assert_eq!(
-        GRAPH_SCOPE_REQUEST,
-        "DeviceManagementManagedDevices.Read.All \
-DeviceManagementServiceConfig.Read.All \
-DeviceManagementApps.Read.All \
-DeviceManagementConfiguration.Read.All \
-DeviceManagementScripts.Read.All"
-    );
-}
-
-#[test]
-fn graph_wam_request_targets_microsoft_graph_resource() {
-    assert_eq!(GRAPH_WAM_REQUEST.scope, GRAPH_SCOPE_REQUEST);
-    assert_eq!(GRAPH_WAM_REQUEST.resource_property, "resource");
-    assert_eq!(GRAPH_WAM_REQUEST.resource, "https://graph.microsoft.com");
-}
-
-#[test]
-fn graph_wam_permission_request_requires_explicit_v2_consent() {
-    assert_eq!(
-        GRAPH_WAM_PERMISSION_REQUEST.scope,
-        GRAPH_WAM_PERMISSION_SCOPE_REQUEST
-    );
-    let actual_scopes = GRAPH_WAM_PERMISSION_REQUEST
+fn graph_wam_request_uses_one_organizations_scope_contract() {
+    assert_eq!(GRAPH_WAM_REQUEST.scope, GRAPH_WAM_SCOPE_REQUEST);
+    let actual_scopes = GRAPH_WAM_REQUEST
         .scope
         .split_ascii_whitespace()
         .collect::<Vec<_>>();
@@ -656,28 +614,6 @@ fn graph_wam_permission_request_requires_explicit_v2_consent() {
         .chain(["openid", "profile", "offline_access"])
         .collect::<Vec<_>>();
     assert_eq!(actual_scopes, expected_scopes);
-    assert!(std::hint::black_box(
-        GRAPH_WAM_PERMISSION_REQUEST.force_authentication
-    ));
-    assert_eq!(
-        GRAPH_WAM_PERMISSION_REQUEST.properties,
-        &[
-            ("wam_compat", "2.0"),
-            ("prompt", "consent"),
-            (
-                "authority",
-                "https://login.microsoftonline.com/organizations/",
-            ),
-            ("validateAuthority", "yes")
-        ]
-    );
-    assert!(
-        GRAPH_WAM_PERMISSION_REQUEST
-            .properties
-            .iter()
-            .all(|(name, _)| !name.eq_ignore_ascii_case("resource")),
-        "a v2 incremental-consent request must not be downgraded to a v1 resource request"
-    );
 }
 
 #[test]

--- a/src/components/dialogs/settings/GraphApiTab.test.tsx
+++ b/src/components/dialogs/settings/GraphApiTab.test.tsx
@@ -144,7 +144,9 @@ describe("GraphApiTab delegated capabilities", () => {
     useIntuneStore.setState({ guidRegistry: {} });
     vi.mocked(graphProbeCapability).mockResolvedValue({ kind: "available" });
     vi.mocked(graphCancelAuthentication).mockResolvedValue(true);
-    vi.mocked(graphAuthenticate).mockResolvedValue(authResult(partialStatus(true)));
+    vi.mocked(graphAuthenticate).mockResolvedValue(
+      authResult(partialStatus(true)),
+    );
     vi.mocked(graphFetchAllApps).mockResolvedValue([]);
     vi.mocked(graphRequestMissingPermissions).mockResolvedValue(
       permissionResult("unchanged"),
@@ -548,7 +550,6 @@ describe("GraphApiTab delegated capabilities", () => {
     expect(useUiStore.getState().graphApiStatus).toBe("connected");
   });
 
-
   it("retains permission guidance during app cache hydration", async () => {
     const apps = deferred<Awaited<ReturnType<typeof graphFetchAllApps>>>();
     vi.mocked(graphGetAuthStatus).mockResolvedValue(partialStatus(true));
@@ -711,7 +712,6 @@ describe("GraphApiTab delegated capabilities", () => {
     ).not.toBeInTheDocument();
   });
 
-
   it("keeps a pending permission action shared across remounts without hydration superseding it", async () => {
     const request = deferred<GraphPermissionUpgradeResult>();
     vi.mocked(graphGetAuthStatus)
@@ -859,8 +859,6 @@ describe("GraphApiTab delegated capabilities", () => {
     ).not.toBeInTheDocument();
   });
 
-
-
   it("does not let an invalidated sign-out completion overwrite a newer remounted sign-in", async () => {
     const staleSignOut = deferred<void>();
     const currentAuthentication = deferred<GraphAuthAttemptResult>();
@@ -933,7 +931,9 @@ describe("GraphApiTab delegated capabilities", () => {
 
   it("publishes a successful manual connection for first-use ESP enrichment", async () => {
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
-    vi.mocked(graphAuthenticate).mockResolvedValue(authResult(partialStatus(true)));
+    vi.mocked(graphAuthenticate).mockResolvedValue(
+      authResult(partialStatus(true)),
+    );
 
     render(<GraphApiTab />);
 
@@ -949,7 +949,9 @@ describe("GraphApiTab delegated capabilities", () => {
 
   it("restores mounted-local publication after StrictMode effect replay", async () => {
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
-    vi.mocked(graphAuthenticate).mockResolvedValue(authResult(partialStatus(true)));
+    vi.mocked(graphAuthenticate).mockResolvedValue(
+      authResult(partialStatus(true)),
+    );
 
     render(
       <StrictMode>
@@ -1142,7 +1144,7 @@ describe("GraphApiTab delegated capabilities", () => {
     ).toBeEnabled();
   });
 
-  it("cancels a disabled sign-in and blocks replacement until native settles", async () => {
+  it("retires a disabled sign-in across re-enable and blocks replacement until native settles", async () => {
     const cancelledAuthentication = deferred<GraphAuthAttemptResult>();
     const currentAuthentication = deferred<GraphAuthAttemptResult>();
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
@@ -1172,15 +1174,16 @@ describe("GraphApiTab delegated capabilities", () => {
     expect(graphAuthenticate).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      cancelledAuthentication.resolve(
-        authResult(
-          disconnectedStatus(),
-          "cancelled",
-          "Microsoft Graph sign-in was cancelled.",
-        ),
-      );
+      cancelledAuthentication.resolve(authResult(partialStatus(true)));
       await cancelledAuthentication.promise;
     });
+    await waitFor(() =>
+      expect(useUiStore.getState().graphApiStatus).toBe("disconnected"),
+    );
+    expect(useUiStore.getState().graphApiLastAttempt).toBeNull();
+    expect(
+      screen.queryByText("Connected with partial permissions"),
+    ).not.toBeInTheDocument();
     fireEvent.click(
       await screen.findByRole("button", { name: "Sign in with Windows" }),
     );
@@ -1245,9 +1248,9 @@ describe("GraphApiTab delegated capabilities", () => {
     );
 
     expect(await screen.findByRole("alert")).toHaveTextContent(message);
-    expect(screen.getAllByText(/Only a personal Microsoft account/)).toHaveLength(
-      1,
-    );
+    expect(
+      screen.getAllByText(/Only a personal Microsoft account/),
+    ).toHaveLength(1);
     expect(useUiStore.getState().graphApiStatus).toBe("unsupported");
   });
 
@@ -1310,5 +1313,29 @@ describe("GraphApiTab delegated capabilities", () => {
     );
     expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
     expect(useUiStore.getState().graphApiLastAttempt?.outcome).toBe("timedOut");
+  });
+
+  it("keeps a stale attempt distinct from connection state", async () => {
+    vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
+    vi.mocked(graphAuthenticate).mockResolvedValue(
+      authResult(
+        partialStatus(true),
+        "stale",
+        "The sign-in result was superseded by a newer Graph connection change.",
+      ),
+    );
+
+    render(<GraphApiTab />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Sign in with Windows" }),
+    );
+
+    await waitFor(() =>
+      expect(useUiStore.getState().graphApiLastAttempt?.outcome).toBe("stale"),
+    );
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
+    expect(
+      screen.queryByText("Connected with partial permissions"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/dialogs/settings/GraphApiTab.test.tsx
+++ b/src/components/dialogs/settings/GraphApiTab.test.tsx
@@ -10,11 +10,15 @@ import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   graphAuthenticate,
+  graphCancelAuthentication,
   graphFetchAllApps,
   graphGetAuthStatus,
+  graphProbeCapability,
   graphRequestMissingPermissions,
   graphSignOut,
   type GraphAuthStatus,
+  type GraphAuthAttemptOutcome,
+  type GraphAuthAttemptResult,
   type GraphPermissionUpgradeOutcome,
   type GraphPermissionUpgradeResult,
 } from "../../../lib/commands";
@@ -24,8 +28,10 @@ import { GraphApiTab } from "./GraphApiTab";
 
 vi.mock("../../../lib/commands", () => ({
   graphAuthenticate: vi.fn(),
+  graphCancelAuthentication: vi.fn(),
   graphFetchAllApps: vi.fn(),
   graphGetAuthStatus: vi.fn(),
+  graphProbeCapability: vi.fn(),
   graphRequestMissingPermissions: vi.fn(),
   graphSignOut: vi.fn(),
 }));
@@ -42,6 +48,7 @@ const partialStatus = (apps: boolean): GraphAuthStatus =>
   ({
     isAuthenticated: true,
     userPrincipalName: "user@contoso.example",
+    objectId: "00000000-0000-0000-0000-0000000000a1",
     tenantId: "tenant-a",
     grantedScopes: apps ? ["DeviceManagementApps.Read.All"] : [],
     missingScopes: [
@@ -59,12 +66,12 @@ const partialStatus = (apps: boolean): GraphAuthStatus =>
       configuration: false,
       scripts: false,
     },
-    error: null,
   }) as GraphAuthStatus;
 
 const disconnectedStatus = (): GraphAuthStatus => ({
   isAuthenticated: false,
   userPrincipalName: null,
+  objectId: null,
   tenantId: null,
   grantedScopes: [],
   missingScopes: [
@@ -82,7 +89,6 @@ const disconnectedStatus = (): GraphAuthStatus => ({
     configuration: false,
     scripts: false,
   },
-  error: null,
 });
 
 const fullStatus = (): GraphAuthStatus => ({
@@ -104,6 +110,19 @@ const permissionResult = (
   message: string | null = null,
 ): GraphPermissionUpgradeResult => ({ outcome, status, message });
 
+const authResult = (
+  status: GraphAuthStatus,
+  outcome: GraphAuthAttemptOutcome = status.isAuthenticated
+    ? "connected"
+    : "cancelled",
+  message: string | null = null,
+): GraphAuthAttemptResult => ({
+  outcome,
+  status,
+  capability: { kind: "available" },
+  message,
+});
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((resolvePromise) => {
@@ -118,10 +137,14 @@ describe("GraphApiTab delegated capabilities", () => {
     useUiStore.setState({
       currentPlatform: "windows",
       graphApiEnabled: true,
-      graphApiStatus: "idle",
+      graphApiStatus: "disconnected",
+      graphApiCapability: null,
+      graphApiLastAttempt: null,
     });
     useIntuneStore.setState({ guidRegistry: {} });
-    vi.mocked(graphAuthenticate).mockResolvedValue(partialStatus(true));
+    vi.mocked(graphProbeCapability).mockResolvedValue({ kind: "available" });
+    vi.mocked(graphCancelAuthentication).mockResolvedValue(true);
+    vi.mocked(graphAuthenticate).mockResolvedValue(authResult(partialStatus(true)));
     vi.mocked(graphFetchAllApps).mockResolvedValue([]);
     vi.mocked(graphRequestMissingPermissions).mockResolvedValue(
       permissionResult("unchanged"),
@@ -222,7 +245,7 @@ describe("GraphApiTab delegated capabilities", () => {
   });
 
   it("keeps initial sign-in locked while its Graph action is pending", async () => {
-    const authentication = deferred<GraphAuthStatus>();
+    const authentication = deferred<GraphAuthAttemptResult>();
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
     vi.mocked(graphAuthenticate).mockReturnValue(authentication.promise);
 
@@ -233,12 +256,12 @@ describe("GraphApiTab delegated capabilities", () => {
     );
 
     expect(
-      await screen.findByRole("button", { name: "Signing in..." }),
-    ).toBeDisabled();
+      await screen.findByRole("button", { name: "Cancel sign-in" }),
+    ).toBeEnabled();
     expect(graphRequestMissingPermissions).not.toHaveBeenCalled();
 
     await act(async () => {
-      authentication.resolve(partialStatus(true));
+      authentication.resolve(authResult(partialStatus(true)));
       await authentication.promise;
     });
   });
@@ -398,7 +421,7 @@ describe("GraphApiTab delegated capabilities", () => {
       }),
     ).toBeVisible();
     expect(screen.getByText("Not connected")).toBeVisible();
-    expect(useUiStore.getState().graphApiStatus).toBe("idle");
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
   });
 
   it.each(["denied", "failed", "stale"] as const)(
@@ -490,7 +513,7 @@ describe("GraphApiTab delegated capabilities", () => {
       screen.queryByText("secret-token-shaped expired-state payload"),
     ).not.toBeInTheDocument();
     expect(graphGetAuthStatus).toHaveBeenCalledTimes(2);
-    expect(useUiStore.getState().graphApiStatus).toBe("idle");
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
   });
 
   it("reconciles a rejected permission request to authoritative complete state", async () => {
@@ -525,57 +548,6 @@ describe("GraphApiTab delegated capabilities", () => {
     expect(useUiStore.getState().graphApiStatus).toBe("connected");
   });
 
-  it("does not let delayed permission reconciliation overwrite a newer remounted action", async () => {
-    const reconciliation = deferred<GraphAuthStatus>();
-    const currentAuthentication = deferred<GraphAuthStatus>();
-    vi.mocked(graphGetAuthStatus)
-      .mockResolvedValueOnce(partialStatus(true))
-      .mockReturnValueOnce(reconciliation.promise)
-      .mockResolvedValueOnce(disconnectedStatus());
-    vi.mocked(graphRequestMissingPermissions).mockRejectedValue(
-      new Error("secret-token-shaped stale reconciliation payload"),
-    );
-    vi.mocked(graphAuthenticate).mockReturnValue(currentAuthentication.promise);
-
-    const firstTab = render(<GraphApiTab />);
-
-    fireEvent.click(
-      await screen.findByRole("button", {
-        name: "Request missing permissions",
-      }),
-    );
-    await waitFor(() => expect(graphGetAuthStatus).toHaveBeenCalledTimes(2));
-    fireEvent.click(screen.getByRole("checkbox"));
-    firstTab.unmount();
-
-    useUiStore.setState({ graphApiEnabled: true });
-    render(<GraphApiTab />);
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Sign in with Windows" }),
-    );
-    await waitFor(() => expect(graphAuthenticate).toHaveBeenCalledOnce());
-
-    await act(async () => {
-      reconciliation.resolve(fullStatus());
-      await reconciliation.promise;
-    });
-
-    expect(useUiStore.getState().graphApiStatus).toBe("connecting");
-    expect(
-      screen.getByRole("button", { name: "Signing in..." }),
-    ).toBeDisabled();
-    expect(
-      screen.queryByText("secret-token-shaped stale reconciliation payload"),
-    ).not.toBeInTheDocument();
-
-    await act(async () => {
-      currentAuthentication.resolve(partialStatus(true));
-      await currentAuthentication.promise;
-    });
-    expect(
-      await screen.findByText("Connected with partial permissions"),
-    ).toBeVisible();
-  });
 
   it("retains permission guidance during app cache hydration", async () => {
     const apps = deferred<Awaited<ReturnType<typeof graphFetchAllApps>>>();
@@ -643,7 +615,7 @@ describe("GraphApiTab delegated capabilities", () => {
   });
 
   it("clears permission guidance when a fresh initial sign-in begins", async () => {
-    const authentication = deferred<GraphAuthStatus>();
+    const authentication = deferred<GraphAuthAttemptResult>();
     vi.mocked(graphGetAuthStatus).mockResolvedValue(partialStatus(true));
     vi.mocked(graphRequestMissingPermissions).mockResolvedValue(
       permissionResult("stale", disconnectedStatus()),
@@ -668,12 +640,12 @@ describe("GraphApiTab delegated capabilities", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: "Signing in..." }),
-    ).toBeDisabled();
+      screen.getByRole("button", { name: "Cancel sign-in" }),
+    ).toBeEnabled();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 
     await act(async () => {
-      authentication.resolve(partialStatus(true));
+      authentication.resolve(authResult(partialStatus(true)));
       await authentication.promise;
     });
   });
@@ -731,7 +703,7 @@ describe("GraphApiTab delegated capabilities", () => {
     });
 
     expect(useUiStore.getState().graphApiEnabled).toBe(false);
-    expect(useUiStore.getState().graphApiStatus).toBe("idle");
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
     expect(
       screen.queryByText(
         "Permissions updated. Additional Graph capabilities are now available.",
@@ -739,59 +711,6 @@ describe("GraphApiTab delegated capabilities", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not let a stale permission result overwrite a newer frontend operation", async () => {
-    const staleRequest = deferred<GraphPermissionUpgradeResult>();
-    const currentAuthentication = deferred<GraphAuthStatus>();
-    vi.mocked(graphGetAuthStatus)
-      .mockResolvedValueOnce(partialStatus(true))
-      .mockResolvedValueOnce(disconnectedStatus());
-    vi.mocked(graphRequestMissingPermissions).mockReturnValue(
-      staleRequest.promise,
-    );
-    vi.mocked(graphAuthenticate).mockReturnValue(currentAuthentication.promise);
-
-    render(<GraphApiTab />);
-
-    fireEvent.click(
-      await screen.findByRole("button", {
-        name: "Request missing permissions",
-      }),
-    );
-    await waitFor(() =>
-      expect(graphRequestMissingPermissions).toHaveBeenCalledOnce(),
-    );
-    fireEvent.click(screen.getByRole("checkbox"));
-    fireEvent.click(screen.getByRole("checkbox"));
-    fireEvent.click(
-      screen.getByRole("button", { name: "I understand, enable it" }),
-    );
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Sign in with Windows" }),
-    );
-    await waitFor(() => expect(graphAuthenticate).toHaveBeenCalledOnce());
-
-    await act(async () => {
-      staleRequest.resolve(permissionResult("upgraded", fullStatus()));
-      await staleRequest.promise;
-    });
-
-    expect(
-      screen.getByRole("button", { name: "Signing in..." }),
-    ).toBeDisabled();
-    expect(
-      screen.queryByText(
-        "Permissions updated. Additional Graph capabilities are now available.",
-      ),
-    ).not.toBeInTheDocument();
-
-    await act(async () => {
-      currentAuthentication.resolve(partialStatus(true));
-      await currentAuthentication.promise;
-    });
-    expect(
-      await screen.findByText("Connected with partial permissions"),
-    ).toBeVisible();
-  });
 
   it("keeps a pending permission action shared across remounts without hydration superseding it", async () => {
     const request = deferred<GraphPermissionUpgradeResult>();
@@ -834,7 +753,7 @@ describe("GraphApiTab delegated capabilities", () => {
   });
 
   it("publishes a pending sign-in globally after unmount and then hydrates the remounted tab", async () => {
-    const authentication = deferred<GraphAuthStatus>();
+    const authentication = deferred<GraphAuthAttemptResult>();
     vi.mocked(graphGetAuthStatus)
       .mockResolvedValueOnce(disconnectedStatus())
       .mockResolvedValueOnce(partialStatus(true));
@@ -851,12 +770,12 @@ describe("GraphApiTab delegated capabilities", () => {
     render(<GraphApiTab />);
 
     expect(
-      await screen.findByRole("button", { name: "Signing in..." }),
-    ).toBeDisabled();
+      await screen.findByRole("button", { name: "Cancel sign-in" }),
+    ).toBeEnabled();
     expect(graphGetAuthStatus).toHaveBeenCalledOnce();
 
     await act(async () => {
-      authentication.resolve(partialStatus(true));
+      authentication.resolve(authResult(partialStatus(true)));
       await authentication.promise;
     });
 
@@ -892,7 +811,7 @@ describe("GraphApiTab delegated capabilities", () => {
       await signOut.promise;
     });
 
-    expect(useUiStore.getState().graphApiStatus).toBe("idle");
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
     await waitFor(() => expect(graphGetAuthStatus).toHaveBeenCalledTimes(2));
     expect(await screen.findByText("Not connected")).toBeVisible();
   });
@@ -931,7 +850,7 @@ describe("GraphApiTab delegated capabilities", () => {
       await reconciliation.promise;
     });
 
-    expect(useUiStore.getState().graphApiStatus).toBe("idle");
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
     await waitFor(() => expect(graphGetAuthStatus).toHaveBeenCalledTimes(3));
     expect(await screen.findByText("Not connected")).toBeVisible();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
@@ -940,110 +859,11 @@ describe("GraphApiTab delegated capabilities", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not let an invalidated permission completion overwrite a newer remounted action", async () => {
-    const staleRequest = deferred<GraphPermissionUpgradeResult>();
-    const currentAuthentication = deferred<GraphAuthStatus>();
-    vi.mocked(graphGetAuthStatus)
-      .mockResolvedValueOnce(partialStatus(true))
-      .mockResolvedValueOnce(disconnectedStatus());
-    vi.mocked(graphRequestMissingPermissions).mockReturnValue(
-      staleRequest.promise,
-    );
-    vi.mocked(graphAuthenticate).mockReturnValue(currentAuthentication.promise);
 
-    const firstTab = render(<GraphApiTab />);
-
-    fireEvent.click(
-      await screen.findByRole("button", {
-        name: "Request missing permissions",
-      }),
-    );
-    await waitFor(() =>
-      expect(graphRequestMissingPermissions).toHaveBeenCalledOnce(),
-    );
-    fireEvent.click(screen.getByRole("checkbox"));
-    firstTab.unmount();
-
-    useUiStore.setState({ graphApiEnabled: true });
-    render(<GraphApiTab />);
-
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Sign in with Windows" }),
-    );
-    await waitFor(() => expect(graphAuthenticate).toHaveBeenCalledOnce());
-    expect(useUiStore.getState().graphApiStatus).toBe("connecting");
-
-    await act(async () => {
-      staleRequest.resolve(permissionResult("upgraded", fullStatus()));
-      await staleRequest.promise;
-    });
-
-    expect(useUiStore.getState().graphApiStatus).toBe("connecting");
-    expect(screen.getByText("Not connected")).toBeVisible();
-    expect(
-      screen.queryByLabelText("Graph delegated capabilities"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Signing in..." }),
-    ).toBeDisabled();
-
-    await act(async () => {
-      currentAuthentication.resolve(partialStatus(true));
-      await currentAuthentication.promise;
-    });
-    expect(
-      await screen.findByText("Connected with partial permissions"),
-    ).toBeVisible();
-  });
-
-  it("does not let an invalidated sign-in completion overwrite a newer remounted sign-in", async () => {
-    const staleAuthentication = deferred<GraphAuthStatus>();
-    const currentAuthentication = deferred<GraphAuthStatus>();
-    vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
-    vi.mocked(graphAuthenticate)
-      .mockReturnValueOnce(staleAuthentication.promise)
-      .mockReturnValueOnce(currentAuthentication.promise);
-
-    const firstTab = render(<GraphApiTab />);
-
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Sign in with Windows" }),
-    );
-    await waitFor(() => expect(graphAuthenticate).toHaveBeenCalledTimes(1));
-    fireEvent.click(screen.getByRole("checkbox"));
-    firstTab.unmount();
-
-    useUiStore.setState({ graphApiEnabled: true });
-    render(<GraphApiTab />);
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Sign in with Windows" }),
-    );
-    await waitFor(() => expect(graphAuthenticate).toHaveBeenCalledTimes(2));
-
-    await act(async () => {
-      staleAuthentication.resolve(fullStatus());
-      await staleAuthentication.promise;
-    });
-
-    expect(useUiStore.getState().graphApiStatus).toBe("connecting");
-    expect(
-      screen.getByRole("button", { name: "Signing in..." }),
-    ).toBeDisabled();
-
-    await act(async () => {
-      currentAuthentication.resolve(partialStatus(true));
-      await currentAuthentication.promise;
-    });
-    expect(
-      await screen.findByText("Connected with partial permissions"),
-    ).toBeVisible();
-  });
 
   it("does not let an invalidated sign-out completion overwrite a newer remounted sign-in", async () => {
     const staleSignOut = deferred<void>();
-    const currentAuthentication = deferred<GraphAuthStatus>();
+    const currentAuthentication = deferred<GraphAuthAttemptResult>();
     vi.mocked(graphGetAuthStatus)
       .mockResolvedValueOnce(partialStatus(true))
       .mockResolvedValueOnce(disconnectedStatus());
@@ -1069,13 +889,13 @@ describe("GraphApiTab delegated capabilities", () => {
       await staleSignOut.promise;
     });
 
-    expect(useUiStore.getState().graphApiStatus).toBe("connecting");
+    expect(useUiStore.getState().graphApiStatus).toBe("signingIn");
     expect(
-      screen.getByRole("button", { name: "Signing in..." }),
-    ).toBeDisabled();
+      screen.getByRole("button", { name: "Cancel sign-in" }),
+    ).toBeEnabled();
 
     await act(async () => {
-      currentAuthentication.resolve(partialStatus(true));
+      currentAuthentication.resolve(authResult(partialStatus(true)));
       await currentAuthentication.promise;
     });
     expect(
@@ -1084,7 +904,7 @@ describe("GraphApiTab delegated capabilities", () => {
   });
 
   it("publishes an existing authenticated status after settings refresh", async () => {
-    useUiStore.setState({ graphApiStatus: "idle" });
+    useUiStore.setState({ graphApiStatus: "disconnected" });
     vi.mocked(graphGetAuthStatus).mockResolvedValue(partialStatus(true));
 
     render(<GraphApiTab />);
@@ -1113,7 +933,7 @@ describe("GraphApiTab delegated capabilities", () => {
 
   it("publishes a successful manual connection for first-use ESP enrichment", async () => {
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
-    vi.mocked(graphAuthenticate).mockResolvedValue(partialStatus(true));
+    vi.mocked(graphAuthenticate).mockResolvedValue(authResult(partialStatus(true)));
 
     render(<GraphApiTab />);
 
@@ -1129,7 +949,7 @@ describe("GraphApiTab delegated capabilities", () => {
 
   it("restores mounted-local publication after StrictMode effect replay", async () => {
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
-    vi.mocked(graphAuthenticate).mockResolvedValue(partialStatus(true));
+    vi.mocked(graphAuthenticate).mockResolvedValue(authResult(partialStatus(true)));
 
     render(
       <StrictMode>
@@ -1150,10 +970,9 @@ describe("GraphApiTab delegated capabilities", () => {
   it("clears a stale connected phase when manual authentication is rejected", async () => {
     useUiStore.setState({ graphApiStatus: "connected" });
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
-    vi.mocked(graphAuthenticate).mockResolvedValue({
-      ...disconnectedStatus(),
-      error: "Consent was not granted",
-    });
+    vi.mocked(graphAuthenticate).mockResolvedValue(
+      authResult(disconnectedStatus(), "failed", "Consent was not granted"),
+    );
 
     render(<GraphApiTab />);
 
@@ -1174,7 +993,7 @@ describe("GraphApiTab delegated capabilities", () => {
     fireEvent.click(await screen.findByRole("checkbox"));
 
     expect(useUiStore.getState().graphApiEnabled).toBe(false);
-    expect(useUiStore.getState().graphApiStatus).toBe("idle");
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
   });
 
   it("does not restore connected state when a refresh finishes after Graph is disabled", async () => {
@@ -1195,11 +1014,11 @@ describe("GraphApiTab delegated capabilities", () => {
     });
 
     expect(useUiStore.getState().graphApiEnabled).toBe(false);
-    expect(useUiStore.getState().graphApiStatus).toBe("idle");
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
   });
 
   it("does not restore connected state when manual authentication finishes after Graph is disabled", async () => {
-    let resolveAuthentication!: (status: GraphAuthStatus) => void;
+    let resolveAuthentication!: (result: GraphAuthAttemptResult) => void;
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
     vi.mocked(graphAuthenticate).mockReturnValue(
       new Promise((resolve) => {
@@ -1216,15 +1035,15 @@ describe("GraphApiTab delegated capabilities", () => {
 
     fireEvent.click(screen.getByRole("checkbox"));
     expect(useUiStore.getState().graphApiEnabled).toBe(false);
-    expect(useUiStore.getState().graphApiStatus).toBe("idle");
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
 
     await act(async () => {
-      resolveAuthentication(partialStatus(true));
+      resolveAuthentication(authResult(partialStatus(true)));
       await Promise.resolve();
     });
 
     expect(useUiStore.getState().graphApiEnabled).toBe(false);
-    expect(useUiStore.getState().graphApiStatus).toBe("idle");
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
   });
 
   it("does not merge app data when Graph is disabled during manual cache hydration", async () => {
@@ -1271,7 +1090,7 @@ describe("GraphApiTab delegated capabilities", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Sign out" }));
 
     await waitFor(() => expect(graphSignOut).toHaveBeenCalledOnce());
-    expect(useUiStore.getState().graphApiStatus).toBe("idle");
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
   });
 
   it("does not let cache hydration supersede an in-flight sign-out", async () => {
@@ -1296,7 +1115,7 @@ describe("GraphApiTab delegated capabilities", () => {
       signOut.resolve();
       await signOut.promise;
     });
-    expect(useUiStore.getState().graphApiStatus).toBe("idle");
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
   });
 
   it("does not let sign-out supersede in-flight cache hydration", async () => {
@@ -1323,12 +1142,12 @@ describe("GraphApiTab delegated capabilities", () => {
     ).toBeEnabled();
   });
 
-  it("keeps a newer sign-in busy when a disabled operation settles late", async () => {
-    const staleAuthentication = deferred<GraphAuthStatus>();
-    const currentAuthentication = deferred<GraphAuthStatus>();
+  it("cancels a disabled sign-in and blocks replacement until native settles", async () => {
+    const cancelledAuthentication = deferred<GraphAuthAttemptResult>();
+    const currentAuthentication = deferred<GraphAuthAttemptResult>();
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
     vi.mocked(graphAuthenticate)
-      .mockReturnValueOnce(staleAuthentication.promise)
+      .mockReturnValueOnce(cancelledAuthentication.promise)
       .mockReturnValueOnce(currentAuthentication.promise);
 
     render(<GraphApiTab />);
@@ -1337,30 +1156,130 @@ describe("GraphApiTab delegated capabilities", () => {
       await screen.findByRole("button", { name: "Sign in with Windows" }),
     );
     await waitFor(() => expect(graphAuthenticate).toHaveBeenCalledTimes(1));
+    const firstRequestId = vi.mocked(graphAuthenticate).mock.calls[0][0];
     fireEvent.click(screen.getByRole("checkbox"));
+    expect(graphCancelAuthentication).toHaveBeenCalledWith(firstRequestId);
     fireEvent.click(screen.getByRole("checkbox"));
     fireEvent.click(
       screen.getByRole("button", { name: "I understand, enable it" }),
     );
+    expect(
+      await screen.findByRole("button", { name: "Cancelling..." }),
+    ).toBeDisabled();
+    expect(graphAuthenticate).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      cancelledAuthentication.resolve(
+        authResult(
+          disconnectedStatus(),
+          "cancelled",
+          "Microsoft Graph sign-in was cancelled.",
+        ),
+      );
+      await cancelledAuthentication.promise;
+    });
     fireEvent.click(
       await screen.findByRole("button", { name: "Sign in with Windows" }),
     );
     await waitFor(() => expect(graphAuthenticate).toHaveBeenCalledTimes(2));
+    expect(vi.mocked(graphAuthenticate).mock.calls[1][0]).not.toBe(
+      firstRequestId,
+    );
 
     await act(async () => {
-      staleAuthentication.resolve(partialStatus(true));
-      await staleAuthentication.promise;
-    });
-    expect(
-      screen.getByRole("button", { name: "Signing in..." }),
-    ).toBeDisabled();
-
-    await act(async () => {
-      currentAuthentication.resolve(partialStatus(true));
+      currentAuthentication.resolve(authResult(partialStatus(true)));
       await currentAuthentication.promise;
     });
     expect(
       await screen.findByText("Connected with partial permissions"),
     ).toBeVisible();
+  });
+
+  it("probes capability on a persisted opt-in without starting WAM", async () => {
+    vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
+
+    render(<GraphApiTab />);
+
+    await waitFor(() => expect(graphProbeCapability).toHaveBeenCalledOnce());
+    await screen.findByRole("button", { name: "Sign in with Windows" });
+    expect(graphGetAuthStatus).toHaveBeenCalledOnce();
+    expect(graphAuthenticate).not.toHaveBeenCalled();
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
+  });
+
+  it("reports a personal-only host without opening WAM", async () => {
+    vi.mocked(graphProbeCapability).mockResolvedValue({
+      kind: "personalAccountOnly",
+    });
+
+    render(<GraphApiTab />);
+
+    expect(
+      await screen.findByText(/Only a personal Microsoft account is available/),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Sign in with Windows" }),
+    ).toBeDisabled();
+    expect(graphGetAuthStatus).not.toHaveBeenCalled();
+    expect(graphAuthenticate).not.toHaveBeenCalled();
+    expect(useUiStore.getState().graphApiStatus).toBe("unsupported");
+  });
+
+  it("cancels the matching request and remains cancelling until native settles", async () => {
+    const authentication = deferred<GraphAuthAttemptResult>();
+    vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
+    vi.mocked(graphAuthenticate).mockReturnValue(authentication.promise);
+
+    render(<GraphApiTab />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Sign in with Windows" }),
+    );
+    await waitFor(() => expect(graphAuthenticate).toHaveBeenCalledOnce());
+    const requestId = vi.mocked(graphAuthenticate).mock.calls[0][0];
+    fireEvent.click(screen.getByRole("button", { name: "Cancel sign-in" }));
+
+    expect(graphCancelAuthentication).toHaveBeenCalledWith(requestId);
+    expect(useUiStore.getState().graphApiStatus).toBe("cancelling");
+    expect(
+      screen.getByRole("button", { name: "Cancelling..." }),
+    ).toBeDisabled();
+
+    await act(async () => {
+      authentication.resolve(
+        authResult(
+          disconnectedStatus(),
+          "cancelled",
+          "Microsoft Graph sign-in was cancelled.",
+        ),
+      );
+      await authentication.promise;
+    });
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
+    expect(useUiStore.getState().graphApiLastAttempt).toEqual({
+      outcome: "cancelled",
+      message: "Microsoft Graph sign-in was cancelled.",
+    });
+  });
+
+  it("keeps a timed-out attempt distinct from connection state", async () => {
+    vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
+    vi.mocked(graphAuthenticate).mockResolvedValue(
+      authResult(
+        disconnectedStatus(),
+        "timedOut",
+        "Microsoft Graph sign-in timed out after 120 seconds.",
+      ),
+    );
+
+    render(<GraphApiTab />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Sign in with Windows" }),
+    );
+
+    await screen.findByText(
+      "Microsoft Graph sign-in timed out after 120 seconds.",
+    );
+    expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
+    expect(useUiStore.getState().graphApiLastAttempt?.outcome).toBe("timedOut");
   });
 });

--- a/src/components/dialogs/settings/GraphApiTab.test.tsx
+++ b/src/components/dialogs/settings/GraphApiTab.test.tsx
@@ -13,7 +13,7 @@ import {
   graphCancelAuthentication,
   graphFetchAllApps,
   graphGetAuthStatus,
-  graphProbeCapability,
+  graphReserveInteractiveOperation,
   graphRequestMissingPermissions,
   graphSignOut,
   type GraphAuthStatus,
@@ -31,7 +31,7 @@ vi.mock("../../../lib/commands", () => ({
   graphCancelAuthentication: vi.fn(),
   graphFetchAllApps: vi.fn(),
   graphGetAuthStatus: vi.fn(),
-  graphProbeCapability: vi.fn(),
+  graphReserveInteractiveOperation: vi.fn(),
   graphRequestMissingPermissions: vi.fn(),
   graphSignOut: vi.fn(),
 }));
@@ -142,8 +142,13 @@ describe("GraphApiTab delegated capabilities", () => {
       graphApiLastAttempt: null,
     });
     useIntuneStore.setState({ guidRegistry: {} });
-    vi.mocked(graphProbeCapability).mockResolvedValue({ kind: "available" });
     vi.mocked(graphCancelAuthentication).mockResolvedValue(true);
+    let nextAttempt = 1;
+    vi.mocked(graphReserveInteractiveOperation).mockImplementation(
+      async () => ({
+        attemptId: `00000000-0000-4000-8000-${String(nextAttempt++).padStart(12, "0")}`,
+      }),
+    );
     vi.mocked(graphAuthenticate).mockResolvedValue(
       authResult(partialStatus(true)),
     );
@@ -745,7 +750,11 @@ describe("GraphApiTab delegated capabilities", () => {
       await request.promise;
     });
 
-    await waitFor(() => expect(graphGetAuthStatus).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(
+        vi.mocked(graphGetAuthStatus).mock.calls.length,
+      ).toBeGreaterThanOrEqual(2),
+    );
     expect(
       await screen.findByText("Connected with partial permissions"),
     ).toBeVisible();
@@ -780,7 +789,11 @@ describe("GraphApiTab delegated capabilities", () => {
     });
 
     expect(useUiStore.getState().graphApiStatus).toBe("connected");
-    await waitFor(() => expect(graphGetAuthStatus).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(
+        vi.mocked(graphGetAuthStatus).mock.calls.length,
+      ).toBeGreaterThanOrEqual(2),
+    );
     expect(
       await screen.findByText("Connected with partial permissions"),
     ).toBeVisible();
@@ -1201,34 +1214,117 @@ describe("GraphApiTab delegated capabilities", () => {
     ).toBeVisible();
   });
 
-  it("probes capability on a persisted opt-in without starting WAM", async () => {
+  it("never starts native WAM during opt-in, restart, mount, remount, or passive initialization", async () => {
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
 
-    render(<GraphApiTab />);
+    const firstMount = render(<GraphApiTab />);
 
-    await waitFor(() => expect(graphProbeCapability).toHaveBeenCalledOnce());
     await screen.findByRole("button", { name: "Sign in with Windows" });
     expect(graphGetAuthStatus).toHaveBeenCalledOnce();
     expect(graphAuthenticate).not.toHaveBeenCalled();
+    expect(graphReserveInteractiveOperation).not.toHaveBeenCalled();
+    expect(graphRequestMissingPermissions).not.toHaveBeenCalled();
+
+    firstMount.unmount();
+    render(
+      <StrictMode>
+        <GraphApiTab />
+      </StrictMode>,
+    );
+    await waitFor(() =>
+      expect(
+        vi.mocked(graphGetAuthStatus).mock.calls.length,
+      ).toBeGreaterThanOrEqual(2),
+    );
+    expect(graphAuthenticate).not.toHaveBeenCalled();
+    expect(graphReserveInteractiveOperation).not.toHaveBeenCalled();
+    expect(graphRequestMissingPermissions).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(useUiStore.getState().graphApiEnabled).toBe(false);
+    const passiveCallsBeforeEnable =
+      vi.mocked(graphGetAuthStatus).mock.calls.length;
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "I understand, enable it" }),
+    );
+    await waitFor(() =>
+      expect(vi.mocked(graphGetAuthStatus).mock.calls.length).toBeGreaterThan(
+        passiveCallsBeforeEnable,
+      ),
+    );
+    expect(graphAuthenticate).not.toHaveBeenCalled();
+    expect(graphReserveInteractiveOperation).not.toHaveBeenCalled();
+    expect(graphRequestMissingPermissions).not.toHaveBeenCalled();
     expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
   });
 
-  it("reports a personal-only host without opening WAM", async () => {
-    vi.mocked(graphProbeCapability).mockResolvedValue({
-      kind: "personalAccountOnly",
-    });
+  it("cancels a delayed native ticket before WAM and serializes disable, restart, and rapid retry", async () => {
+    const reservation = deferred<{ attemptId: string }>();
+    const retiredAttemptId = "10000000-0000-4000-8000-000000000001";
+    vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
+    vi.mocked(graphReserveInteractiveOperation).mockReturnValueOnce(
+      reservation.promise,
+    );
 
     render(<GraphApiTab />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Sign in with Windows" }),
+    );
+    await waitFor(() =>
+      expect(graphReserveInteractiveOperation).toHaveBeenCalledWith(
+        "authentication",
+      ),
+    );
 
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "I understand, enable it" }),
+    );
     expect(
-      await screen.findByText(/Only a personal Microsoft account is available/),
-    ).toBeVisible();
-    expect(
-      screen.getByRole("button", { name: "Sign in with Windows" }),
+      await screen.findByRole("button", { name: "Cancelling..." }),
     ).toBeDisabled();
-    expect(graphGetAuthStatus).not.toHaveBeenCalled();
+
+    await act(async () => {
+      reservation.resolve({ attemptId: retiredAttemptId });
+      await reservation.promise;
+    });
+    expect(graphCancelAuthentication).toHaveBeenCalledWith(retiredAttemptId);
     expect(graphAuthenticate).not.toHaveBeenCalled();
-    expect(useUiStore.getState().graphApiStatus).toBe("unsupported");
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Sign in with Windows" }),
+    );
+    await waitFor(() => expect(graphAuthenticate).toHaveBeenCalledOnce());
+    expect(vi.mocked(graphAuthenticate).mock.calls[0][0]).not.toBe(
+      retiredAttemptId,
+    );
+  });
+
+  it("cancels a ticket that arrives after unmount without opening WAM", async () => {
+    const reservation = deferred<{ attemptId: string }>();
+    const retiredAttemptId = "20000000-0000-4000-8000-000000000001";
+    vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
+    vi.mocked(graphReserveInteractiveOperation).mockReturnValueOnce(
+      reservation.promise,
+    );
+
+    const view = render(<GraphApiTab />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Sign in with Windows" }),
+    );
+    await waitFor(() =>
+      expect(graphReserveInteractiveOperation).toHaveBeenCalledOnce(),
+    );
+    view.unmount();
+
+    await act(async () => {
+      reservation.resolve({ attemptId: retiredAttemptId });
+      await reservation.promise;
+    });
+    expect(graphCancelAuthentication).toHaveBeenCalledWith(retiredAttemptId);
+    expect(graphAuthenticate).not.toHaveBeenCalled();
   });
 
   it("shows one announced native message when sign-in discovers an unsupported host", async () => {

--- a/src/components/dialogs/settings/GraphApiTab.test.tsx
+++ b/src/components/dialogs/settings/GraphApiTab.test.tsx
@@ -1146,6 +1146,9 @@ describe("GraphApiTab delegated capabilities", () => {
     const cancelledAuthentication = deferred<GraphAuthAttemptResult>();
     const currentAuthentication = deferred<GraphAuthAttemptResult>();
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
+    vi.mocked(graphCancelAuthentication).mockRejectedValueOnce(
+      new Error("cancel transport failed"),
+    );
     vi.mocked(graphAuthenticate)
       .mockReturnValueOnce(cancelledAuthentication.promise)
       .mockReturnValueOnce(currentAuthentication.promise);
@@ -1225,6 +1228,29 @@ describe("GraphApiTab delegated capabilities", () => {
     expect(useUiStore.getState().graphApiStatus).toBe("unsupported");
   });
 
+  it("shows one announced native message when sign-in discovers an unsupported host", async () => {
+    const message =
+      "Only a personal Microsoft account is available. Connect a Windows work or school account to use Microsoft Graph.";
+    vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
+    vi.mocked(graphAuthenticate).mockResolvedValue({
+      outcome: "unavailable",
+      status: disconnectedStatus(),
+      capability: { kind: "personalAccountOnly" },
+      message,
+    });
+
+    render(<GraphApiTab />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Sign in with Windows" }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(message);
+    expect(screen.getAllByText(/Only a personal Microsoft account/)).toHaveLength(
+      1,
+    );
+    expect(useUiStore.getState().graphApiStatus).toBe("unsupported");
+  });
+
   it("cancels the matching request and remains cancelling until native settles", async () => {
     const authentication = deferred<GraphAuthAttemptResult>();
     vi.mocked(graphGetAuthStatus).mockResolvedValue(disconnectedStatus());
@@ -1277,6 +1303,9 @@ describe("GraphApiTab delegated capabilities", () => {
     );
 
     await screen.findByText(
+      "Microsoft Graph sign-in timed out after 120 seconds.",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
       "Microsoft Graph sign-in timed out after 120 seconds.",
     );
     expect(useUiStore.getState().graphApiStatus).toBe("disconnected");

--- a/src/components/dialogs/settings/GraphApiTab.tsx
+++ b/src/components/dialogs/settings/GraphApiTab.tsx
@@ -11,7 +11,7 @@ import {
   graphAuthenticate,
   graphCancelAuthentication,
   graphGetAuthStatus,
-  graphProbeCapability,
+  graphReserveInteractiveOperation,
   graphRequestMissingPermissions,
   graphSignOut,
   graphFetchAllApps,
@@ -63,7 +63,7 @@ type PermissionNoticeTone = "success" | "warning" | "error";
 interface SharedGraphAction {
   action: GraphAction;
   generation: number;
-  requestId: string | null;
+  attemptId: string | null;
   statusAtStart: GraphAuthStatus | null;
   retired: boolean;
 }
@@ -96,15 +96,25 @@ function beginSharedGraphAction(
   sharedGraphAction = {
     action,
     generation: graphActionGeneration,
-    requestId:
-      action === "signIn" || action === "permissions"
-        ? globalThis.crypto.randomUUID()
-        : null,
+    attemptId: null,
     statusAtStart,
     retired: false,
   };
   notifyGraphActionSubscribers();
   return graphActionGeneration;
+}
+
+function attachSharedGraphAttemptId(generation: number, attemptId: string) {
+  if (
+    sharedGraphAction?.generation !== generation ||
+    sharedGraphAction.retired ||
+    sharedGraphAction.attemptId !== null
+  ) {
+    return false;
+  }
+  sharedGraphAction = { ...sharedGraphAction, attemptId };
+  notifyGraphActionSubscribers();
+  return true;
 }
 
 function isCurrentSharedGraphAction(generation: number) {
@@ -290,15 +300,6 @@ export function GraphApiTab() {
       sharedGraphAction === null &&
       useUiStore.getState().graphApiEnabled;
     try {
-      useUiStore.getState().setGraphApiStatus("checkingCapability");
-      const capability = await graphProbeCapability();
-      if (!isCurrentRefresh()) return;
-      useUiStore.getState().setGraphApiCapability(capability);
-      if (capability.kind !== "available" && capability.kind !== "unknown") {
-        setAuthStatus(null);
-        useUiStore.getState().setGraphApiStatus("unsupported");
-        return;
-      }
       const status = await graphGetAuthStatus();
       if (!isCurrentRefresh()) return;
       setAuthStatus(status);
@@ -323,11 +324,13 @@ export function GraphApiTab() {
         sharedGraphAction?.action === "permissions"
           ? sharedGraphAction
           : null;
-      if (interactiveAction?.requestId) {
+      if (interactiveAction) {
         retireSharedGraphAction(interactiveAction.generation);
-        void graphCancelAuthentication(interactiveAction.requestId).catch(
-          () => false,
-        );
+        if (interactiveAction.attemptId) {
+          void graphCancelAuthentication(interactiveAction.attemptId).catch(
+            () => false,
+          );
+        }
       } else {
         invalidateSharedGraphActions();
       }
@@ -370,15 +373,21 @@ export function GraphApiTab() {
   const handleSignIn = async () => {
     const generation = beginGraphAction("signIn");
     if (generation === null) return;
-    const requestId = sharedGraphAction?.requestId;
-    if (!requestId) {
-      finishGraphAction("signIn", generation);
-      return;
-    }
     setPermissionNotice(null);
     useUiStore.getState().setGraphApiStatus("signingIn");
     try {
-      const result = await graphAuthenticate(requestId);
+      const { attemptId } =
+        await graphReserveInteractiveOperation("authentication");
+      if (
+        !mountedRef.current ||
+        !canApplySharedGraphAction(generation) ||
+        !useUiStore.getState().graphApiEnabled ||
+        !attachSharedGraphAttemptId(generation, attemptId)
+      ) {
+        await graphCancelAuthentication(attemptId).catch(() => false);
+        return;
+      }
+      const result = await graphAuthenticate(attemptId);
       if (!canApplySharedGraphAction(generation)) return;
       if (useUiStore.getState().graphApiEnabled) {
         useUiStore.getState().setGraphApiLastAttempt({
@@ -445,14 +454,20 @@ export function GraphApiTab() {
   const handleRequestMissingPermissions = async () => {
     const generation = beginGraphAction("permissions");
     if (generation === null) return;
-    const requestId = sharedGraphAction?.requestId;
-    if (!requestId) {
-      finishGraphAction("permissions", generation);
-      return;
-    }
     setPermissionNotice(null);
     try {
-      const result = await graphRequestMissingPermissions(requestId);
+      const { attemptId } =
+        await graphReserveInteractiveOperation("permissionConsent");
+      if (
+        !mountedRef.current ||
+        !canApplySharedGraphAction(generation) ||
+        !useUiStore.getState().graphApiEnabled ||
+        !attachSharedGraphAttemptId(generation, attemptId)
+      ) {
+        await graphCancelAuthentication(attemptId).catch(() => false);
+        return;
+      }
+      const result = await graphRequestMissingPermissions(attemptId);
       if (!canApplySharedGraphAction(generation)) return;
       if (useUiStore.getState().graphApiEnabled) {
         useUiStore
@@ -493,13 +508,13 @@ export function GraphApiTab() {
   const handleCancelAuthentication = async () => {
     const action = sharedGraphAction;
     if (
-      !action?.requestId ||
+      !action?.attemptId ||
       (action.action !== "signIn" && action.action !== "permissions")
     ) {
       return;
     }
     useUiStore.getState().setGraphApiStatus("cancelling");
-    await graphCancelAuthentication(action.requestId).catch(() => false);
+    await graphCancelAuthentication(action.attemptId).catch(() => false);
   };
 
   const handlePrePopulateCache = async () => {
@@ -958,13 +973,11 @@ export function GraphApiTab() {
                     }}
                   />
                   <span>
-                    {graphApiStatus === "checkingCapability"
-                      ? "Checking Windows account support..."
-                      : graphApiStatus === "unsupported"
-                        ? "Work or school account unavailable"
-                        : graphApiStatus === "cancelling"
-                          ? "Cancelling sign-in..."
-                          : "Not connected"}
+                    {graphApiStatus === "unsupported"
+                      ? "Work or school account unavailable"
+                      : graphApiStatus === "cancelling"
+                        ? "Cancelling sign-in..."
+                        : "Not connected"}
                   </span>
                 </div>
                 {graphApiLastAttempt?.message && (
@@ -1016,11 +1029,7 @@ export function GraphApiTab() {
                   <button
                     type="button"
                     onClick={handleSignIn}
-                    disabled={
-                      graphActionBusy ||
-                      graphApiStatus === "checkingCapability" ||
-                      graphApiStatus === "unsupported"
-                    }
+                    disabled={graphActionBusy}
                     style={{
                       padding: "4px 12px",
                       fontSize: "12px",
@@ -1028,17 +1037,8 @@ export function GraphApiTab() {
                       backgroundColor: tokens.colorBrandBackground,
                       color: tokens.colorNeutralForegroundOnBrand,
                       borderRadius: "4px",
-                      cursor:
-                        graphApiStatus === "checkingCapability"
-                          ? "wait"
-                          : graphApiStatus === "unsupported"
-                            ? "not-allowed"
-                            : "pointer",
-                      opacity:
-                        graphApiStatus === "checkingCapability" ||
-                        graphApiStatus === "unsupported"
-                          ? 0.7
-                          : 1,
+                      cursor: graphActionBusy ? "wait" : "pointer",
+                      opacity: graphActionBusy ? 0.7 : 1,
                     }}
                   >
                     Sign in with Windows

--- a/src/components/dialogs/settings/GraphApiTab.tsx
+++ b/src/components/dialogs/settings/GraphApiTab.tsx
@@ -9,11 +9,15 @@ import { tokens } from "@fluentui/react-components";
 import { useUiStore } from "../../../stores/ui-store";
 import {
   graphAuthenticate,
+  graphCancelAuthentication,
   graphGetAuthStatus,
+  graphProbeCapability,
   graphRequestMissingPermissions,
   graphSignOut,
   graphFetchAllApps,
   type GraphAuthStatus,
+  type GraphAuthAttemptResult,
+  type GraphHostCapabilityKind,
   type GraphPermissionUpgradeOutcome,
   type GraphPermissionUpgradeResult,
 } from "../../../lib/commands";
@@ -43,6 +47,8 @@ const PERMISSION_NOTICE_COPY: Record<GraphPermissionUpgradeOutcome, string> = {
     "No additional permissions were granted. A tenant administrator may need to approve the missing permissions.",
   cancelled:
     "Permission request cancelled. Your existing Graph permissions are unchanged.",
+  timedOut:
+    "The Windows permission request timed out. Your existing Graph permissions are unchanged.",
   denied:
     "Consent was not granted. Your existing Graph permissions remain available. A tenant administrator may need to approve the missing permissions.",
   failed:
@@ -57,6 +63,7 @@ type PermissionNoticeTone = "success" | "warning" | "error";
 interface SharedGraphAction {
   action: GraphAction;
   generation: number;
+  requestId: string | null;
   statusAtStart: GraphAuthStatus | null;
 }
 
@@ -88,6 +95,10 @@ function beginSharedGraphAction(
   sharedGraphAction = {
     action,
     generation: graphActionGeneration,
+    requestId:
+      action === "signIn" || action === "permissions"
+        ? globalThis.crypto.randomUUID()
+        : null,
     statusAtStart,
   };
   notifyGraphActionSubscribers();
@@ -97,8 +108,7 @@ function beginSharedGraphAction(
 function isCurrentSharedGraphAction(generation: number) {
   return (
     sharedGraphAction?.generation === generation &&
-    graphActionGeneration === generation &&
-    useUiStore.getState().graphApiEnabled
+    graphActionGeneration === generation
   );
 }
 
@@ -166,6 +176,7 @@ function buildPermissionNotice(
   const useNativeMessage =
     result.outcome === "denied" ||
     result.outcome === "failed" ||
+    result.outcome === "timedOut" ||
     result.outcome === "stale";
 
   return {
@@ -179,12 +190,39 @@ function buildPermissionNotice(
 
 function graphApiPhaseFromStatus(
   status: GraphAuthStatus,
-): "connected" | "error" | "idle" {
-  return status.isAuthenticated ? "connected" : status.error ? "error" : "idle";
+): "connected" | "disconnected" {
+  return status.isAuthenticated ? "connected" : "disconnected";
+}
+
+function graphApiPhaseFromAttempt(
+  result: GraphAuthAttemptResult,
+): "connected" | "disconnected" | "unsupported" | "error" {
+  if (result.status.isAuthenticated) return "connected";
+  if (result.outcome === "unavailable") return "unsupported";
+  if (result.outcome === "failed") return "error";
+  return "disconnected";
+}
+
+function unsupportedCapabilityMessage(
+  kind: GraphHostCapabilityKind | undefined,
+): string | null {
+  switch (kind) {
+    case "personalAccountOnly":
+      return "Only a personal Microsoft account is available. Add a Windows work or school account to continue.";
+    case "noOrganizationalAccount":
+      return "No Windows work or school account is available for Microsoft Graph.";
+    case "providerUnavailable":
+      return "Windows Web Account Manager is unavailable on this host.";
+    default:
+      return null;
+  }
 }
 
 export function GraphApiTab() {
   const graphApiEnabled = useUiStore((state) => state.graphApiEnabled);
+  const graphApiStatus = useUiStore((state) => state.graphApiStatus);
+  const graphApiCapability = useUiStore((state) => state.graphApiCapability);
+  const graphApiLastAttempt = useUiStore((state) => state.graphApiLastAttempt);
   const setGraphApiEnabled = useUiStore((state) => state.setGraphApiEnabled);
   const currentPlatform = useUiStore((state) => state.currentPlatform);
 
@@ -237,6 +275,15 @@ export function GraphApiTab() {
       sharedGraphAction === null &&
       useUiStore.getState().graphApiEnabled;
     try {
+      useUiStore.getState().setGraphApiStatus("checkingCapability");
+      const capability = await graphProbeCapability();
+      if (!isCurrentRefresh()) return;
+      useUiStore.getState().setGraphApiCapability(capability);
+      if (capability.kind !== "available" && capability.kind !== "unknown") {
+        setAuthStatus(null);
+        useUiStore.getState().setGraphApiStatus("unsupported");
+        return;
+      }
       const status = await graphGetAuthStatus();
       if (!isCurrentRefresh()) return;
       setAuthStatus(status);
@@ -256,19 +303,38 @@ export function GraphApiTab() {
     if (checked) {
       setShowConfirmEnable(true);
     } else {
-      invalidateSharedGraphActions();
+      const interactiveAction =
+        sharedGraphAction?.action === "signIn" ||
+        sharedGraphAction?.action === "permissions"
+          ? sharedGraphAction
+          : null;
+      if (interactiveAction?.requestId) {
+        void graphCancelAuthentication(interactiveAction.requestId);
+      } else {
+        invalidateSharedGraphActions();
+      }
       localRefreshGeneration.current += 1;
       setGraphApiEnabled(false);
       setAuthStatus(null);
       setCachedAppCount(null);
       setCacheError(null);
       setPermissionNotice(null);
-      useUiStore.getState().setGraphApiStatus("idle");
+      useUiStore.getState().setGraphApiStatus("disconnected");
+      useUiStore.getState().setGraphApiCapability(null);
+      useUiStore.getState().setGraphApiLastAttempt(null);
     }
   };
 
   const confirmEnable = () => {
+    useUiStore.getState().setGraphApiCapability(null);
+    useUiStore.getState().setGraphApiLastAttempt(null);
     setGraphApiEnabled(true);
+    if (
+      sharedGraphAction?.action === "signIn" ||
+      sharedGraphAction?.action === "permissions"
+    ) {
+      useUiStore.getState().setGraphApiStatus("cancelling");
+    }
     setShowConfirmEnable(false);
   };
 
@@ -286,38 +352,38 @@ export function GraphApiTab() {
   const handleSignIn = async () => {
     const generation = beginGraphAction("signIn");
     if (generation === null) return;
+    const requestId = sharedGraphAction?.requestId;
+    if (!requestId) {
+      finishGraphAction("signIn", generation);
+      return;
+    }
     setPermissionNotice(null);
-    useUiStore.getState().setGraphApiStatus("connecting");
+    useUiStore.getState().setGraphApiStatus("signingIn");
     try {
-      const status = await graphAuthenticate();
+      const result = await graphAuthenticate(requestId);
       if (!isCurrentSharedGraphAction(generation)) return;
-      useUiStore
-        .getState()
-        .setGraphApiStatus(status.isAuthenticated ? "connected" : "error");
-      if (isCurrentMountedGraphAction(generation)) {
-        setAuthStatus(status);
+      if (useUiStore.getState().graphApiEnabled) {
+        useUiStore.getState().setGraphApiCapability(result.capability);
+        useUiStore.getState().setGraphApiLastAttempt({
+          outcome: result.outcome,
+          message: result.message,
+        });
+        useUiStore.getState().setGraphApiStatus(graphApiPhaseFromAttempt(result));
       }
-    } catch (e) {
+      if (
+        isCurrentMountedGraphAction(generation) &&
+        useUiStore.getState().graphApiEnabled
+      ) {
+        setAuthStatus(result.status);
+      }
+    } catch {
       if (!isCurrentSharedGraphAction(generation)) return;
-      const status: GraphAuthStatus = {
-        isAuthenticated: false,
-        userPrincipalName: null,
-        tenantId: null,
-        grantedScopes: [],
-        missingScopes: GRAPH_CAPABILITY_ROWS.map(([, , scope]) => scope),
-        expiresAt: null,
-        capabilities: {
-          managedDevices: false,
-          serviceConfig: false,
-          apps: false,
-          configuration: false,
-          scripts: false,
-        },
-        error: e instanceof Error ? e.message : String(e),
-      };
-      useUiStore.getState().setGraphApiStatus("error");
-      if (isCurrentMountedGraphAction(generation)) {
-        setAuthStatus(status);
+      if (useUiStore.getState().graphApiEnabled) {
+        useUiStore.getState().setGraphApiLastAttempt({
+          outcome: "failed",
+          message: "Windows could not complete Microsoft Graph sign-in.",
+        });
+        useUiStore.getState().setGraphApiStatus("error");
       }
     } finally {
       finishGraphAction("signIn", generation);
@@ -330,7 +396,8 @@ export function GraphApiTab() {
     try {
       await graphSignOut();
       if (!isCurrentSharedGraphAction(generation)) return;
-      useUiStore.getState().setGraphApiStatus("idle");
+      useUiStore.getState().setGraphApiStatus("disconnected");
+      useUiStore.getState().setGraphApiLastAttempt(null);
       if (isCurrentMountedGraphAction(generation)) {
         setAuthStatus(null);
         setCachedAppCount(null);
@@ -346,14 +413,24 @@ export function GraphApiTab() {
   const handleRequestMissingPermissions = async () => {
     const generation = beginGraphAction("permissions");
     if (generation === null) return;
+    const requestId = sharedGraphAction?.requestId;
+    if (!requestId) {
+      finishGraphAction("permissions", generation);
+      return;
+    }
     setPermissionNotice(null);
     try {
-      const result = await graphRequestMissingPermissions();
+      const result = await graphRequestMissingPermissions(requestId);
       if (!isCurrentSharedGraphAction(generation)) return;
-      useUiStore
-        .getState()
-        .setGraphApiStatus(graphApiPhaseFromStatus(result.status));
-      if (isCurrentMountedGraphAction(generation)) {
+      if (useUiStore.getState().graphApiEnabled) {
+        useUiStore
+          .getState()
+          .setGraphApiStatus(graphApiPhaseFromStatus(result.status));
+      }
+      if (
+        isCurrentMountedGraphAction(generation) &&
+        useUiStore.getState().graphApiEnabled
+      ) {
         setAuthStatus(result.status);
         setPermissionNotice(buildPermissionNotice(result));
       }
@@ -362,9 +439,11 @@ export function GraphApiTab() {
       try {
         const status = await graphGetAuthStatus();
         if (!isCurrentSharedGraphAction(generation)) return;
-        useUiStore
-          .getState()
-          .setGraphApiStatus(graphApiPhaseFromStatus(status));
+        if (useUiStore.getState().graphApiEnabled) {
+          useUiStore
+            .getState()
+            .setGraphApiStatus(graphApiPhaseFromStatus(status));
+        }
         if (isCurrentMountedGraphAction(generation)) {
           setAuthStatus(status);
           setPermissionNotice(buildPermissionReconciliationNotice(status));
@@ -377,6 +456,18 @@ export function GraphApiTab() {
     } finally {
       finishGraphAction("permissions", generation);
     }
+  };
+
+  const handleCancelAuthentication = async () => {
+    const action = sharedGraphAction;
+    if (
+      !action?.requestId ||
+      (action.action !== "signIn" && action.action !== "permissions")
+    ) {
+      return;
+    }
+    useUiStore.getState().setGraphApiStatus("cancelling");
+    await graphCancelAuthentication(action.requestId).catch(() => false);
   };
 
   const handlePrePopulateCache = async () => {
@@ -708,6 +799,27 @@ export function GraphApiTab() {
                         : "Request missing permissions"}
                     </button>
                   )}
+                  {permissionsLoading && (
+                    <button
+                      type="button"
+                      onClick={handleCancelAuthentication}
+                      disabled={graphApiStatus === "cancelling"}
+                      style={{
+                        padding: "4px 12px",
+                        fontSize: "12px",
+                        border: `1px solid ${tokens.colorNeutralStroke1}`,
+                        backgroundColor: "transparent",
+                        color: tokens.colorNeutralForeground2,
+                        borderRadius: "4px",
+                        cursor:
+                          graphApiStatus === "cancelling" ? "wait" : "pointer",
+                      }}
+                    >
+                      {graphApiStatus === "cancelling"
+                        ? "Cancelling..."
+                        : "Cancel permission request"}
+                    </button>
+                  )}
                   <button
                     type="button"
                     onClick={handlePrePopulateCache}
@@ -813,9 +925,17 @@ export function GraphApiTab() {
                       display: "inline-block",
                     }}
                   />
-                  <span>Not connected</span>
+                  <span>
+                    {graphApiStatus === "checkingCapability"
+                      ? "Checking Windows account support..."
+                      : graphApiStatus === "unsupported"
+                        ? "Work or school account unavailable"
+                        : graphApiStatus === "cancelling"
+                          ? "Cancelling sign-in..."
+                          : "Not connected"}
+                  </span>
                 </div>
-                {displayedAuthStatus?.error && (
+                {graphApiLastAttempt?.message && (
                   <div
                     style={{
                       color: tokens.colorPaletteRedForeground1,
@@ -823,26 +943,73 @@ export function GraphApiTab() {
                       fontSize: "11px",
                     }}
                   >
-                    {displayedAuthStatus.error}
+                    {graphApiLastAttempt.message}
                   </div>
                 )}
-                <button
-                  type="button"
-                  onClick={handleSignIn}
-                  disabled={graphActionBusy}
-                  style={{
-                    padding: "4px 12px",
-                    fontSize: "12px",
-                    border: `1px solid ${tokens.colorBrandStroke1}`,
-                    backgroundColor: tokens.colorBrandBackground,
-                    color: tokens.colorNeutralForegroundOnBrand,
-                    borderRadius: "4px",
-                    cursor: loading ? "wait" : "pointer",
-                    opacity: loading ? 0.7 : 1,
-                  }}
-                >
-                  {loading ? "Signing in..." : "Sign in with Windows"}
-                </button>
+                {graphApiStatus === "unsupported" && (
+                  <div
+                    role="status"
+                    style={{
+                      color: tokens.colorPaletteYellowForeground2,
+                      marginBottom: "8px",
+                      fontSize: "11px",
+                    }}
+                  >
+                    {unsupportedCapabilityMessage(graphApiCapability?.kind)}
+                  </div>
+                )}
+                {loading ? (
+                  <button
+                    type="button"
+                    onClick={handleCancelAuthentication}
+                    disabled={graphApiStatus === "cancelling"}
+                    style={{
+                      padding: "4px 12px",
+                      fontSize: "12px",
+                      border: `1px solid ${tokens.colorNeutralStroke1}`,
+                      backgroundColor: "transparent",
+                      color: tokens.colorNeutralForeground2,
+                      borderRadius: "4px",
+                      cursor:
+                        graphApiStatus === "cancelling" ? "wait" : "pointer",
+                    }}
+                  >
+                    {graphApiStatus === "cancelling"
+                      ? "Cancelling..."
+                      : "Cancel sign-in"}
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleSignIn}
+                    disabled={
+                      graphActionBusy ||
+                      graphApiStatus === "checkingCapability" ||
+                      graphApiStatus === "unsupported"
+                    }
+                    style={{
+                      padding: "4px 12px",
+                      fontSize: "12px",
+                      border: `1px solid ${tokens.colorBrandStroke1}`,
+                      backgroundColor: tokens.colorBrandBackground,
+                      color: tokens.colorNeutralForegroundOnBrand,
+                      borderRadius: "4px",
+                      cursor:
+                        graphApiStatus === "checkingCapability"
+                          ? "wait"
+                          : graphApiStatus === "unsupported"
+                            ? "not-allowed"
+                            : "pointer",
+                      opacity:
+                        graphApiStatus === "checkingCapability" ||
+                        graphApiStatus === "unsupported"
+                          ? 0.7
+                          : 1,
+                    }}
+                  >
+                    Sign in with Windows
+                  </button>
+                )}
               </div>
             )}
             {permissionNotice && (

--- a/src/components/dialogs/settings/GraphApiTab.tsx
+++ b/src/components/dialogs/settings/GraphApiTab.tsx
@@ -65,6 +65,7 @@ interface SharedGraphAction {
   generation: number;
   requestId: string | null;
   statusAtStart: GraphAuthStatus | null;
+  retired: boolean;
 }
 
 let graphActionGeneration = 0;
@@ -100,6 +101,7 @@ function beginSharedGraphAction(
         ? globalThis.crypto.randomUUID()
         : null,
     statusAtStart,
+    retired: false,
   };
   notifyGraphActionSubscribers();
   return graphActionGeneration;
@@ -110,6 +112,19 @@ function isCurrentSharedGraphAction(generation: number) {
     sharedGraphAction?.generation === generation &&
     graphActionGeneration === generation
   );
+}
+
+function canApplySharedGraphAction(generation: number) {
+  return (
+    isCurrentSharedGraphAction(generation) &&
+    sharedGraphAction?.retired === false
+  );
+}
+
+function retireSharedGraphAction(generation: number) {
+  if (sharedGraphAction?.generation !== generation) return;
+  sharedGraphAction = { ...sharedGraphAction, retired: true };
+  notifyGraphActionSubscribers();
 }
 
 function finishSharedGraphAction(action: GraphAction, generation: number) {
@@ -249,7 +264,7 @@ export function GraphApiTab() {
   const graphActionBusy = activeAction !== null;
 
   const isCurrentMountedGraphAction = useCallback((generation: number) => {
-    return mountedRef.current && isCurrentSharedGraphAction(generation);
+    return mountedRef.current && canApplySharedGraphAction(generation);
   }, []);
 
   useEffect(() => {
@@ -309,6 +324,7 @@ export function GraphApiTab() {
           ? sharedGraphAction
           : null;
       if (interactiveAction?.requestId) {
+        retireSharedGraphAction(interactiveAction.generation);
         void graphCancelAuthentication(interactiveAction.requestId).catch(
           () => false,
         );
@@ -345,7 +361,7 @@ export function GraphApiTab() {
   };
 
   const finishGraphAction = (action: GraphAction, generation: number) => {
-    if (mountedRef.current && isCurrentSharedGraphAction(generation)) {
+    if (mountedRef.current && canApplySharedGraphAction(generation)) {
       skipNextSettledActionRefresh.current = true;
     }
     finishSharedGraphAction(action, generation);
@@ -363,23 +379,37 @@ export function GraphApiTab() {
     useUiStore.getState().setGraphApiStatus("signingIn");
     try {
       const result = await graphAuthenticate(requestId);
-      if (!isCurrentSharedGraphAction(generation)) return;
+      if (!canApplySharedGraphAction(generation)) return;
       if (useUiStore.getState().graphApiEnabled) {
-        useUiStore.getState().setGraphApiCapability(result.capability);
         useUiStore.getState().setGraphApiLastAttempt({
           outcome: result.outcome,
           message: result.message,
         });
-        useUiStore.getState().setGraphApiStatus(graphApiPhaseFromAttempt(result));
+        if (result.outcome === "stale") {
+          const statusAtStart = sharedGraphAction?.statusAtStart;
+          useUiStore
+            .getState()
+            .setGraphApiStatus(
+              statusAtStart
+                ? graphApiPhaseFromStatus(statusAtStart)
+                : "disconnected",
+            );
+        } else {
+          useUiStore.getState().setGraphApiCapability(result.capability);
+          useUiStore
+            .getState()
+            .setGraphApiStatus(graphApiPhaseFromAttempt(result));
+        }
       }
       if (
+        result.outcome !== "stale" &&
         isCurrentMountedGraphAction(generation) &&
         useUiStore.getState().graphApiEnabled
       ) {
         setAuthStatus(result.status);
       }
     } catch {
-      if (!isCurrentSharedGraphAction(generation)) return;
+      if (!canApplySharedGraphAction(generation)) return;
       if (useUiStore.getState().graphApiEnabled) {
         useUiStore.getState().setGraphApiLastAttempt({
           outcome: "failed",
@@ -423,7 +453,7 @@ export function GraphApiTab() {
     setPermissionNotice(null);
     try {
       const result = await graphRequestMissingPermissions(requestId);
-      if (!isCurrentSharedGraphAction(generation)) return;
+      if (!canApplySharedGraphAction(generation)) return;
       if (useUiStore.getState().graphApiEnabled) {
         useUiStore
           .getState()
@@ -437,10 +467,10 @@ export function GraphApiTab() {
         setPermissionNotice(buildPermissionNotice(result));
       }
     } catch {
-      if (!isCurrentSharedGraphAction(generation)) return;
+      if (!canApplySharedGraphAction(generation)) return;
       try {
         const status = await graphGetAuthStatus();
-        if (!isCurrentSharedGraphAction(generation)) return;
+        if (!canApplySharedGraphAction(generation)) return;
         if (useUiStore.getState().graphApiEnabled) {
           useUiStore
             .getState()

--- a/src/components/dialogs/settings/GraphApiTab.tsx
+++ b/src/components/dialogs/settings/GraphApiTab.tsx
@@ -309,7 +309,9 @@ export function GraphApiTab() {
           ? sharedGraphAction
           : null;
       if (interactiveAction?.requestId) {
-        void graphCancelAuthentication(interactiveAction.requestId);
+        void graphCancelAuthentication(interactiveAction.requestId).catch(
+          () => false,
+        );
       } else {
         invalidateSharedGraphActions();
       }
@@ -937,6 +939,7 @@ export function GraphApiTab() {
                 </div>
                 {graphApiLastAttempt?.message && (
                   <div
+                    role="alert"
                     style={{
                       color: tokens.colorPaletteRedForeground1,
                       marginBottom: "8px",
@@ -946,18 +949,19 @@ export function GraphApiTab() {
                     {graphApiLastAttempt.message}
                   </div>
                 )}
-                {graphApiStatus === "unsupported" && (
-                  <div
-                    role="status"
-                    style={{
-                      color: tokens.colorPaletteYellowForeground2,
-                      marginBottom: "8px",
-                      fontSize: "11px",
-                    }}
-                  >
-                    {unsupportedCapabilityMessage(graphApiCapability?.kind)}
-                  </div>
-                )}
+                {graphApiStatus === "unsupported" &&
+                  !graphApiLastAttempt?.message && (
+                    <div
+                      role="status"
+                      style={{
+                        color: tokens.colorPaletteYellowForeground2,
+                        marginBottom: "8px",
+                        fontSize: "11px",
+                      }}
+                    >
+                      {unsupportedCapabilityMessage(graphApiCapability?.kind)}
+                    </div>
+                  )}
                 {loading ? (
                   <button
                     type="button"

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -537,60 +537,76 @@ export function StatusBar() {
             </span>
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: "10px", flexShrink: 0 }}>
-        {graphApiStatus !== "idle" && (
-          <span
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "4px",
-              fontSize: "11px",
-              color: graphApiStatus === "connected"
-                ? tokens.colorPaletteGreenForeground1
-                : graphApiStatus === "connecting"
-                  ? tokens.colorNeutralForeground3
-                  : tokens.colorPaletteRedForeground1,
-            }}
-            title={
-              graphApiStatus === "connected"
-                ? "Graph API connected — GUID resolution active"
-                : graphApiStatus === "connecting"
-                  ? "Connecting to Graph API..."
-                  : "Graph API connection failed"
-            }
-          >
+            {graphApiStatus !== "disconnected" && (
+              <span
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "4px",
+                  fontSize: "11px",
+                  color: graphApiStatus === "connected"
+                    ? tokens.colorPaletteGreenForeground1
+                    : graphApiStatus === "checkingCapability" ||
+                        graphApiStatus === "signingIn" ||
+                        graphApiStatus === "cancelling"
+                      ? tokens.colorNeutralForeground3
+                      : graphApiStatus === "unsupported"
+                        ? tokens.colorPaletteYellowForeground2
+                        : tokens.colorPaletteRedForeground1,
+                }}
+                title={
+                  graphApiStatus === "connected"
+                    ? "Graph API connected — GUID resolution active"
+                    : graphApiStatus === "checkingCapability"
+                      ? "Checking Microsoft Graph host capability..."
+                      : graphApiStatus === "signingIn"
+                        ? "Connecting to Graph API..."
+                        : graphApiStatus === "cancelling"
+                          ? "Cancelling Microsoft Graph sign-in..."
+                          : graphApiStatus === "unsupported"
+                            ? "Microsoft Graph is unavailable on this host"
+                            : "Graph API connection failed"
+                }
+              >
+                <span
+                  style={{
+                    width: "6px",
+                    height: "6px",
+                    borderRadius: "50%",
+                    backgroundColor: "currentColor",
+                    display: "inline-block",
+                  }}
+                />
+                {graphApiStatus === "checkingCapability"
+                  ? "Graph API: Checking..."
+                  : graphApiStatus === "signingIn"
+                    ? "Graph API: Connecting..."
+                    : graphApiStatus === "cancelling"
+                      ? "Graph API: Cancelling..."
+                      : graphApiStatus === "connected"
+                        ? "Graph API: Connected"
+                        : graphApiStatus === "unsupported"
+                          ? "Graph API: Unavailable"
+                          : "Graph API: Error"}
+              </span>
+            )}
+            {activeView === "event-log" && evtxIsLoading && (
+              <Spinner size="tiny" />
+            )}
             <span
+              title={rightStatusText}
               style={{
-                width: "6px",
-                height: "6px",
-                borderRadius: "50%",
-                backgroundColor: "currentColor",
-                display: "inline-block",
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                color: rightTone,
+                fontWeight: 500,
+                fontVariantNumeric: "tabular-nums",
               }}
-            />
-            {graphApiStatus === "connecting"
-              ? "Graph API: Connecting..."
-              : graphApiStatus === "connected"
-                ? "Graph API: Connected"
-                : "Graph API: Error"}
-          </span>
-        )}
-        {activeView === "event-log" && evtxIsLoading && (
-          <Spinner size="tiny" />
-        )}
-        <span
-          title={rightStatusText}
-          style={{
-            minWidth: 0,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            color: rightTone,
-            fontWeight: 500,
-            fontVariantNumeric: "tabular-nums",
-          }}
-        >
-          {rightStatusText}
-        </span>
+            >
+              {rightStatusText}
+            </span>
           </div>
         </>
       </WorkspaceStatusBarContent>

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -17,6 +17,7 @@ import {
   getUiChromeStatus,
   isIntuneWorkspace,
   useUiStore,
+  type GraphApiPhase,
 } from "../../stores/ui-store";
 import { useIntuneStore } from "../../workspaces/intune/intune-store";
 import { useDsregcmdStore } from "../../workspaces/dsregcmd/dsregcmd-store";
@@ -34,10 +35,50 @@ interface SeverityCounts {
   success: number;
 }
 
+type GraphApiIndicatorPhase = Exclude<GraphApiPhase, "disconnected">;
+
+const GRAPH_API_INDICATORS: Record<
+  GraphApiIndicatorPhase,
+  { color: string; title: string; label: string }
+> = {
+  checkingCapability: {
+    color: tokens.colorNeutralForeground3,
+    title: "Checking Microsoft Graph host capability...",
+    label: "Graph API: Checking...",
+  },
+  signingIn: {
+    color: tokens.colorNeutralForeground3,
+    title: "Connecting to Graph API...",
+    label: "Graph API: Connecting...",
+  },
+  cancelling: {
+    color: tokens.colorNeutralForeground3,
+    title: "Cancelling Microsoft Graph sign-in...",
+    label: "Graph API: Cancelling...",
+  },
+  connected: {
+    color: tokens.colorPaletteGreenForeground1,
+    title: "Graph API connected — GUID resolution active",
+    label: "Graph API: Connected",
+  },
+  unsupported: {
+    color: tokens.colorPaletteYellowForeground2,
+    title: "Microsoft Graph is unavailable on this host",
+    label: "Graph API: Unavailable",
+  },
+  error: {
+    color: tokens.colorPaletteRedForeground1,
+    title: "Graph API connection failed",
+    label: "Graph API: Error",
+  },
+};
+
 function formatSeverityCounts(counts: SeverityCounts): string {
   const parts: string[] = [];
-  if (counts.errors > 0) parts.push(`${counts.errors} error${counts.errors === 1 ? "" : "s"}`);
-  if (counts.warnings > 0) parts.push(`${counts.warnings} warning${counts.warnings === 1 ? "" : "s"}`);
+  if (counts.errors > 0)
+    parts.push(`${counts.errors} error${counts.errors === 1 ? "" : "s"}`);
+  if (counts.warnings > 0)
+    parts.push(`${counts.warnings} warning${counts.warnings === 1 ? "" : "s"}`);
   if (counts.info > 0) parts.push(`${counts.info} info`);
   if (counts.success > 0) parts.push(`${counts.success} success`);
   return parts.join(", ");
@@ -79,7 +120,9 @@ export function StatusBar() {
   const sourceStatus = useLogStore((s) => s.sourceStatus);
   const folderLoadProgress = useLogStore((s) => s.folderLoadProgress);
   const folderLoadCurrentFile = useLogStore((s) => s.folderLoadCurrentFile);
-  const folderLoadCompletedFiles = useLogStore((s) => s.folderLoadCompletedFiles);
+  const folderLoadCompletedFiles = useLogStore(
+    (s) => s.folderLoadCompletedFiles,
+  );
   const folderLoadTotalFiles = useLogStore((s) => s.folderLoadTotalFiles);
 
   const activeView = useUiStore((s) => s.activeView);
@@ -89,6 +132,10 @@ export function StatusBar() {
   const activeTabIndex = useUiStore((s) => s.activeTabIndex);
 
   const graphApiStatus = useUiStore((s) => s.graphApiStatus);
+  const graphApiIndicator =
+    graphApiStatus === "disconnected"
+      ? null
+      : GRAPH_API_INDICATORS[graphApiStatus];
 
   const intuneAnalysisState = useIntuneStore((s) => s.analysisState);
   const intuneSummary = useIntuneStore((s) => s.summary);
@@ -196,15 +243,19 @@ export function StatusBar() {
     isLoading,
     isPaused,
     activeSource,
-    openFilePath
+    openFilePath,
   );
   const parserDisplay = getParserSelectionDisplay(parserSelection);
-  const uiChromeStatus = getUiChromeStatus(activeView, showDetails, showInfoPane);
+  const uiChromeStatus = getUiChromeStatus(
+    activeView,
+    showDetails,
+    showInfoPane,
+  );
   const filterStatus = getFilterStatusSnapshot(
     filterClauseCount,
     filteredIds?.size ?? null,
     isFiltering,
-    filterError
+    filterError,
   );
 
   let leftParts: string[] = [];
@@ -261,8 +312,8 @@ export function StatusBar() {
         : null;
 
     const logStatusText =
-      folderLoadStatusText
-        ?? (entries.length > 0
+      folderLoadStatusText ??
+      (entries.length > 0
         ? [
             positionText ?? entriesCountText,
             `${totalLines} lines`,
@@ -279,22 +330,29 @@ export function StatusBar() {
         : failureReason
           ? `Reason: ${failureReason}`
           : sourceStatus.kind !== "idle"
-            ? sourceStatus.detail ?? sourceStatus.message
+            ? (sourceStatus.detail ?? sourceStatus.message)
             : "");
 
-    const filterStatusText = filterError ? `Filter error: ${filterError}` : filterStatus.label;
+    const filterStatusText = filterError
+      ? `Filter error: ${filterError}`
+      : filterStatus.label;
 
     rightStatusText = [logStatusText, filterStatusText]
       .filter((part) => part.length > 0)
       .join(" | ");
-    rightTone = filterStatus.tone === "error" ? tokens.colorPaletteRedForeground2 : undefined;
+    rightTone =
+      filterStatus.tone === "error"
+        ? tokens.colorPaletteRedForeground2
+        : undefined;
   } else if (isIntuneWorkspace(activeView)) {
     const intuneSourceLabel = getBaseName(
-      intuneAnalysisState.requestedPath ?? intuneSourceContext.analyzedPath
+      intuneAnalysisState.requestedPath ?? intuneSourceContext.analyzedPath,
     );
 
     leftParts = [
-      activeView === "new-intune" ? "New Intune Workspace" : "Intune Diagnostics",
+      activeView === "new-intune"
+        ? "New Intune Workspace"
+        : "Intune Diagnostics",
       intuneAnalysisState.phase === "analyzing"
         ? "Analyzing"
         : intuneAnalysisState.phase === "error"
@@ -315,13 +373,23 @@ export function StatusBar() {
     }
 
     if (intuneAnalysisState.phase === "analyzing") {
-      rightStatusText = intuneAnalysisState.detail ?? intuneAnalysisState.message;
+      rightStatusText =
+        intuneAnalysisState.detail ?? intuneAnalysisState.message;
       rightTone = tokens.colorPaletteBlueForeground2;
-    } else if (intuneAnalysisState.phase === "error" || intuneAnalysisState.phase === "empty") {
-      rightStatusText = [intuneAnalysisState.message, intuneAnalysisState.detail]
+    } else if (
+      intuneAnalysisState.phase === "error" ||
+      intuneAnalysisState.phase === "empty"
+    ) {
+      rightStatusText = [
+        intuneAnalysisState.message,
+        intuneAnalysisState.detail,
+      ]
         .filter((part): part is string => Boolean(part))
         .join(" | ");
-      rightTone = intuneAnalysisState.phase === "error" ? tokens.colorPaletteRedForeground2 : tokens.colorPaletteMarigoldForeground2;
+      rightTone =
+        intuneAnalysisState.phase === "error"
+          ? tokens.colorPaletteRedForeground2
+          : tokens.colorPaletteMarigoldForeground2;
     } else if (intuneSummary) {
       rightStatusText = [
         `${intuneSummary.totalEvents} events`,
@@ -377,8 +445,12 @@ export function StatusBar() {
       rightStatusText = [
         `${deploymentResult.succeeded} succeeded`,
         `${deploymentResult.failed} failed`,
-        deploymentResult.deferred > 0 ? `${deploymentResult.deferred} deferred` : null,
-      ].filter(Boolean).join(" | ");
+        deploymentResult.deferred > 0
+          ? `${deploymentResult.deferred} deferred`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" | ");
     }
   } else if (activeView === "event-log") {
     leftParts = [
@@ -393,20 +465,24 @@ export function StatusBar() {
     ];
 
     if (evtxIsLoading) {
-      rightStatusText = evtxRecordCount > 0
-        ? `${evtxRecordCount.toLocaleString()} events loaded...`
-        : "Querying event logs...";
+      rightStatusText =
+        evtxRecordCount > 0
+          ? `${evtxRecordCount.toLocaleString()} events loaded...`
+          : "Querying event logs...";
       rightTone = tokens.colorPaletteBlueForeground2;
     } else if (evtxRecordCount > 0) {
-      const timeStr = evtxLoadElapsedMs != null
-        ? ` in ${(evtxLoadElapsedMs / 1000).toFixed(1)}s`
-        : "";
+      const timeStr =
+        evtxLoadElapsedMs != null
+          ? ` in ${(evtxLoadElapsedMs / 1000).toFixed(1)}s`
+          : "";
       rightStatusText = `${evtxRecordCount.toLocaleString()} events${timeStr}`;
     }
   } else if (activeView === "secureboot") {
     const sbDiagnostics = securebootResult?.diagnostics ?? [];
     const sbErrors = sbDiagnostics.filter((d) => d.severity === "error").length;
-    const sbWarnings = sbDiagnostics.filter((d) => d.severity === "warning").length;
+    const sbWarnings = sbDiagnostics.filter(
+      (d) => d.severity === "warning",
+    ).length;
 
     leftParts = [
       "Secure Boot",
@@ -422,10 +498,14 @@ export function StatusBar() {
     }
 
     if (securebootAnalysisState.phase === "analyzing") {
-      rightStatusText = securebootAnalysisState.detail ?? securebootAnalysisState.message;
+      rightStatusText =
+        securebootAnalysisState.detail ?? securebootAnalysisState.message;
       rightTone = tokens.colorPaletteBlueForeground2;
     } else if (securebootAnalysisState.phase === "error") {
-      rightStatusText = [securebootAnalysisState.message, securebootAnalysisState.detail]
+      rightStatusText = [
+        securebootAnalysisState.message,
+        securebootAnalysisState.detail,
+      ]
         .filter((part): part is string => Boolean(part))
         .join(" | ");
       rightTone = tokens.colorPaletteRedForeground2;
@@ -440,8 +520,12 @@ export function StatusBar() {
     }
   } else {
     const diagnostics = dsregcmdResult?.diagnostics ?? [];
-    const errorCount = diagnostics.filter((item) => item.severity === "Error").length;
-    const warningCount = diagnostics.filter((item) => item.severity === "Warning").length;
+    const errorCount = diagnostics.filter(
+      (item) => item.severity === "Error",
+    ).length;
+    const warningCount = diagnostics.filter(
+      (item) => item.severity === "Warning",
+    ).length;
 
     leftParts = [
       "dsregcmd",
@@ -457,10 +541,14 @@ export function StatusBar() {
     }
 
     if (dsregcmdAnalysisState.phase === "analyzing") {
-      rightStatusText = dsregcmdAnalysisState.detail ?? dsregcmdAnalysisState.message;
+      rightStatusText =
+        dsregcmdAnalysisState.detail ?? dsregcmdAnalysisState.message;
       rightTone = tokens.colorPaletteBlueForeground2;
     } else if (dsregcmdAnalysisState.phase === "error") {
-      rightStatusText = [dsregcmdAnalysisState.message, dsregcmdAnalysisState.detail]
+      rightStatusText = [
+        dsregcmdAnalysisState.message,
+        dsregcmdAnalysisState.detail,
+      ]
         .filter((part): part is string => Boolean(part))
         .join(" | ");
       rightTone = tokens.colorPaletteRedForeground2;
@@ -494,10 +582,10 @@ export function StatusBar() {
                 : activeView === "macos-diag"
                   ? "macOS Diagnostics"
                   : activeView === "secureboot"
-                  ? "Secure Boot"
-                  : activeView === "dsregcmd"
-                    ? "dsregcmd"
-                    : activeView;
+                    ? "Secure Boot"
+                    : activeView === "dsregcmd"
+                      ? "dsregcmd"
+                      : activeView;
 
   return (
     <div
@@ -531,42 +619,34 @@ export function StatusBar() {
             </Badge>
             <span
               title={leftStatusText}
-              style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+              style={{
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
             >
               {leftStatusText}
             </span>
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "10px", flexShrink: 0 }}>
-            {graphApiStatus !== "disconnected" && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "10px",
+              flexShrink: 0,
+            }}
+          >
+            {graphApiIndicator && (
               <span
                 style={{
                   display: "flex",
                   alignItems: "center",
                   gap: "4px",
                   fontSize: "11px",
-                  color: graphApiStatus === "connected"
-                    ? tokens.colorPaletteGreenForeground1
-                    : graphApiStatus === "checkingCapability" ||
-                        graphApiStatus === "signingIn" ||
-                        graphApiStatus === "cancelling"
-                      ? tokens.colorNeutralForeground3
-                      : graphApiStatus === "unsupported"
-                        ? tokens.colorPaletteYellowForeground2
-                        : tokens.colorPaletteRedForeground1,
+                  color: graphApiIndicator.color,
                 }}
-                title={
-                  graphApiStatus === "connected"
-                    ? "Graph API connected — GUID resolution active"
-                    : graphApiStatus === "checkingCapability"
-                      ? "Checking Microsoft Graph host capability..."
-                      : graphApiStatus === "signingIn"
-                        ? "Connecting to Graph API..."
-                        : graphApiStatus === "cancelling"
-                          ? "Cancelling Microsoft Graph sign-in..."
-                          : graphApiStatus === "unsupported"
-                            ? "Microsoft Graph is unavailable on this host"
-                            : "Graph API connection failed"
-                }
+                title={graphApiIndicator.title}
               >
                 <span
                   style={{
@@ -577,17 +657,7 @@ export function StatusBar() {
                     display: "inline-block",
                   }}
                 />
-                {graphApiStatus === "checkingCapability"
-                  ? "Graph API: Checking..."
-                  : graphApiStatus === "signingIn"
-                    ? "Graph API: Connecting..."
-                    : graphApiStatus === "cancelling"
-                      ? "Graph API: Cancelling..."
-                      : graphApiStatus === "connected"
-                        ? "Graph API: Connected"
-                        : graphApiStatus === "unsupported"
-                          ? "Graph API: Unavailable"
-                          : "Graph API: Error"}
+                {graphApiIndicator.label}
               </span>
             )}
             {activeView === "event-log" && evtxIsLoading && (

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -41,11 +41,6 @@ const GRAPH_API_INDICATORS: Record<
   GraphApiIndicatorPhase,
   { color: string; title: string; label: string }
 > = {
-  checkingCapability: {
-    color: tokens.colorNeutralForeground3,
-    title: "Checking Microsoft Graph host capability...",
-    label: "Graph API: Checking...",
-  },
   signingIn: {
     color: tokens.colorNeutralForeground3,
     title: "Connecting to Graph API...",

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -7,7 +7,7 @@ import {
   graphGetAuthStatus,
   graphAuthenticate,
   graphCancelAuthentication,
-  graphProbeCapability,
+  graphReserveInteractiveOperation,
   graphRequestMissingPermissions,
   openLogFile,
   revealInFileManager,
@@ -151,12 +151,41 @@ describe("Graph permission upgrade IPC boundary", () => {
     expect(invoke).toHaveBeenNthCalledWith(
       1,
       "graph_request_missing_permissions",
-      { requestId: "permission-request-1" },
+      { attemptId: "permission-request-1" },
     );
   });
 });
 
 describe("Graph authentication IPC boundary", () => {
+  it("accepts only native-issued UUID-shaped operation tickets", async () => {
+    const ticket = {
+      attemptId: "22d12752-4b6e-45e0-aac4-0bc351e91118",
+    };
+    vi.mocked(invoke).mockResolvedValueOnce(ticket).mockResolvedValueOnce({
+      attemptId: "frontend-controlled",
+    });
+
+    await expect(
+      graphReserveInteractiveOperation("authentication"),
+    ).resolves.toBe(ticket);
+    await expect(
+      graphReserveInteractiveOperation("permissionConsent"),
+    ).rejects.toThrow(
+      "Command 'graph_reserve_interactive_operation' returned an invalid response.",
+    );
+
+    expect(invoke).toHaveBeenNthCalledWith(
+      1,
+      "graph_reserve_interactive_operation",
+      { kind: "authentication" },
+    );
+    expect(invoke).toHaveBeenNthCalledWith(
+      2,
+      "graph_reserve_interactive_operation",
+      { kind: "permissionConsent" },
+    );
+  });
+
   it("passes request ownership through authenticate and cancellation", async () => {
     const result = {
       outcome: "cancelled",
@@ -164,34 +193,22 @@ describe("Graph authentication IPC boundary", () => {
       capability: { kind: "available" },
       message: "Microsoft Graph sign-in was cancelled.",
     };
-    vi.mocked(invoke)
-      .mockResolvedValueOnce({ kind: "available" })
-      .mockResolvedValueOnce(result)
-      .mockResolvedValueOnce(true);
+    vi.mocked(invoke).mockResolvedValueOnce(result).mockResolvedValueOnce(true);
 
-    await expect(graphProbeCapability()).resolves.toEqual({
-      kind: "available",
-    });
     await expect(graphAuthenticate("auth-request-1")).resolves.toBe(result);
     await expect(graphCancelAuthentication("auth-request-1")).resolves.toBe(
       true,
     );
 
-    expect(invoke).toHaveBeenNthCalledWith(
-      1,
-      "graph_probe_capability",
-      undefined,
-    );
-    expect(invoke).toHaveBeenNthCalledWith(2, "graph_authenticate", {
-      requestId: "auth-request-1",
+    expect(invoke).toHaveBeenNthCalledWith(1, "graph_authenticate", {
+      attemptId: "auth-request-1",
     });
-    expect(invoke).toHaveBeenNthCalledWith(3, "graph_cancel_authentication", {
-      requestId: "auth-request-1",
+    expect(invoke).toHaveBeenNthCalledWith(2, "graph_cancel_authentication", {
+      attemptId: "auth-request-1",
     });
   });
 
   it.each([
-    ["graph_probe_capability", () => graphProbeCapability(), { kind: "other" }],
     ["graph_authenticate", () => graphAuthenticate("auth-request-1"), null],
     [
       "graph_authenticate",

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -5,6 +5,9 @@ import {
   discoverSccmEnvironment,
   getSafeErrorMessage,
   graphGetAuthStatus,
+  graphAuthenticate,
+  graphCancelAuthentication,
+  graphProbeCapability,
   graphRequestMissingPermissions,
   openLogFile,
   revealInFileManager,
@@ -117,6 +120,7 @@ describe("Graph permission upgrade IPC boundary", () => {
       status: {
         isAuthenticated: true,
         userPrincipalName: "admin@contoso.com",
+        objectId: "00000000-0000-0000-0000-0000000000a1",
         tenantId: "tenant-1",
         grantedScopes: ["DeviceManagementManagedDevices.Read.All"],
         missingScopes: [],
@@ -128,20 +132,43 @@ describe("Graph permission upgrade IPC boundary", () => {
           configuration: false,
           scripts: false,
         },
-        error: null,
       },
       message: null,
     };
     vi.mocked(invoke).mockResolvedValueOnce(result);
 
-    await expect(graphRequestMissingPermissions()).resolves.toBe(result);
+    await expect(
+      graphRequestMissingPermissions("permission-request-1"),
+    ).resolves.toBe(result);
 
     expect(invoke).toHaveBeenCalledTimes(1);
     expect(invoke).toHaveBeenNthCalledWith(
       1,
       "graph_request_missing_permissions",
-      undefined,
+      { requestId: "permission-request-1" },
     );
+  });
+});
+
+describe("Graph authentication IPC boundary", () => {
+  it("passes request ownership through authenticate and cancellation", async () => {
+    const result = { outcome: "cancelled" };
+    vi.mocked(invoke)
+      .mockResolvedValueOnce({ kind: "available" })
+      .mockResolvedValueOnce(result)
+      .mockResolvedValueOnce(true);
+
+    await expect(graphProbeCapability()).resolves.toEqual({ kind: "available" });
+    await expect(graphAuthenticate("auth-request-1")).resolves.toBe(result);
+    await expect(graphCancelAuthentication("auth-request-1")).resolves.toBe(true);
+
+    expect(invoke).toHaveBeenNthCalledWith(1, "graph_probe_capability", undefined);
+    expect(invoke).toHaveBeenNthCalledWith(2, "graph_authenticate", {
+      requestId: "auth-request-1",
+    });
+    expect(invoke).toHaveBeenNthCalledWith(3, "graph_cancel_authentication", {
+      requestId: "auth-request-1",
+    });
   });
 });
 

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -77,6 +77,25 @@ beforeEach(() => {
   vi.mocked(invoke).mockReset();
 });
 
+function validGraphStatus() {
+  return {
+    isAuthenticated: true,
+    userPrincipalName: "admin@contoso.com",
+    objectId: "00000000-0000-0000-0000-0000000000a1",
+    tenantId: "tenant-1",
+    grantedScopes: ["DeviceManagementManagedDevices.Read.All"],
+    missingScopes: [],
+    expiresAt: 1_800_000_000,
+    capabilities: {
+      managedDevices: true,
+      serviceConfig: false,
+      apps: false,
+      configuration: false,
+      scripts: false,
+    },
+  };
+}
+
 describe("SCCM product-path IPC boundary", () => {
   it("invokes discovery and capture without accepting frontend inputs", async () => {
     const discovery = { supported: true, roles: [], sources: [], issues: [] };
@@ -95,7 +114,9 @@ describe("SCCM product-path IPC boundary", () => {
 
     await expect(discoverSccmEnvironment()).resolves.toBe(discovery);
     await expect(captureSccmDiagnostics()).resolves.toBe(capture);
-    await expect(revealInFileManager(capture.bundleRoot)).resolves.toBeUndefined();
+    await expect(
+      revealInFileManager(capture.bundleRoot),
+    ).resolves.toBeUndefined();
 
     expect(invoke).toHaveBeenNthCalledWith(
       1,
@@ -117,22 +138,7 @@ describe("Graph permission upgrade IPC boundary", () => {
   it("invokes the zero-argument native permission upgrade command", async () => {
     const result = {
       outcome: "upgraded",
-      status: {
-        isAuthenticated: true,
-        userPrincipalName: "admin@contoso.com",
-        objectId: "00000000-0000-0000-0000-0000000000a1",
-        tenantId: "tenant-1",
-        grantedScopes: ["DeviceManagementManagedDevices.Read.All"],
-        missingScopes: [],
-        expiresAt: 1_800_000_000,
-        capabilities: {
-          managedDevices: true,
-          serviceConfig: false,
-          apps: false,
-          configuration: false,
-          scripts: false,
-        },
-      },
+      status: validGraphStatus(),
       message: null,
     };
     vi.mocked(invoke).mockResolvedValueOnce(result);
@@ -152,17 +158,30 @@ describe("Graph permission upgrade IPC boundary", () => {
 
 describe("Graph authentication IPC boundary", () => {
   it("passes request ownership through authenticate and cancellation", async () => {
-    const result = { outcome: "cancelled" };
+    const result = {
+      outcome: "cancelled",
+      status: validGraphStatus(),
+      capability: { kind: "available" },
+      message: "Microsoft Graph sign-in was cancelled.",
+    };
     vi.mocked(invoke)
       .mockResolvedValueOnce({ kind: "available" })
       .mockResolvedValueOnce(result)
       .mockResolvedValueOnce(true);
 
-    await expect(graphProbeCapability()).resolves.toEqual({ kind: "available" });
+    await expect(graphProbeCapability()).resolves.toEqual({
+      kind: "available",
+    });
     await expect(graphAuthenticate("auth-request-1")).resolves.toBe(result);
-    await expect(graphCancelAuthentication("auth-request-1")).resolves.toBe(true);
+    await expect(graphCancelAuthentication("auth-request-1")).resolves.toBe(
+      true,
+    );
 
-    expect(invoke).toHaveBeenNthCalledWith(1, "graph_probe_capability", undefined);
+    expect(invoke).toHaveBeenNthCalledWith(
+      1,
+      "graph_probe_capability",
+      undefined,
+    );
     expect(invoke).toHaveBeenNthCalledWith(2, "graph_authenticate", {
       requestId: "auth-request-1",
     });
@@ -170,6 +189,54 @@ describe("Graph authentication IPC boundary", () => {
       requestId: "auth-request-1",
     });
   });
+
+  it.each([
+    ["graph_probe_capability", () => graphProbeCapability(), { kind: "other" }],
+    ["graph_authenticate", () => graphAuthenticate("auth-request-1"), null],
+    [
+      "graph_authenticate",
+      () => graphAuthenticate("auth-request-1"),
+      {
+        outcome: "connected",
+        status: { ...validGraphStatus(), capabilities: {} },
+        capability: { kind: "available" },
+        message: null,
+      },
+    ],
+    [
+      "graph_authenticate",
+      () => graphAuthenticate("auth-request-1"),
+      {
+        outcome: "other",
+        status: validGraphStatus(),
+        capability: { kind: "available" },
+        message: null,
+      },
+    ],
+    [
+      "graph_cancel_authentication",
+      () => graphCancelAuthentication("auth-request-1"),
+      "true",
+    ],
+    [
+      "graph_request_missing_permissions",
+      () => graphRequestMissingPermissions("permission-request-1"),
+      {
+        outcome: "other",
+        status: validGraphStatus(),
+        message: null,
+      },
+    ],
+  ] as const)(
+    "rejects malformed %s responses",
+    async (commandName, call, malformedResponse) => {
+      vi.mocked(invoke).mockResolvedValueOnce(malformedResponse);
+
+      await expect(call()).rejects.toThrow(
+        `Command '${commandName}' returned an invalid response.`,
+      );
+    },
+  );
 });
 
 describe("command rejection sanitization", () => {
@@ -401,7 +468,11 @@ describe("getSafeErrorMessage", () => {
   it("surfaces the message from a plain-data-object rejection", () => {
     expect(
       getSafeErrorMessage(
-        { kind: "sourceNotFound", path: "C:\\bundle", message: "manifest missing" },
+        {
+          kind: "sourceNotFound",
+          path: "C:\\bundle",
+          message: "manifest missing",
+        },
         "safe fallback",
       ),
     ).toBe("manifest missing");
@@ -464,7 +535,9 @@ describe("Access Denied classification", () => {
   it("records a well-formed verdict on the normalized error", async () => {
     invokeMock.mockRejectedValue(accessDeniedPayload());
 
-    const error = await captureRejection(openLogFile("C:\\Windows\\Logs\\CBS.log"));
+    const error = await captureRejection(
+      openLogFile("C:\\Windows\\Logs\\CBS.log"),
+    );
 
     expect(readAccessDenied(error)).toEqual({
       kind: "accessDenied",

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -741,12 +741,7 @@ export interface GraphHostCapability {
 }
 
 export type GraphAuthAttemptOutcome =
-  | "connected"
-  | "cancelled"
-  | "timedOut"
-  | "unavailable"
-  | "failed"
-  | "stale";
+  "connected" | "cancelled" | "timedOut" | "unavailable" | "failed" | "stale";
 
 export interface GraphAuthAttemptResult {
   outcome: GraphAuthAttemptOutcome;
@@ -770,6 +765,132 @@ export interface GraphPermissionUpgradeResult {
   message: string | null;
 }
 
+function isGraphRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function isGraphAuthStatus(value: unknown): value is GraphAuthStatus {
+  if (!isGraphRecord(value) || !isGraphRecord(value.capabilities)) return false;
+  const capabilities = value.capabilities;
+  return (
+    typeof value.isAuthenticated === "boolean" &&
+    isNullableString(value.userPrincipalName) &&
+    isNullableString(value.objectId) &&
+    isNullableString(value.tenantId) &&
+    isStringArray(value.grantedScopes) &&
+    isStringArray(value.missingScopes) &&
+    (value.expiresAt === null ||
+      (typeof value.expiresAt === "number" &&
+        Number.isFinite(value.expiresAt))) &&
+    typeof capabilities.managedDevices === "boolean" &&
+    typeof capabilities.serviceConfig === "boolean" &&
+    typeof capabilities.apps === "boolean" &&
+    typeof capabilities.configuration === "boolean" &&
+    typeof capabilities.scripts === "boolean"
+  );
+}
+
+const GRAPH_HOST_CAPABILITY_KINDS = new Set<GraphHostCapabilityKind>([
+  "available",
+  "personalAccountOnly",
+  "noOrganizationalAccount",
+  "providerUnavailable",
+  "unknown",
+]);
+
+const GRAPH_AUTH_ATTEMPT_OUTCOMES = new Set<GraphAuthAttemptOutcome>([
+  "connected",
+  "cancelled",
+  "timedOut",
+  "unavailable",
+  "failed",
+  "stale",
+]);
+
+const GRAPH_PERMISSION_UPGRADE_OUTCOMES =
+  new Set<GraphPermissionUpgradeOutcome>([
+    "upgraded",
+    "unchanged",
+    "cancelled",
+    "timedOut",
+    "denied",
+    "failed",
+    "stale",
+  ]);
+
+function invalidGraphResponse(commandName: string): never {
+  throw new Error(`Command '${commandName}' returned an invalid response.`);
+}
+
+function decodeGraphHostCapability(
+  value: unknown,
+  commandName: string,
+): GraphHostCapability {
+  if (
+    !isGraphRecord(value) ||
+    typeof value.kind !== "string" ||
+    !GRAPH_HOST_CAPABILITY_KINDS.has(value.kind as GraphHostCapabilityKind)
+  ) {
+    return invalidGraphResponse(commandName);
+  }
+  return value as unknown as GraphHostCapability;
+}
+
+function decodeGraphAuthStatus(
+  value: unknown,
+  commandName: string,
+): GraphAuthStatus {
+  if (!isGraphAuthStatus(value)) return invalidGraphResponse(commandName);
+  return value;
+}
+
+function decodeGraphAuthAttemptResult(
+  value: unknown,
+  commandName: string,
+): GraphAuthAttemptResult {
+  if (
+    !isGraphRecord(value) ||
+    typeof value.outcome !== "string" ||
+    !GRAPH_AUTH_ATTEMPT_OUTCOMES.has(
+      value.outcome as GraphAuthAttemptOutcome,
+    ) ||
+    !isGraphAuthStatus(value.status) ||
+    !isNullableString(value.message)
+  ) {
+    return invalidGraphResponse(commandName);
+  }
+  decodeGraphHostCapability(value.capability, commandName);
+  return value as unknown as GraphAuthAttemptResult;
+}
+
+function decodeGraphPermissionUpgradeResult(
+  value: unknown,
+  commandName: string,
+): GraphPermissionUpgradeResult {
+  if (
+    !isGraphRecord(value) ||
+    typeof value.outcome !== "string" ||
+    !GRAPH_PERMISSION_UPGRADE_OUTCOMES.has(
+      value.outcome as GraphPermissionUpgradeOutcome,
+    ) ||
+    !isGraphAuthStatus(value.status) ||
+    !isNullableString(value.message)
+  ) {
+    return invalidGraphResponse(commandName);
+  }
+  return value as unknown as GraphPermissionUpgradeResult;
+}
+
 export interface GraphAppInfo {
   id: string;
   displayName: string;
@@ -784,34 +905,49 @@ export interface GraphResolutionResult {
 }
 
 export async function graphProbeCapability(): Promise<GraphHostCapability> {
-  return invokeCommand<GraphHostCapability>("graph_probe_capability");
+  const commandName = "graph_probe_capability";
+  return decodeGraphHostCapability(
+    await invokeCommand<unknown>(commandName),
+    commandName,
+  );
 }
 
 export async function graphAuthenticate(
   requestId: string,
 ): Promise<GraphAuthAttemptResult> {
-  return invokeCommand<GraphAuthAttemptResult>("graph_authenticate", {
-    requestId,
-  });
+  const commandName = "graph_authenticate";
+  return decodeGraphAuthAttemptResult(
+    await invokeCommand<unknown>(commandName, { requestId }),
+    commandName,
+  );
 }
 
 export async function graphCancelAuthentication(
   requestId: string,
 ): Promise<boolean> {
-  return invokeCommand<boolean>("graph_cancel_authentication", { requestId });
+  const commandName = "graph_cancel_authentication";
+  const result = await invokeCommand<unknown>(commandName, { requestId });
+  return typeof result === "boolean"
+    ? result
+    : invalidGraphResponse(commandName);
 }
 
 export async function graphRequestMissingPermissions(
   requestId: string,
 ): Promise<GraphPermissionUpgradeResult> {
-  return invokeCommand<GraphPermissionUpgradeResult>(
-    "graph_request_missing_permissions",
-    { requestId },
+  const commandName = "graph_request_missing_permissions";
+  return decodeGraphPermissionUpgradeResult(
+    await invokeCommand<unknown>(commandName, { requestId }),
+    commandName,
   );
 }
 
 export async function graphGetAuthStatus(): Promise<GraphAuthStatus> {
-  return invokeCommand<GraphAuthStatus>("graph_get_auth_status");
+  const commandName = "graph_get_auth_status";
+  return decodeGraphAuthStatus(
+    await invokeCommand<unknown>(commandName),
+    commandName,
+  );
 }
 
 export async function graphSignOut(): Promise<void> {

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -765,6 +765,13 @@ export interface GraphPermissionUpgradeResult {
   message: string | null;
 }
 
+export type GraphInteractiveOperationKind =
+  "authentication" | "permissionConsent";
+
+export interface GraphInteractiveOperationTicket {
+  attemptId: string;
+}
+
 function isGraphRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
@@ -891,6 +898,22 @@ function decodeGraphPermissionUpgradeResult(
   return value as unknown as GraphPermissionUpgradeResult;
 }
 
+function decodeGraphInteractiveOperationTicket(
+  value: unknown,
+  commandName: string,
+): GraphInteractiveOperationTicket {
+  if (
+    !isGraphRecord(value) ||
+    typeof value.attemptId !== "string" ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value.attemptId,
+    )
+  ) {
+    return invalidGraphResponse(commandName);
+  }
+  return value as unknown as GraphInteractiveOperationTicket;
+}
+
 export interface GraphAppInfo {
   id: string;
   displayName: string;
@@ -904,40 +927,42 @@ export interface GraphResolutionResult {
   errors: string[];
 }
 
-export async function graphProbeCapability(): Promise<GraphHostCapability> {
-  const commandName = "graph_probe_capability";
-  return decodeGraphHostCapability(
-    await invokeCommand<unknown>(commandName),
+export async function graphReserveInteractiveOperation(
+  kind: GraphInteractiveOperationKind,
+): Promise<GraphInteractiveOperationTicket> {
+  const commandName = "graph_reserve_interactive_operation";
+  return decodeGraphInteractiveOperationTicket(
+    await invokeCommand<unknown>(commandName, { kind }),
     commandName,
   );
 }
 
 export async function graphAuthenticate(
-  requestId: string,
+  attemptId: string,
 ): Promise<GraphAuthAttemptResult> {
   const commandName = "graph_authenticate";
   return decodeGraphAuthAttemptResult(
-    await invokeCommand<unknown>(commandName, { requestId }),
+    await invokeCommand<unknown>(commandName, { attemptId }),
     commandName,
   );
 }
 
 export async function graphCancelAuthentication(
-  requestId: string,
+  attemptId: string,
 ): Promise<boolean> {
   const commandName = "graph_cancel_authentication";
-  const result = await invokeCommand<unknown>(commandName, { requestId });
+  const result = await invokeCommand<unknown>(commandName, { attemptId });
   return typeof result === "boolean"
     ? result
     : invalidGraphResponse(commandName);
 }
 
 export async function graphRequestMissingPermissions(
-  requestId: string,
+  attemptId: string,
 ): Promise<GraphPermissionUpgradeResult> {
   const commandName = "graph_request_missing_permissions";
   return decodeGraphPermissionUpgradeResult(
-    await invokeCommand<unknown>(commandName, { requestId }),
+    await invokeCommand<unknown>(commandName, { attemptId }),
     commandName,
   );
 }

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -721,16 +721,48 @@ export interface GraphAuthCapabilities {
 export interface GraphAuthStatus {
   isAuthenticated: boolean;
   userPrincipalName: string | null;
+  objectId: string | null;
   tenantId: string | null;
   grantedScopes: string[];
   missingScopes: string[];
   expiresAt: number | null;
   capabilities: GraphAuthCapabilities;
-  error: string | null;
+}
+
+export type GraphHostCapabilityKind =
+  | "available"
+  | "personalAccountOnly"
+  | "noOrganizationalAccount"
+  | "providerUnavailable"
+  | "unknown";
+
+export interface GraphHostCapability {
+  kind: GraphHostCapabilityKind;
+}
+
+export type GraphAuthAttemptOutcome =
+  | "connected"
+  | "cancelled"
+  | "timedOut"
+  | "unavailable"
+  | "failed"
+  | "stale";
+
+export interface GraphAuthAttemptResult {
+  outcome: GraphAuthAttemptOutcome;
+  status: GraphAuthStatus;
+  capability: GraphHostCapability;
+  message: string | null;
 }
 
 export type GraphPermissionUpgradeOutcome =
-  "upgraded" | "unchanged" | "cancelled" | "denied" | "failed" | "stale";
+  | "upgraded"
+  | "unchanged"
+  | "cancelled"
+  | "timedOut"
+  | "denied"
+  | "failed"
+  | "stale";
 
 export interface GraphPermissionUpgradeResult {
   outcome: GraphPermissionUpgradeOutcome;
@@ -751,13 +783,30 @@ export interface GraphResolutionResult {
   errors: string[];
 }
 
-export async function graphAuthenticate(): Promise<GraphAuthStatus> {
-  return invokeCommand<GraphAuthStatus>("graph_authenticate");
+export async function graphProbeCapability(): Promise<GraphHostCapability> {
+  return invokeCommand<GraphHostCapability>("graph_probe_capability");
 }
 
-export async function graphRequestMissingPermissions(): Promise<GraphPermissionUpgradeResult> {
+export async function graphAuthenticate(
+  requestId: string,
+): Promise<GraphAuthAttemptResult> {
+  return invokeCommand<GraphAuthAttemptResult>("graph_authenticate", {
+    requestId,
+  });
+}
+
+export async function graphCancelAuthentication(
+  requestId: string,
+): Promise<boolean> {
+  return invokeCommand<boolean>("graph_cancel_authentication", { requestId });
+}
+
+export async function graphRequestMissingPermissions(
+  requestId: string,
+): Promise<GraphPermissionUpgradeResult> {
   return invokeCommand<GraphPermissionUpgradeResult>(
     "graph_request_missing_permissions",
+    { requestId },
   );
 }
 

--- a/src/stores/ui-store.test.ts
+++ b/src/stores/ui-store.test.ts
@@ -58,24 +58,34 @@ describe("ui-store", () => {
       expect(useUiStore.getState().activeView).toBe("log");
     });
 
-    it("persists only Graph opt-in and never transient authentication state", () => {
+    it("rehydrates only Graph opt-in and discards transient authentication state", async () => {
       useUiStore.setState({
-        graphApiEnabled: true,
-        graphApiStatus: "connected",
-        graphApiCapability: { kind: "available" },
-        graphApiLastAttempt: {
-          outcome: "connected",
-          message: "transient-attempt",
-        },
+        graphApiEnabled: false,
+        graphApiStatus: "disconnected",
+        graphApiCapability: null,
+        graphApiLastAttempt: null,
       });
+      localStorage.setItem(
+        "cmtraceopen-ui-preferences",
+        JSON.stringify({
+          state: {
+            graphApiEnabled: true,
+            graphApiStatus: "connected",
+            graphApiCapability: { kind: "available" },
+            graphApiLastAttempt: {
+              outcome: "connected",
+              message: "stale-attempt",
+            },
+          },
+        }),
+      );
 
-      const persisted = JSON.parse(
-        localStorage.getItem("cmtraceopen-ui-preferences") ?? "{}",
-      ).state;
-      expect(persisted.graphApiEnabled).toBe(true);
-      expect(persisted).not.toHaveProperty("graphApiStatus");
-      expect(persisted).not.toHaveProperty("graphApiCapability");
-      expect(persisted).not.toHaveProperty("graphApiLastAttempt");
+      await useUiStore.persist.rehydrate();
+
+      expect(useUiStore.getState().graphApiEnabled).toBe(true);
+      expect(useUiStore.getState().graphApiStatus).toBe("disconnected");
+      expect(useUiStore.getState().graphApiCapability).toBeNull();
+      expect(useUiStore.getState().graphApiLastAttempt).toBeNull();
     });
   });
 

--- a/src/stores/ui-store.test.ts
+++ b/src/stores/ui-store.test.ts
@@ -57,6 +57,26 @@ describe("ui-store", () => {
       expect(useUiStore.persist.hasHydrated()).toBe(true);
       expect(useUiStore.getState().activeView).toBe("log");
     });
+
+    it("persists only Graph opt-in and never transient authentication state", () => {
+      useUiStore.setState({
+        graphApiEnabled: true,
+        graphApiStatus: "connected",
+        graphApiCapability: { kind: "available" },
+        graphApiLastAttempt: {
+          outcome: "connected",
+          message: "transient-attempt",
+        },
+      });
+
+      const persisted = JSON.parse(
+        localStorage.getItem("cmtraceopen-ui-preferences") ?? "{}",
+      ).state;
+      expect(persisted.graphApiEnabled).toBe(true);
+      expect(persisted).not.toHaveProperty("graphApiStatus");
+      expect(persisted).not.toHaveProperty("graphApiCapability");
+      expect(persisted).not.toHaveProperty("graphApiLastAttempt");
+    });
   });
 
   describe("font size controls", () => {

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -38,7 +38,6 @@ export interface ErrorLookupHistoryEntry {
 }
 
 export type GraphApiPhase =
-  | "checkingCapability"
   | "disconnected"
   | "signingIn"
   | "cancelling"

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -265,6 +265,13 @@ const sanitizePersistedUiState = (
 ): Partial<UiState> => {
   const sanitized: Partial<UiState> = { ...state };
 
+  // Authentication lifecycle state is process-local. Ignore stale or
+  // externally injected values during rehydration even though current writes
+  // already omit them through `partialize`.
+  delete sanitized.graphApiStatus;
+  delete sanitized.graphApiCapability;
+  delete sanitized.graphApiLastAttempt;
+
   if (sanitized.logListFontSize !== undefined) {
     const raw = Number(sanitized.logListFontSize);
     const base = Number.isFinite(raw) ? raw : DEFAULT_LOG_LIST_FONT_SIZE;

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -12,7 +12,11 @@ import { useLogStore } from "./log-store";
 import { clearAllTabSnapshots, clearCachedTabSnapshot } from "../lib/tab-snapshot-cache";
 import { useFilterStore } from "./filter-store";
 import type { ColumnId } from "../lib/column-config";
-import type { CollectionResult } from "../lib/commands";
+import type {
+  CollectionResult,
+  GraphAuthAttemptOutcome,
+  GraphHostCapability,
+} from "../lib/commands";
 import type { WorkspaceId } from "../types/log";
 import type { ElevationRequest } from "../types/elevation";
 import { getAvailableWorkspaces as getRegistryWorkspaces, getWorkspace } from "../workspaces/registry";
@@ -31,6 +35,20 @@ export interface ErrorLookupHistoryEntry {
   category: string;
   found: boolean;
   timestamp: number;
+}
+
+export type GraphApiPhase =
+  | "checkingCapability"
+  | "disconnected"
+  | "signingIn"
+  | "cancelling"
+  | "connected"
+  | "unsupported"
+  | "error";
+
+export interface GraphApiLastAttempt {
+  outcome: GraphAuthAttemptOutcome;
+  message: string | null;
 }
 
 export type IntuneWorkspaceId = "intune" | "new-intune";
@@ -165,7 +183,9 @@ interface UiState {
   showUpdateDialog: boolean;
   recentSessions: string[];
   graphApiEnabled: boolean;
-  graphApiStatus: "idle" | "connecting" | "connected" | "error";
+  graphApiStatus: GraphApiPhase;
+  graphApiCapability: GraphHostCapability | null;
+  graphApiLastAttempt: GraphApiLastAttempt | null;
 
   setActiveWorkspace: (workspace: WorkspaceId) => void;
   setCurrentPlatform: (platform: PlatformId) => void;
@@ -233,7 +253,9 @@ interface UiState {
   addRecentSession: (path: string) => void;
   clearRecentSessions: () => void;
   setGraphApiEnabled: (enabled: boolean) => void;
-  setGraphApiStatus: (status: "idle" | "connecting" | "connected" | "error") => void;
+  setGraphApiStatus: (status: GraphApiPhase) => void;
+  setGraphApiCapability: (capability: GraphHostCapability | null) => void;
+  setGraphApiLastAttempt: (attempt: GraphApiLastAttempt | null) => void;
 }
 
 const DEFAULT_WORKSPACE: WorkspaceId = "log";
@@ -318,7 +340,9 @@ export const useUiStore = create<UiState>()(
       showUpdateDialog: false,
       recentSessions: [],
       graphApiEnabled: false,
-      graphApiStatus: "idle",
+      graphApiStatus: "disconnected",
+      graphApiCapability: null,
+      graphApiLastAttempt: null,
 
       setCurrentPlatform: (platform) => set({ currentPlatform: platform }),
       setAlwaysOnTop: (alwaysOnTop) => set({ alwaysOnTop }),
@@ -617,6 +641,8 @@ export const useUiStore = create<UiState>()(
       clearRecentSessions: () => set({ recentSessions: [] }),
       setGraphApiEnabled: (enabled) => set({ graphApiEnabled: enabled }),
       setGraphApiStatus: (status) => set({ graphApiStatus: status }),
+      setGraphApiCapability: (capability) => set({ graphApiCapability: capability }),
+      setGraphApiLastAttempt: (attempt) => set({ graphApiLastAttempt: attempt }),
     }),
     {
       name: "cmtraceopen-ui-preferences",

--- a/src/workspaces/esp-diagnostics/EspDiagnosticsWorkspace.test.tsx
+++ b/src/workspaces/esp-diagnostics/EspDiagnosticsWorkspace.test.tsx
@@ -581,7 +581,7 @@ describe("optional Graph enrichment presentation", () => {
     const snapshot = makeSnapshot();
     useUiStore.setState({
       graphApiEnabled: false,
-      graphApiStatus: "idle",
+      graphApiStatus: "disconnected",
     });
     useEspDiagnosticsStore.setState({
       snapshot,
@@ -604,7 +604,7 @@ describe("optional Graph enrichment presentation", () => {
     act(() => {
       useUiStore.setState({
         graphApiEnabled: true,
-        graphApiStatus: "connecting",
+        graphApiStatus: "signingIn",
       });
       useEspDiagnosticsStore
         .getState()

--- a/src/workspaces/esp-diagnostics/esp-diagnostics-store.test.ts
+++ b/src/workspaces/esp-diagnostics/esp-diagnostics-store.test.ts
@@ -276,7 +276,7 @@ beforeEach(() => {
   );
   useUiStore.setState({
     graphApiEnabled: false,
-    graphApiStatus: "idle",
+    graphApiStatus: "disconnected",
   });
 });
 
@@ -2510,7 +2510,7 @@ describe("ESP Graph scheduling", () => {
     coordinator.dispose();
   });
 
-  it.each(["idle", "connecting", "error"] as const)(
+  it.each(["disconnected", "signingIn", "error"] as const)(
     "requires explicit refresh after Graph is %s and never queues behind WAM",
     async (graphApiStatus) => {
       const fetchGraph = vi.fn(async (request: EspGraphRequest) =>
@@ -3918,7 +3918,7 @@ describe("ESP Graph scheduling", () => {
       cancelGraph: nonOwnerCancelGraph,
       createRequestId: () => "graph-non-owner",
     });
-    useUiStore.setState({ graphApiEnabled: true, graphApiStatus: "idle" });
+    useUiStore.setState({ graphApiEnabled: true, graphApiStatus: "disconnected" });
     useEspDiagnosticsStore.setState({
       phase: "ready",
       snapshot: makeSnapshot(["local-owner"], "owner-device"),
@@ -3986,7 +3986,7 @@ describe("ESP Graph scheduling", () => {
       }
       throw new Error(`Unexpected IPC command: ${command}`);
     });
-    useUiStore.setState({ graphApiEnabled: true, graphApiStatus: "idle" });
+    useUiStore.setState({ graphApiEnabled: true, graphApiStatus: "disconnected" });
     useEspDiagnosticsStore.setState({
       phase: "ready",
       snapshot: makeSnapshot(["local-hook"], "hook-device"),
@@ -4704,7 +4704,7 @@ describe("ESP Graph publication reentrancy", () => {
       cancelGraph,
       createRequestId: () => "graph-reentrant-analysis",
     });
-    useUiStore.setState({ graphApiEnabled: false, graphApiStatus: "idle" });
+    useUiStore.setState({ graphApiEnabled: false, graphApiStatus: "disconnected" });
     useEspDiagnosticsStore.setState({
       phase: "ready",
       snapshot: makeSnapshot(["local-reentrant-analysis"]),

--- a/src/workspaces/registry.test.ts
+++ b/src/workspaces/registry.test.ts
@@ -193,7 +193,7 @@ beforeEach(() => {
     currentPlatform: "windows",
     enabledWorkspaces: null,
     graphApiEnabled: false,
-    graphApiStatus: "idle",
+    graphApiStatus: "disconnected",
   });
 });
 


### PR DESCRIPTION
## Summary
- probe Windows Web Account Manager capability off-thread before sign-in
- allow organizational accounts only and report personal-only or unavailable hosts explicitly
- enforce one request-ID-owned interactive operation with matching cancellation, one absolute 120-second deadline, and late-token publication protection
- expose async, runtime-validated Tauri authentication and permission-consent commands without blocking the UI thread
- model checking, signing in, cancelling, connected, unsupported, stale, and error outcomes separately; enabling the feature no longer launches WAM automatically
- retire disabled requests so a late completion cannot reapply state after disable and re-enable

## Verification
- local frontend suite: 51 files, 648 tests passed
- local Graph integration suite: 83 tests passed
- local Graph unit suite: 19 tests passed
- TypeScript typecheck and production frontend build passed
- exact-head CI for `8d95da5a` passed: TypeScript, E2E, full Rust checks/tests/Clippy, supply-chain and security audit, Rust 1.88 on Ubuntu and Windows, Windows Graph/ESP/full-workspace/Clippy, CodeQL, and Windows/Linux/macOS release builds
- CI evidence: https://github.com/adamgell/cmtraceopen/actions/runs/31001022606
- CodeRabbit review has no current unresolved threads

## Residual manual acceptance
CI exercises the Windows implementation and all deterministic cancellation, timeout, stale-result, capability, and publication contracts. It does not open the interactive WAM dialog against a live organizational account. A Windows demo with a real Entra account remains the final environment acceptance step; it is not a code or merge blocker.

Closes #441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive Graph sign-in with progress states, cancellation, timeout handling, and clearer capability-specific messaging.
  * Added support for detecting unsupported account or host capabilities before authentication.
  * Added safer permission upgrades and protection against stale or cancelled authentication attempts.
  * Expanded connection status details, including identity, tenant, scopes, expiration, and recent attempt outcomes.

* **Documentation**
  * Added implementation plans for the updated Graph authentication experience and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->