### PR TITLE
ci(probe): widened ESP Windows job on plain main (do not merge)

### DIFF
--- a/.github/workflows/cmtrace-ci.yml
+++ b/.github/workflows/cmtrace-ci.yml
@@ -242,8 +242,12 @@ jobs:
           key: ${{ runner.os }}-esp-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: ${{ runner.os }}-esp-cargo-
 
-      - name: Test ESP parser contracts
-        run: cargo test --locked -p cmtraceopen-parser --test esp_diagnostics
+      # Run all parser-crate targets on Windows in addition to the Linux checks.
+      - name: Test parser crate contracts
+        run: cargo test --locked -p cmtraceopen-parser
+
+      - name: Clippy parser crate
+        run: cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings
 
       - name: Test native ESP diagnostics
         run: cargo test --locked -p cmtrace-open --all-features --test esp_diagnostics_sources


### PR DESCRIPTION
Probe for the PR #460 `STATUS_ENTRYPOINT_NOT_FOUND` failure: main + only the widened ESP Windows steps from #460. If the ESP job here fails the same way, the widened job itself is the trigger and #460's code is exonerated. Will be closed after one CI cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)