### PR TITLE
feat(intune): model configuration policy evidence (#363)

### DIFF
--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/identity.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/identity.rs
@@ -1,0 +1,417 @@
+//! Canonical identity for one configuration setting transaction.
+//!
+//! # What is in the key, and what is deliberately not
+//!
+//! The key is `scope | resource`. The configuration source (policy id) is *not*
+//! part of it, even though issue #363 lists source alongside scope. Including it
+//! would put two policies targeting the same OMA-URI into two separate
+//! transactions, and the conflict and supersedence states the same issue requires
+//! could then never be observed: a conflict is by definition two sources arguing
+//! over one resource. Sources are therefore recorded inside the transaction, and
+//! the rules cite them.
+//!
+//! Display name is never part of the key. Two settings sharing a friendly name
+//! with different CSP paths stay separate, which is the twelfth fixture in the
+//! required matrix.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+/// Whether the setting targets the device or a user.
+///
+/// `Unspecified` is not a default-to-device: a device-scoped and a user-scoped
+/// instance of the same CSP node are different settings, and collapsing an
+/// unknown scope into either one invents a correlation.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfigurationScope {
+    Device,
+    User,
+    Unspecified,
+}
+
+impl ConfigurationScope {
+    fn as_key(self) -> &'static str {
+        match self {
+            Self::Device => "device",
+            Self::User => "user",
+            Self::Unspecified => "unspecified",
+        }
+    }
+
+    /// Parse a scope token as written in an OMA-URI segment or a report column.
+    pub fn from_token(token: &str) -> Self {
+        match token.trim().trim_matches('/').to_ascii_lowercase().as_str() {
+            "device" => Self::Device,
+            "user" => Self::User,
+            _ => Self::Unspecified,
+        }
+    }
+}
+
+/// The canonical resource an observation is about.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationSettingIdentity {
+    /// Deterministic dedupe key: `scope|resource`.
+    pub key: String,
+    /// The OMA-URI with `./` and duplicate or trailing separators removed.
+    pub canonical_uri: Option<String>,
+    /// The OMA-URI exactly as the source wrote it.
+    pub raw_uri: Option<String>,
+    /// The canonical URI with its leading scope segment removed, used to detect
+    /// the same CSP node appearing under two scopes.
+    pub resource_path: Option<String>,
+    pub setting_id: Option<String>,
+    pub policy_id: Option<String>,
+    pub display_name: Option<String>,
+    pub scope: ConfigurationScope,
+    /// CSP vendor node, e.g. `Policy` in `./Device/Vendor/MSFT/Policy/Config/...`.
+    pub csp: Option<String>,
+    /// True when no stable identifier was available and the key falls back to the
+    /// originating evidence id. Such a transaction can never be high confidence.
+    pub is_unidentified: bool,
+}
+
+/// Everything an observation offered about which setting it is about.
+#[derive(Debug, Clone, Default)]
+pub struct IdentityHints<'a> {
+    pub uri: Option<&'a str>,
+    pub setting_id: Option<&'a str>,
+    pub policy_id: Option<&'a str>,
+    pub display_name: Option<&'a str>,
+    /// Explicit scope token from a report column or named value, used only when
+    /// the URI does not carry one.
+    pub scope_token: Option<&'a str>,
+    /// Evidence id, used as the last-resort key so unidentified records never
+    /// merge with one another.
+    pub evidence_id: &'a str,
+}
+
+/// Build the canonical identity for one observation.
+pub fn resolve_identity(hints: &IdentityHints<'_>) -> ConfigurationSettingIdentity {
+    let raw_uri = hints
+        .uri
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    let canonical_uri = raw_uri.as_deref().map(canonicalize_uri);
+    let uri_scope = canonical_uri.as_deref().map(scope_of_uri);
+
+    let scope = match uri_scope {
+        Some(ConfigurationScope::Unspecified) | None => hints
+            .scope_token
+            .map(ConfigurationScope::from_token)
+            .unwrap_or(ConfigurationScope::Unspecified),
+        Some(scope) => scope,
+    };
+
+    let resource_path = canonical_uri.as_deref().map(strip_scope_segment);
+    let csp = canonical_uri.as_deref().and_then(csp_of_uri);
+
+    let setting_id = normalize_opt(hints.setting_id);
+    let policy_id = normalize_opt(hints.policy_id);
+    let display_name = normalize_opt(hints.display_name);
+
+    let (resource_key, is_unidentified) = match (&canonical_uri, &setting_id) {
+        (Some(uri), _) => (format!("uri:{}", uri.to_ascii_lowercase()), false),
+        (None, Some(id)) => (format!("settingId:{}", id.to_ascii_lowercase()), false),
+        (None, None) => (format!("unidentified:{}", hints.evidence_id), true),
+    };
+
+    ConfigurationSettingIdentity {
+        key: format!("{}|{resource_key}", scope.as_key()),
+        canonical_uri,
+        raw_uri,
+        resource_path,
+        setting_id,
+        policy_id,
+        display_name,
+        scope,
+        csp,
+        is_unidentified,
+    }
+}
+
+fn normalize_opt(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+/// Strip `./`, normalize separators, collapse repeats, drop a trailing separator.
+///
+/// Case is preserved: CSP node names are documented with specific casing and a
+/// lowercased URI is harder to match against Microsoft's documentation. Only the
+/// dedupe key lowercases.
+pub fn canonicalize_uri(uri: &str) -> String {
+    let replaced = uri.trim().replace('\\', "/");
+    let without_prefix = replaced.strip_prefix("./").unwrap_or(&replaced);
+    without_prefix
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Scope implied by the first segment of a canonical URI.
+fn scope_of_uri(canonical: &str) -> ConfigurationScope {
+    match canonical.split('/').next() {
+        Some(first) => ConfigurationScope::from_token(first),
+        None => ConfigurationScope::Unspecified,
+    }
+}
+
+/// The canonical URI without its leading `Device`/`User` segment.
+///
+/// Two scopes of the same CSP node share this string, which is what lets the
+/// scope-mismatch rule find them without merging their transactions.
+fn strip_scope_segment(canonical: &str) -> String {
+    let mut segments = canonical.split('/');
+    match segments.next() {
+        Some(first)
+            if matches!(
+                ConfigurationScope::from_token(first),
+                ConfigurationScope::Device | ConfigurationScope::User
+            ) =>
+        {
+            segments.collect::<Vec<_>>().join("/")
+        }
+        _ => canonical.to_owned(),
+    }
+}
+
+/// The CSP vendor node named by a canonical URI, e.g. `Policy` or `BitLocker`.
+fn csp_of_uri(canonical: &str) -> Option<String> {
+    let segments = canonical.split('/').collect::<Vec<_>>();
+    let vendor = segments
+        .iter()
+        .position(|segment| segment.eq_ignore_ascii_case("MSFT"))?;
+    segments.get(vendor + 1).map(|node| (*node).to_owned())
+}
+
+// ── Message scraping ────────────────────────────────────────────────────────
+//
+// Rendered MDM Admin-channel messages carry the CSP URI, configuration source,
+// and result code inline. Some adapters populate named data from the event XML
+// and some can only supply the rendered message, so when named data is empty the
+// message text is the only place the identity lives. Parenthesized values are the
+// shape Microsoft's provider actually renders, so the patterns strip them.
+
+fn csp_uri_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)\bCSP\s+URI:\s*\(?([^,()\r\n]+?)\)?\s*(?:,|\.\s|$)")
+            .expect("CSP URI pattern is valid")
+    })
+}
+
+fn result_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)\bResult:?\s*\(?(0x[0-9A-Fa-f]+|-?\d+)\)?")
+            .expect("result pattern is valid")
+    })
+}
+
+fn policy_area_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"(?i)\bPolicy:\s*\(?([^,()\r\n]+?)\)?\s*,\s*Area:\s*\(?([^,()\r\n]+?)\)?\s*(?:,|$)",
+        )
+        .expect("policy/area pattern is valid")
+    })
+}
+
+fn source_id_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)\bConfiguration\s+Source\s+ID:\s*\(?([0-9A-Fa-f-]{8,})\)?")
+            .expect("configuration source pattern is valid")
+    })
+}
+
+/// Extract `CSP URI: …` from a rendered event message.
+pub fn csp_uri_from_message(message: &str) -> Option<String> {
+    csp_uri_regex()
+        .captures(message)
+        .map(|captures| captures[1].trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+/// Extract `Result: …` from a rendered event message.
+pub fn result_token_from_message(message: &str) -> Option<String> {
+    result_regex()
+        .captures(message)
+        .map(|captures| captures[1].trim().to_owned())
+}
+
+/// Extract `Configuration Source ID: …` from a rendered event message.
+pub fn source_id_from_message(message: &str) -> Option<String> {
+    source_id_regex()
+        .captures(message)
+        .map(|captures| captures[1].trim().to_owned())
+}
+
+/// Rebuild a Policy CSP URI from a `Policy: X, Area: Y` message.
+///
+/// PolicyManager events name the area and policy rather than the node path, so
+/// without this the set-policy events and the CSP failure events would key on
+/// different resources and never correlate.
+pub fn policy_uri_from_message(message: &str, scope: ConfigurationScope) -> Option<String> {
+    let captures = policy_area_regex().captures(message)?;
+    let policy = captures[1].trim();
+    let area = captures[2].trim();
+    if policy.is_empty() || area.is_empty() {
+        return None;
+    }
+    let scope_segment = match scope {
+        ConfigurationScope::User => "User",
+        // PolicyManager writes device policy under the device node; an
+        // unspecified scope is reported as device only when the caller already
+        // determined the record is device-scoped.
+        _ => "Device",
+    };
+    Some(format!(
+        "{scope_segment}/Vendor/MSFT/Policy/Config/{area}/{policy}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hints<'a>(uri: Option<&'a str>, evidence_id: &'a str) -> IdentityHints<'a> {
+        IdentityHints {
+            uri,
+            evidence_id,
+            ..IdentityHints::default()
+        }
+    }
+
+    #[test]
+    fn canonicalization_removes_prefix_duplicates_and_trailing_separator() {
+        assert_eq!(
+            canonicalize_uri(".//Device//Vendor/MSFT/Policy/Config/DeviceLock/"),
+            "Device/Vendor/MSFT/Policy/Config/DeviceLock"
+        );
+    }
+
+    #[test]
+    fn scope_comes_from_the_uri_before_any_hint() {
+        let identity = resolve_identity(&IdentityHints {
+            uri: Some("./User/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"),
+            scope_token: Some("Device"),
+            evidence_id: "e1",
+            ..IdentityHints::default()
+        });
+        assert_eq!(identity.scope, ConfigurationScope::User);
+    }
+
+    #[test]
+    fn the_same_node_under_two_scopes_produces_two_keys_but_one_resource_path() {
+        let device = resolve_identity(&hints(
+            Some("./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"),
+            "e1",
+        ));
+        let user = resolve_identity(&hints(
+            Some("./User/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"),
+            "e2",
+        ));
+        assert_ne!(device.key, user.key);
+        assert_eq!(device.resource_path, user.resource_path);
+    }
+
+    #[test]
+    fn display_name_never_merges_two_csp_paths() {
+        let first = resolve_identity(&IdentityHints {
+            uri: Some("./Device/Vendor/MSFT/Policy/Config/DeviceLock/DevicePasswordEnabled"),
+            display_name: Some("Require password"),
+            evidence_id: "e1",
+            ..IdentityHints::default()
+        });
+        let second = resolve_identity(&IdentityHints {
+            uri: Some("./Device/Vendor/MSFT/PassportForWork/Policies/UsePassportForWork"),
+            display_name: Some("Require password"),
+            evidence_id: "e2",
+            ..IdentityHints::default()
+        });
+        assert_ne!(first.key, second.key);
+    }
+
+    #[test]
+    fn casing_differences_in_a_uri_do_not_split_a_transaction() {
+        let upper = resolve_identity(&hints(
+            Some("./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"),
+            "e1",
+        ));
+        let lower = resolve_identity(&hints(
+            Some("./Device/Vendor/MSFT/Policy/Config/update/allowautoupdate"),
+            "e2",
+        ));
+        assert_eq!(upper.key, lower.key);
+    }
+
+    #[test]
+    fn an_unidentified_record_keys_on_its_own_evidence_id() {
+        let first = resolve_identity(&hints(None, "e1"));
+        let second = resolve_identity(&hints(None, "e2"));
+        assert!(first.is_unidentified);
+        assert_ne!(first.key, second.key);
+    }
+
+    #[test]
+    fn setting_id_is_used_when_no_uri_is_present() {
+        let identity = resolve_identity(&IdentityHints {
+            setting_id: Some("Update_AllowAutoUpdate"),
+            evidence_id: "e1",
+            ..IdentityHints::default()
+        });
+        assert!(!identity.is_unidentified);
+        assert_eq!(identity.key, "unspecified|settingId:update_allowautoupdate");
+    }
+
+    #[test]
+    fn csp_node_is_taken_from_the_segment_after_msft() {
+        let identity = resolve_identity(&hints(
+            Some("./Device/Vendor/MSFT/BitLocker/RequireDeviceEncryption"),
+            "e1",
+        ));
+        assert_eq!(identity.csp.as_deref(), Some("BitLocker"));
+    }
+
+    #[test]
+    fn message_scraping_recovers_uri_result_and_source() {
+        let message = "MDM ConfigurationManager: Command failure status. \
+             Configuration Source ID: (11111111-1111-4111-8111-111111111111), \
+             Enrollment Name: (MDMDeviceWithAAD), Provider Name: (Policy), \
+             Command Type: (Add), CSP URI: (./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate), \
+             Result: (0x82B00006).";
+        assert_eq!(
+            csp_uri_from_message(message).as_deref(),
+            Some("./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate")
+        );
+        assert_eq!(
+            result_token_from_message(message).as_deref(),
+            Some("0x82B00006")
+        );
+        assert_eq!(
+            source_id_from_message(message).as_deref(),
+            Some("11111111-1111-4111-8111-111111111111")
+        );
+    }
+
+    #[test]
+    fn policy_manager_messages_rebuild_the_config_node_path() {
+        let message = "MDM PolicyManager: Set policy int, Policy: (AllowAutoUpdate), \
+             Area: (Update), EnrollmentID requesting merge: (E1), Value: (1)";
+        assert_eq!(
+            policy_uri_from_message(message, ConfigurationScope::Device).as_deref(),
+            Some("Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate")
+        );
+    }
+}

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/identity.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/identity.rs
@@ -27,8 +27,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
 pub enum ConfigurationScope {
+    /// The setting targets the machine: `./Device/Vendor/MSFT/…`.
     Device,
+    /// The setting targets a signed-in user: `./User/Vendor/MSFT/…`.
     User,
+    /// No source stated a scope. Never resolved to one of the others by
+    /// inference; see the type-level note above.
     Unspecified,
 }
 
@@ -64,9 +68,19 @@ pub struct ConfigurationSettingIdentity {
     /// The canonical URI with its leading scope segment removed, used to detect
     /// the same CSP node appearing under two scopes.
     pub resource_path: Option<String>,
+    /// Source-stated setting identifier, used as the resource key when no URI was
+    /// available. Never merged with a URI-keyed transaction.
     pub setting_id: Option<String>,
+    /// Configuration source / policy identifier, when a record stated one.
+    /// Descriptive only: it is deliberately not part of [`Self::key`], because two
+    /// policies arguing over one node must land in one transaction for the
+    /// conflict to be observable.
     pub policy_id: Option<String>,
+    /// Friendly name as the portal shows it. Never part of the key: two settings
+    /// can share a display name and resolve to different CSP nodes.
     pub display_name: Option<String>,
+    /// Whether this transaction is the device-scoped or user-scoped instance of
+    /// the node. Part of the key.
     pub scope: ConfigurationScope,
     /// CSP vendor node, e.g. `Policy` in `./Device/Vendor/MSFT/Policy/Config/...`.
     pub csp: Option<String>,
@@ -78,9 +92,13 @@ pub struct ConfigurationSettingIdentity {
 /// Everything an observation offered about which setting it is about.
 #[derive(Debug, Clone, Default)]
 pub struct IdentityHints<'a> {
+    /// OMA-URI exactly as the source wrote it, if it wrote one.
     pub uri: Option<&'a str>,
+    /// Source-stated setting identifier, used only when no URI is present.
     pub setting_id: Option<&'a str>,
+    /// Configuration source / policy identifier, recorded but never keyed on.
     pub policy_id: Option<&'a str>,
+    /// Friendly name, recorded but never keyed on.
     pub display_name: Option<&'a str>,
     /// Explicit scope token from a report column or named value, used only when
     /// the URI does not carry one.
@@ -204,7 +222,12 @@ fn csp_of_uri(canonical: &str) -> Option<String> {
 fn csp_uri_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?i)\bCSP\s+URI:\s*\(?([^,()\r\n]+?)\)?\s*(?:,|\.\s|$)")
+        // The terminal alternation allows an optional sentence-ending period
+        // before the boundary. Without it, `CSP URI: ./Device/…/Node.` captured
+        // the period as part of the node path and `CSP URI: (./Device/…/Node).`
+        // did not match at all — one produced a URI that correlates with nothing,
+        // the other produced no identity.
+        Regex::new(r"(?i)\bCSP\s+URI:\s*\(?([^,()\r\n]+?)\)?\s*(?:,|\.?(?:\s|$))")
             .expect("CSP URI pattern is valid")
     })
 }
@@ -419,6 +442,23 @@ mod tests {
             policy_uri_from_message(message, ConfigurationScope::Device).as_deref(),
             Some("Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate")
         );
+    }
+
+    #[test]
+    fn a_sentence_ending_period_is_not_part_of_the_node_path() {
+        let node = "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate";
+        for message in [
+            format!("Command failure status. CSP URI: {node}."),
+            format!("Command failure status. CSP URI: ({node})."),
+            format!("Command failure status. CSP URI: ({node}), Result: (0x1)."),
+            format!("Command failure status. CSP URI: {node}"),
+        ] {
+            assert_eq!(
+                csp_uri_from_message(&message).as_deref(),
+                Some(node),
+                "got {message}"
+            );
+        }
     }
 
     #[test]

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/identity.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/identity.rs
@@ -262,6 +262,14 @@ pub fn source_id_from_message(message: &str) -> Option<String> {
 /// PolicyManager events name the area and policy rather than the node path, so
 /// without this the set-policy events and the CSP failure events would key on
 /// different resources and never correlate.
+///
+/// When the caller could not determine a scope, the rebuilt path carries **no**
+/// scope segment. Defaulting to `Device` synthesized a joinable device-scoped
+/// URI out of a record that never said it was device-scoped, which contradicts
+/// this module's own contract that an unknown scope must not merge with a known
+/// one. A scope-free path keys on `unspecified|…` and stays in its own
+/// transaction; it still shares a `resource_path` with the scoped instances, so
+/// nothing about the node is lost.
 pub fn policy_uri_from_message(message: &str, scope: ConfigurationScope) -> Option<String> {
     let captures = policy_area_regex().captures(message)?;
     let policy = captures[1].trim();
@@ -270,14 +278,12 @@ pub fn policy_uri_from_message(message: &str, scope: ConfigurationScope) -> Opti
         return None;
     }
     let scope_segment = match scope {
-        ConfigurationScope::User => "User",
-        // PolicyManager writes device policy under the device node; an
-        // unspecified scope is reported as device only when the caller already
-        // determined the record is device-scoped.
-        _ => "Device",
+        ConfigurationScope::User => "User/",
+        ConfigurationScope::Device => "Device/",
+        ConfigurationScope::Unspecified => "",
     };
     Some(format!(
-        "{scope_segment}/Vendor/MSFT/Policy/Config/{area}/{policy}"
+        "{scope_segment}Vendor/MSFT/Policy/Config/{area}/{policy}"
     ))
 }
 
@@ -412,6 +418,30 @@ mod tests {
         assert_eq!(
             policy_uri_from_message(message, ConfigurationScope::Device).as_deref(),
             Some("Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate")
+        );
+    }
+
+    #[test]
+    fn a_scopeless_policy_manager_message_does_not_become_device_scoped() {
+        let message = "MDM PolicyManager: Set policy int, Policy: (AllowAutoUpdate), \
+             Area: (Update), Value: (1)";
+        let rebuilt = policy_uri_from_message(message, ConfigurationScope::Unspecified)
+            .expect("the node path is still recoverable");
+        assert_eq!(rebuilt, "Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate");
+
+        let unspecified = resolve_identity(&hints(Some(&rebuilt), "e1"));
+        let device = resolve_identity(&hints(
+            Some("./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"),
+            "e2",
+        ));
+        assert_eq!(unspecified.scope, ConfigurationScope::Unspecified);
+        assert_ne!(
+            unspecified.key, device.key,
+            "an unknown scope must not join a device-scoped transaction"
+        );
+        assert_eq!(
+            unspecified.resource_path, device.resource_path,
+            "the node itself is still comparable across scopes"
         );
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/mod.rs
@@ -1,10 +1,80 @@
 //! Intune/MDM configuration policy evidence.
 //!
-//! Owner: issue #363 of epic #356. Implementation pending.
+//! Owner: issue #363 of epic #356.
 //!
-//! Explains whether a setting was delivered, processed by its CSP, applied, rejected, conflicted, superseded, or left unresolved.
+//! Explains whether a configuration setting was delivered, processed by its CSP,
+//! applied, rejected, conflicted, superseded, removed, or left unresolved.
 //!
-//! This is a reserved slot created by the parser-family skeleton so that issue
-//! #363 can be implemented without editing any file shared with a sibling issue.
-//! Add source classification, reduction, and findings submodules here, and
-//! consume the shared contracts in [`crate::intune::evidence`].
+//! # The shape of the answer
+//!
+//! An administrator asking "did this setting apply?" is really asking three
+//! questions that routinely have different answers:
+//!
+//! 1. did the device *receive* a command for the node ([`ConfigurationReceiptState`]),
+//! 2. what did the *CSP* do with it ([`ConfigurationLocalState`]),
+//! 3. what was *Intune* told ([`ConfigurationServiceState`]).
+//!
+//! The output keeps all three and only then states a single
+//! [`ConfigurationResolution`]. When the device and the service disagree, the
+//! resolution is [`ConfigurationResolution::Contradicted`] and both statements
+//! are cited; the newer one is never preferred, because the two clocks are not
+//! comparable without provenance this crate is rarely given.
+//!
+//! # Pipeline
+//!
+//! ```text
+//! ConfigurationInput            normalized events + report rows + coverage
+//!     -> sources::observation_from_{event,report}   one typed statement per record
+//!     -> reduce_configuration                       one transaction per CSP identity
+//!     -> derive_findings                            evidence-backed conclusions
+//!     -> redacted_configuration_snapshot            default export
+//! ```
+//!
+//! # Boundaries
+//!
+//! Nothing here reads EVTX, HTML reports, the registry, or Graph. The native
+//! adapter decodes those and supplies
+//! [`crate::intune::normalized::NormalizedWindowsEvent`] and
+//! [`crate::intune::normalized::NormalizedSettingReport`], which keeps this leaf
+//! `wasm32-unknown-unknown` clean and testable from fixtures with no device
+//! present.
+
+mod identity;
+mod models;
+mod redaction;
+mod reducer;
+mod rules;
+mod sources;
+
+pub use identity::{
+    canonicalize_uri, csp_uri_from_message, policy_uri_from_message, resolve_identity,
+    result_token_from_message, source_id_from_message, ConfigurationScope,
+    ConfigurationSettingIdentity, IdentityHints,
+};
+pub use models::{
+    evidence_side, ConfigurationDisposition, ConfigurationEventKind, ConfigurationEvidenceSide,
+    ConfigurationInput, ConfigurationLocalState, ConfigurationObservation,
+    ConfigurationReceiptState, ConfigurationResolution, ConfigurationServiceState,
+    ConfigurationSetting, ConfigurationSnapshot, ConfigurationSourceStatement,
+    INTUNE_CONFIGURATION_SCHEMA_VERSION,
+};
+pub use redaction::{looks_like_identity, redacted_configuration_snapshot, redaction_token};
+pub use reducer::reduce_configuration;
+pub use rules::derive_findings;
+pub use sources::{
+    build_error_code, classify_event, is_device_side, is_failure, is_service_side,
+    observation_from_event, observation_from_report, timestamp_is_reliable,
+    EVENT_ID_COMMAND_FAILURE, EVENT_ID_DELETE_POLICY, EVENT_ID_SET_POLICY_INT,
+    EVENT_ID_SET_POLICY_STRING, MDM_DIAGNOSTICS_PROVIDER,
+};
+
+/// Reduce one evidence bundle and attach the findings derived from it.
+///
+/// This is the entry point callers want; [`reduce_configuration`] and
+/// [`derive_findings`] are exposed separately so a caller that wants to attach
+/// supplemental evidence between the two steps can do so without re-parsing.
+pub fn analyze_configuration(input: &ConfigurationInput) -> ConfigurationSnapshot {
+    let mut snapshot = reduce_configuration(input);
+    snapshot.findings = derive_findings(&snapshot);
+    snapshot
+}

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/mod.rs
@@ -27,8 +27,17 @@
 //!     -> sources::observation_from_{event,report}   one typed statement per record
 //!     -> reduce_configuration                       one transaction per CSP identity
 //!     -> derive_findings                            evidence-backed conclusions
-//!     -> redacted_configuration_snapshot            default export
 //! ```
+//!
+//! [`analyze_configuration`] runs that pipeline and stops there. Its result is
+//! **not** redacted: [`ConfigurationSnapshot::redacted`] is `false` and the
+//! applied values, node paths, and finding prose are the raw ones. A caller that
+//! exports, persists, or transmits a snapshot must pass it through
+//! [`redacted_configuration_snapshot`] first; that function is the export
+//! projection, not something the analyzer applies on its own. Keeping the two
+//! apart is deliberate — a caller correlating two settings by value needs the raw
+//! reduction — but it means the redaction step is the caller's obligation and is
+//! stated here rather than left to be inferred.
 //!
 //! # Boundaries
 //!
@@ -46,27 +55,22 @@ mod reducer;
 mod rules;
 mod sources;
 
-pub use identity::{
-    canonicalize_uri, csp_uri_from_message, policy_uri_from_message, resolve_identity,
-    result_token_from_message, source_id_from_message, ConfigurationScope,
-    ConfigurationSettingIdentity, IdentityHints,
-};
+// The exported surface is the input contract, the snapshot's own type graph, and
+// the four entry points. Projection helpers (URI canonicalization, message
+// scraping, per-record classification, error-token parsing) stay internal: they
+// are how this module reaches its answer, not part of the answer, and exporting
+// them would commit the crate to their signatures with no caller asking for them.
+pub use identity::{ConfigurationScope, ConfigurationSettingIdentity};
 pub use models::{
-    evidence_side, ConfigurationDisposition, ConfigurationEventKind, ConfigurationEvidenceSide,
+    ConfigurationDisposition, ConfigurationEventKind, ConfigurationEvidenceSide,
     ConfigurationInput, ConfigurationLocalState, ConfigurationObservation,
     ConfigurationReceiptState, ConfigurationResolution, ConfigurationServiceState,
     ConfigurationSetting, ConfigurationSnapshot, ConfigurationSourceStatement,
     INTUNE_CONFIGURATION_SCHEMA_VERSION,
 };
-pub use redaction::{looks_like_identity, redacted_configuration_snapshot, redaction_token};
+pub use redaction::redacted_configuration_snapshot;
 pub use reducer::reduce_configuration;
 pub use rules::derive_findings;
-pub use sources::{
-    build_error_code, classify_event, is_device_side, is_failure, is_service_side,
-    observation_from_event, observation_from_report, timestamp_is_reliable,
-    EVENT_ID_COMMAND_FAILURE, EVENT_ID_DELETE_POLICY, EVENT_ID_SET_POLICY_INT,
-    EVENT_ID_SET_POLICY_STRING, MDM_DIAGNOSTICS_PROVIDER,
-};
 
 /// Reduce one evidence bundle and attach the findings derived from it.
 ///

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/mod.rs
@@ -39,6 +39,16 @@
 //! reduction — but it means the redaction step is the caller's obligation and is
 //! stated here rather than left to be inferred.
 //!
+//! The caller owns one more thing: [`ConfigurationInput::analysis_scope`], the
+//! identity of this analysis. It is what the redaction tokens are scoped to, so a
+//! caller that supplies a per-analysis unique value gets exports that cannot be
+//! joined to one another by comparing tokens, and a caller that omits it gets no
+//! such boundary. This crate cannot supply it: it is pure and has no clock,
+//! entropy, or surviving process state from which to mint an identifier. What the
+//! scope does and does not guarantee is stated in full on
+//! [`ConfigurationInput::analysis_scope`] and
+//! [`ConfigurationSnapshot::analysis_scope`].
+//!
 //! # Boundaries
 //!
 //! Nothing here reads EVTX, HTML reports, the registry, or Graph. The native

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
@@ -262,6 +262,16 @@ pub struct ConfigurationSetting {
     pub ordering_is_contradictory: bool,
     /// True when at least one contributing record was malformed or unsupported.
     pub has_uninterpretable_evidence: bool,
+    /// True when a device record whose *direction* is known to be failure could
+    /// not be assessed — a command-failure event with an unreadable status, or one
+    /// the collector could not fully read.
+    ///
+    /// Direction survives even when detail does not. Such a record cannot state
+    /// which error occurred, but it does rule out reporting the node as a clean
+    /// success, which is why it is tracked separately from
+    /// [`ConfigurationSetting::has_uninterpretable_evidence`]: that flag covers
+    /// records whose direction is unknown as well.
+    pub has_unassessable_failure: bool,
     pub observations: Vec<ConfigurationObservation>,
     pub evidence: Vec<IntuneEvidenceRef>,
 }

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
@@ -29,7 +29,34 @@ pub const INTUNE_CONFIGURATION_SCHEMA_VERSION: u32 = 1;
 #[serde(rename_all = "camelCase")]
 pub struct ConfigurationInput {
     /// UTC instant the bundle was assembled, used only for snapshot provenance.
+    ///
+    /// It is deliberately *not* the redaction token scope: a second-resolution
+    /// timestamp is not an identifier, and two unrelated analyses can carry the
+    /// same one. See [`ConfigurationInput::analysis_scope`].
     pub generated_at_utc: String,
+    /// Caller-supplied identity of *this* analysis, and nothing else.
+    ///
+    /// It scopes the redaction token vocabulary (ADR-004): two analyses that
+    /// supply *different* values never mint the same `[redacted:…]` token for
+    /// the same input value, so an export cannot be joined to an unrelated one
+    /// by comparing tokens. Any opaque per-analysis value works — a capture
+    /// GUID, a support-case id, a digest of the collected bundle.
+    ///
+    /// Uniqueness is the caller's obligation and cannot be checked here: this
+    /// crate is pure and `wasm32-unknown-unknown` clean, so it has no clock, no
+    /// entropy source, and no process state that survives a restart from which
+    /// it could mint an identifier of its own. Two analyses that supply the
+    /// *same* value are deliberately joinable, because that is what "one
+    /// analysis" means.
+    ///
+    /// `None` means the caller declines the boundary: the token scope then
+    /// falls back to [`ConfigurationInput::generated_at_utc`] alone, which
+    /// preserves equality inside the one export and provides **no** isolation
+    /// from any other export that shares that timestamp. The resulting snapshot
+    /// says so — [`ConfigurationSnapshot::analysis_scope`] is `None`.
+    ///
+    /// The value never reaches the export verbatim; only a digest of it does.
+    pub analysis_scope: Option<String>,
     /// Normalized MDM Admin-channel records the adapter decoded from EVTX.
     pub events: Vec<NormalizedWindowsEvent>,
     /// Normalized per-setting rows from an MDM diagnostic report or imported
@@ -352,8 +379,26 @@ impl ConfigurationSetting {
 pub struct ConfigurationSnapshot {
     /// [`INTUNE_CONFIGURATION_SCHEMA_VERSION`] at the time of reduction.
     pub schema_version: u32,
-    /// Copied from the input; also the scope every redaction token is bound to.
+    /// Copied from the input, for provenance only.
     pub generated_at_utc: String,
+    /// Opaque digest of the analysis scope every redaction token is bound to.
+    ///
+    /// `Some` when the caller supplied [`ConfigurationInput::analysis_scope`].
+    /// Two snapshots carrying *different* digests share no token vocabulary: a
+    /// token in one says nothing about a token in the other. Two carrying the
+    /// *same* digest were declared by the caller to be one analysis and their
+    /// tokens do compare.
+    ///
+    /// `None` says the caller supplied no scope, so the tokens in this snapshot
+    /// are bound to [`ConfigurationSnapshot::generated_at_utc`] alone and make
+    /// **no** cross-export isolation claim at all.
+    ///
+    /// It is a digest, not a secret and not a key: it exists so an export can
+    /// name its own token scope without republishing the caller's identifier.
+    /// Anyone who already knows the scope material can recompute it, and the
+    /// tokens themselves remain unkeyed (ADR-004 leaves keying to the Store
+    /// pilot).
+    pub analysis_scope: Option<String>,
     /// Sorted by identity key so the serialized form is deterministic.
     pub settings: Vec<ConfigurationSetting>,
     /// Observations that named no resolvable resource at all.

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
@@ -37,9 +37,9 @@ pub struct ConfigurationInput {
     /// Caller-supplied identity of *this* analysis, and nothing else.
     ///
     /// It scopes the redaction token vocabulary (ADR-004): two analyses that
-    /// supply *different* values never mint the same `[redacted:…]` token for
-    /// the same input value, so an export cannot be joined to an unrelated one
-    /// by comparing tokens. Any opaque per-analysis value works — a capture
+    /// supply *different* values do not mint the same `[redacted:…]` token for
+    /// the same input value (barring hash collision), so an export cannot be
+    /// joined to an unrelated one by comparing tokens. Any opaque per-analysis value works — a capture
     /// GUID, a support-case id, a digest of the collected bundle.
     ///
     /// Uniqueness is the caller's obligation and cannot be checked here: this

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
@@ -30,7 +30,11 @@ pub const INTUNE_CONFIGURATION_SCHEMA_VERSION: u32 = 1;
 pub struct ConfigurationInput {
     /// UTC instant the bundle was assembled, used only for snapshot provenance.
     pub generated_at_utc: String,
+    /// Normalized MDM Admin-channel records the adapter decoded from EVTX.
     pub events: Vec<NormalizedWindowsEvent>,
+    /// Normalized per-setting rows from an MDM diagnostic report or imported
+    /// Intune reporting. The source kind on each row decides which side of the
+    /// device/service boundary it speaks for.
     pub reports: Vec<NormalizedSettingReport>,
     /// Coverage for every artifact that was expected, including the ones that
     /// were never read. A finding may cite one of these instead of evidence.
@@ -90,12 +94,19 @@ pub fn evidence_side(kind: &IntuneSourceKind) -> ConfigurationEvidenceSide {
 pub enum ConfigurationDisposition {
     /// The resource was named but no outcome was stated.
     Received,
+    /// The value was written.
     Applied,
+    /// The CSP returned a terminal error.
     Rejected,
+    /// Another configuration source claimed the same node.
     Conflict,
+    /// Another configuration source replaced this one.
     Superseded,
+    /// The CSP decided the node does not apply to this device.
     NotApplicable,
+    /// The value was deleted.
     Removed,
+    /// The service is still waiting for a result.
     Pending,
     /// The record named the resource but could not be interpreted.
     Indeterminate,
@@ -136,21 +147,32 @@ pub enum ConfigurationEventKind {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigurationObservation {
+    /// Back-reference to the record this statement was projected from.
     pub evidence_ref: IntuneEvidenceRef,
+    /// Which side of the device/service boundary the record speaks for.
     pub side: ConfigurationEvidenceSide,
+    /// The source kind `side` was derived from, retained so a reader can see why.
     pub source_kind: IntuneSourceKind,
     /// Privacy classification the adapter assigned to the originating record.
     pub sensitivity: IntuneSensitivity,
+    /// The canonical resource this record is about.
     pub identity: ConfigurationSettingIdentity,
+    /// What this one record says happened.
     pub disposition: ConfigurationDisposition,
+    /// The recognized event shape, for records projected from an event log.
     pub event_kind: Option<ConfigurationEventKind>,
+    /// The raw event id, retained even when unrecognized.
     pub event_id: Option<u32>,
     /// Configuration source / policy id that issued this statement, when stated.
     pub source_id: Option<String>,
+    /// Enrollment this record belongs to, when stated. Tokenized on export.
     pub enrollment_id: Option<String>,
+    /// The OMA-DM command verb as written. Evidence only: it never decides a
+    /// disposition, because a typed outcome outranks free text.
     pub command_type: Option<String>,
     /// The setting value, if one was stated. Classified by `sensitivity`.
     pub value: Option<String>,
+    /// Status code the record carried, in every form it could be written in.
     pub error: Option<IntuneErrorCode>,
     /// Source id that this statement says won a conflict, when stated.
     pub winning_source_id: Option<String>,
@@ -162,8 +184,10 @@ pub struct ConfigurationObservation {
     pub time_is_reliable: bool,
     /// Record ordinal within its channel, when the source carried one.
     pub record_id: Option<u64>,
-    /// True when the record itself was malformed or of an unsupported schema.
+    /// True when the record itself was malformed, of an unsupported schema, or
+    /// not fully read by the collector.
     pub is_uninterpretable: bool,
+    /// Everything the record carried that this build does not model, verbatim.
     pub named_data: Vec<IntuneNamedValue>,
 }
 
@@ -185,14 +209,22 @@ pub enum ConfigurationReceiptState {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum ConfigurationLocalState {
+    /// No device-side record names this resource.
     NoEvidence,
+    /// The CSP wrote the value.
     Applied,
+    /// The CSP returned a terminal error.
     Rejected,
+    /// Another configuration source won the node.
     Conflicted,
+    /// Another configuration source replaced this one.
     Superseded,
+    /// The CSP decided the node does not apply here.
     NotApplicable,
+    /// The CSP deleted the value.
     Removed,
-    /// Device-side records disagree with one another.
+    /// Device-side records disagree with one another, including the case where a
+    /// success stands beside a failure record that could not be read.
     Contested,
     /// A record named the resource but nothing could be concluded.
     Indeterminate,
@@ -202,14 +234,21 @@ pub enum ConfigurationLocalState {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum ConfigurationServiceState {
+    /// No Intune reporting was imported for this resource.
     NoEvidence,
     /// Assignment intent only; no per-setting status was imported.
     Assigned,
+    /// Intune was told the setting succeeded.
     ReportedSuccess,
+    /// Intune was told the setting failed.
     ReportedFailure,
+    /// Intune was told another source claimed the node.
     ReportedConflict,
+    /// Intune was told another source replaced this one.
     ReportedSuperseded,
+    /// Intune was told the node does not apply.
     ReportedNotApplicable,
+    /// Intune is still waiting for a result.
     ReportedPending,
     /// Service-side rows disagree with one another.
     Contested,
@@ -219,11 +258,17 @@ pub enum ConfigurationServiceState {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum ConfigurationResolution {
+    /// Device evidence shows the value was written.
     Applied,
+    /// Device evidence shows a terminal error.
     Rejected,
+    /// Two configuration sources claimed the node and one lost.
     Conflicted,
+    /// Another configuration source replaced this one.
     Superseded,
+    /// The node does not apply to this device.
     NotApplicable,
+    /// The value was deleted.
     Removed,
     /// Device and service evidence state incompatible outcomes.
     Contradicted,
@@ -237,8 +282,11 @@ pub enum ConfigurationResolution {
 pub struct ConfigurationSourceStatement {
     /// Configuration source / policy id, or `null` when the record did not state one.
     pub source_id: Option<String>,
+    /// Which side of the boundary this source spoke from.
     pub side: ConfigurationEvidenceSide,
+    /// What this source said happened.
     pub disposition: ConfigurationDisposition,
+    /// Every record that carried this statement.
     pub evidence: Vec<IntuneEvidenceRef>,
 }
 
@@ -246,10 +294,15 @@ pub struct ConfigurationSourceStatement {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigurationSetting {
+    /// The canonical resource every observation here is about.
     pub identity: ConfigurationSettingIdentity,
+    /// What the device received.
     pub receipt: ConfigurationReceiptState,
+    /// What the CSP did.
     pub local: ConfigurationLocalState,
+    /// What Intune was told.
     pub service: ConfigurationServiceState,
+    /// The single conclusion drawn from the three tracks above.
     pub resolution: ConfigurationResolution,
     /// Distinct configuration sources seen for this resource, sorted.
     pub sources: Vec<ConfigurationSourceStatement>,
@@ -276,7 +329,11 @@ pub struct ConfigurationSetting {
     /// [`ConfigurationSetting::has_uninterpretable_evidence`]: that flag covers
     /// records whose direction is unknown as well.
     pub has_unassessable_failure: bool,
+    /// Every contributing record, in a canonical order that does not depend on
+    /// how the caller supplied them.
     pub observations: Vec<ConfigurationObservation>,
+    /// Back-references for every contributing record, for a caller that wants the
+    /// citations without the projections.
     pub evidence: Vec<IntuneEvidenceRef>,
 }
 
@@ -293,13 +350,17 @@ impl ConfigurationSetting {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigurationSnapshot {
+    /// [`INTUNE_CONFIGURATION_SCHEMA_VERSION`] at the time of reduction.
     pub schema_version: u32,
+    /// Copied from the input; also the scope every redaction token is bound to.
     pub generated_at_utc: String,
     /// Sorted by identity key so the serialized form is deterministic.
     pub settings: Vec<ConfigurationSetting>,
     /// Observations that named no resolvable resource at all.
     pub unattributed: Vec<ConfigurationObservation>,
+    /// Every expected artifact and what became of it, copied from the input.
     pub coverage: Vec<IntuneArtifactCoverage>,
+    /// Conclusions derived from this snapshot, in a fixed rule order.
     pub findings: Vec<IntuneFinding>,
     /// True when the values in this snapshot have been through
     /// [`redacted_configuration_snapshot`].

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
@@ -66,12 +66,16 @@ pub fn evidence_side(kind: &IntuneSourceKind) -> ConfigurationEvidenceSide {
         | IntuneSourceKind::CcmLog
         | IntuneSourceKind::AgentLog
         | IntuneSourceKind::PlainTextLog
-        | IntuneSourceKind::UnifiedLog
-        | IntuneSourceKind::Json => ConfigurationEvidenceSide::Device,
+        | IntuneSourceKind::UnifiedLog => ConfigurationEvidenceSide::Device,
         IntuneSourceKind::Graph | IntuneSourceKind::SuppliedFact => {
             ConfigurationEvidenceSide::Service
         }
-        IntuneSourceKind::Coverage | IntuneSourceKind::Unknown(_) => {
+        // `Json` says how the bytes were encoded, not where they came from: a
+        // portal export and a device-side agent state file are both JSON. Granting
+        // it device authority let an exported portal view resolve a setting the
+        // CSP was never shown to have applied. An adapter that has a device-side
+        // JSON source should declare the source kind it actually is.
+        IntuneSourceKind::Json | IntuneSourceKind::Coverage | IntuneSourceKind::Unknown(_) => {
             ConfigurationEvidenceSide::Unclassified
         }
     }

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
@@ -42,6 +42,12 @@ pub struct ConfigurationInput {
     /// joined to an unrelated one by comparing tokens. Any opaque per-analysis value works — a capture
     /// GUID, a support-case id, a digest of the collected bundle.
     ///
+    /// The value is used verbatim: only a whitespace-only string counts as no
+    /// scope at all, so `"a"` and `" a "` are two different analyses. The crate
+    /// cannot know which bytes a caller's identity scheme treats as
+    /// significant, and normalizing them would silently join exports the caller
+    /// meant to keep apart.
+    ///
     /// Uniqueness is the caller's obligation and cannot be checked here: this
     /// crate is pure and `wasm32-unknown-unknown` clean, so it has no clock, no
     /// entropy source, and no process state that survives a restart from which

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/models.rs
@@ -1,0 +1,295 @@
+//! Typed observations, per-setting state, and the immutable snapshot.
+//!
+//! The three state tracks ([`ConfigurationReceiptState`],
+//! [`ConfigurationLocalState`], [`ConfigurationServiceState`]) are deliberately
+//! separate rather than collapsed into one status. Issue #363 requires the output
+//! to distinguish what the device received, what its CSP did, and what the
+//! service was told, because those three routinely disagree and the disagreement
+//! is the diagnosis. A single field would have to pick a winner, and picking a
+//! winner is exactly what the evidence does not license.
+
+use serde::{Deserialize, Serialize};
+
+use crate::intune::evidence::{
+    IntuneArtifactCoverage, IntuneErrorCode, IntuneEvidenceRef, IntuneFinding, IntuneNamedValue,
+    IntuneSensitivity, IntuneSourceKind,
+};
+use crate::intune::normalized::{NormalizedSettingReport, NormalizedWindowsEvent};
+
+use super::identity::ConfigurationSettingIdentity;
+
+/// Schema version of the serialized configuration snapshot.
+pub const INTUNE_CONFIGURATION_SCHEMA_VERSION: u32 = 1;
+
+/// Everything the pure analyzer is given for one device.
+///
+/// The native adapter decodes EVTX, MDM diagnostic reports, and registry facts
+/// and hands them over as the shared normalized types; nothing here reads a file.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationInput {
+    /// UTC instant the bundle was assembled, used only for snapshot provenance.
+    pub generated_at_utc: String,
+    pub events: Vec<NormalizedWindowsEvent>,
+    pub reports: Vec<NormalizedSettingReport>,
+    /// Coverage for every artifact that was expected, including the ones that
+    /// were never read. A finding may cite one of these instead of evidence.
+    pub coverage: Vec<IntuneArtifactCoverage>,
+}
+
+/// Which side of the boundary an observation came from.
+///
+/// A local CSP error is device evidence. A portal status is service evidence and
+/// is supplemental: it describes what Intune was told, not what the CSP did.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfigurationEvidenceSide {
+    /// Read from the device: event log, MDM diagnostic report, registry, agent log.
+    Device,
+    /// Imported from Intune assignment or reporting data.
+    Service,
+    /// Source kind this build does not classify; makes no contribution.
+    Unclassified,
+}
+
+/// Classify a source kind onto the device/service boundary.
+///
+/// `Unknown` source kinds stay [`ConfigurationEvidenceSide::Unclassified`] on
+/// purpose: guessing a side for an unrecognized token would let a future source
+/// silently acquire device authority it was never granted.
+pub fn evidence_side(kind: &IntuneSourceKind) -> ConfigurationEvidenceSide {
+    match kind {
+        IntuneSourceKind::EventLog
+        | IntuneSourceKind::Registry
+        | IntuneSourceKind::DiagnosticReport
+        | IntuneSourceKind::ImeLog
+        | IntuneSourceKind::CcmLog
+        | IntuneSourceKind::AgentLog
+        | IntuneSourceKind::PlainTextLog
+        | IntuneSourceKind::UnifiedLog
+        | IntuneSourceKind::Json => ConfigurationEvidenceSide::Device,
+        IntuneSourceKind::Graph | IntuneSourceKind::SuppliedFact => {
+            ConfigurationEvidenceSide::Service
+        }
+        IntuneSourceKind::Coverage | IntuneSourceKind::Unknown(_) => {
+            ConfigurationEvidenceSide::Unclassified
+        }
+    }
+}
+
+/// What a single observation says happened to the setting.
+///
+/// `Received`, `Pending`, and `Indeterminate` are non-terminal; everything else
+/// is a terminal disposition and drives [`ConfigurationReceiptState::CspProcessed`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfigurationDisposition {
+    /// The resource was named but no outcome was stated.
+    Received,
+    Applied,
+    Rejected,
+    Conflict,
+    Superseded,
+    NotApplicable,
+    Removed,
+    Pending,
+    /// The record named the resource but could not be interpreted.
+    Indeterminate,
+}
+
+impl ConfigurationDisposition {
+    /// Whether this disposition proves the CSP reached a decision.
+    pub fn is_terminal(self) -> bool {
+        !matches!(self, Self::Received | Self::Pending | Self::Indeterminate)
+    }
+}
+
+/// The event-log records this build recognizes on the MDM Admin channel.
+///
+/// Only IDs whose meaning is documented by Microsoft are listed. Every other ID
+/// stays [`ConfigurationEventKind::Unrecognized`]: the record is retained as
+/// evidence that the device saw the resource, but it contributes no outcome.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfigurationEventKind {
+    /// 404 — MDM ConfigurationManager command failure status.
+    CommandFailure,
+    /// 813 / 814 — MDM PolicyManager set policy (int / string).
+    PolicySet,
+    /// 815 — MDM PolicyManager delete policy.
+    PolicyDeleted,
+    /// Names the resource with no documented outcome.
+    Unrecognized,
+}
+
+/// One device-side or service-side statement about one setting.
+///
+/// The observation keeps its full [`IntuneObservationContext`] through
+/// `evidence_ref` plus the fields the reducer keys on. Anything not modeled is
+/// carried verbatim in `named_data`.
+///
+/// [`IntuneObservationContext`]: crate::intune::evidence::IntuneObservationContext
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationObservation {
+    pub evidence_ref: IntuneEvidenceRef,
+    pub side: ConfigurationEvidenceSide,
+    pub source_kind: IntuneSourceKind,
+    /// Privacy classification the adapter assigned to the originating record.
+    pub sensitivity: IntuneSensitivity,
+    pub identity: ConfigurationSettingIdentity,
+    pub disposition: ConfigurationDisposition,
+    pub event_kind: Option<ConfigurationEventKind>,
+    pub event_id: Option<u32>,
+    /// Configuration source / policy id that issued this statement, when stated.
+    pub source_id: Option<String>,
+    pub enrollment_id: Option<String>,
+    pub command_type: Option<String>,
+    /// The setting value, if one was stated. Classified by `sensitivity`.
+    pub value: Option<String>,
+    pub error: Option<IntuneErrorCode>,
+    /// Source id that this statement says won a conflict, when stated.
+    pub winning_source_id: Option<String>,
+    /// Source id that this statement says superseded the setting, when stated.
+    pub superseded_by_source_id: Option<String>,
+    /// Normalized UTC instant, when the source carried a usable one.
+    pub occurred_at_utc: Option<String>,
+    /// Whether the source timestamp survived normalization.
+    pub time_is_reliable: bool,
+    /// Record ordinal within its channel, when the source carried one.
+    pub record_id: Option<u64>,
+    /// True when the record itself was malformed or of an unsupported schema.
+    pub is_uninterpretable: bool,
+    pub named_data: Vec<IntuneNamedValue>,
+}
+
+/// What the device received.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfigurationReceiptState {
+    /// Nothing names this resource.
+    NoEvidence,
+    /// Only service-side data names it; the device may never have seen it.
+    Intended,
+    /// A device-side record names it but states no outcome.
+    CommandReceived,
+    /// A device-side record shows the CSP reached a decision.
+    CspProcessed,
+}
+
+/// What the CSP did on the device.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfigurationLocalState {
+    NoEvidence,
+    Applied,
+    Rejected,
+    Conflicted,
+    Superseded,
+    NotApplicable,
+    Removed,
+    /// Device-side records disagree with one another.
+    Contested,
+    /// A record named the resource but nothing could be concluded.
+    Indeterminate,
+}
+
+/// What Intune was told.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfigurationServiceState {
+    NoEvidence,
+    /// Assignment intent only; no per-setting status was imported.
+    Assigned,
+    ReportedSuccess,
+    ReportedFailure,
+    ReportedConflict,
+    ReportedSuperseded,
+    ReportedNotApplicable,
+    ReportedPending,
+    /// Service-side rows disagree with one another.
+    Contested,
+}
+
+/// The single conclusion the analyzer is willing to state.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfigurationResolution {
+    Applied,
+    Rejected,
+    Conflicted,
+    Superseded,
+    NotApplicable,
+    Removed,
+    /// Device and service evidence state incompatible outcomes.
+    Contradicted,
+    /// The evidence names the setting but does not settle its fate.
+    InsufficientEvidence,
+}
+
+/// A configuration source that made a statement about a setting.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationSourceStatement {
+    /// Configuration source / policy id, or `null` when the record did not state one.
+    pub source_id: Option<String>,
+    pub side: ConfigurationEvidenceSide,
+    pub disposition: ConfigurationDisposition,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+/// One setting transaction: everything observed about one canonical resource.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationSetting {
+    pub identity: ConfigurationSettingIdentity,
+    pub receipt: ConfigurationReceiptState,
+    pub local: ConfigurationLocalState,
+    pub service: ConfigurationServiceState,
+    pub resolution: ConfigurationResolution,
+    /// Distinct configuration sources seen for this resource, sorted.
+    pub sources: Vec<ConfigurationSourceStatement>,
+    /// Terminal error reported by the device, when one was.
+    pub local_error: Option<IntuneErrorCode>,
+    /// Error the service reported, when one was.
+    pub service_error: Option<IntuneErrorCode>,
+    /// Value the device reported applying, subject to redaction on export.
+    pub applied_value: Option<String>,
+    /// False when any contributing record had an unusable timestamp, which
+    /// forbids resolving a contradiction by recency.
+    pub time_is_reliable: bool,
+    /// True when device record order and device timestamp order disagree.
+    pub ordering_is_contradictory: bool,
+    /// True when at least one contributing record was malformed or unsupported.
+    pub has_uninterpretable_evidence: bool,
+    pub observations: Vec<ConfigurationObservation>,
+    pub evidence: Vec<IntuneEvidenceRef>,
+}
+
+impl ConfigurationSetting {
+    /// Whether device and service evidence can be trusted to be about the same
+    /// point in time. Used by the contradiction rules, which refuse to prefer
+    /// whichever side is newer when this is false.
+    pub fn recency_is_usable(&self) -> bool {
+        self.time_is_reliable && !self.ordering_is_contradictory
+    }
+}
+
+/// Immutable result of reducing one bundle.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationSnapshot {
+    pub schema_version: u32,
+    pub generated_at_utc: String,
+    /// Sorted by identity key so the serialized form is deterministic.
+    pub settings: Vec<ConfigurationSetting>,
+    /// Observations that named no resolvable resource at all.
+    pub unattributed: Vec<ConfigurationObservation>,
+    pub coverage: Vec<IntuneArtifactCoverage>,
+    pub findings: Vec<IntuneFinding>,
+    /// True when the values in this snapshot have been through
+    /// [`redacted_configuration_snapshot`].
+    ///
+    /// [`redacted_configuration_snapshot`]: super::redacted_configuration_snapshot
+    pub redacted: bool,
+}

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
@@ -1,29 +1,77 @@
-//! Deterministic redaction for the default export.
+//! Deterministic redaction for the configuration export.
 //!
 //! Configuration values are arbitrary tenant data: a proxy URL, a certificate
 //! subject, a wallpaper path, a user principal name. The default export must not
 //! carry them, but simply deleting them destroys the one comparison that matters
 //! most — whether two configuration sources are fighting over the *same* value or
-//! two different ones.
+//! two different ones. A redacted value therefore becomes `[redacted:<hash>]`,
+//! and equal inputs produce equal tokens.
 //!
-//! So a redacted value becomes `[redacted:<hash>]`, where the hash is FNV-1a over
-//! the original bytes. Equal inputs produce equal tokens, so a conflict stays
-//! legible after redaction, and the token is stable across runs and machines,
-//! which is what makes it golden-testable.
+//! # One choke point
 //!
-//! FNV is used rather than a cryptographic digest because this crate takes no new
-//! dependencies and the token is a correlation aid, not an authentication tag.
-//! It is not a defense against an attacker who can guess a value and confirm it;
-//! nothing in this file claims to be.
+//! Everything that leaves this module is produced by [`RedactionScope`]. There
+//! are exactly three ways to emit a value — [`RedactionScope::token`] for a
+//! classified value, [`RedactionScope::free_text`] for prose, and
+//! [`RedactionScope::uri`] for a node path — and every field of the snapshot goes
+//! through one of them. [`redacted_configuration_snapshot`] builds its result
+//! with a struct literal rather than `clone()` + mutate, so a new snapshot field
+//! is a compile error here rather than a silent leak. That is what closes the
+//! previous gap where findings and coverage bypassed redaction entirely and
+//! exported the un-scrubbed node path embedded in a finding summary.
+//!
+//! # Token scope (ADR-004)
+//!
+//! ADR-004 accepts the redaction *boundary* but records the token algorithm,
+//! caller-supplied key, and equality scope as **provisional**, and forbids a new
+//! reducer from introducing a stable identifier token intended for cross-artifact,
+//! cross-session, or cross-export correlation. This module therefore scopes token
+//! equality to **one analysis**: the hash is salted with the snapshot's
+//! `generatedAtUtc`, so two settings inside one export that carry the same value
+//! still show the same token — which is the equality the conflict diagnosis needs
+//! — while two separate exports of the same device produce different tokens and
+//! cannot be joined.
+//!
+//! No keyed-token API is invented here. Defining one (a caller-supplied secret,
+//! a documented equality scope, and the tests that pin it) is the Store pilot's
+//! decision under ADR-004, and this module adopts it when it lands. Until then
+//! the honest statement of what the token defends is: it prevents casual
+//! disclosure and cross-export correlation. It is not a defense against an
+//! attacker who can enumerate candidate values and confirm a match *within a
+//! single export*, because the salt travels with the export.
+//!
+//! Free-text spans are masked by the family-owned
+//! [`crate::intune::apps::windows::common::redact_text`], which is where
+//! user-profile-path and inline-credential masking is maintained for every
+//! Windows Intune analyzer, rather than by a second whole-value predicate here.
+//! The two shapes that also occur as CSP *node segments* — a SID and a UPN — are
+//! masked locally first, with this analysis's token, so the same identity reads
+//! identically whether it reached the export through `canonicalUri`, through the
+//! lowercased dedupe key, or through a finding summary built from either.
+//!
+//! # Idempotence
+//!
+//! Re-projecting an already redacted snapshot returns it unchanged. A value that
+//! is exactly a token this module produced is passed through rather than hashed
+//! again, using the same full-shape check the compliance sibling settled on: a
+//! source-supplied value that merely wears brackets does not get to skip
+//! redaction.
 
-use crate::intune::evidence::{IntuneNamedValue, IntuneSensitivity};
+use std::sync::OnceLock;
 
+use regex::Regex;
+
+use crate::intune::apps::windows::common::redact_text;
+use crate::intune::evidence::{
+    IntuneArtifactCoverage, IntuneFinding, IntuneNamedValue, IntuneSensitivity,
+};
+
+use super::identity::ConfigurationSettingIdentity;
 use super::models::{
     ConfigurationObservation, ConfigurationSetting, ConfigurationSnapshot,
     ConfigurationSourceStatement,
 };
 
-/// Named-value keys whose contents are redacted regardless of classification.
+/// Named-value keys whose contents are tokenized regardless of classification.
 ///
 /// The value-bearing keys are here for the same reason the typed fields are
 /// tokenized: a configuration value is arbitrary tenant data, and leaving the
@@ -57,54 +105,229 @@ const SENSITIVE_NAMES: [&str; 24] = [
     "TenantId",
 ];
 
-/// Return a copy of the snapshot with every value-bearing field redacted.
+/// Named-value keys whose contents are a CSP node path.
 ///
-/// The snapshot's structure, identities, states, findings, and coverage are
-/// untouched: those are the diagnosis, and redacting them would defeat the
-/// export. Only free-text values are replaced.
-pub fn redacted_configuration_snapshot(snapshot: &ConfigurationSnapshot) -> ConfigurationSnapshot {
-    let mut redacted = snapshot.clone();
-    redacted.settings = snapshot.settings.iter().map(redact_setting).collect();
-    redacted.unattributed = snapshot
-        .unattributed
-        .iter()
-        .map(redact_observation)
-        .collect();
-    redacted.redacted = true;
-    redacted
+/// These are scrubbed segment by segment rather than replaced wholesale: the node
+/// path is the single most useful thing in the export, and a whole-value token
+/// would have hidden a SID segment *and* the node it belongs to. Some nodes embed
+/// a SID or an account name as a segment, and only those segments are tokenized.
+const URI_NAMES: [&str; 6] = ["NodeUri", "CspUri", "CSPURI", "SettingUri", "Uri", "OmaUri"];
+
+/// Named-value keys the reducer itself keys on to reach a diagnosis.
+///
+/// A record classified [`IntuneSensitivity::Sensitive`] is one the adapter has
+/// told us carries identity, so its free text is replaced wholesale — except for
+/// these, which are policy identifiers, status codes, and command verbs. Dropping
+/// them would leave a redacted export that can no longer state *why* it concluded
+/// what it concluded, which ADR-004 forbids just as firmly as leaking the value.
+/// The list mirrors the lookup keys in [`super::sources`].
+const DIAGNOSTIC_NAMES: [&str; 15] = [
+    "ConfigurationSourceId",
+    "PolicyId",
+    "SourceId",
+    "ConfigSourceId",
+    "SettingId",
+    "CommandType",
+    "Command",
+    "Result",
+    "ResultCode",
+    "ErrorCode",
+    "Hresult",
+    "Scope",
+    "TargetScope",
+    "Area",
+    "SchemaVersion",
+];
+
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// The redaction scope of one analysis.
+///
+/// Constructed from the snapshot's own `generatedAtUtc`, which is the only
+/// identifier of "this analysis" the pure crate is given. Every token in one
+/// export shares this scope; no two exports share it.
+struct RedactionScope {
+    salt: u64,
 }
 
-/// The deterministic replacement token for one value.
-pub fn redaction_token(value: &str) -> String {
-    format!("[redacted:{:016x}]", fnv1a64(value.as_bytes()))
+impl RedactionScope {
+    fn new(analysis_id: &str) -> Self {
+        Self {
+            salt: fnv1a64(FNV_OFFSET_BASIS, analysis_id.as_bytes()),
+        }
+    }
+
+    /// The replacement token for one whole value.
+    fn token(&self, value: &str) -> String {
+        if is_redaction_token(value) {
+            return value.to_owned();
+        }
+        format!("[redacted:{:016x}]", fnv1a64(self.salt, value.as_bytes()))
+    }
+
+    fn token_opt(&self, value: Option<&str>) -> Option<String> {
+        value.map(|value| self.token(value))
+    }
+
+    /// The replacement token for an identity that is being *matched*, not stated.
+    ///
+    /// Case is folded first. The dedupe key is lowercased at build time while the
+    /// canonical URI keeps the documented CSP casing, so hashing the bytes as
+    /// written would give the same SID two different tokens in one snapshot and
+    /// destroy exactly the equality redaction exists to preserve.
+    fn identity_token(&self, value: &str) -> String {
+        self.token(&value.to_ascii_lowercase())
+    }
+
+    /// Mask the identity-bearing spans inside free text, keeping the rest.
+    ///
+    /// Whole-value replacement is not enough for prose: `"user a@b could not
+    /// apply"` is not itself an identity by any whole-value predicate, and used to
+    /// export intact.
+    /// The two shapes that also appear as CSP node segments — a SID and a UPN —
+    /// are masked here first, with this analysis's token, so the same identity
+    /// reads identically whether it reached the export through `canonicalUri` or
+    /// through a finding summary built from it. Whatever is left goes to the
+    /// family-owned helper, which owns user-profile paths and inline credentials.
+    fn free_text(&self, value: &str) -> String {
+        let masked = sid_regex().replace_all(value, |captures: &regex::Captures<'_>| {
+            self.identity_token(&captures[0])
+        });
+        let masked = upn_regex().replace_all(&masked, |captures: &regex::Captures<'_>| {
+            self.identity_token(&captures[0])
+        });
+        redact_text(&masked)
+    }
+
+    fn free_text_opt(&self, value: Option<&str>) -> Option<String> {
+        value.map(|value| self.free_text(value))
+    }
+
+    /// Scrub the identity segments out of a node path, keeping the path.
+    fn uri(&self, uri: &str) -> String {
+        uri.split('/')
+            .map(|segment| {
+                if looks_like_identity(segment) {
+                    self.identity_token(segment)
+                } else {
+                    self.free_text(segment)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+
+    fn uri_opt(&self, uri: Option<&str>) -> Option<String> {
+        uri.map(|uri| self.uri(uri))
+    }
 }
 
-fn fnv1a64(bytes: &[u8]) -> u64 {
-    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
-    const PRIME: u64 = 0x0000_0100_0000_01b3;
-    let mut hash = OFFSET_BASIS;
+fn fnv1a64(seed: u64, bytes: &[u8]) -> u64 {
+    let mut hash = seed;
     for byte in bytes {
         hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(PRIME);
+        hash = hash.wrapping_mul(FNV_PRIME);
     }
     hash
 }
 
-fn redact_setting(setting: &ConfigurationSetting) -> ConfigurationSetting {
-    let mut redacted = setting.clone();
-    redacted.identity = redact_identity(&setting.identity);
-    redacted.applied_value = setting.applied_value.as_deref().map(redaction_token);
-    redacted.observations = setting
-        .observations
-        .iter()
-        .map(redact_observation)
-        .collect();
-    redacted.sources = setting
-        .sources
-        .iter()
-        .map(redact_source_statement)
-        .collect();
-    redacted
+/// Whether a value is exactly a token this module produced.
+///
+/// The shape must match `[redacted:<16 hex digits>]` in full. Treating any
+/// bracketed value as already masked would let a source-supplied value such as
+/// `[redacted:pick-me]` skip redaction simply by wearing brackets.
+fn is_redaction_token(value: &str) -> bool {
+    let Some(rest) = value.strip_prefix("[redacted:") else {
+        return false;
+    };
+    let Some(digits) = rest.strip_suffix(']') else {
+        return false;
+    };
+    digits.len() == 16 && digits.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+/// A Windows security identifier appearing anywhere inside a longer string.
+fn sid_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)S-1-(?:\d+-){2,}\d+").expect("SID pattern is valid"))
+}
+
+/// A user principal name or address appearing anywhere inside a longer string.
+///
+/// Deliberately the same shape the shared helper uses, because this module needs
+/// the span tokenized in *its* scope and must therefore win the race.
+fn upn_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+            .expect("UPN pattern is valid")
+    })
+}
+
+/// Return a copy of the snapshot with every value-bearing field redacted.
+///
+/// The states, resolutions, source identifiers, evidence references, finding
+/// identifiers, severities, and confidences are untouched: those are the
+/// diagnosis, and ADR-004 requires redaction to leave non-sensitive conclusions
+/// alone. Only free text is replaced.
+pub fn redacted_configuration_snapshot(snapshot: &ConfigurationSnapshot) -> ConfigurationSnapshot {
+    let scope = RedactionScope::new(&snapshot.generated_at_utc);
+
+    // Written as a struct literal on purpose: adding a field to the snapshot must
+    // not silently inherit an un-redacted value from a `clone()`.
+    ConfigurationSnapshot {
+        schema_version: snapshot.schema_version,
+        generated_at_utc: snapshot.generated_at_utc.clone(),
+        settings: snapshot
+            .settings
+            .iter()
+            .map(|setting| redact_setting(setting, &scope))
+            .collect(),
+        unattributed: snapshot
+            .unattributed
+            .iter()
+            .map(|observation| redact_observation(observation, &scope))
+            .collect(),
+        coverage: snapshot
+            .coverage
+            .iter()
+            .map(|entry| redact_coverage(entry, &scope))
+            .collect(),
+        findings: snapshot
+            .findings
+            .iter()
+            .map(|finding| redact_finding(finding, &scope))
+            .collect(),
+        redacted: true,
+    }
+}
+
+fn redact_setting(setting: &ConfigurationSetting, scope: &RedactionScope) -> ConfigurationSetting {
+    ConfigurationSetting {
+        identity: redact_identity(&setting.identity, scope),
+        receipt: setting.receipt,
+        local: setting.local,
+        service: setting.service,
+        resolution: setting.resolution,
+        sources: setting
+            .sources
+            .iter()
+            .map(redact_source_statement)
+            .collect(),
+        local_error: setting.local_error.clone(),
+        service_error: setting.service_error.clone(),
+        applied_value: scope.token_opt(setting.applied_value.as_deref()),
+        time_is_reliable: setting.time_is_reliable,
+        ordering_is_contradictory: setting.ordering_is_contradictory,
+        has_uninterpretable_evidence: setting.has_uninterpretable_evidence,
+        observations: setting
+            .observations
+            .iter()
+            .map(|observation| redact_observation(observation, scope))
+            .collect(),
+        evidence: setting.evidence.clone(),
+    }
 }
 
 fn redact_source_statement(
@@ -116,79 +339,150 @@ fn redact_source_statement(
     statement.clone()
 }
 
-fn redact_observation(observation: &ConfigurationObservation) -> ConfigurationObservation {
-    let mut redacted = observation.clone();
-    redacted.identity = redact_identity(&observation.identity);
-    redacted.value = observation.value.as_deref().map(redaction_token);
-    // An enrollment id identifies this device's enrollment, so it is tokenized
-    // rather than dropped: correlating two records to the same enrollment stays
-    // possible without disclosing which enrollment it is.
-    redacted.enrollment_id = observation.enrollment_id.as_deref().map(redaction_token);
-    redacted.named_data = observation
-        .named_data
-        .iter()
-        .map(|entry| redact_named_value(entry, &observation.sensitivity))
-        .collect();
-    redacted
+fn redact_observation(
+    observation: &ConfigurationObservation,
+    scope: &RedactionScope,
+) -> ConfigurationObservation {
+    ConfigurationObservation {
+        evidence_ref: observation.evidence_ref.clone(),
+        side: observation.side,
+        source_kind: observation.source_kind.clone(),
+        sensitivity: observation.sensitivity.clone(),
+        identity: redact_identity(&observation.identity, scope),
+        disposition: observation.disposition,
+        event_kind: observation.event_kind,
+        event_id: observation.event_id,
+        source_id: observation.source_id.clone(),
+        // An enrollment id identifies this device's enrollment, so it is
+        // tokenized rather than dropped: correlating two records to the same
+        // enrollment stays possible without disclosing which enrollment it is.
+        enrollment_id: scope.token_opt(observation.enrollment_id.as_deref()),
+        command_type: observation.command_type.clone(),
+        value: scope.token_opt(observation.value.as_deref()),
+        error: observation.error.clone(),
+        winning_source_id: observation.winning_source_id.clone(),
+        superseded_by_source_id: observation.superseded_by_source_id.clone(),
+        occurred_at_utc: observation.occurred_at_utc.clone(),
+        time_is_reliable: observation.time_is_reliable,
+        record_id: observation.record_id,
+        is_uninterpretable: observation.is_uninterpretable,
+        named_data: observation
+            .named_data
+            .iter()
+            .map(|entry| redact_named_value(entry, &observation.sensitivity, scope))
+            .collect(),
+    }
 }
 
 fn redact_named_value(
     entry: &IntuneNamedValue,
     sensitivity: &IntuneSensitivity,
+    scope: &RedactionScope,
 ) -> IntuneNamedValue {
-    let redact = matches!(sensitivity, IntuneSensitivity::Restricted)
-        || SENSITIVE_NAMES
-            .iter()
-            .any(|name| entry.name.eq_ignore_ascii_case(name))
-        || looks_like_identity(&entry.value);
+    let value = if matches!(sensitivity, IntuneSensitivity::Restricted) {
+        // Restricted means the record may not contribute free text at all, and
+        // that outranks keeping the node path legible.
+        scope.token(&entry.value)
+    } else if matches_name(&entry.name, &URI_NAMES) {
+        scope.uri(&entry.value)
+    } else if matches_name(&entry.name, &SENSITIVE_NAMES)
+        || looks_like_identity(&entry.value)
+        || (matches!(sensitivity, IntuneSensitivity::Sensitive)
+            && !matches_name(&entry.name, &DIAGNOSTIC_NAMES))
+    {
+        scope.token(&entry.value)
+    } else {
+        scope.free_text(&entry.value)
+    };
 
     IntuneNamedValue {
         name: entry.name.clone(),
-        value: if redact {
-            redaction_token(&entry.value)
-        } else {
-            entry.value.clone()
-        },
+        value,
     }
 }
 
-/// Redact only the URI segments that carry identity, keeping the node path.
+fn matches_name(name: &str, names: &[&str]) -> bool {
+    names
+        .iter()
+        .any(|candidate| name.eq_ignore_ascii_case(candidate))
+}
+
+/// Scrub the identity segments out of every URI-shaped identity field.
 ///
-/// A CSP node path is the single most useful thing in the output and must
-/// survive. Some nodes embed a SID or account name as a segment, and those
-/// segments are tokenized. Because the dedupe key is derived from the same
-/// string, it is scrubbed with the same function so a redacted snapshot stays
-/// internally consistent.
+/// Because the dedupe key is derived from the same string, it is scrubbed with
+/// the same function so a redacted snapshot stays internally consistent. The key
+/// is lowercased at build time, which is why every detector below is
+/// case-insensitive: a case-sensitive detector matched the `canonicalUri` copy of
+/// a SID and missed the lowercased `key` copy sitting beside it.
 fn redact_identity(
-    identity: &super::identity::ConfigurationSettingIdentity,
-) -> super::identity::ConfigurationSettingIdentity {
-    let mut redacted = identity.clone();
-    redacted.canonical_uri = identity.canonical_uri.as_deref().map(scrub_uri);
-    redacted.raw_uri = identity.raw_uri.as_deref().map(scrub_uri);
-    redacted.resource_path = identity.resource_path.as_deref().map(scrub_uri);
-    redacted.key = scrub_uri(&identity.key);
-    redacted
+    identity: &ConfigurationSettingIdentity,
+    scope: &RedactionScope,
+) -> ConfigurationSettingIdentity {
+    ConfigurationSettingIdentity {
+        key: scope.uri(&identity.key),
+        canonical_uri: scope.uri_opt(identity.canonical_uri.as_deref()),
+        raw_uri: scope.uri_opt(identity.raw_uri.as_deref()),
+        resource_path: scope.uri_opt(identity.resource_path.as_deref()),
+        setting_id: identity.setting_id.clone(),
+        policy_id: identity.policy_id.clone(),
+        display_name: scope.free_text_opt(identity.display_name.as_deref()),
+        scope: identity.scope,
+        csp: identity.csp.clone(),
+        is_unidentified: identity.is_unidentified,
+    }
 }
 
-fn scrub_uri(uri: &str) -> String {
-    uri.split('/')
-        .map(|segment| {
-            if looks_like_identity(segment) {
-                redaction_token(segment)
-            } else {
-                segment.to_owned()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
+/// Scrub a coverage entry's collector-supplied detail.
+fn redact_coverage(
+    entry: &IntuneArtifactCoverage,
+    scope: &RedactionScope,
+) -> IntuneArtifactCoverage {
+    IntuneArtifactCoverage {
+        artifact_id: entry.artifact_id.clone(),
+        family: entry.family.clone(),
+        status: entry.status.clone(),
+        detail: scope.free_text_opt(entry.detail.as_deref()),
+        observed_at_utc: entry.observed_at_utc.clone(),
+        evidence: entry.evidence.clone(),
+    }
 }
 
-/// Whether a free-text value carries identity, path, or credential material.
+/// Scrub a finding's prose, leaving the conclusion it states untouched.
+///
+/// The identifier, severity, confidence, citations, and coverage-gap references
+/// are the diagnosis and must survive byte-for-byte; ADR-004's invariant is that
+/// redaction does not alter non-sensitive conclusions. The title, summary, and
+/// recommended checks are prose built from setting labels, and a label is a node
+/// path that can embed a SID.
+fn redact_finding(finding: &IntuneFinding, scope: &RedactionScope) -> IntuneFinding {
+    IntuneFinding {
+        finding_id: finding.finding_id.clone(),
+        severity: finding.severity.clone(),
+        confidence: finding.confidence.clone(),
+        title: scope.free_text(&finding.title),
+        summary: scope.free_text(&finding.summary),
+        recommended_checks: finding
+            .recommended_checks
+            .iter()
+            .map(|check| scope.free_text(check))
+            .collect(),
+        evidence: finding.evidence.clone(),
+        coverage_gap_ids: finding.coverage_gap_ids.clone(),
+    }
+}
+
+/// Whether a value is *entirely* identity, path, or credential material.
+///
+/// Used for whole-value replacement, where a partial mask would be a false
+/// assurance. Free text goes through [`RedactionScope::free_text`] instead.
+///
+/// Every check is case-insensitive because the dedupe key is lowercased and is
+/// scrubbed by the same code path as the mixed-case URI it was derived from.
 ///
 /// GUIDs are deliberately *not* matched: policy, configuration source, and
 /// setting identifiers are GUIDs, and tokenizing them would remove the only
 /// handle an administrator has for finding the offending policy in the portal.
-pub fn looks_like_identity(value: &str) -> bool {
+fn looks_like_identity(value: &str) -> bool {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return false;
@@ -199,17 +493,25 @@ pub fn looks_like_identity(value: &str) -> bool {
     if is_mail_like(trimmed) {
         return true;
     }
-    if trimmed.contains(":\\") || trimmed.starts_with("\\\\") || trimmed.contains("/Users/") {
+    let lowercased = trimmed.to_ascii_lowercase();
+    if lowercased.contains(":\\")
+        || lowercased.starts_with("\\\\")
+        || lowercased.contains("/users/")
+    {
         return true;
     }
     // JWTs and bearer tokens.
-    trimmed.starts_with("eyJ") || trimmed.to_ascii_lowercase().contains("bearer ")
+    lowercased.starts_with("eyj") || lowercased.contains("bearer ")
 }
 
 fn is_windows_sid(value: &str) -> bool {
-    let Some(rest) = value.strip_prefix("S-1-") else {
+    let Some(rest) = value
+        .get(..4)
+        .filter(|head| head.eq_ignore_ascii_case("S-1-"))
+    else {
         return false;
     };
+    let rest = &value[rest.len()..];
     rest.matches('-').count() >= 2
         && rest
             .chars()
@@ -227,17 +529,52 @@ fn is_mail_like(value: &str) -> bool {
 mod tests {
     use super::*;
 
-    #[test]
-    fn the_same_value_always_redacts_to_the_same_token() {
-        assert_eq!(redaction_token("secret"), redaction_token("secret"));
-        assert_ne!(redaction_token("secret"), redaction_token("other"));
+    fn scope() -> RedactionScope {
+        RedactionScope::new("2026-07-31T10:00:00Z")
     }
 
     #[test]
-    fn the_token_is_a_fixed_width_stable_string() {
-        // Pinned so a change to the hashing scheme cannot pass unnoticed: every
-        // committed golden fixture depends on this exact value.
-        assert_eq!(redaction_token("1"), "[redacted:af63ac4c86019afc]");
+    fn the_same_value_always_redacts_to_the_same_token_within_one_analysis() {
+        let scope = scope();
+        assert_eq!(scope.token("secret"), scope.token("secret"));
+        assert_ne!(scope.token("secret"), scope.token("other"));
+    }
+
+    #[test]
+    fn two_analyses_do_not_share_a_token_for_the_same_value() {
+        // ADR-004: a new reducer must not introduce a token that joins two
+        // exports. Pinning the *inequality* is what stops a future refactor from
+        // quietly restoring a globally stable dictionary of low-entropy values.
+        let first = RedactionScope::new("2026-07-31T10:00:00Z");
+        let second = RedactionScope::new("2026-08-01T10:00:00Z");
+        assert_ne!(first.token("1"), second.token("1"));
+    }
+
+    #[test]
+    fn the_token_is_a_fixed_width_stable_string_within_its_scope() {
+        // Pinned so a change to the hashing scheme cannot pass unnoticed. The
+        // scope is named explicitly: the value alone no longer determines the
+        // token, which is the point.
+        assert_eq!(scope().token("1"), "[redacted:187c4fa5b79764ea]");
+    }
+
+    #[test]
+    fn redacting_a_token_again_returns_it_unchanged() {
+        let scope = scope();
+        let once = scope.token("D:\\Data\\wallpaper.png");
+        assert_eq!(scope.token(&once), once);
+        assert_eq!(scope.free_text(&once), once);
+        assert_eq!(scope.uri(&once), once);
+    }
+
+    #[test]
+    fn a_value_that_merely_wears_brackets_is_still_redacted() {
+        let scope = scope();
+        assert_ne!(
+            scope.token("[redacted:pick-me]"),
+            "[redacted:pick-me]",
+            "a source-supplied bracketed value must not bypass redaction"
+        );
     }
 
     #[test]
@@ -252,9 +589,107 @@ mod tests {
     }
 
     #[test]
+    fn identity_detection_is_case_insensitive_because_the_dedupe_key_is_lowercased() {
+        // The regression this pins: `key` is built lowercased while the detectors
+        // were case-sensitive, so a SID was tokenized in `canonicalUri` and
+        // shipped verbatim in `key` right beside it.
+        assert!(looks_like_identity("s-1-5-21-1-2-3-1001"));
+        assert!(looks_like_identity("d:\\data\\wallpaper.png"));
+        assert!(looks_like_identity("eyjhbgcioijiuzi1nij9.e30"));
+    }
+
+    #[test]
     fn scrubbing_a_uri_keeps_the_node_path_and_tokenizes_only_identity_segments() {
-        let scrubbed = scrub_uri("Device/Vendor/MSFT/Policy/Config/S-1-5-21-1-2-3-1001/Setting");
+        let scrubbed = scope().uri("Device/Vendor/MSFT/Policy/Config/S-1-5-21-1-2-3-1001/Setting");
         assert!(scrubbed.starts_with("Device/Vendor/MSFT/Policy/Config/[redacted:"));
         assert!(scrubbed.ends_with("/Setting"));
+    }
+
+    #[test]
+    fn a_lowercased_dedupe_key_is_scrubbed_the_same_way_as_its_uri() {
+        let scope = scope();
+        let uri = scope.uri("Device/Vendor/MSFT/Policy/Config/S-1-5-21-1-2-3-1001/Setting");
+        let key =
+            scope.uri("device|uri:device/vendor/msft/policy/config/s-1-5-21-1-2-3-1001/setting");
+        let token = uri
+            .split('/')
+            .find(|segment| segment.starts_with("[redacted:"))
+            .expect("the URI carries a token");
+        assert!(key.contains(token), "key {key} must reuse the URI's token");
+        assert!(!key.contains("s-1-5-21"), "got {key}");
+    }
+
+    #[test]
+    fn an_identity_embedded_in_prose_is_masked_without_destroying_the_sentence() {
+        let masked = scope().free_text("user a@b.invalid could not apply S-1-5-21-1-2-3-1001");
+        assert!(!masked.contains("a@b.invalid"), "got {masked}");
+        assert!(!masked.contains("S-1-5-21"), "got {masked}");
+        assert!(masked.contains("could not apply"), "got {masked}");
+    }
+
+    #[test]
+    fn free_text_masking_is_idempotent() {
+        let scope = scope();
+        let once = scope.free_text("owner S-1-5-21-1-2-3-1001 at a@b.invalid");
+        assert_eq!(scope.free_text(&once), once);
+    }
+
+    #[test]
+    fn a_sensitive_record_keeps_the_identifiers_the_diagnosis_is_built_from() {
+        let scope = scope();
+        let source = redact_named_value(
+            &IntuneNamedValue {
+                name: "ConfigurationSourceId".to_owned(),
+                value: "11111111-1111-4111-8111-111111111111".to_owned(),
+            },
+            &IntuneSensitivity::Sensitive,
+            &scope,
+        );
+        assert_eq!(source.value, "11111111-1111-4111-8111-111111111111");
+
+        let other = redact_named_value(
+            &IntuneNamedValue {
+                name: "Comment".to_owned(),
+                value: "set by the helpdesk".to_owned(),
+            },
+            &IntuneSensitivity::Sensitive,
+            &scope,
+        );
+        assert!(
+            other.value.starts_with("[redacted:"),
+            "a sensitive record's free text is replaced wholesale, got {}",
+            other.value
+        );
+    }
+
+    #[test]
+    fn a_uri_valued_named_entry_is_scrubbed_rather_than_replaced() {
+        let entry = redact_named_value(
+            &IntuneNamedValue {
+                name: "NodeUri".to_owned(),
+                value: "./Device/Vendor/MSFT/Policy/Config/S-1-5-21-1-2-3-1001/Setting".to_owned(),
+            },
+            &IntuneSensitivity::Public,
+            &scope(),
+        );
+        assert!(
+            entry.value.contains("Vendor/MSFT/Policy"),
+            "got {}",
+            entry.value
+        );
+        assert!(!entry.value.contains("S-1-5-21"), "got {}", entry.value);
+    }
+
+    #[test]
+    fn a_restricted_record_contributes_no_free_text_at_all() {
+        let entry = redact_named_value(
+            &IntuneNamedValue {
+                name: "NodeUri".to_owned(),
+                value: "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate".to_owned(),
+            },
+            &IntuneSensitivity::Restricted,
+            &scope(),
+        );
+        assert!(entry.value.starts_with("[redacted:"), "got {}", entry.value);
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
@@ -197,9 +197,11 @@ pub(super) fn analysis_scope_digest(
     analysis_scope: Option<&str>,
     generated_at_utc: &str,
 ) -> Option<String> {
-    let scope = analysis_scope
-        .map(str::trim)
-        .filter(|scope| !scope.is_empty())?;
+    // Only a whitespace-only value means "no identity". Every other value is
+    // hashed verbatim: trimming first would make `"a"` and `" a "` the same
+    // analysis, and the crate cannot know which bytes a caller's identity
+    // scheme treats as significant.
+    let scope = analysis_scope.filter(|scope| !scope.trim().is_empty())?;
     let mut material = scope.as_bytes().to_vec();
     material.push(SCOPE_SEPARATOR);
     material.extend_from_slice(generated_at_utc.as_bytes());
@@ -653,6 +655,27 @@ mod tests {
         let first = scope_of(Some("analysis-a"), INSTANT);
         let second = scope_of(Some("analysis-b"), INSTANT);
         assert_ne!(first.token("secret"), second.token("secret"));
+    }
+
+    #[test]
+    fn scopes_differing_only_in_surrounding_whitespace_stay_distinct() {
+        // Trimming before hashing normalized two distinct caller identities
+        // into one digest, so `"analysis-a"` and `" analysis-a "` minted the
+        // same tokens and their exports could be joined. Only a whitespace-only
+        // scope means "no identity"; every other value is hashed verbatim,
+        // because the crate cannot know which bytes a caller considers
+        // significant.
+        let first = scope_of(Some("analysis-a"), INSTANT);
+        let second = scope_of(Some(" analysis-a "), INSTANT);
+        assert_ne!(first.token("secret"), second.token("secret"));
+    }
+
+    #[test]
+    fn a_whitespace_only_scope_is_no_scope_at_all() {
+        // The one normalization that survives: a blank string is an absent
+        // identity, not an identity made of spaces.
+        assert!(analysis_scope_digest(Some("   "), INSTANT).is_none());
+        assert!(analysis_scope_digest(Some(""), INSTANT).is_none());
     }
 
     #[test]

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
@@ -321,6 +321,7 @@ fn redact_setting(setting: &ConfigurationSetting, scope: &RedactionScope) -> Con
         time_is_reliable: setting.time_is_reliable,
         ordering_is_contradictory: setting.ordering_is_contradictory,
         has_uninterpretable_evidence: setting.has_uninterpretable_evidence,
+        has_unassessable_failure: setting.has_unassessable_failure,
         observations: setting
             .observations
             .iter()

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
@@ -42,9 +42,10 @@
 //! - Values equal within one scope produce equal tokens; values that differ
 //!   produce different tokens (barring hash collision). That is what makes a
 //!   conflict legible inside one export.
-//! - Two analyses that supply *different* scope values never produce the same
-//!   token for the same value, so their exports cannot be joined by comparing
-//!   tokens.
+//! - Two analyses that supply *different* scope values do not produce the same
+//!   token for the same value (barring hash collision, the same qualification
+//!   the differing-values guarantee above carries), so their exports cannot be
+//!   joined by comparing tokens.
 //!
 //! ## What it does not guarantee
 //!

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
@@ -1,0 +1,260 @@
+//! Deterministic redaction for the default export.
+//!
+//! Configuration values are arbitrary tenant data: a proxy URL, a certificate
+//! subject, a wallpaper path, a user principal name. The default export must not
+//! carry them, but simply deleting them destroys the one comparison that matters
+//! most — whether two configuration sources are fighting over the *same* value or
+//! two different ones.
+//!
+//! So a redacted value becomes `[redacted:<hash>]`, where the hash is FNV-1a over
+//! the original bytes. Equal inputs produce equal tokens, so a conflict stays
+//! legible after redaction, and the token is stable across runs and machines,
+//! which is what makes it golden-testable.
+//!
+//! FNV is used rather than a cryptographic digest because this crate takes no new
+//! dependencies and the token is a correlation aid, not an authentication tag.
+//! It is not a defense against an attacker who can guess a value and confirm it;
+//! nothing in this file claims to be.
+
+use crate::intune::evidence::{IntuneNamedValue, IntuneSensitivity};
+
+use super::models::{
+    ConfigurationObservation, ConfigurationSetting, ConfigurationSnapshot,
+    ConfigurationSourceStatement,
+};
+
+/// Named-value keys whose contents are redacted regardless of classification.
+///
+/// The value-bearing keys are here for the same reason the typed fields are
+/// tokenized: a configuration value is arbitrary tenant data, and leaving the
+/// `namedData` copy of it intact would have made the field-level redaction
+/// pointless. The same applies to `EnrollmentId`, which is also tokenized in
+/// [`ConfigurationObservation::enrollment_id`].
+const SENSITIVE_NAMES: [&str; 24] = [
+    "Value",
+    "SettingValue",
+    "PreviousValue",
+    "Data",
+    "EnrollmentId",
+    "EnrollmentName",
+    "User",
+    "UserName",
+    "CurrentUser",
+    "Upn",
+    "UserPrincipalName",
+    "Sid",
+    "Account",
+    "Email",
+    "Owner",
+    "Token",
+    "AccessToken",
+    "Secret",
+    "Password",
+    "Path",
+    "FilePath",
+    "DeviceName",
+    "SerialNumber",
+    "TenantId",
+];
+
+/// Return a copy of the snapshot with every value-bearing field redacted.
+///
+/// The snapshot's structure, identities, states, findings, and coverage are
+/// untouched: those are the diagnosis, and redacting them would defeat the
+/// export. Only free-text values are replaced.
+pub fn redacted_configuration_snapshot(snapshot: &ConfigurationSnapshot) -> ConfigurationSnapshot {
+    let mut redacted = snapshot.clone();
+    redacted.settings = snapshot.settings.iter().map(redact_setting).collect();
+    redacted.unattributed = snapshot
+        .unattributed
+        .iter()
+        .map(redact_observation)
+        .collect();
+    redacted.redacted = true;
+    redacted
+}
+
+/// The deterministic replacement token for one value.
+pub fn redaction_token(value: &str) -> String {
+    format!("[redacted:{:016x}]", fnv1a64(value.as_bytes()))
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET_BASIS;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+fn redact_setting(setting: &ConfigurationSetting) -> ConfigurationSetting {
+    let mut redacted = setting.clone();
+    redacted.identity = redact_identity(&setting.identity);
+    redacted.applied_value = setting.applied_value.as_deref().map(redaction_token);
+    redacted.observations = setting
+        .observations
+        .iter()
+        .map(redact_observation)
+        .collect();
+    redacted.sources = setting
+        .sources
+        .iter()
+        .map(redact_source_statement)
+        .collect();
+    redacted
+}
+
+fn redact_source_statement(
+    statement: &ConfigurationSourceStatement,
+) -> ConfigurationSourceStatement {
+    // A configuration source id is a policy identifier, not an identity, and the
+    // whole point of the conflict findings is to name which policies collided.
+    // It is left intact deliberately.
+    statement.clone()
+}
+
+fn redact_observation(observation: &ConfigurationObservation) -> ConfigurationObservation {
+    let mut redacted = observation.clone();
+    redacted.identity = redact_identity(&observation.identity);
+    redacted.value = observation.value.as_deref().map(redaction_token);
+    // An enrollment id identifies this device's enrollment, so it is tokenized
+    // rather than dropped: correlating two records to the same enrollment stays
+    // possible without disclosing which enrollment it is.
+    redacted.enrollment_id = observation.enrollment_id.as_deref().map(redaction_token);
+    redacted.named_data = observation
+        .named_data
+        .iter()
+        .map(|entry| redact_named_value(entry, &observation.sensitivity))
+        .collect();
+    redacted
+}
+
+fn redact_named_value(
+    entry: &IntuneNamedValue,
+    sensitivity: &IntuneSensitivity,
+) -> IntuneNamedValue {
+    let redact = matches!(sensitivity, IntuneSensitivity::Restricted)
+        || SENSITIVE_NAMES
+            .iter()
+            .any(|name| entry.name.eq_ignore_ascii_case(name))
+        || looks_like_identity(&entry.value);
+
+    IntuneNamedValue {
+        name: entry.name.clone(),
+        value: if redact {
+            redaction_token(&entry.value)
+        } else {
+            entry.value.clone()
+        },
+    }
+}
+
+/// Redact only the URI segments that carry identity, keeping the node path.
+///
+/// A CSP node path is the single most useful thing in the output and must
+/// survive. Some nodes embed a SID or account name as a segment, and those
+/// segments are tokenized. Because the dedupe key is derived from the same
+/// string, it is scrubbed with the same function so a redacted snapshot stays
+/// internally consistent.
+fn redact_identity(
+    identity: &super::identity::ConfigurationSettingIdentity,
+) -> super::identity::ConfigurationSettingIdentity {
+    let mut redacted = identity.clone();
+    redacted.canonical_uri = identity.canonical_uri.as_deref().map(scrub_uri);
+    redacted.raw_uri = identity.raw_uri.as_deref().map(scrub_uri);
+    redacted.resource_path = identity.resource_path.as_deref().map(scrub_uri);
+    redacted.key = scrub_uri(&identity.key);
+    redacted
+}
+
+fn scrub_uri(uri: &str) -> String {
+    uri.split('/')
+        .map(|segment| {
+            if looks_like_identity(segment) {
+                redaction_token(segment)
+            } else {
+                segment.to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Whether a free-text value carries identity, path, or credential material.
+///
+/// GUIDs are deliberately *not* matched: policy, configuration source, and
+/// setting identifiers are GUIDs, and tokenizing them would remove the only
+/// handle an administrator has for finding the offending policy in the portal.
+pub fn looks_like_identity(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if is_windows_sid(trimmed) {
+        return true;
+    }
+    if is_mail_like(trimmed) {
+        return true;
+    }
+    if trimmed.contains(":\\") || trimmed.starts_with("\\\\") || trimmed.contains("/Users/") {
+        return true;
+    }
+    // JWTs and bearer tokens.
+    trimmed.starts_with("eyJ") || trimmed.to_ascii_lowercase().contains("bearer ")
+}
+
+fn is_windows_sid(value: &str) -> bool {
+    let Some(rest) = value.strip_prefix("S-1-") else {
+        return false;
+    };
+    rest.matches('-').count() >= 2
+        && rest
+            .chars()
+            .all(|character| character.is_ascii_digit() || character == '-')
+}
+
+fn is_mail_like(value: &str) -> bool {
+    let Some((local, domain)) = value.split_once('@') else {
+        return false;
+    };
+    !local.is_empty() && domain.contains('.') && !domain.contains(' ')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_same_value_always_redacts_to_the_same_token() {
+        assert_eq!(redaction_token("secret"), redaction_token("secret"));
+        assert_ne!(redaction_token("secret"), redaction_token("other"));
+    }
+
+    #[test]
+    fn the_token_is_a_fixed_width_stable_string() {
+        // Pinned so a change to the hashing scheme cannot pass unnoticed: every
+        // committed golden fixture depends on this exact value.
+        assert_eq!(redaction_token("1"), "[redacted:af63ac4c86019afc]");
+    }
+
+    #[test]
+    fn identity_detection_covers_sids_upns_and_paths_but_not_guids() {
+        assert!(looks_like_identity("S-1-5-21-1-2-3-1001"));
+        assert!(looks_like_identity("someone@example.invalid"));
+        assert!(looks_like_identity("D:\\Data\\wallpaper.png"));
+        assert!(looks_like_identity("\\\\server\\share"));
+        assert!(looks_like_identity("eyJhbGciOiJIUzI1NiJ9.e30"));
+        assert!(!looks_like_identity("11111111-1111-4111-8111-111111111111"));
+        assert!(!looks_like_identity("Update/AllowAutoUpdate"));
+    }
+
+    #[test]
+    fn scrubbing_a_uri_keeps_the_node_path_and_tokenizes_only_identity_segments() {
+        let scrubbed = scrub_uri("Device/Vendor/MSFT/Policy/Config/S-1-5-21-1-2-3-1001/Setting");
+        assert!(scrubbed.starts_with("Device/Vendor/MSFT/Policy/Config/[redacted:"));
+        assert!(scrubbed.ends_with("/Setting"));
+    }
+}

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/redaction.rs
@@ -25,19 +25,49 @@
 //! caller-supplied key, and equality scope as **provisional**, and forbids a new
 //! reducer from introducing a stable identifier token intended for cross-artifact,
 //! cross-session, or cross-export correlation. This module therefore scopes token
-//! equality to **one analysis**: the hash is salted with the snapshot's
-//! `generatedAtUtc`, so two settings inside one export that carry the same value
-//! still show the same token — which is the equality the conflict diagnosis needs
-//! — while two separate exports of the same device produce different tokens and
-//! cannot be joined.
+//! equality to **one analysis**, and takes the identity of that analysis from the
+//! caller: [`ConfigurationInput::analysis_scope`]. Every token in one export is
+//! salted with it, so two settings carrying the same value still show the same
+//! token — the equality the conflict diagnosis needs — while an export made under
+//! a different scope shares no token vocabulary with it.
 //!
-//! No keyed-token API is invented here. Defining one (a caller-supplied secret,
-//! a documented equality scope, and the tests that pin it) is the Store pilot's
-//! decision under ADR-004, and this module adopts it when it lands. Until then
-//! the honest statement of what the token defends is: it prevents casual
-//! disclosure and cross-export correlation. It is not a defense against an
-//! attacker who can enumerate candidate values and confirm a match *within a
-//! single export*, because the salt travels with the export.
+//! An earlier revision salted with the snapshot's `generatedAtUtc` and claimed
+//! that no two exports could share it. That claim was false. A second-resolution
+//! UTC timestamp is not a nonce: two independent analyses can legitimately carry
+//! the same instant, and when they did they minted identical tokens for identical
+//! values, so the cross-export join ADR-004 forbids still worked.
+//!
+//! ## What the scope guarantees
+//!
+//! - Values equal within one scope produce equal tokens; values that differ
+//!   produce different tokens (barring hash collision). That is what makes a
+//!   conflict legible inside one export.
+//! - Two analyses that supply *different* scope values never produce the same
+//!   token for the same value, so their exports cannot be joined by comparing
+//!   tokens.
+//!
+//! ## What it does not guarantee
+//!
+//! - **It does not make uniqueness true; it only consumes it.** The caller owns
+//!   analysis identity. Nothing in a pure, `wasm32-unknown-unknown`-clean crate
+//!   with no clock, no entropy source, and no state surviving a restart can mint
+//!   a unique identifier, and this module does not pretend otherwise. Two
+//!   analyses that supply the same scope value are joinable — deliberately, since
+//!   that is the caller declaring them one analysis.
+//! - **Omitting the scope buys no isolation.** With `analysis_scope: None` the
+//!   salt falls back to `generatedAtUtc` alone, which is precisely the defective
+//!   arrangement above; it is retained only so equality still holds inside the
+//!   one export. Such a snapshot reports [`ConfigurationSnapshot::analysis_scope`]
+//!   as `None`, which is the export saying it makes no cross-export claim.
+//! - **The token is not keyed.** The salt is derived from material that travels
+//!   with the export, so it is no defense against an attacker who can enumerate
+//!   candidate values and confirm a match *within a single export*. Defining a
+//!   keyed-token API — a caller-supplied secret, a documented equality scope, and
+//!   the tests that pin it — is the Store pilot's decision under ADR-004, and
+//!   this module adopts it when it lands rather than inventing a local one.
+//!
+//! [`ConfigurationInput::analysis_scope`]: super::models::ConfigurationInput::analysis_scope
+//! [`ConfigurationSnapshot::analysis_scope`]: ConfigurationSnapshot::analysis_scope
 //!
 //! Free-text spans are masked by the family-owned
 //! [`crate::intune::apps::windows::common::redact_text`], which is where
@@ -142,19 +172,60 @@ const DIAGNOSTIC_NAMES: [&str; 15] = [
 const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
 const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
+/// Separator between the caller's scope value and the generation instant.
+///
+/// ASCII unit separator, chosen because it cannot occur in a well-formed
+/// ISO-8601 instant: that keeps the two components unambiguous however odd a
+/// scope value the caller picks. It is not claimed to be injection-proof against
+/// a caller that puts a unit separator in *both* fields — such a caller has
+/// composed its own ambiguity, and the scope it gets is the scope it described.
+const SCOPE_SEPARATOR: u8 = 0x1f;
+
+/// Digest of one analysis's redaction scope, or `None` when the caller declined
+/// to supply one.
+///
+/// This is what [`ConfigurationSnapshot::analysis_scope`] carries: the caller's
+/// own identifier never reaches the export, because a caller is free to use a
+/// serial number or a case title as its scope and this module exists to keep
+/// exactly that kind of string out of an exported artifact.
+///
+/// A caller-supplied value that is blank or only whitespace is treated as absent
+/// rather than as the scope `""`, so an empty configuration field cannot look
+/// like a boundary that was never established.
+pub(super) fn analysis_scope_digest(
+    analysis_scope: Option<&str>,
+    generated_at_utc: &str,
+) -> Option<String> {
+    let scope = analysis_scope
+        .map(str::trim)
+        .filter(|scope| !scope.is_empty())?;
+    let mut material = scope.as_bytes().to_vec();
+    material.push(SCOPE_SEPARATOR);
+    material.extend_from_slice(generated_at_utc.as_bytes());
+    Some(format!("{:016x}", fnv1a64(FNV_OFFSET_BASIS, &material)))
+}
+
 /// The redaction scope of one analysis.
 ///
-/// Constructed from the snapshot's own `generatedAtUtc`, which is the only
-/// identifier of "this analysis" the pure crate is given. Every token in one
-/// export shares this scope; no two exports share it.
+/// Built from the snapshot's scope digest when it has one, and from its
+/// `generatedAtUtc` when it does not. Every token in one export shares this
+/// scope. Two exports share it exactly when the caller gave them the same
+/// analysis identity — or when neither was given one and both were generated at
+/// the same instant, which is the case the module docs decline to call
+/// isolation.
 struct RedactionScope {
     salt: u64,
 }
 
 impl RedactionScope {
-    fn new(analysis_id: &str) -> Self {
+    /// `scope_digest` is [`analysis_scope_digest`]'s output, not the caller's
+    /// raw scope value: the snapshot only ever carries the digest, and taking
+    /// the salt from anything else would make an export's tokens depend on
+    /// material the export does not carry.
+    fn new(scope_digest: Option<&str>, generated_at_utc: &str) -> Self {
+        let material = scope_digest.unwrap_or(generated_at_utc);
         Self {
-            salt: fnv1a64(FNV_OFFSET_BASIS, analysis_id.as_bytes()),
+            salt: fnv1a64(FNV_OFFSET_BASIS, material.as_bytes()),
         }
     }
 
@@ -272,13 +343,20 @@ fn upn_regex() -> &'static Regex {
 /// diagnosis, and ADR-004 requires redaction to leave non-sensitive conclusions
 /// alone. Only free text is replaced.
 pub fn redacted_configuration_snapshot(snapshot: &ConfigurationSnapshot) -> ConfigurationSnapshot {
-    let scope = RedactionScope::new(&snapshot.generated_at_utc);
+    let scope = RedactionScope::new(
+        snapshot.analysis_scope.as_deref(),
+        &snapshot.generated_at_utc,
+    );
 
     // Written as a struct literal on purpose: adding a field to the snapshot must
     // not silently inherit an un-redacted value from a `clone()`.
     ConfigurationSnapshot {
         schema_version: snapshot.schema_version,
         generated_at_utc: snapshot.generated_at_utc.clone(),
+        // Carried through unchanged: it is already a digest, and it is what lets
+        // a consumer tell that this export's tokens are not comparable with
+        // another's. Re-tokenizing it would destroy that statement.
+        analysis_scope: snapshot.analysis_scope.clone(),
         settings: snapshot
             .settings
             .iter()
@@ -530,8 +608,20 @@ fn is_mail_like(value: &str) -> bool {
 mod tests {
     use super::*;
 
+    const INSTANT: &str = "2026-07-31T10:00:00Z";
+
+    /// Resolve a scope exactly the way the pipeline does: the reducer digests the
+    /// caller's value onto the snapshot, and the export salts from that digest.
+    /// A test that skipped either step could pass while the pipeline collided.
+    fn scope_of(analysis_scope: Option<&str>, generated_at_utc: &str) -> RedactionScope {
+        RedactionScope::new(
+            analysis_scope_digest(analysis_scope, generated_at_utc).as_deref(),
+            generated_at_utc,
+        )
+    }
+
     fn scope() -> RedactionScope {
-        RedactionScope::new("2026-07-31T10:00:00Z")
+        scope_of(Some("test-analysis"), INSTANT)
     }
 
     #[test]
@@ -546,9 +636,56 @@ mod tests {
         // ADR-004: a new reducer must not introduce a token that joins two
         // exports. Pinning the *inequality* is what stops a future refactor from
         // quietly restoring a globally stable dictionary of low-entropy values.
-        let first = RedactionScope::new("2026-07-31T10:00:00Z");
-        let second = RedactionScope::new("2026-08-01T10:00:00Z");
+        let first = scope_of(Some("analysis-a"), INSTANT);
+        let second = scope_of(Some("analysis-b"), "2026-08-01T10:00:00Z");
         assert_ne!(first.token("1"), second.token("1"));
+    }
+
+    #[test]
+    fn two_analyses_that_share_a_generated_at_utc_do_not_share_a_token() {
+        // The defect this pins: `generatedAtUtc` is a timestamp, not a nonce.
+        // Two independent analyses can legitimately carry the same
+        // second-resolution instant, and when the scope was nothing but that
+        // instant they minted identical tokens for identical values — exactly
+        // the cross-export join ADR-004 forbids. The scope is now the caller's
+        // analysis identity, so the shared instant no longer joins them.
+        let first = scope_of(Some("analysis-a"), INSTANT);
+        let second = scope_of(Some("analysis-b"), INSTANT);
+        assert_ne!(first.token("secret"), second.token("secret"));
+    }
+
+    #[test]
+    fn one_analysis_split_across_two_projections_keeps_its_tokens() {
+        // The other half of the boundary: the same analysis identity must still
+        // mint the same token, or a conflict stops being legible the moment a
+        // caller projects the snapshot twice.
+        let first = scope_of(Some("analysis-a"), INSTANT);
+        let second = scope_of(Some("analysis-a"), INSTANT);
+        assert_eq!(first.token("secret"), second.token("secret"));
+    }
+
+    #[test]
+    fn an_omitted_scope_is_documented_as_no_boundary_at_all() {
+        // Not an endorsement: this pins the disclaimer so it cannot quietly
+        // become a claim. With no caller scope the salt is the timestamp alone,
+        // two analyses sharing an instant do collide, and the snapshot says so
+        // by carrying no scope digest.
+        assert_eq!(analysis_scope_digest(None, INSTANT), None);
+        assert_eq!(analysis_scope_digest(Some("   "), INSTANT), None);
+        assert_eq!(
+            scope_of(None, INSTANT).token("secret"),
+            scope_of(None, INSTANT).token("secret")
+        );
+    }
+
+    #[test]
+    fn the_scope_digest_does_not_republish_the_callers_scope_value() {
+        let digest =
+            analysis_scope_digest(Some("case-4711/DESKTOP-ABC123"), INSTANT).expect("a digest");
+        assert_eq!(digest.len(), 16);
+        assert!(digest.bytes().all(|byte| byte.is_ascii_hexdigit()));
+        assert!(!digest.contains("case-4711"));
+        assert!(!digest.contains("DESKTOP"));
     }
 
     #[test]
@@ -556,7 +693,7 @@ mod tests {
         // Pinned so a change to the hashing scheme cannot pass unnoticed. The
         // scope is named explicitly: the value alone no longer determines the
         // token, which is the point.
-        assert_eq!(scope().token("1"), "[redacted:187c4fa5b79764ea]");
+        assert_eq!(scope().token("1"), "[redacted:68b803c6400ef40f]");
     }
 
     #[test]

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
@@ -6,6 +6,7 @@
 //! contributing observation so a rule can cite the competing evidence rather than
 //! assert an outcome.
 
+use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
@@ -21,6 +22,7 @@ use super::models::{
 };
 use super::sources::{
     is_device_side, is_service_side, observation_from_event, observation_from_report,
+    same_source_id,
 };
 
 /// Project every input record and fold it into per-setting transactions.
@@ -225,107 +227,181 @@ fn local_state(observations: &[ConfigurationObservation]) -> ConfigurationLocalS
 
 /// Several device-side terminal dispositions for one setting.
 ///
-/// A removal following an application is a lifecycle, not a disagreement: the
-/// setting was applied and then deleted, and `Removed` is the current fact.
-/// The same holds for a conflict or supersedence recorded alongside an
-/// application, where the losing write genuinely did happen first. Anything else
-/// is a real disagreement and stays `Contested` so a rule must cite both sides.
+/// Two mechanisms settle this, in order, and neither is caller order.
+///
+/// 1. **Explicit linkage.** A row that reports a conflict or a supersedence and
+///    *names the source that beat it*, with that source present in the same
+///    bundle, has stated the relationship outright. ADR-002 calls an explicit
+///    shared key strong correlation, and this is the shape real MDM report
+///    snapshots actually emit: the losing row carries `WinningPolicyId` or
+///    `SupersededBy` and the winning row is simply `Applied`. Requiring the
+///    *loser* to also emit an `Applied` row — which reports do not do — was what
+///    made both headline scenarios unreachable.
+/// 2. **Last terminal disposition.** Failing an explicit link, a lifecycle is
+///    read from a comparable record order, and the current fact is the *last*
+///    disposition in it. `[Applied, Removed, Applied]` is a re-application, not a
+///    removal, and `[Removed, Applied]` (unassign, then re-assign) is not a
+///    disagreement.
+///
+/// Only the lifecycle dispositions participate in step 2. A `Rejected` or
+/// `NotApplicable` mixed with anything else is a genuine disagreement about what
+/// the CSP did, and ADR-003 forbids letting a later-looking success quietly
+/// replace a failure without explicit retry linkage. Those stay `Contested` so a
+/// rule must cite both sides.
 fn reconcile_multiple_local(
     terminal: &[ConfigurationDisposition],
     observations: &[ConfigurationObservation],
 ) -> ConfigurationLocalState {
+    if let Some(state) = explicitly_linked_state(terminal, observations) {
+        return state;
+    }
+    if !terminal.iter().copied().all(is_lifecycle_disposition) {
+        return ConfigurationLocalState::Contested;
+    }
     let Some(ordered) = ordered_terminal_dispositions(observations) else {
         return ConfigurationLocalState::Contested;
     };
-    let has = |disposition: ConfigurationDisposition| terminal.contains(&disposition);
-    let applied_precedes = |disposition: ConfigurationDisposition| {
-        ordered
-            .iter()
-            .position(|candidate| *candidate == ConfigurationDisposition::Applied)
-            .zip(
-                ordered
-                    .iter()
-                    .position(|candidate| *candidate == disposition),
-            )
-            .is_some_and(|(applied, terminal)| applied < terminal)
-    };
+    match ordered.last() {
+        Some(ConfigurationDisposition::Applied) => ConfigurationLocalState::Applied,
+        Some(ConfigurationDisposition::Removed) => ConfigurationLocalState::Removed,
+        Some(ConfigurationDisposition::Superseded) => ConfigurationLocalState::Superseded,
+        Some(ConfigurationDisposition::Conflict) => ConfigurationLocalState::Conflicted,
+        _ => ConfigurationLocalState::Contested,
+    }
+}
 
-    if has(ConfigurationDisposition::Removed)
-        && terminal.iter().all(|d| {
-            matches!(
-                d,
-                ConfigurationDisposition::Removed | ConfigurationDisposition::Applied
-            )
-        })
-        && applied_precedes(ConfigurationDisposition::Removed)
-    {
-        return ConfigurationLocalState::Removed;
+/// Whether a disposition describes a stage of one setting's life rather than a
+/// verdict that contradicts another verdict.
+fn is_lifecycle_disposition(disposition: ConfigurationDisposition) -> bool {
+    matches!(
+        disposition,
+        ConfigurationDisposition::Applied
+            | ConfigurationDisposition::Removed
+            | ConfigurationDisposition::Superseded
+            | ConfigurationDisposition::Conflict
+    )
+}
+
+/// The state implied by a losing row that names its winner, when the winner is
+/// also in the bundle.
+///
+/// Returns `None` when no such link exists, when the terminal set contains
+/// something the link cannot explain, or when the only "link" is a row naming
+/// itself.
+fn explicitly_linked_state(
+    terminal: &[ConfigurationDisposition],
+    observations: &[ConfigurationObservation],
+) -> Option<ConfigurationLocalState> {
+    let explainable = terminal.iter().all(|disposition| {
+        matches!(
+            disposition,
+            ConfigurationDisposition::Applied
+                | ConfigurationDisposition::Conflict
+                | ConfigurationDisposition::Superseded
+        )
+    });
+    if !explainable {
+        return None;
     }
-    if has(ConfigurationDisposition::Superseded)
-        && terminal.iter().all(|d| {
-            matches!(
-                d,
-                ConfigurationDisposition::Superseded | ConfigurationDisposition::Applied
-            )
-        })
-        && applied_precedes(ConfigurationDisposition::Superseded)
-    {
-        return ConfigurationLocalState::Superseded;
+
+    if linked_source_is_observed(
+        observations,
+        ConfigurationDisposition::Conflict,
+        |observation| observation.winning_source_id.as_deref(),
+    ) {
+        return Some(ConfigurationLocalState::Conflicted);
     }
-    if has(ConfigurationDisposition::Conflict)
-        && terminal.iter().all(|d| {
-            matches!(
-                d,
-                ConfigurationDisposition::Conflict | ConfigurationDisposition::Applied
-            )
-        })
-        && applied_precedes(ConfigurationDisposition::Conflict)
-    {
-        return ConfigurationLocalState::Conflicted;
+    if linked_source_is_observed(
+        observations,
+        ConfigurationDisposition::Superseded,
+        |observation| observation.superseded_by_source_id.as_deref(),
+    ) {
+        return Some(ConfigurationLocalState::Superseded);
     }
-    ConfigurationLocalState::Contested
+    None
+}
+
+/// Whether some record with `disposition` names another source that the bundle
+/// actually contains.
+fn linked_source_is_observed(
+    observations: &[ConfigurationObservation],
+    disposition: ConfigurationDisposition,
+    named: fn(&ConfigurationObservation) -> Option<&str>,
+) -> bool {
+    observations
+        .iter()
+        .filter(|observation| is_device_side(observation) && observation.disposition == disposition)
+        .filter_map(|observation| named(observation).map(|link| (observation, link)))
+        .any(|(observation, link)| {
+            // A row naming itself as its own winner substantiates nothing.
+            let names_another = observation
+                .source_id
+                .as_deref()
+                .is_none_or(|own| !same_source_id(own, link));
+            names_another
+                && observations.iter().any(|candidate| {
+                    candidate
+                        .source_id
+                        .as_deref()
+                        .is_some_and(|source| same_source_id(source, link))
+                })
+        })
 }
 
 /// Return terminal dispositions in their evidence order, when that order is
-/// comparable. Record ordinals and reliable timestamps must describe one artifact;
-/// otherwise a lifecycle conclusion would be inferred from an unordered set.
+/// comparable.
+///
+/// Records are deduplicated by artifact and record ordinal *before* the
+/// comparability guard runs. Re-collecting the same channel, or collecting it
+/// twice under two artifact ids, previously made this refuse and degraded a clean
+/// `configuration-removed` into a contested-evidence error: duplication was
+/// making the diagnosis worse. Two artifacts are accepted only when they yield
+/// the identical sequence, which is what a duplicate collection looks like; two
+/// artifacts telling different stories stay incomparable.
 fn ordered_terminal_dispositions(
     observations: &[ConfigurationObservation],
 ) -> Option<Vec<ConfigurationDisposition>> {
-    let mut terminal = observations
+    let terminal = observations
         .iter()
         .filter(|observation| is_device_side(observation) && observation.disposition.is_terminal())
         .collect::<Vec<_>>();
     if terminal.len() < 2 || ordering_is_contradictory(observations) {
         return None;
     }
-    let artifact = terminal.first()?.evidence_ref.source_artifact_id.as_str();
-    if terminal
-        .iter()
-        .any(|observation| observation.evidence_ref.source_artifact_id != artifact)
-    {
+
+    let mut by_artifact: BTreeMap<&str, BTreeMap<u64, ConfigurationDisposition>> = BTreeMap::new();
+    for observation in &terminal {
+        let (Some(record_id), Some(_)) =
+            (observation.record_id, observation.occurred_at_utc.as_ref())
+        else {
+            return None;
+        };
+        if !observation.time_is_reliable {
+            return None;
+        }
+        match by_artifact
+            .entry(observation.evidence_ref.source_artifact_id.as_str())
+            .or_default()
+            .entry(record_id)
+        {
+            Entry::Vacant(slot) => {
+                slot.insert(observation.disposition);
+            }
+            // One ordinal in one artifact cannot have said two different things;
+            // that is a broken collection, not a lifecycle.
+            Entry::Occupied(slot) if *slot.get() != observation.disposition => return None,
+            Entry::Occupied(_) => {}
+        }
+    }
+
+    let mut sequences = by_artifact
+        .into_values()
+        .map(|records| records.into_values().collect::<Vec<_>>());
+    let first = sequences.next()?;
+    if sequences.any(|sequence| sequence != first) || first.len() < 2 {
         return None;
     }
-    if terminal.iter().any(|observation| {
-        observation.record_id.is_none()
-            || !observation.time_is_reliable
-            || observation.occurred_at_utc.is_none()
-    }) {
-        return None;
-    }
-    terminal.sort_by_key(|observation| observation.record_id);
-    if terminal
-        .windows(2)
-        .any(|pair| pair[0].record_id == pair[1].record_id)
-    {
-        return None;
-    }
-    Some(
-        terminal
-            .iter()
-            .map(|observation| observation.disposition)
-            .collect(),
-    )
+    Some(first)
 }
 
 fn service_state(observations: &[ConfigurationObservation]) -> ConfigurationServiceState {
@@ -607,6 +683,236 @@ mod tests {
                 ConfigurationServiceState::ReportedSuccess,
             ),
             ConfigurationResolution::Removed
+        );
+    }
+
+    /// `[Applied, Removed, Applied]` is a re-application. Reading the *first*
+    /// index of each disposition reported `Removed`, which is the opposite of
+    /// what the last record says happened.
+    #[test]
+    fn a_re_application_after_a_removal_is_applied() {
+        let observations = vec![
+            observation(
+                "apply",
+                ConfigurationDisposition::Applied,
+                Some(1),
+                Some("2026-07-31T09:00:00Z"),
+            ),
+            observation(
+                "remove",
+                ConfigurationDisposition::Removed,
+                Some(2),
+                Some("2026-07-31T10:00:00Z"),
+            ),
+            observation(
+                "reapply",
+                ConfigurationDisposition::Applied,
+                Some(3),
+                Some("2026-07-31T11:00:00Z"),
+            ),
+        ];
+        assert_eq!(local_state(&observations), ConfigurationLocalState::Applied);
+    }
+
+    /// Unassign, then re-assign. The old first-index comparison failed the guard
+    /// here and reported a disagreement at Error severity.
+    #[test]
+    fn a_removal_followed_by_an_application_is_applied_not_contested() {
+        let observations = vec![
+            observation(
+                "remove",
+                ConfigurationDisposition::Removed,
+                Some(1),
+                Some("2026-07-31T09:00:00Z"),
+            ),
+            observation(
+                "apply",
+                ConfigurationDisposition::Applied,
+                Some(2),
+                Some("2026-07-31T10:00:00Z"),
+            ),
+        ];
+        assert_eq!(local_state(&observations), ConfigurationLocalState::Applied);
+    }
+
+    #[test]
+    fn a_rejection_alongside_an_application_is_never_resolved_by_order() {
+        // ADR-003: a later-looking success may not replace a failure without
+        // explicit retry linkage, which no configuration source supplies.
+        let observations = vec![
+            observation(
+                "reject",
+                ConfigurationDisposition::Rejected,
+                Some(1),
+                Some("2026-07-31T09:00:00Z"),
+            ),
+            observation(
+                "apply",
+                ConfigurationDisposition::Applied,
+                Some(2),
+                Some("2026-07-31T10:00:00Z"),
+            ),
+        ];
+        assert_eq!(
+            local_state(&observations),
+            ConfigurationLocalState::Contested
+        );
+    }
+
+    #[test]
+    fn re_collecting_the_same_record_does_not_escalate_a_clean_lifecycle() {
+        let apply = observation(
+            "apply",
+            ConfigurationDisposition::Applied,
+            Some(1),
+            Some("2026-07-31T09:00:00Z"),
+        );
+        let remove = observation(
+            "remove",
+            ConfigurationDisposition::Removed,
+            Some(2),
+            Some("2026-07-31T10:00:00Z"),
+        );
+        let mut duplicate = remove.clone();
+        duplicate.evidence_ref.evidence_id = "remove-again".to_owned();
+        assert_eq!(
+            local_state(&[apply, remove, duplicate]),
+            ConfigurationLocalState::Removed,
+            "a duplicated record must not turn a removal into a disagreement"
+        );
+    }
+
+    #[test]
+    fn collecting_one_channel_under_two_artifact_ids_is_a_duplicate_not_a_disagreement() {
+        let apply = observation(
+            "apply",
+            ConfigurationDisposition::Applied,
+            Some(1),
+            Some("2026-07-31T09:00:00Z"),
+        );
+        let remove = observation(
+            "remove",
+            ConfigurationDisposition::Removed,
+            Some(2),
+            Some("2026-07-31T10:00:00Z"),
+        );
+        let second_copy = |observation: &ConfigurationObservation, id: &str| {
+            let mut copy = observation.clone();
+            copy.evidence_ref.evidence_id = id.to_owned();
+            copy.evidence_ref.source_artifact_id = "second-capture".to_owned();
+            copy
+        };
+        let observations = vec![
+            apply.clone(),
+            remove.clone(),
+            second_copy(&apply, "apply-again"),
+            second_copy(&remove, "remove-again"),
+        ];
+        assert_eq!(local_state(&observations), ConfigurationLocalState::Removed);
+    }
+
+    #[test]
+    fn two_artifacts_telling_different_stories_stay_incomparable() {
+        let apply = observation(
+            "apply",
+            ConfigurationDisposition::Applied,
+            Some(1),
+            Some("2026-07-31T09:00:00Z"),
+        );
+        let mut elsewhere = observation(
+            "remove",
+            ConfigurationDisposition::Removed,
+            Some(1),
+            Some("2026-07-31T10:00:00Z"),
+        );
+        elsewhere.evidence_ref.source_artifact_id = "other-artifact".to_owned();
+        assert_eq!(
+            local_state(&[apply, elsewhere]),
+            ConfigurationLocalState::Contested
+        );
+    }
+
+    /// The shape a real MDM report emits: the losing row names the winner and the
+    /// winner is simply `Applied`. No losing `Applied` row exists, and the record
+    /// numbers say nothing about which policy won.
+    #[test]
+    fn an_explicitly_named_winner_makes_the_node_conflicted_whatever_the_record_order() {
+        let winner = "22222222-2222-4222-8222-222222222222";
+        let build = |loser_record: u64, winner_record: u64| {
+            let mut loser = observation(
+                "loser",
+                ConfigurationDisposition::Conflict,
+                Some(loser_record),
+                Some("2026-07-31T09:00:00Z"),
+            );
+            loser.source_id = Some("11111111-1111-4111-8111-111111111111".to_owned());
+            loser.winning_source_id = Some(winner.to_ascii_uppercase());
+            let mut applied = observation(
+                "winner",
+                ConfigurationDisposition::Applied,
+                Some(winner_record),
+                Some("2026-07-31T09:00:00Z"),
+            );
+            applied.source_id = Some(format!("{{{winner}}}"));
+            vec![loser, applied]
+        };
+        assert_eq!(
+            local_state(&build(1, 2)),
+            ConfigurationLocalState::Conflicted
+        );
+        assert_eq!(
+            local_state(&build(2, 1)),
+            ConfigurationLocalState::Conflicted,
+            "swapping the record numbers must not change the diagnosis"
+        );
+    }
+
+    #[test]
+    fn an_explicitly_named_replacement_makes_the_node_superseded() {
+        let replacement = "22222222-2222-4222-8222-222222222222";
+        let mut superseded = observation(
+            "superseded",
+            ConfigurationDisposition::Superseded,
+            Some(1),
+            Some("2026-07-31T09:00:00Z"),
+        );
+        superseded.source_id = Some("11111111-1111-4111-8111-111111111111".to_owned());
+        superseded.superseded_by_source_id = Some(replacement.to_owned());
+        let mut applied = observation(
+            "replacement",
+            ConfigurationDisposition::Applied,
+            Some(2),
+            Some("2026-07-31T09:00:00Z"),
+        );
+        applied.source_id = Some(replacement.to_owned());
+        assert_eq!(
+            local_state(&[superseded, applied]),
+            ConfigurationLocalState::Superseded
+        );
+    }
+
+    #[test]
+    fn a_row_naming_itself_as_the_winner_links_nothing() {
+        let own = "11111111-1111-4111-8111-111111111111";
+        let mut loser = observation(
+            "self-referential",
+            ConfigurationDisposition::Conflict,
+            Some(1),
+            Some("2026-07-31T09:00:00Z"),
+        );
+        loser.source_id = Some(own.to_owned());
+        loser.winning_source_id = Some(own.to_ascii_uppercase());
+        let mut applied = observation(
+            "applied",
+            ConfigurationDisposition::Applied,
+            Some(2),
+            Some("2026-07-31T09:00:00Z"),
+        );
+        applied.source_id = Some(own.to_owned());
+        // Falls through to the ordered path, where the last record is the fact.
+        assert_eq!(
+            local_state(&[loser, applied]),
+            ConfigurationLocalState::Applied
         );
     }
 }

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
@@ -54,6 +54,10 @@ pub fn reduce_configuration(input: &ConfigurationInput) -> ConfigurationSnapshot
     }
 
     let settings = grouped.into_values().map(reduce_setting).collect();
+    // ADR-003: the caller's vector order is an acquisition detail, not chronology.
+    // Sorting the unattributed records by their evidence reference means the
+    // export never carries it.
+    unattributed.sort_by(|left, right| left.evidence_ref.cmp(&right.evidence_ref));
 
     ConfigurationSnapshot {
         schema_version: INTUNE_CONFIGURATION_SCHEMA_VERSION,
@@ -66,7 +70,14 @@ pub fn reduce_configuration(input: &ConfigurationInput) -> ConfigurationSnapshot
     }
 }
 
-fn reduce_setting(observations: Vec<ConfigurationObservation>) -> ConfigurationSetting {
+fn reduce_setting(mut observations: Vec<ConfigurationObservation>) -> ConfigurationSetting {
+    // Canonical order first, so nothing downstream — nor the exported vector —
+    // can depend on how the caller happened to hand the records over. ADR-003
+    // permits caller order as chronology only where the source contract defines
+    // it, and no configuration source defines it. Where real order exists it is
+    // read from record ordinals, not from this vector.
+    observations.sort_by(|left, right| left.evidence_ref.cmp(&right.evidence_ref));
+
     let identity = merge_identity(&observations);
 
     let receipt = receipt_state(&observations);
@@ -77,11 +88,7 @@ fn reduce_setting(observations: Vec<ConfigurationObservation>) -> ConfigurationS
     let local_error = terminal_error(&observations, is_device_side);
     let service_error = terminal_error(&observations, is_service_side);
 
-    let applied_value = observations
-        .iter()
-        .filter(|observation| is_device_side(observation))
-        .filter(|observation| observation.disposition == ConfigurationDisposition::Applied)
-        .find_map(|observation| observation.value.clone());
+    let applied_value = agreed_applied_value(&observations);
 
     let time_is_reliable = observations
         .iter()
@@ -116,41 +123,76 @@ fn reduce_setting(observations: Vec<ConfigurationObservation>) -> ConfigurationS
     }
 }
 
+/// The value the device reported writing, when its records agree on one.
+///
+/// Two sources applying *different* values to one node do not entitle the export
+/// to name whichever arrived first — that made the exported value a function of
+/// the caller's vector. A disagreement is reported as no stated value; the
+/// conflict rules already name the sources that are arguing.
+fn agreed_applied_value(observations: &[ConfigurationObservation]) -> Option<String> {
+    let mut agreed: Option<&str> = None;
+    for value in observations
+        .iter()
+        .filter(|observation| is_device_side(observation))
+        .filter(|observation| observation.disposition == ConfigurationDisposition::Applied)
+        .filter_map(|observation| observation.value.as_deref())
+    {
+        match agreed {
+            None => agreed = Some(value),
+            Some(existing) if existing == value => {}
+            Some(_) => return None,
+        }
+    }
+    agreed.map(str::to_owned)
+}
+
 /// Fill in the identity fields that only some records carried.
 ///
 /// Every observation in the group already shares a key, so this widens the
-/// description without changing which transaction it is. The first non-empty
-/// value wins, and observations arrive in input order, so the result is
-/// deterministic.
+/// description without changing which transaction it is. Where records offer
+/// different values for one field, the smallest is taken rather than the first:
+/// "first" meant the serializer's order, and it could flip
+/// `configuration-duplicate-display-name` on and off between two runs over the
+/// same evidence.
 fn merge_identity(observations: &[ConfigurationObservation]) -> ConfigurationSettingIdentity {
-    let mut identity = observations
+    let base = &observations
         .first()
         .expect("a group always has at least one observation")
-        .identity
-        .clone();
+        .identity;
 
-    for observation in observations.iter().skip(1) {
-        let other = &observation.identity;
-        if identity.canonical_uri.is_none() {
-            identity.canonical_uri.clone_from(&other.canonical_uri);
-            identity.raw_uri.clone_from(&other.raw_uri);
-            identity.resource_path.clone_from(&other.resource_path);
-        }
-        if identity.setting_id.is_none() {
-            identity.setting_id.clone_from(&other.setting_id);
-        }
-        if identity.policy_id.is_none() {
-            identity.policy_id.clone_from(&other.policy_id);
-        }
-        if identity.display_name.is_none() {
-            identity.display_name.clone_from(&other.display_name);
-        }
-        if identity.csp.is_none() {
-            identity.csp.clone_from(&other.csp);
-        }
+    // The three URI views are derived from one string and must move as a unit; a
+    // canonical URI from one record beside a raw URI from another would describe
+    // no record at all.
+    let uri_source = observations
+        .iter()
+        .map(|observation| &observation.identity)
+        .filter(|identity| identity.canonical_uri.is_some())
+        .min_by(|left, right| left.canonical_uri.cmp(&right.canonical_uri));
+
+    ConfigurationSettingIdentity {
+        // Shared by construction: it is the grouping key.
+        key: base.key.clone(),
+        canonical_uri: uri_source.and_then(|identity| identity.canonical_uri.clone()),
+        raw_uri: uri_source.and_then(|identity| identity.raw_uri.clone()),
+        resource_path: uri_source.and_then(|identity| identity.resource_path.clone()),
+        setting_id: smallest_stated(observations, |identity| identity.setting_id.as_ref()),
+        policy_id: smallest_stated(observations, |identity| identity.policy_id.as_ref()),
+        display_name: smallest_stated(observations, |identity| identity.display_name.as_ref()),
+        scope: base.scope,
+        csp: smallest_stated(observations, |identity| identity.csp.as_ref()),
+        is_unidentified: base.is_unidentified,
     }
+}
 
-    identity
+fn smallest_stated(
+    observations: &[ConfigurationObservation],
+    pick: fn(&ConfigurationSettingIdentity) -> Option<&String>,
+) -> Option<String> {
+    observations
+        .iter()
+        .filter_map(|observation| pick(&observation.identity))
+        .min()
+        .cloned()
 }
 
 fn receipt_state(observations: &[ConfigurationObservation]) -> ConfigurationReceiptState {
@@ -515,6 +557,13 @@ fn resolve(
     }
 }
 
+/// The terminal status one side reported.
+///
+/// When two records of one side report *different* codes, the smallest by
+/// canonical ordering is named rather than whichever arrived first: two 404s used
+/// to flip which HRESULT the rejection finding quoted depending on the caller's
+/// vector order. Both records stay cited either way, so nothing is hidden — only
+/// the choice of which code to lead with is made stable.
 fn terminal_error(
     observations: &[ConfigurationObservation],
     side: fn(&ConfigurationObservation) -> bool,
@@ -523,7 +572,11 @@ fn terminal_error(
         .iter()
         .filter(|observation| side(observation))
         .filter(|observation| observation.disposition == ConfigurationDisposition::Rejected)
-        .find_map(|observation| observation.error.clone())
+        .filter_map(|observation| observation.error.as_ref())
+        .min_by(|left, right| {
+            (&left.decimal, &left.hex, &left.raw).cmp(&(&right.decimal, &right.hex, &right.raw))
+        })
+        .cloned()
 }
 
 /// One entry per distinct configuration source that stated something.

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
@@ -21,8 +21,8 @@ use super::models::{
     ConfigurationSnapshot, ConfigurationSourceStatement, INTUNE_CONFIGURATION_SCHEMA_VERSION,
 };
 use super::sources::{
-    is_device_side, is_service_side, observation_from_event, observation_from_report,
-    same_source_id,
+    is_device_side, is_service_side, is_unassessable_failure, observation_from_event,
+    observation_from_report, same_source_id,
 };
 
 /// Project every input record and fold it into per-setting transactions.
@@ -90,6 +90,7 @@ fn reduce_setting(observations: Vec<ConfigurationObservation>) -> ConfigurationS
     let has_uninterpretable_evidence = observations
         .iter()
         .any(|observation| observation.is_uninterpretable);
+    let has_unassessable_failure = observations.iter().any(is_unassessable_failure);
 
     let evidence = observations
         .iter()
@@ -109,6 +110,7 @@ fn reduce_setting(observations: Vec<ConfigurationObservation>) -> ConfigurationS
         time_is_reliable,
         ordering_is_contradictory,
         has_uninterpretable_evidence,
+        has_unassessable_failure,
         observations,
         evidence,
     }
@@ -192,6 +194,25 @@ fn terminal_dispositions(
 }
 
 fn local_state(observations: &[ConfigurationObservation]) -> ConfigurationLocalState {
+    let state = terminal_local_state(observations);
+
+    // ADR-001: non-assessable evidence cannot produce a terminal conclusion. A
+    // command-failure record whose status could not be read still establishes the
+    // *direction*, so a clean success alongside it is a disagreement, not a
+    // success with a footnote. Failure-shaped states are left alone: the node is
+    // already reported as trouble and the unreadable record is reported by its own
+    // rule.
+    let blocks_success = matches!(
+        state,
+        ConfigurationLocalState::Applied | ConfigurationLocalState::Removed
+    ) && observations.iter().any(is_unassessable_failure);
+    if blocks_success {
+        return ConfigurationLocalState::Contested;
+    }
+    state
+}
+
+fn terminal_local_state(observations: &[ConfigurationObservation]) -> ConfigurationLocalState {
     let terminal = terminal_dispositions(observations, is_device_side);
     match terminal.as_slice() {
         [] => {

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
@@ -170,19 +170,22 @@ fn receipt_state(observations: &[ConfigurationObservation]) -> ConfigurationRece
     ConfigurationReceiptState::NoEvidence
 }
 
-/// Distinct terminal dispositions stated by one side, in a stable order.
+/// Distinct terminal dispositions stated by one side, preserving observation order.
 fn terminal_dispositions(
     observations: &[ConfigurationObservation],
     side: fn(&ConfigurationObservation) -> bool,
 ) -> Vec<ConfigurationDisposition> {
-    let mut seen: Vec<ConfigurationDisposition> = observations
+    let mut seen = Vec::new();
+    for disposition in observations
         .iter()
         .filter(|observation| side(observation))
         .map(|observation| observation.disposition)
         .filter(|disposition| disposition.is_terminal())
-        .collect();
-    seen.sort();
-    seen.dedup();
+    {
+        if !seen.contains(&disposition) {
+            seen.push(disposition);
+        }
+    }
     seen
 }
 
@@ -216,7 +219,7 @@ fn local_state(observations: &[ConfigurationObservation]) -> ConfigurationLocalS
             | ConfigurationDisposition::Pending
             | ConfigurationDisposition::Indeterminate => ConfigurationLocalState::Indeterminate,
         },
-        many => reconcile_multiple_local(many),
+        many => reconcile_multiple_local(many, observations),
     }
 }
 
@@ -227,8 +230,25 @@ fn local_state(observations: &[ConfigurationObservation]) -> ConfigurationLocalS
 /// The same holds for a conflict or supersedence recorded alongside an
 /// application, where the losing write genuinely did happen first. Anything else
 /// is a real disagreement and stays `Contested` so a rule must cite both sides.
-fn reconcile_multiple_local(terminal: &[ConfigurationDisposition]) -> ConfigurationLocalState {
+fn reconcile_multiple_local(
+    terminal: &[ConfigurationDisposition],
+    observations: &[ConfigurationObservation],
+) -> ConfigurationLocalState {
+    let Some(ordered) = ordered_terminal_dispositions(observations) else {
+        return ConfigurationLocalState::Contested;
+    };
     let has = |disposition: ConfigurationDisposition| terminal.contains(&disposition);
+    let applied_precedes = |disposition: ConfigurationDisposition| {
+        ordered
+            .iter()
+            .position(|candidate| *candidate == ConfigurationDisposition::Applied)
+            .zip(
+                ordered
+                    .iter()
+                    .position(|candidate| *candidate == disposition),
+            )
+            .is_some_and(|(applied, terminal)| applied < terminal)
+    };
 
     if has(ConfigurationDisposition::Removed)
         && terminal.iter().all(|d| {
@@ -237,6 +257,7 @@ fn reconcile_multiple_local(terminal: &[ConfigurationDisposition]) -> Configurat
                 ConfigurationDisposition::Removed | ConfigurationDisposition::Applied
             )
         })
+        && applied_precedes(ConfigurationDisposition::Removed)
     {
         return ConfigurationLocalState::Removed;
     }
@@ -247,6 +268,7 @@ fn reconcile_multiple_local(terminal: &[ConfigurationDisposition]) -> Configurat
                 ConfigurationDisposition::Superseded | ConfigurationDisposition::Applied
             )
         })
+        && applied_precedes(ConfigurationDisposition::Superseded)
     {
         return ConfigurationLocalState::Superseded;
     }
@@ -257,10 +279,53 @@ fn reconcile_multiple_local(terminal: &[ConfigurationDisposition]) -> Configurat
                 ConfigurationDisposition::Conflict | ConfigurationDisposition::Applied
             )
         })
+        && applied_precedes(ConfigurationDisposition::Conflict)
     {
         return ConfigurationLocalState::Conflicted;
     }
     ConfigurationLocalState::Contested
+}
+
+/// Return terminal dispositions in their evidence order, when that order is
+/// comparable. Record ordinals and reliable timestamps must describe one artifact;
+/// otherwise a lifecycle conclusion would be inferred from an unordered set.
+fn ordered_terminal_dispositions(
+    observations: &[ConfigurationObservation],
+) -> Option<Vec<ConfigurationDisposition>> {
+    let mut terminal = observations
+        .iter()
+        .filter(|observation| is_device_side(observation) && observation.disposition.is_terminal())
+        .collect::<Vec<_>>();
+    if terminal.len() < 2 || ordering_is_contradictory(observations) {
+        return None;
+    }
+    let artifact = terminal.first()?.evidence_ref.source_artifact_id.as_str();
+    if terminal
+        .iter()
+        .any(|observation| observation.evidence_ref.source_artifact_id != artifact)
+    {
+        return None;
+    }
+    if terminal.iter().any(|observation| {
+        observation.record_id.is_none()
+            || !observation.time_is_reliable
+            || observation.occurred_at_utc.is_none()
+    }) {
+        return None;
+    }
+    terminal.sort_by_key(|observation| observation.record_id);
+    if terminal
+        .windows(2)
+        .any(|pair| pair[0].record_id == pair[1].record_id)
+    {
+        return None;
+    }
+    Some(
+        terminal
+            .iter()
+            .map(|observation| observation.disposition)
+            .collect(),
+    )
 }
 
 fn service_state(observations: &[ConfigurationObservation]) -> ConfigurationServiceState {
@@ -339,6 +404,12 @@ fn resolve(
     };
 
     match (local_conclusion, service_conclusion) {
+        // A service-side removal is represented as reported success. When the
+        // device also says Removed, those statements agree on the lifecycle
+        // outcome rather than contradicting one another.
+        (Some(ConfigurationResolution::Removed), Some(ConfigurationResolution::Applied)) => {
+            ConfigurationResolution::Removed
+        }
         (Some(local), Some(service)) if local != service => ConfigurationResolution::Contradicted,
         (Some(local), _) => local,
         // Service-only evidence is supplemental. It cannot establish that the
@@ -425,4 +496,117 @@ fn ordering_is_contradictory(observations: &[ConfigurationObservation]) -> bool 
         records.sort_by_key(|(record_id, _)| *record_id);
         records.windows(2).any(|pair| pair[0].1 > pair[1].1)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intune::evidence::{
+        IntuneEvidenceRef, IntuneNamedValue, IntuneSensitivity, IntuneSourceKind,
+    };
+
+    fn observation(
+        evidence_id: &str,
+        disposition: ConfigurationDisposition,
+        record_id: Option<u64>,
+        occurred_at_utc: Option<&str>,
+    ) -> ConfigurationObservation {
+        let identity =
+            super::super::identity::resolve_identity(&super::super::identity::IdentityHints {
+                uri: Some("./Device/Vendor/MSFT/Policy/Config/Test"),
+                evidence_id,
+                ..Default::default()
+            });
+        ConfigurationObservation {
+            evidence_ref: IntuneEvidenceRef {
+                evidence_id: evidence_id.to_owned(),
+                source_artifact_id: "test-artifact".to_owned(),
+            },
+            side: ConfigurationEvidenceSide::Device,
+            source_kind: IntuneSourceKind::PlainTextLog,
+            sensitivity: IntuneSensitivity::Public,
+            identity,
+            disposition,
+            event_kind: None,
+            event_id: None,
+            source_id: None,
+            enrollment_id: None,
+            command_type: None,
+            value: None,
+            error: None,
+            winning_source_id: None,
+            superseded_by_source_id: None,
+            occurred_at_utc: occurred_at_utc.map(str::to_owned),
+            time_is_reliable: occurred_at_utc.is_some(),
+            record_id,
+            is_uninterpretable: false,
+            named_data: Vec::<IntuneNamedValue>::new(),
+        }
+    }
+
+    #[test]
+    fn apply_then_remove_is_removed_but_reverse_observation_is_ordered_by_metadata() {
+        let apply = observation(
+            "apply",
+            ConfigurationDisposition::Applied,
+            Some(1),
+            Some("2026-07-31T09:00:00Z"),
+        );
+        let remove = observation(
+            "remove",
+            ConfigurationDisposition::Removed,
+            Some(2),
+            Some("2026-07-31T10:00:00Z"),
+        );
+        assert_eq!(
+            local_state(&[apply.clone(), remove.clone()]),
+            ConfigurationLocalState::Removed
+        );
+        assert_eq!(
+            local_state(&[remove, apply]),
+            ConfigurationLocalState::Removed
+        );
+    }
+
+    #[test]
+    fn contradictory_or_unavailable_order_stays_contested() {
+        let observations = vec![
+            observation(
+                "apply",
+                ConfigurationDisposition::Applied,
+                Some(1),
+                Some("2026-07-31T10:00:00Z"),
+            ),
+            observation(
+                "remove",
+                ConfigurationDisposition::Removed,
+                Some(2),
+                Some("2026-07-31T09:00:00Z"),
+            ),
+        ];
+        assert_eq!(
+            local_state(&observations),
+            ConfigurationLocalState::Contested
+        );
+
+        let unavailable = vec![
+            observation("apply", ConfigurationDisposition::Applied, None, None),
+            observation("remove", ConfigurationDisposition::Removed, None, None),
+        ];
+        assert_eq!(
+            local_state(&unavailable),
+            ConfigurationLocalState::Contested
+        );
+    }
+
+    #[test]
+    fn removed_local_and_reported_success_agree_on_removed_resolution() {
+        assert_eq!(
+            resolve(
+                ConfigurationLocalState::Removed,
+                ConfigurationServiceState::ReportedSuccess,
+            ),
+            ConfigurationResolution::Removed
+        );
+    }
 }

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
@@ -20,6 +20,7 @@ use super::models::{
     ConfigurationResolution, ConfigurationServiceState, ConfigurationSetting,
     ConfigurationSnapshot, ConfigurationSourceStatement, INTUNE_CONFIGURATION_SCHEMA_VERSION,
 };
+use super::redaction::analysis_scope_digest;
 use super::sources::{
     is_device_side, is_service_side, is_unassessable_failure, observation_from_event,
     observation_from_report, same_source_id,
@@ -62,6 +63,13 @@ pub fn reduce_configuration(input: &ConfigurationInput) -> ConfigurationSnapshot
     ConfigurationSnapshot {
         schema_version: INTUNE_CONFIGURATION_SCHEMA_VERSION,
         generated_at_utc: input.generated_at_utc.clone(),
+        // Resolved once, here, so every projection of this snapshot — including a
+        // redaction of a redaction — mints tokens in the same scope. The caller's
+        // own scope value is reduced to a digest and does not travel further.
+        analysis_scope: analysis_scope_digest(
+            input.analysis_scope.as_deref(),
+            &input.generated_at_utc,
+        ),
         settings,
         unattributed,
         coverage: input.coverage.clone(),

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
@@ -1,0 +1,428 @@
+//! Combine observations into one immutable per-setting snapshot.
+//!
+//! The reducer never picks a winner between disagreeing evidence. When device
+//! records disagree with one another the local state is `Contested`; when device
+//! and service disagree the resolution is `Contradicted`. Both keep every
+//! contributing observation so a rule can cite the competing evidence rather than
+//! assert an outcome.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+
+use crate::intune::evidence::{IntuneErrorCode, IntuneEvidenceRef};
+
+use super::identity::ConfigurationSettingIdentity;
+use super::models::{
+    ConfigurationDisposition, ConfigurationEvidenceSide, ConfigurationInput,
+    ConfigurationLocalState, ConfigurationObservation, ConfigurationReceiptState,
+    ConfigurationResolution, ConfigurationServiceState, ConfigurationSetting,
+    ConfigurationSnapshot, ConfigurationSourceStatement, INTUNE_CONFIGURATION_SCHEMA_VERSION,
+};
+use super::sources::{
+    is_device_side, is_service_side, observation_from_event, observation_from_report,
+};
+
+/// Project every input record and fold it into per-setting transactions.
+///
+/// The returned snapshot carries no findings; [`super::derive_findings`] produces
+/// those from it, and [`super::analyze_configuration`] does both.
+pub fn reduce_configuration(input: &ConfigurationInput) -> ConfigurationSnapshot {
+    let mut observations = Vec::new();
+    for event in &input.events {
+        if let Some(observation) = observation_from_event(event) {
+            observations.push(observation);
+        }
+    }
+    for report in &input.reports {
+        observations.push(observation_from_report(report));
+    }
+
+    let mut grouped: BTreeMap<String, Vec<ConfigurationObservation>> = BTreeMap::new();
+    let mut unattributed = Vec::new();
+    for observation in observations {
+        if observation.identity.is_unidentified {
+            unattributed.push(observation);
+            continue;
+        }
+        grouped
+            .entry(observation.identity.key.clone())
+            .or_default()
+            .push(observation);
+    }
+
+    let settings = grouped.into_values().map(reduce_setting).collect();
+
+    ConfigurationSnapshot {
+        schema_version: INTUNE_CONFIGURATION_SCHEMA_VERSION,
+        generated_at_utc: input.generated_at_utc.clone(),
+        settings,
+        unattributed,
+        coverage: input.coverage.clone(),
+        findings: Vec::new(),
+        redacted: false,
+    }
+}
+
+fn reduce_setting(observations: Vec<ConfigurationObservation>) -> ConfigurationSetting {
+    let identity = merge_identity(&observations);
+
+    let receipt = receipt_state(&observations);
+    let local = local_state(&observations);
+    let service = service_state(&observations);
+    let resolution = resolve(local, service);
+
+    let local_error = terminal_error(&observations, is_device_side);
+    let service_error = terminal_error(&observations, is_service_side);
+
+    let applied_value = observations
+        .iter()
+        .filter(|observation| is_device_side(observation))
+        .filter(|observation| observation.disposition == ConfigurationDisposition::Applied)
+        .find_map(|observation| observation.value.clone());
+
+    let time_is_reliable = observations
+        .iter()
+        .all(|observation| observation.time_is_reliable);
+    let ordering_is_contradictory = ordering_is_contradictory(&observations);
+    let has_uninterpretable_evidence = observations
+        .iter()
+        .any(|observation| observation.is_uninterpretable);
+
+    let evidence = observations
+        .iter()
+        .map(|observation| observation.evidence_ref.clone())
+        .collect::<Vec<_>>();
+
+    ConfigurationSetting {
+        identity,
+        receipt,
+        local,
+        service,
+        resolution,
+        sources: source_statements(&observations),
+        local_error,
+        service_error,
+        applied_value,
+        time_is_reliable,
+        ordering_is_contradictory,
+        has_uninterpretable_evidence,
+        observations,
+        evidence,
+    }
+}
+
+/// Fill in the identity fields that only some records carried.
+///
+/// Every observation in the group already shares a key, so this widens the
+/// description without changing which transaction it is. The first non-empty
+/// value wins, and observations arrive in input order, so the result is
+/// deterministic.
+fn merge_identity(observations: &[ConfigurationObservation]) -> ConfigurationSettingIdentity {
+    let mut identity = observations
+        .first()
+        .expect("a group always has at least one observation")
+        .identity
+        .clone();
+
+    for observation in observations.iter().skip(1) {
+        let other = &observation.identity;
+        if identity.canonical_uri.is_none() {
+            identity.canonical_uri.clone_from(&other.canonical_uri);
+            identity.raw_uri.clone_from(&other.raw_uri);
+            identity.resource_path.clone_from(&other.resource_path);
+        }
+        if identity.setting_id.is_none() {
+            identity.setting_id.clone_from(&other.setting_id);
+        }
+        if identity.policy_id.is_none() {
+            identity.policy_id.clone_from(&other.policy_id);
+        }
+        if identity.display_name.is_none() {
+            identity.display_name.clone_from(&other.display_name);
+        }
+        if identity.csp.is_none() {
+            identity.csp.clone_from(&other.csp);
+        }
+    }
+
+    identity
+}
+
+fn receipt_state(observations: &[ConfigurationObservation]) -> ConfigurationReceiptState {
+    let device: Vec<&ConfigurationObservation> = observations
+        .iter()
+        .filter(|observation| is_device_side(observation))
+        .collect();
+
+    if device
+        .iter()
+        .any(|observation| observation.disposition.is_terminal())
+    {
+        return ConfigurationReceiptState::CspProcessed;
+    }
+    if !device.is_empty() {
+        return ConfigurationReceiptState::CommandReceived;
+    }
+    if observations.iter().any(is_service_side) {
+        return ConfigurationReceiptState::Intended;
+    }
+    ConfigurationReceiptState::NoEvidence
+}
+
+/// Distinct terminal dispositions stated by one side, in a stable order.
+fn terminal_dispositions(
+    observations: &[ConfigurationObservation],
+    side: fn(&ConfigurationObservation) -> bool,
+) -> Vec<ConfigurationDisposition> {
+    let mut seen: Vec<ConfigurationDisposition> = observations
+        .iter()
+        .filter(|observation| side(observation))
+        .map(|observation| observation.disposition)
+        .filter(|disposition| disposition.is_terminal())
+        .collect();
+    seen.sort();
+    seen.dedup();
+    seen
+}
+
+fn local_state(observations: &[ConfigurationObservation]) -> ConfigurationLocalState {
+    let terminal = terminal_dispositions(observations, is_device_side);
+    match terminal.as_slice() {
+        [] => {
+            // A device record that named the setting but could not be
+            // interpreted is not the same as no device record at all: the first
+            // is a parse problem worth reporting, the second is a coverage gap.
+            let indeterminate = observations
+                .iter()
+                .filter(|observation| is_device_side(observation))
+                .any(|observation| {
+                    observation.disposition == ConfigurationDisposition::Indeterminate
+                });
+            if indeterminate {
+                ConfigurationLocalState::Indeterminate
+            } else {
+                ConfigurationLocalState::NoEvidence
+            }
+        }
+        [only] => match only {
+            ConfigurationDisposition::Applied => ConfigurationLocalState::Applied,
+            ConfigurationDisposition::Rejected => ConfigurationLocalState::Rejected,
+            ConfigurationDisposition::Conflict => ConfigurationLocalState::Conflicted,
+            ConfigurationDisposition::Superseded => ConfigurationLocalState::Superseded,
+            ConfigurationDisposition::NotApplicable => ConfigurationLocalState::NotApplicable,
+            ConfigurationDisposition::Removed => ConfigurationLocalState::Removed,
+            ConfigurationDisposition::Received
+            | ConfigurationDisposition::Pending
+            | ConfigurationDisposition::Indeterminate => ConfigurationLocalState::Indeterminate,
+        },
+        many => reconcile_multiple_local(many),
+    }
+}
+
+/// Several device-side terminal dispositions for one setting.
+///
+/// A removal following an application is a lifecycle, not a disagreement: the
+/// setting was applied and then deleted, and `Removed` is the current fact.
+/// The same holds for a conflict or supersedence recorded alongside an
+/// application, where the losing write genuinely did happen first. Anything else
+/// is a real disagreement and stays `Contested` so a rule must cite both sides.
+fn reconcile_multiple_local(terminal: &[ConfigurationDisposition]) -> ConfigurationLocalState {
+    let has = |disposition: ConfigurationDisposition| terminal.contains(&disposition);
+
+    if has(ConfigurationDisposition::Removed)
+        && terminal.iter().all(|d| {
+            matches!(
+                d,
+                ConfigurationDisposition::Removed | ConfigurationDisposition::Applied
+            )
+        })
+    {
+        return ConfigurationLocalState::Removed;
+    }
+    if has(ConfigurationDisposition::Superseded)
+        && terminal.iter().all(|d| {
+            matches!(
+                d,
+                ConfigurationDisposition::Superseded | ConfigurationDisposition::Applied
+            )
+        })
+    {
+        return ConfigurationLocalState::Superseded;
+    }
+    if has(ConfigurationDisposition::Conflict)
+        && terminal.iter().all(|d| {
+            matches!(
+                d,
+                ConfigurationDisposition::Conflict | ConfigurationDisposition::Applied
+            )
+        })
+    {
+        return ConfigurationLocalState::Conflicted;
+    }
+    ConfigurationLocalState::Contested
+}
+
+fn service_state(observations: &[ConfigurationObservation]) -> ConfigurationServiceState {
+    let service: Vec<&ConfigurationObservation> = observations
+        .iter()
+        .filter(|observation| is_service_side(observation))
+        .collect();
+    if service.is_empty() {
+        return ConfigurationServiceState::NoEvidence;
+    }
+
+    let terminal = terminal_dispositions(observations, is_service_side);
+    match terminal.as_slice() {
+        [] => {
+            if service
+                .iter()
+                .any(|observation| observation.disposition == ConfigurationDisposition::Pending)
+            {
+                ConfigurationServiceState::ReportedPending
+            } else {
+                ConfigurationServiceState::Assigned
+            }
+        }
+        [only] => match only {
+            ConfigurationDisposition::Applied => ConfigurationServiceState::ReportedSuccess,
+            ConfigurationDisposition::Rejected => ConfigurationServiceState::ReportedFailure,
+            ConfigurationDisposition::Conflict => ConfigurationServiceState::ReportedConflict,
+            ConfigurationDisposition::Superseded => ConfigurationServiceState::ReportedSuperseded,
+            ConfigurationDisposition::NotApplicable => {
+                ConfigurationServiceState::ReportedNotApplicable
+            }
+            // The service has no "removed" vocabulary; a delete reported as
+            // success is still just a success from its point of view.
+            ConfigurationDisposition::Removed => ConfigurationServiceState::ReportedSuccess,
+            ConfigurationDisposition::Received
+            | ConfigurationDisposition::Pending
+            | ConfigurationDisposition::Indeterminate => ConfigurationServiceState::Assigned,
+        },
+        _ => ConfigurationServiceState::Contested,
+    }
+}
+
+/// Decide the single conclusion, or refuse to.
+///
+/// Service evidence never overrides device evidence and never fills in for it.
+/// A portal success with a local rejection is a contradiction, not a success,
+/// and a portal success with no local evidence at all remains insufficient:
+/// Intune reports what it was told, which is not the same as what the CSP did.
+fn resolve(
+    local: ConfigurationLocalState,
+    service: ConfigurationServiceState,
+) -> ConfigurationResolution {
+    let local_conclusion = match local {
+        ConfigurationLocalState::Applied => Some(ConfigurationResolution::Applied),
+        ConfigurationLocalState::Rejected => Some(ConfigurationResolution::Rejected),
+        ConfigurationLocalState::Conflicted => Some(ConfigurationResolution::Conflicted),
+        ConfigurationLocalState::Superseded => Some(ConfigurationResolution::Superseded),
+        ConfigurationLocalState::NotApplicable => Some(ConfigurationResolution::NotApplicable),
+        ConfigurationLocalState::Removed => Some(ConfigurationResolution::Removed),
+        ConfigurationLocalState::Contested => Some(ConfigurationResolution::Contradicted),
+        ConfigurationLocalState::NoEvidence | ConfigurationLocalState::Indeterminate => None,
+    };
+
+    let service_conclusion = match service {
+        ConfigurationServiceState::ReportedSuccess => Some(ConfigurationResolution::Applied),
+        ConfigurationServiceState::ReportedFailure => Some(ConfigurationResolution::Rejected),
+        ConfigurationServiceState::ReportedConflict => Some(ConfigurationResolution::Conflicted),
+        ConfigurationServiceState::ReportedSuperseded => Some(ConfigurationResolution::Superseded),
+        ConfigurationServiceState::ReportedNotApplicable => {
+            Some(ConfigurationResolution::NotApplicable)
+        }
+        ConfigurationServiceState::Contested => Some(ConfigurationResolution::Contradicted),
+        ConfigurationServiceState::NoEvidence
+        | ConfigurationServiceState::Assigned
+        | ConfigurationServiceState::ReportedPending => None,
+    };
+
+    match (local_conclusion, service_conclusion) {
+        (Some(local), Some(service)) if local != service => ConfigurationResolution::Contradicted,
+        (Some(local), _) => local,
+        // Service-only evidence is supplemental. It cannot establish that the
+        // CSP applied anything, so it does not become a resolution on its own.
+        (None, _) => ConfigurationResolution::InsufficientEvidence,
+    }
+}
+
+fn terminal_error(
+    observations: &[ConfigurationObservation],
+    side: fn(&ConfigurationObservation) -> bool,
+) -> Option<IntuneErrorCode> {
+    observations
+        .iter()
+        .filter(|observation| side(observation))
+        .filter(|observation| observation.disposition == ConfigurationDisposition::Rejected)
+        .find_map(|observation| observation.error.clone())
+}
+
+/// One entry per distinct configuration source that stated something.
+fn source_statements(
+    observations: &[ConfigurationObservation],
+) -> Vec<ConfigurationSourceStatement> {
+    let mut grouped: BTreeMap<
+        (
+            Option<String>,
+            ConfigurationEvidenceSide,
+            ConfigurationDisposition,
+        ),
+        Vec<IntuneEvidenceRef>,
+    > = BTreeMap::new();
+
+    for observation in observations {
+        grouped
+            .entry((
+                observation.source_id.clone(),
+                observation.side,
+                observation.disposition,
+            ))
+            .or_default()
+            .push(observation.evidence_ref.clone());
+    }
+
+    grouped
+        .into_iter()
+        .map(
+            |((source_id, side, disposition), evidence)| ConfigurationSourceStatement {
+                source_id,
+                side,
+                disposition,
+                evidence,
+            },
+        )
+        .collect()
+}
+
+/// True when device record order and device timestamp order disagree.
+///
+/// Compared only within one artifact: record numbers are per-channel ordinals and
+/// comparing them across two files would manufacture a contradiction that the
+/// evidence does not contain.
+fn ordering_is_contradictory(observations: &[ConfigurationObservation]) -> bool {
+    let mut by_artifact: BTreeMap<&str, Vec<(u64, DateTime<Utc>)>> = BTreeMap::new();
+    for observation in observations.iter().filter(|obs| is_device_side(obs)) {
+        let (Some(record_id), Some(instant)) = (
+            observation.record_id,
+            observation.occurred_at_utc.as_deref(),
+        ) else {
+            continue;
+        };
+        if !observation.time_is_reliable {
+            continue;
+        }
+        let Ok(instant) = DateTime::parse_from_rfc3339(instant) else {
+            continue;
+        };
+        by_artifact
+            .entry(observation.evidence_ref.source_artifact_id.as_str())
+            .or_default()
+            .push((record_id, instant.with_timezone(&Utc)));
+    }
+
+    by_artifact.into_values().any(|mut records| {
+        records.sort_by_key(|(record_id, _)| *record_id);
+        records.windows(2).any(|pair| pair[0].1 > pair[1].1)
+    })
+}

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/reducer.rs
@@ -542,13 +542,14 @@ fn resolve(
         | ConfigurationServiceState::ReportedPending => None,
     };
 
+    // A device removal beside a service success used to resolve to `Removed`, on
+    // the assumption that Intune reports a completed delete as a success. No
+    // documented contract says so, and ADR-003 is explicit that an unresolved
+    // authoritative contradiction becomes conflicting rather than an arbitrary
+    // winner. It is now treated like any other disagreement: both statements are
+    // kept and cited, and the reader decides. If Intune's reporting vocabulary is
+    // ever written down, this is the one line that changes.
     match (local_conclusion, service_conclusion) {
-        // A service-side removal is represented as reported success. When the
-        // device also says Removed, those statements agree on the lifecycle
-        // outcome rather than contradicting one another.
-        (Some(ConfigurationResolution::Removed), Some(ConfigurationResolution::Applied)) => {
-            ConfigurationResolution::Removed
-        }
         (Some(local), Some(service)) if local != service => ConfigurationResolution::Contradicted,
         (Some(local), _) => local,
         // Service-only evidence is supplemental. It cannot establish that the
@@ -750,13 +751,16 @@ mod tests {
     }
 
     #[test]
-    fn removed_local_and_reported_success_agree_on_removed_resolution() {
+    fn removed_local_and_reported_success_stay_a_contradiction() {
+        // Previously hard-coded to `Removed` on the assumption that Intune reports
+        // a completed delete as a success. Nothing documents that, and ADR-003
+        // requires an unresolved authoritative contradiction to stay conservative.
         assert_eq!(
             resolve(
                 ConfigurationLocalState::Removed,
                 ConfigurationServiceState::ReportedSuccess,
             ),
-            ConfigurationResolution::Removed
+            ConfigurationResolution::Contradicted
         );
     }
 

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/rules.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/rules.rs
@@ -27,6 +27,7 @@ use super::models::{
     ConfigurationObservation, ConfigurationReceiptState, ConfigurationResolution,
     ConfigurationServiceState, ConfigurationSetting, ConfigurationSnapshot,
 };
+use super::sources::{normalize_source_id, same_source_id};
 
 /// Maximum number of setting labels quoted in a summary before it is truncated.
 const MAX_LABELS: usize = 6;
@@ -383,18 +384,31 @@ fn is_conflicted(setting: &ConfigurationSetting) -> bool {
         || setting.service == ConfigurationServiceState::ReportedConflict
 }
 
-/// Whether the bundle actually contains the second side of the argument.
+/// Every distinct configuration source that stated something about this node.
 ///
-/// Either two distinct configuration source identifiers stated something about
-/// the node, or a record explicitly named the winner. A lone row saying
-/// "conflict" is not itself evidence of a competing source.
-fn competing_sources_are_observed(setting: &ConfigurationSetting) -> bool {
-    let distinct = setting
+/// Normalized, because one policy GUID written braced by the event provider and
+/// bare by the report is one source, and comparing the bytes made it two
+/// competing ones — enough on its own to raise a conflict finding.
+fn observed_source_ids(setting: &ConfigurationSetting) -> BTreeSet<String> {
+    setting
         .sources
         .iter()
         .filter_map(|statement| statement.source_id.as_deref())
-        .collect::<BTreeSet<_>>();
-    if distinct.len() >= 2 {
+        .map(normalize_source_id)
+        .collect()
+}
+
+/// Whether the bundle actually contains the second side of the argument.
+///
+/// Either two distinct configuration sources stated something about the node, or
+/// a record named a winner *that is itself in the bundle*. Merely naming someone
+/// is not observing them: a single row carrying `WinningProvider: GPO` used to
+/// substantiate a conflict at Warning/High with one source present and the
+/// alleged winner nowhere in the evidence. Such a row now reaches the
+/// unsubstantiated variant, which asks for the missing artifact instead.
+fn competing_sources_are_observed(setting: &ConfigurationSetting) -> bool {
+    let observed = observed_source_ids(setting);
+    if observed.len() >= 2 {
         return true;
     }
     setting.observations.iter().any(|observation| {
@@ -402,10 +416,11 @@ fn competing_sources_are_observed(setting: &ConfigurationSetting) -> bool {
             .winning_source_id
             .as_deref()
             .is_some_and(|winner| {
-                observation
+                let names_another = observation
                     .source_id
                     .as_deref()
-                    .is_none_or(|source| !source.eq_ignore_ascii_case(winner))
+                    .is_none_or(|source| !same_source_id(source, winner));
+                names_another && observed.contains(&normalize_source_id(winner))
             })
     })
 }
@@ -478,21 +493,24 @@ fn is_superseded(setting: &ConfigurationSetting) -> bool {
         || setting.service == ConfigurationServiceState::ReportedSuperseded
 }
 
+/// Whether the replacing source named by a superseded record is in the bundle.
+///
+/// The self-reference guard mirrors the conflict rule's: a row naming *itself* as
+/// its own replacement matched the bundle trivially and produced
+/// `configuration-superseded` at High confidence with one source present.
 fn superseding_source_is_observed(setting: &ConfigurationSetting) -> bool {
-    let named_replacements = setting
-        .observations
-        .iter()
-        .filter_map(|observation| observation.superseded_by_source_id.as_deref())
-        .collect::<BTreeSet<_>>();
-    if named_replacements.is_empty() {
-        return false;
-    }
-    setting.sources.iter().any(|statement| {
-        statement.source_id.as_deref().is_some_and(|source| {
-            named_replacements
-                .iter()
-                .any(|replacement| replacement.eq_ignore_ascii_case(source))
-        })
+    let observed = observed_source_ids(setting);
+    setting.observations.iter().any(|observation| {
+        observation
+            .superseded_by_source_id
+            .as_deref()
+            .is_some_and(|replacement| {
+                let names_another = observation
+                    .source_id
+                    .as_deref()
+                    .is_none_or(|source| !same_source_id(source, replacement));
+                names_another && observed.contains(&normalize_source_id(replacement))
+            })
     })
 }
 

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/rules.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/rules.rs
@@ -17,8 +17,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::intune::evidence::{
-    IntuneArtifactStatus, IntuneEvidenceRef, IntuneFinding, IntuneFindingConfidence,
-    IntuneFindingSeverity,
+    IntuneArtifactStatus, IntuneErrorCode, IntuneEvidenceRef, IntuneFinding,
+    IntuneFindingConfidence, IntuneFindingSeverity,
 };
 
 use super::identity::ConfigurationScope;
@@ -58,6 +58,7 @@ pub fn derive_findings(snapshot: &ConfigurationSnapshot) -> Vec<IntuneFinding> {
     push_uncollected_artifacts(snapshot, &mut findings);
     push_truncated_artifacts(snapshot, &mut findings);
     push_unreadable_artifacts(snapshot, &mut findings);
+    push_artifacts_without_usable_records(snapshot, &mut findings);
     push_applied(snapshot, &mut findings);
 
     findings
@@ -222,6 +223,36 @@ fn push_local_service_contradiction(
     } else {
         "At least one side has unusable time provenance, so the newer statement cannot be preferred."
     };
+    // `service_error` was populated and cited by no rule at all, so the code
+    // Intune reported never reached a reader. It belongs here: the whole point of
+    // the finding is to put the two statements side by side.
+    let codes = |pick: fn(&ConfigurationSetting) -> Option<&IntuneErrorCode>| {
+        settings
+            .iter()
+            .filter_map(|setting| pick(setting))
+            .map(|code| code.hex.clone().unwrap_or_else(|| code.raw.clone()))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+    };
+    let reported = |label: &str, codes: Vec<String>| {
+        if codes.is_empty() {
+            String::new()
+        } else {
+            format!(" {label} status: {}.", codes.join(", "))
+        }
+    };
+    let statuses = format!(
+        "{}{}",
+        reported(
+            "Device-reported",
+            codes(|setting| setting.local_error.as_ref())
+        ),
+        reported(
+            "Service-reported",
+            codes(|setting| setting.service_error.as_ref())
+        ),
+    );
     push_finding(
         findings,
         finding(
@@ -230,7 +261,7 @@ fn push_local_service_contradiction(
             IntuneFindingConfidence::High,
             "Device evidence and Intune reporting disagree",
             format!(
-                "The device and the imported Intune report state incompatible outcomes for {}. {recency} The device statement describes what the CSP did; the service statement describes what Intune was told.",
+                "The device and the imported Intune report state incompatible outcomes for {}.{statuses} {recency} The device statement describes what the CSP did; the service statement describes what Intune was told.",
                 join_labels(&settings)
             ),
             vec![
@@ -576,7 +607,7 @@ fn push_not_applicable(snapshot: &ConfigurationSnapshot, findings: &mut Vec<Intu
 
 /// The same CSP node observed under both device and user scope.
 fn push_scope_split(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
-    let mut by_resource: BTreeMap<&str, Vec<&ConfigurationSetting>> = BTreeMap::new();
+    let mut by_resource: BTreeMap<String, Vec<&ConfigurationSetting>> = BTreeMap::new();
     for setting in &snapshot.settings {
         if matches!(setting.identity.scope, ConfigurationScope::Unspecified) {
             continue;
@@ -584,7 +615,15 @@ fn push_scope_split(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneF
         let Some(resource) = setting.identity.resource_path.as_deref() else {
             continue;
         };
-        by_resource.entry(resource).or_default().push(setting);
+        // Lowercased for the same reason the dedupe key is: CSP node names are
+        // documented with specific casing but are not case-sensitive, and grouping
+        // on the exact bytes meant a device `Start/…` and a user `start/…` were
+        // two separate transactions that never met, so the scope split they
+        // represent went unreported.
+        by_resource
+            .entry(resource.to_ascii_lowercase())
+            .or_default()
+            .push(setting);
     }
 
     let split: Vec<&ConfigurationSetting> = by_resource
@@ -950,6 +989,58 @@ fn coverage_gaps(snapshot: &ConfigurationSnapshot) -> Vec<String> {
             IntuneArtifactStatus::Unsupported,
         ],
     )
+}
+
+/// An artifact the collector read in full that nevertheless settled nothing.
+///
+/// `available` is easy to read as "we looked and there was nothing wrong". When
+/// every record an artifact contributed is unrecognized, unsupported, or states no
+/// outcome, the honest statement is that this artifact answered no question — the
+/// same class of admission as a coverage gap, reached from the other direction.
+fn push_artifacts_without_usable_records(
+    snapshot: &ConfigurationSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let productive = snapshot
+        .settings
+        .iter()
+        .flat_map(|setting| setting.observations.iter())
+        .chain(snapshot.unattributed.iter())
+        .filter(|observation| !observation.is_uninterpretable)
+        .filter(|observation| observation.disposition.is_terminal())
+        .map(|observation| observation.evidence_ref.source_artifact_id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    let barren = snapshot
+        .coverage
+        .iter()
+        .filter(|entry| entry.status == IntuneArtifactStatus::Available)
+        .filter(|entry| !productive.contains(entry.artifact_id.as_str()))
+        .map(|entry| entry.artifact_id.clone())
+        .collect::<Vec<_>>();
+    if barren.is_empty() {
+        return;
+    }
+
+    push_finding(
+        findings,
+        finding(
+            "configuration-artifact-without-usable-records",
+            IntuneFindingSeverity::Info,
+            IntuneFindingConfidence::High,
+            "An artifact was read in full but settled nothing",
+            format!(
+                "{} artifact(s) were collected successfully and produced no record this build could turn into an outcome. Their `available` status describes the collection, not the analysis: no setting is resolved by them, so their silence is not evidence that nothing happened.",
+                barren.len()
+            ),
+            vec![
+                "Check whether the artifact's record schema or event ids are newer than this build supports.".to_owned(),
+                "Collect the companion artifact for the same workload before concluding a setting was never delivered.".to_owned(),
+            ],
+            Vec::new(),
+            barren,
+        ),
+    );
 }
 
 fn push_applied(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/rules.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/rules.rs
@@ -40,6 +40,7 @@ pub fn derive_findings(snapshot: &ConfigurationSnapshot) -> Vec<IntuneFinding> {
     push_local_rejection(snapshot, &mut findings);
     push_local_service_contradiction(snapshot, &mut findings);
     push_contested_device_evidence(snapshot, &mut findings);
+    push_unassessable_failure(snapshot, &mut findings);
     push_substantiated_conflict(snapshot, &mut findings);
     push_unsubstantiated_conflict(snapshot, &mut findings);
     push_substantiated_supersedence(snapshot, &mut findings);
@@ -247,8 +248,12 @@ fn push_contested_device_evidence(
     snapshot: &ConfigurationSnapshot,
     findings: &mut Vec<IntuneFinding>,
 ) {
+    // A setting contested only because a failure record could not be read is
+    // reported by `push_unassessable_failure`, which can name the actual shape.
+    // Saying "records state a different terminal outcome" about it would be wrong:
+    // one of them states no outcome at all.
     let settings = select(snapshot, |setting| {
-        setting.local == ConfigurationLocalState::Contested
+        setting.local == ConfigurationLocalState::Contested && !setting.has_unassessable_failure
     });
     if settings.is_empty() {
         return;
@@ -271,6 +276,36 @@ fn push_contested_device_evidence(
             evidence_where(&settings, |observation| {
                 observation.side == ConfigurationEvidenceSide::Device
                     && observation.disposition.is_terminal()
+            }),
+            Vec::new(),
+        ),
+    );
+}
+
+/// A device record that reports a failure nobody can read the reason for.
+fn push_unassessable_failure(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let settings = select(snapshot, |setting| setting.has_unassessable_failure);
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-unassessable-failure",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::High,
+            "A reported command failure could not be read",
+            format!(
+                "A device record reports a CSP command failure for {}, but its status could not be interpreted or the record was not fully read. The direction is still evidence: no success is claimed for these settings, even where another record says the value was written.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Re-collect the event channel with the event XML preserved so the status reaches the analyzer.".to_owned(),
+                "Compare the cited failure record with any success record for the same node before acting on either.".to_owned(),
+            ],
+            evidence_where(&settings, |observation| {
+                observation.side == ConfigurationEvidenceSide::Device
+                    && !observation.disposition.is_terminal()
             }),
             Vec::new(),
         ),
@@ -884,23 +919,61 @@ fn push_unreadable_artifacts(snapshot: &ConfigurationSnapshot, findings: &mut Ve
     );
 }
 
+/// Every artifact this bundle expected but did not fully read.
+fn coverage_gaps(snapshot: &ConfigurationSnapshot) -> Vec<String> {
+    artifacts_with_status(
+        snapshot,
+        &[
+            IntuneArtifactStatus::Missing,
+            IntuneArtifactStatus::PermissionDenied,
+            IntuneArtifactStatus::Skipped,
+            IntuneArtifactStatus::Capped,
+            IntuneArtifactStatus::ParseFailed,
+            IntuneArtifactStatus::Unsupported,
+        ],
+    )
+}
+
 fn push_applied(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    // A setting carrying an uninterpretable record is not a clean success: the
+    // unread record may be the one that mattered, and ADR-001 forbids a terminal
+    // success claim built on non-assessable evidence.
     let settings = select(snapshot, |setting| {
         setting.resolution == ConfigurationResolution::Applied
             && setting.local == ConfigurationLocalState::Applied
+            && !setting.has_uninterpretable_evidence
+            && !setting.has_unassessable_failure
     });
     if settings.is_empty() {
         return;
     }
+
+    // ADR-001: coverage gaps cannot raise confidence. Success is the claim a gap
+    // actually undermines — it rests partly on *not* having seen a failure, and a
+    // capped or unreadable artifact is exactly where an unseen failure would be.
+    // A rejection, by contrast, is directly evidenced and keeps its confidence.
+    let gaps = coverage_gaps(snapshot);
+    let (confidence, caveat) = if gaps.is_empty() {
+        (IntuneFindingConfidence::High, String::new())
+    } else {
+        (
+            IntuneFindingConfidence::Medium,
+            format!(
+                " {} expected artifact(s) were not fully read, so this bundle cannot show whether a later record changed any of them.",
+                gaps.len()
+            ),
+        )
+    };
+
     push_finding(
         findings,
         finding(
             "configuration-applied",
             IntuneFindingSeverity::Info,
-            IntuneFindingConfidence::High,
+            confidence,
             "Settings were applied by their CSP",
             format!(
-                "The device's own records show {} written by the responsible configuration service provider.",
+                "The device's own records show {} written by the responsible configuration service provider.{caveat}",
                 join_labels(&settings)
             ),
             Vec::new(),
@@ -908,7 +981,7 @@ fn push_applied(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFindi
                 observation.side == ConfigurationEvidenceSide::Device
                     && observation.disposition == ConfigurationDisposition::Applied
             }),
-            Vec::new(),
+            gaps,
         ),
     );
 }

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/rules.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/rules.rs
@@ -1,0 +1,914 @@
+//! Conservative findings derived from an immutable configuration snapshot.
+//!
+//! Every rule is one private `push_*` and emits at most one aggregated finding,
+//! so the finding identifiers are a fixed vocabulary rather than a function of
+//! how many settings a device happens to have.
+//!
+//! Two invariants hold for all of them:
+//!
+//! 1. A finding cites at least one [`IntuneEvidenceRef`] or at least one coverage
+//!    gap identifier. Callers can assert this with
+//!    [`IntuneFinding::is_evidence_backed`].
+//! 2. Conflict and supersedence are only *claimed* when the competing source was
+//!    actually observed. When the device says "conflict" and the other side of
+//!    the argument is nowhere in the bundle, the finding says exactly that and
+//!    asks for the next artifact instead.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::intune::evidence::{
+    IntuneArtifactStatus, IntuneEvidenceRef, IntuneFinding, IntuneFindingConfidence,
+    IntuneFindingSeverity,
+};
+
+use super::identity::ConfigurationScope;
+use super::models::{
+    ConfigurationDisposition, ConfigurationEvidenceSide, ConfigurationLocalState,
+    ConfigurationObservation, ConfigurationReceiptState, ConfigurationResolution,
+    ConfigurationServiceState, ConfigurationSetting, ConfigurationSnapshot,
+};
+
+/// Maximum number of setting labels quoted in a summary before it is truncated.
+const MAX_LABELS: usize = 6;
+
+/// Derive every finding this build knows how to state.
+///
+/// The order is fixed so a golden fixture can assert the whole vector.
+pub fn derive_findings(snapshot: &ConfigurationSnapshot) -> Vec<IntuneFinding> {
+    let mut findings = Vec::new();
+
+    push_local_rejection(snapshot, &mut findings);
+    push_local_service_contradiction(snapshot, &mut findings);
+    push_contested_device_evidence(snapshot, &mut findings);
+    push_substantiated_conflict(snapshot, &mut findings);
+    push_unsubstantiated_conflict(snapshot, &mut findings);
+    push_substantiated_supersedence(snapshot, &mut findings);
+    push_unsubstantiated_supersedence(snapshot, &mut findings);
+    push_removal(snapshot, &mut findings);
+    push_not_applicable(snapshot, &mut findings);
+    push_scope_split(snapshot, &mut findings);
+    push_duplicate_display_name(snapshot, &mut findings);
+    push_service_only_evidence(snapshot, &mut findings);
+    push_device_only_evidence(snapshot, &mut findings);
+    push_uninterpretable_evidence(snapshot, &mut findings);
+    push_unusable_ordering(snapshot, &mut findings);
+    push_unattributed_records(snapshot, &mut findings);
+    push_uncollected_artifacts(snapshot, &mut findings);
+    push_truncated_artifacts(snapshot, &mut findings);
+    push_unreadable_artifacts(snapshot, &mut findings);
+    push_applied(snapshot, &mut findings);
+
+    findings
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/// The most specific human-readable name for a setting.
+fn label(setting: &ConfigurationSetting) -> String {
+    setting
+        .identity
+        .canonical_uri
+        .clone()
+        .or_else(|| setting.identity.setting_id.clone())
+        .or_else(|| setting.identity.display_name.clone())
+        .unwrap_or_else(|| setting.identity.key.clone())
+}
+
+/// Comma-joined, de-duplicated, capped setting labels.
+fn join_labels(settings: &[&ConfigurationSetting]) -> String {
+    let mut labels: Vec<String> = Vec::new();
+    for setting in settings {
+        let value = label(setting);
+        if !labels.contains(&value) {
+            labels.push(value);
+        }
+    }
+    let extra = labels.len().saturating_sub(MAX_LABELS);
+    labels.truncate(MAX_LABELS);
+    let mut joined = labels.join(", ");
+    if extra > 0 {
+        joined.push_str(&format!(" (+{extra} more)"));
+    }
+    joined
+}
+
+/// Sorted, de-duplicated evidence references.
+fn collect_evidence<'a>(
+    refs: impl IntoIterator<Item = &'a IntuneEvidenceRef>,
+) -> Vec<IntuneEvidenceRef> {
+    refs.into_iter()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+/// Evidence for every observation of `settings` matching `keep`.
+fn evidence_where(
+    settings: &[&ConfigurationSetting],
+    keep: impl Fn(&ConfigurationObservation) -> bool + Copy,
+) -> Vec<IntuneEvidenceRef> {
+    collect_evidence(
+        settings
+            .iter()
+            .flat_map(|setting| setting.observations.iter())
+            .filter(|observation| keep(observation))
+            .map(|observation| &observation.evidence_ref),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finding(
+    finding_id: &str,
+    severity: IntuneFindingSeverity,
+    confidence: IntuneFindingConfidence,
+    title: &str,
+    summary: String,
+    recommended_checks: Vec<String>,
+    evidence: Vec<IntuneEvidenceRef>,
+    coverage_gap_ids: Vec<String>,
+) -> IntuneFinding {
+    IntuneFinding {
+        finding_id: finding_id.to_owned(),
+        severity,
+        confidence,
+        title: title.to_owned(),
+        summary,
+        recommended_checks,
+        evidence,
+        coverage_gap_ids,
+    }
+}
+
+/// Append `candidate` only when it cites something.
+///
+/// This is the single choke point that upholds the evidence-backed invariant; a
+/// rule that computed an empty citation set silently emits nothing rather than an
+/// unsupported claim.
+fn push_finding(findings: &mut Vec<IntuneFinding>, candidate: IntuneFinding) {
+    if candidate.is_evidence_backed() {
+        findings.push(candidate);
+    }
+}
+
+fn select(
+    snapshot: &ConfigurationSnapshot,
+    keep: impl Fn(&ConfigurationSetting) -> bool,
+) -> Vec<&ConfigurationSetting> {
+    snapshot.settings.iter().filter(|s| keep(s)).collect()
+}
+
+// ── Device outcome rules ────────────────────────────────────────────────────
+
+fn push_local_rejection(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let settings = select(snapshot, |setting| {
+        setting.local == ConfigurationLocalState::Rejected
+    });
+    if settings.is_empty() {
+        return;
+    }
+    let codes = settings
+        .iter()
+        .filter_map(|setting| setting.local_error.as_ref())
+        .map(|code| code.hex.clone().unwrap_or_else(|| code.raw.clone()))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let codes = if codes.is_empty() {
+        "no readable status".to_owned()
+    } else {
+        codes.join(", ")
+    };
+    push_finding(
+        findings,
+        finding(
+            "configuration-local-rejection",
+            IntuneFindingSeverity::Error,
+            IntuneFindingConfidence::High,
+            "A CSP rejected a configuration setting on the device",
+            format!(
+                "The configuration service provider returned a terminal error for {}. Reported status: {codes}.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Look up the cited status code for the named CSP node.".to_owned(),
+                "Confirm the device meets the edition, build, and licensing prerequisites for that node.".to_owned(),
+            ],
+            evidence_where(&settings, |observation| {
+                observation.side == ConfigurationEvidenceSide::Device
+                    && observation.disposition == ConfigurationDisposition::Rejected
+            }),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_local_service_contradiction(
+    snapshot: &ConfigurationSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let settings = select(snapshot, |setting| {
+        setting.resolution == ConfigurationResolution::Contradicted
+            && setting.local != ConfigurationLocalState::Contested
+            && setting.service != ConfigurationServiceState::NoEvidence
+    });
+    if settings.is_empty() {
+        return;
+    }
+    let recency = if settings.iter().all(|setting| setting.recency_is_usable()) {
+        "Both sides carry usable time provenance, but neither is authoritative over the other."
+    } else {
+        "At least one side has unusable time provenance, so the newer statement cannot be preferred."
+    };
+    push_finding(
+        findings,
+        finding(
+            "configuration-local-service-contradiction",
+            IntuneFindingSeverity::Error,
+            IntuneFindingConfidence::High,
+            "Device evidence and Intune reporting disagree",
+            format!(
+                "The device and the imported Intune report state incompatible outcomes for {}. {recency} The device statement describes what the CSP did; the service statement describes what Intune was told.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Compare the cited device record and service row side by side before trusting either.".to_owned(),
+                "Re-collect both after a forced sync so the two describe the same policy version.".to_owned(),
+            ],
+            evidence_where(&settings, |observation| {
+                observation.disposition.is_terminal()
+            }),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_contested_device_evidence(
+    snapshot: &ConfigurationSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let settings = select(snapshot, |setting| {
+        setting.local == ConfigurationLocalState::Contested
+    });
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-contested-device-evidence",
+            IntuneFindingSeverity::Error,
+            IntuneFindingConfidence::Medium,
+            "Device records disagree about the same setting",
+            format!(
+                "More than one device-side record states a different terminal outcome for {}. No outcome is claimed.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Order the cited records by their channel record numbers rather than by timestamp.".to_owned(),
+                "Check whether the records belong to different enrollments or configuration sources.".to_owned(),
+            ],
+            evidence_where(&settings, |observation| {
+                observation.side == ConfigurationEvidenceSide::Device
+                    && observation.disposition.is_terminal()
+            }),
+            Vec::new(),
+        ),
+    );
+}
+
+/// A conflict where the competing source is actually present in the bundle.
+fn push_substantiated_conflict(
+    snapshot: &ConfigurationSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let settings = select(snapshot, |setting| {
+        is_conflicted(setting) && competing_sources_are_observed(setting)
+    });
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-conflict",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::High,
+            "Two configuration sources target the same setting",
+            format!(
+                "{} is claimed by more than one configuration source, and the competing statements are cited below.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Compare the cited configuration source identifiers against the policies assigned to this device.".to_owned(),
+                "Remove the setting from all but one policy, or align their values.".to_owned(),
+            ],
+            evidence_where(&settings, |_| true),
+            Vec::new(),
+        ),
+    );
+}
+
+/// A reported conflict whose other side is missing from the bundle.
+fn push_unsubstantiated_conflict(
+    snapshot: &ConfigurationSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let settings = select(snapshot, |setting| {
+        is_conflicted(setting) && !competing_sources_are_observed(setting)
+    });
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-conflict-unsubstantiated",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::Low,
+            "A conflict was reported but the competing source was not collected",
+            format!(
+                "A record reports a conflict for {}, but no second configuration source for that node appears in this bundle, so the competing policy is not identified here.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Collect the full MDM diagnostic report so every configuration source for the node is present.".to_owned(),
+                "Export the device's policy assignments and compare them with the cited node.".to_owned(),
+            ],
+            evidence_where(&settings, |observation| {
+                observation.disposition == ConfigurationDisposition::Conflict
+            }),
+            Vec::new(),
+        ),
+    );
+}
+
+fn is_conflicted(setting: &ConfigurationSetting) -> bool {
+    setting.local == ConfigurationLocalState::Conflicted
+        || setting.service == ConfigurationServiceState::ReportedConflict
+}
+
+/// Whether the bundle actually contains the second side of the argument.
+///
+/// Either two distinct configuration source identifiers stated something about
+/// the node, or a record explicitly named the winner. A lone row saying
+/// "conflict" is not itself evidence of a competing source.
+fn competing_sources_are_observed(setting: &ConfigurationSetting) -> bool {
+    let distinct = setting
+        .sources
+        .iter()
+        .filter_map(|statement| statement.source_id.as_deref())
+        .collect::<BTreeSet<_>>();
+    if distinct.len() >= 2 {
+        return true;
+    }
+    setting.observations.iter().any(|observation| {
+        observation
+            .winning_source_id
+            .as_deref()
+            .is_some_and(|winner| {
+                observation
+                    .source_id
+                    .as_deref()
+                    .is_none_or(|source| !source.eq_ignore_ascii_case(winner))
+            })
+    })
+}
+
+fn push_substantiated_supersedence(
+    snapshot: &ConfigurationSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let settings = select(snapshot, |setting| {
+        is_superseded(setting) && superseding_source_is_observed(setting)
+    });
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-superseded",
+            IntuneFindingSeverity::Info,
+            IntuneFindingConfidence::High,
+            "A setting was replaced by another configuration source",
+            format!(
+                "{} was superseded, and the replacing configuration source is cited below.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Confirm the replacing configuration source carries the value you intended."
+                    .to_owned(),
+            ],
+            evidence_where(&settings, |_| true),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_unsubstantiated_supersedence(
+    snapshot: &ConfigurationSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let settings = select(snapshot, |setting| {
+        is_superseded(setting) && !superseding_source_is_observed(setting)
+    });
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-superseded-unsubstantiated",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::Low,
+            "A setting was reported superseded but the replacement was not collected",
+            format!(
+                "A record reports {} as superseded without naming a replacing source that also appears in this bundle.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Collect the full MDM diagnostic report so the replacing configuration source is present.".to_owned(),
+            ],
+            evidence_where(&settings, |observation| {
+                observation.disposition == ConfigurationDisposition::Superseded
+            }),
+            Vec::new(),
+        ),
+    );
+}
+
+fn is_superseded(setting: &ConfigurationSetting) -> bool {
+    setting.local == ConfigurationLocalState::Superseded
+        || setting.service == ConfigurationServiceState::ReportedSuperseded
+}
+
+fn superseding_source_is_observed(setting: &ConfigurationSetting) -> bool {
+    let named_replacements = setting
+        .observations
+        .iter()
+        .filter_map(|observation| observation.superseded_by_source_id.as_deref())
+        .collect::<BTreeSet<_>>();
+    if named_replacements.is_empty() {
+        return false;
+    }
+    setting.sources.iter().any(|statement| {
+        statement.source_id.as_deref().is_some_and(|source| {
+            named_replacements
+                .iter()
+                .any(|replacement| replacement.eq_ignore_ascii_case(source))
+        })
+    })
+}
+
+fn push_removal(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let settings = select(snapshot, |setting| {
+        setting.resolution == ConfigurationResolution::Removed
+    });
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-removed",
+            IntuneFindingSeverity::Info,
+            IntuneFindingConfidence::High,
+            "A setting was removed from the device",
+            format!(
+                "The CSP deleted {}. A removal is the expected result of unassigning a policy; it is only a problem if the policy is still assigned.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Confirm the policy carrying the cited node is still assigned to this device.".to_owned(),
+            ],
+            evidence_where(&settings, |observation| {
+                observation.disposition == ConfigurationDisposition::Removed
+            }),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_not_applicable(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let settings = select(snapshot, |setting| {
+        setting.resolution == ConfigurationResolution::NotApplicable
+    });
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-not-applicable",
+            IntuneFindingSeverity::Info,
+            IntuneFindingConfidence::High,
+            "A setting does not apply to this device",
+            format!(
+                "{} was reported as not applicable, so no value was written. This build does not infer why; the CSP decides applicability from edition, build, and hardware.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Check the Windows edition and build requirements documented for the cited CSP node.".to_owned(),
+            ],
+            evidence_where(&settings, |observation| {
+                observation.disposition == ConfigurationDisposition::NotApplicable
+            }),
+            Vec::new(),
+        ),
+    );
+}
+
+// ── Identity rules ──────────────────────────────────────────────────────────
+
+/// The same CSP node observed under both device and user scope.
+fn push_scope_split(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let mut by_resource: BTreeMap<&str, Vec<&ConfigurationSetting>> = BTreeMap::new();
+    for setting in &snapshot.settings {
+        if matches!(setting.identity.scope, ConfigurationScope::Unspecified) {
+            continue;
+        }
+        let Some(resource) = setting.identity.resource_path.as_deref() else {
+            continue;
+        };
+        by_resource.entry(resource).or_default().push(setting);
+    }
+
+    let split: Vec<&ConfigurationSetting> = by_resource
+        .into_values()
+        .filter(|settings| {
+            settings
+                .iter()
+                .map(|setting| setting.identity.scope)
+                .collect::<BTreeSet<_>>()
+                .len()
+                > 1
+        })
+        .flatten()
+        .collect();
+    if split.is_empty() {
+        return;
+    }
+
+    push_finding(
+        findings,
+        finding(
+            "configuration-scope-split",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::High,
+            "The same CSP node was targeted in both device and user scope",
+            format!(
+                "{} appears under both ./Device and ./User. These are separate settings with separate outcomes; a value written in one scope does not satisfy the other.",
+                join_labels(&split)
+            ),
+            vec![
+                "Confirm which scope the policy intended, and compare it with the cited records.".to_owned(),
+                "For a user-scoped node, confirm a user was signed in when the CSP ran.".to_owned(),
+            ],
+            evidence_where(&split, |_| true),
+            Vec::new(),
+        ),
+    );
+}
+
+/// One friendly name shared by two different CSP paths.
+fn push_duplicate_display_name(
+    snapshot: &ConfigurationSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let mut by_name: BTreeMap<String, Vec<&ConfigurationSetting>> = BTreeMap::new();
+    for setting in &snapshot.settings {
+        let Some(name) = setting.identity.display_name.as_deref() else {
+            continue;
+        };
+        by_name
+            .entry(name.to_ascii_lowercase())
+            .or_default()
+            .push(setting);
+    }
+
+    let duplicates: Vec<&ConfigurationSetting> = by_name
+        .into_values()
+        .filter(|settings| {
+            settings
+                .iter()
+                .map(|setting| setting.identity.key.as_str())
+                .collect::<BTreeSet<_>>()
+                .len()
+                > 1
+        })
+        .flatten()
+        .collect();
+    if duplicates.is_empty() {
+        return;
+    }
+
+    push_finding(
+        findings,
+        finding(
+            "configuration-duplicate-display-name",
+            IntuneFindingSeverity::Info,
+            IntuneFindingConfidence::High,
+            "One display name covers more than one CSP node",
+            format!(
+                "{} share a display name but resolve to different CSP identities and are reported separately here. A portal view that groups by name will look inconsistent with this output.",
+                join_labels(&duplicates)
+            ),
+            vec![
+                "Match the cited OMA-URIs, not the display names, when comparing with the portal.".to_owned(),
+            ],
+            evidence_where(&duplicates, |_| true),
+            Vec::new(),
+        ),
+    );
+}
+
+// ── Coverage rules ──────────────────────────────────────────────────────────
+
+fn push_service_only_evidence(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let settings = select(snapshot, |setting| {
+        setting.receipt == ConfigurationReceiptState::Intended
+            && setting.service != ConfigurationServiceState::NoEvidence
+    });
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-service-only-evidence",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::Medium,
+            "Only Intune reporting describes these settings",
+            format!(
+                "{} is described solely by imported Intune data. A portal status reports what the service was told and does not prove the CSP applied anything on this device.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Collect the DeviceManagement-Enterprise-Diagnostics-Provider/Admin channel from the device.".to_owned(),
+                "Collect an MDM diagnostic report so the local CSP state is present.".to_owned(),
+            ],
+            evidence_where(&settings, |_| true),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_device_only_evidence(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    // Only settings whose local state actually says something. A device record
+    // that could not be interpreted is reported by the uninterpretable-evidence
+    // rule; calling it "device evidence" here would overstate what was read.
+    let settings = select(snapshot, |setting| {
+        setting.service == ConfigurationServiceState::NoEvidence
+            && !matches!(
+                setting.local,
+                ConfigurationLocalState::NoEvidence | ConfigurationLocalState::Indeterminate
+            )
+    });
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-device-only-evidence",
+            IntuneFindingSeverity::Info,
+            IntuneFindingConfidence::High,
+            "No Intune reporting was imported for these settings",
+            format!(
+                "{} is described only by device evidence. That is sufficient to state what the CSP did, but it cannot show whether Intune received the same answer.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Import the Intune per-setting report if you need to compare device state with service reporting.".to_owned(),
+            ],
+            evidence_where(&settings, |_| true),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_uninterpretable_evidence(
+    snapshot: &ConfigurationSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let settings = select(snapshot, |setting| setting.has_uninterpretable_evidence);
+    let unattributed_uninterpretable = snapshot
+        .unattributed
+        .iter()
+        .filter(|observation| observation.is_uninterpretable)
+        .map(|observation| &observation.evidence_ref);
+
+    let mut evidence = evidence_where(&settings, |observation| observation.is_uninterpretable);
+    evidence.extend(unattributed_uninterpretable.cloned());
+    let evidence = collect_evidence(evidence.iter());
+    if evidence.is_empty() {
+        return;
+    }
+
+    push_finding(
+        findings,
+        finding(
+            "configuration-uninterpretable-evidence",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::High,
+            "Some configuration records could not be interpreted",
+            format!(
+                "{} record(s) were malformed or used a schema this build does not recognize. They are retained as evidence but contribute no outcome, so absence of a result for the settings they mention proves nothing.",
+                evidence.len()
+            ),
+            vec![
+                "Re-export the MDM diagnostic report; a truncated export is the usual cause.".to_owned(),
+                "Check whether the report or event schema is newer than this build supports.".to_owned(),
+            ],
+            evidence,
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_unusable_ordering(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let settings = select(snapshot, |setting| !setting.recency_is_usable());
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-unusable-ordering",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::High,
+            "Record ordering cannot be trusted for these settings",
+            format!(
+                "For {}, a contributing record carries an invalid or ambiguous timestamp, or the channel record numbers contradict the timestamps. No outcome in this report was chosen by preferring the newer record.",
+                join_labels(&settings)
+            ),
+            vec![
+                "Re-collect the event channel; a clock change during capture produces this shape.".to_owned(),
+                "Order the cited records by their channel record numbers instead of their timestamps.".to_owned(),
+            ],
+            evidence_where(&settings, |_| true),
+            Vec::new(),
+        ),
+    );
+}
+
+fn push_unattributed_records(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    if snapshot.unattributed.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-unattributed-records",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::Medium,
+            "Some records name no identifiable setting",
+            format!(
+                "{} record(s) describe a configuration outcome without an OMA-URI or setting identifier. They are kept separate and never merged with an identified setting, because a name alone cannot establish which node they are about.",
+                snapshot.unattributed.len()
+            ),
+            vec![
+                "Re-collect with the event XML preserved so the node URI reaches the analyzer.".to_owned(),
+            ],
+            collect_evidence(
+                snapshot
+                    .unattributed
+                    .iter()
+                    .map(|observation| &observation.evidence_ref),
+            ),
+            Vec::new(),
+        ),
+    );
+}
+
+fn artifacts_with_status(
+    snapshot: &ConfigurationSnapshot,
+    statuses: &[IntuneArtifactStatus],
+) -> Vec<String> {
+    snapshot
+        .coverage
+        .iter()
+        .filter(|entry| statuses.contains(&entry.status))
+        .map(|entry| entry.artifact_id.clone())
+        .collect()
+}
+
+fn push_uncollected_artifacts(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let gaps = artifacts_with_status(
+        snapshot,
+        &[
+            IntuneArtifactStatus::Missing,
+            IntuneArtifactStatus::PermissionDenied,
+            IntuneArtifactStatus::Skipped,
+        ],
+    );
+    if gaps.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-uncollected-artifacts",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::High,
+            "Expected configuration evidence was not collected",
+            format!(
+                "{} expected artifact(s) were missing, inaccessible, or skipped. Any setting they would have described is unresolved rather than absent.",
+                gaps.len()
+            ),
+            vec![
+                "Re-run collection elevated so protected event channels and the MDM report can be read.".to_owned(),
+                "Collect the named artifacts and re-run the analysis.".to_owned(),
+            ],
+            Vec::new(),
+            gaps,
+        ),
+    );
+}
+
+fn push_truncated_artifacts(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let gaps = artifacts_with_status(snapshot, &[IntuneArtifactStatus::Capped]);
+    if gaps.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-truncated-artifacts",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::High,
+            "Configuration evidence was truncated during collection",
+            format!(
+                "{} artifact(s) hit a collection cap. Records past the cap were never read, so the absence of a setting in this bundle is not evidence the device lacks it.",
+                gaps.len()
+            ),
+            vec![
+                "Re-collect with a larger cap, or narrow the collection window.".to_owned(),
+            ],
+            Vec::new(),
+            gaps,
+        ),
+    );
+}
+
+fn push_unreadable_artifacts(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let gaps = artifacts_with_status(
+        snapshot,
+        &[
+            IntuneArtifactStatus::ParseFailed,
+            IntuneArtifactStatus::Unsupported,
+        ],
+    );
+    if gaps.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-unreadable-artifacts",
+            IntuneFindingSeverity::Warning,
+            IntuneFindingConfidence::High,
+            "Configuration evidence was collected but could not be read",
+            format!(
+                "{} artifact(s) were collected and then failed to parse or used an unsupported format. The bytes exist; this build cannot interpret them.",
+                gaps.len()
+            ),
+            vec![
+                "Re-export the MDM diagnostic report and confirm the export completed.".to_owned(),
+                "Check whether the artifact's schema version is newer than this build supports.".to_owned(),
+            ],
+            Vec::new(),
+            gaps,
+        ),
+    );
+}
+
+fn push_applied(snapshot: &ConfigurationSnapshot, findings: &mut Vec<IntuneFinding>) {
+    let settings = select(snapshot, |setting| {
+        setting.resolution == ConfigurationResolution::Applied
+            && setting.local == ConfigurationLocalState::Applied
+    });
+    if settings.is_empty() {
+        return;
+    }
+    push_finding(
+        findings,
+        finding(
+            "configuration-applied",
+            IntuneFindingSeverity::Info,
+            IntuneFindingConfidence::High,
+            "Settings were applied by their CSP",
+            format!(
+                "The device's own records show {} written by the responsible configuration service provider.",
+                join_labels(&settings)
+            ),
+            Vec::new(),
+            evidence_where(&settings, |observation| {
+                observation.side == ConfigurationEvidenceSide::Device
+                    && observation.disposition == ConfigurationDisposition::Applied
+            }),
+            Vec::new(),
+        ),
+    );
+}

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/sources.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/sources.rs
@@ -6,8 +6,8 @@
 //! projected last.
 
 use crate::intune::evidence::{
-    IntuneErrorCode, IntuneNamedValue, IntuneObservationContext, IntuneParseState, IntuneTimestamp,
-    IntuneTimestampKind,
+    IntuneAccessState, IntuneErrorCode, IntuneNamedValue, IntuneObservationContext,
+    IntuneParseState, IntuneTimestamp, IntuneTimestampKind,
 };
 use crate::intune::normalized::{
     NormalizedSettingOutcome, NormalizedSettingReport, NormalizedWindowsEvent,
@@ -147,7 +147,30 @@ fn is_uninterpretable(context: &IntuneObservationContext) -> bool {
     matches!(
         context.parse_state,
         IntuneParseState::Malformed | IntuneParseState::Unsupported
-    )
+    ) || !is_fully_read(context)
+}
+
+/// Whether the collector says it read the whole record.
+///
+/// A record extracted from a source that was capped, denied, or failed mid-read
+/// is not evidence of what it appears to say: the fields this analyzer keys on may
+/// simply be the ones that were never read. Treating it as interpretable would let
+/// a truncated capture assert an outcome.
+fn is_fully_read(context: &IntuneObservationContext) -> bool {
+    matches!(context.access_state, IntuneAccessState::Available)
+}
+
+/// Whether an observation is a failure whose detail could not be assessed.
+///
+/// A 404 command-failure event says a failure happened even when its `Result:`
+/// token is unreadable. The direction is evidence; the code is not. Such a record
+/// must not be silently dropped by a rule that only looks at terminal outcomes,
+/// which is how an 813-Applied plus an unreadable 404 for the same node reported
+/// a clean success with no mention of the failure at all.
+pub fn is_unassessable_failure(observation: &ConfigurationObservation) -> bool {
+    is_device_side(observation)
+        && !observation.disposition.is_terminal()
+        && observation.event_kind == Some(ConfigurationEventKind::CommandFailure)
 }
 
 /// Classify a recognized MDM Admin-channel event ID.

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/sources.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/sources.rs
@@ -193,12 +193,12 @@ pub fn classify_event(event: &NormalizedWindowsEvent) -> ConfigurationEventKind 
     }
 }
 
-fn command_type_is_removal(command_type: Option<&str>) -> bool {
-    command_type.is_some_and(|value| {
-        let value = value.trim().trim_matches(['(', ')']);
-        value.eq_ignore_ascii_case("Delete") || value.eq_ignore_ascii_case("Remove")
-    })
-}
+// `CommandType` / `Command` is recorded on the observation as evidence but never
+// decides a disposition. ADR-002 forbids promoting an untyped local field into
+// shared semantic authority, and `Command: Delete` beside a typed `Applied`
+// outcome was doing exactly that: turning a stated application into a removal on
+// the strength of free text. The typed outcome — the report's `outcome`, or the
+// event id via `ConfigurationEventKind` — is the only thing that decides.
 
 /// Project one normalized event onto a configuration observation.
 ///
@@ -268,13 +268,7 @@ pub fn observation_from_event(event: &NormalizedWindowsEvent) -> Option<Configur
                 Some(code) if is_failure(code) => ConfigurationDisposition::Rejected,
                 _ => ConfigurationDisposition::Indeterminate,
             },
-            ConfigurationEventKind::PolicySet => {
-                if command_type_is_removal(command_type.as_deref()) {
-                    ConfigurationDisposition::Removed
-                } else {
-                    ConfigurationDisposition::Applied
-                }
-            }
+            ConfigurationEventKind::PolicySet => ConfigurationDisposition::Applied,
             ConfigurationEventKind::PolicyDeleted => ConfigurationDisposition::Removed,
             ConfigurationEventKind::Unrecognized => ConfigurationDisposition::Received,
         }
@@ -330,13 +324,7 @@ pub fn observation_from_report(report: &NormalizedSettingReport) -> Configuratio
         ConfigurationDisposition::Indeterminate
     } else {
         match report.outcome {
-            NormalizedSettingOutcome::Applied => {
-                if command_type_is_removal(command_type.as_deref()) {
-                    ConfigurationDisposition::Removed
-                } else {
-                    ConfigurationDisposition::Applied
-                }
-            }
+            NormalizedSettingOutcome::Applied => ConfigurationDisposition::Applied,
             NormalizedSettingOutcome::Pending => ConfigurationDisposition::Pending,
             NormalizedSettingOutcome::Failed => ConfigurationDisposition::Rejected,
             NormalizedSettingOutcome::Conflict => ConfigurationDisposition::Conflict,

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/sources.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/sources.rs
@@ -1,0 +1,415 @@
+//! Turn the shared normalized inputs into typed configuration observations.
+//!
+//! Nothing here decides an outcome for a *setting*; it decides what one record
+//! says. The reducer combines them. Keeping the two apart is what makes a
+//! contradiction visible instead of being resolved by whichever record was
+//! projected last.
+
+use crate::intune::evidence::{
+    IntuneErrorCode, IntuneNamedValue, IntuneObservationContext, IntuneParseState, IntuneTimestamp,
+    IntuneTimestampKind,
+};
+use crate::intune::normalized::{
+    NormalizedSettingOutcome, NormalizedSettingReport, NormalizedWindowsEvent,
+};
+
+use super::identity::{
+    csp_uri_from_message, policy_uri_from_message, resolve_identity, result_token_from_message,
+    source_id_from_message, ConfigurationScope, IdentityHints,
+};
+use super::models::{
+    evidence_side, ConfigurationDisposition, ConfigurationEventKind, ConfigurationEvidenceSide,
+    ConfigurationObservation,
+};
+
+/// The MDM provider family whose Admin channel this analyzer understands.
+///
+/// Records from any other provider are still projected — they may legitimately
+/// name a CSP node — but their event IDs are never interpreted, because event ID
+/// 404 means something entirely different in another provider's namespace.
+pub const MDM_DIAGNOSTICS_PROVIDER: &str =
+    "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider";
+
+/// Event ID for `MDM ConfigurationManager: Command failure status`.
+pub const EVENT_ID_COMMAND_FAILURE: u32 = 404;
+/// Event ID for `MDM PolicyManager: Set policy int`.
+pub const EVENT_ID_SET_POLICY_INT: u32 = 813;
+/// Event ID for `MDM PolicyManager: Set policy string`.
+pub const EVENT_ID_SET_POLICY_STRING: u32 = 814;
+/// Event ID for `MDM PolicyManager: Delete policy`.
+pub const EVENT_ID_DELETE_POLICY: u32 = 815;
+
+/// Named-value keys carrying the CSP node path, in preference order.
+const URI_KEYS: [&str; 6] = ["NodeUri", "CspUri", "CSPURI", "SettingUri", "Uri", "OmaUri"];
+const SOURCE_ID_KEYS: [&str; 4] = [
+    "ConfigurationSourceId",
+    "PolicyId",
+    "SourceId",
+    "ConfigSourceId",
+];
+const ENROLLMENT_KEYS: [&str; 2] = ["EnrollmentId", "EnrollmentName"];
+const COMMAND_TYPE_KEYS: [&str; 2] = ["CommandType", "Command"];
+const RESULT_KEYS: [&str; 4] = ["Result", "ResultCode", "ErrorCode", "Hresult"];
+const VALUE_KEYS: [&str; 3] = ["Value", "SettingValue", "Data"];
+const DISPLAY_NAME_KEYS: [&str; 2] = ["DisplayName", "SettingName"];
+const SCOPE_KEYS: [&str; 2] = ["Scope", "TargetScope"];
+const WINNING_KEYS: [&str; 3] = ["WinningPolicyId", "WinningProvider", "ConflictWinner"];
+const SUPERSEDED_BY_KEYS: [&str; 2] = ["SupersededBy", "SupersedingPolicyId"];
+
+/// Case-insensitive lookup of the first key present in `named_data`.
+pub fn named<'a>(named_data: &'a [IntuneNamedValue], keys: &[&str]) -> Option<&'a str> {
+    for key in keys {
+        if let Some(found) = named_data
+            .iter()
+            .find(|entry| entry.name.eq_ignore_ascii_case(key))
+        {
+            let value = found.value.trim();
+            if !value.is_empty() {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+/// Parse a status token into every form it was or could have been written in.
+///
+/// Hex tokens with the high bit set are also reported as the signed decimal
+/// Windows uses for the same HRESULT, because the two forms show up in different
+/// artifacts for the same failure and a reader should not have to convert.
+pub fn build_error_code(raw: &str) -> Option<IntuneErrorCode> {
+    let trimmed = raw.trim().trim_matches(['(', ')']).trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let (decimal, hex) = if let Some(digits) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        let parsed = u64::from_str_radix(digits, 16).ok()?;
+        let decimal = if parsed <= u64::from(u32::MAX) {
+            Some(i64::from(parsed as u32 as i32))
+        } else {
+            i64::try_from(parsed).ok()
+        };
+        (decimal, Some(format!("0x{parsed:08X}")))
+    } else {
+        let parsed = trimmed.parse::<i64>().ok()?;
+        let hex = u32::try_from(parsed)
+            .map(|value| format!("0x{value:08X}"))
+            .or_else(|_| i32::try_from(parsed).map(|value| format!("0x{:08X}", value as u32)))
+            .ok();
+        (Some(parsed), hex)
+    };
+
+    Some(IntuneErrorCode {
+        raw: trimmed.to_owned(),
+        decimal,
+        hex,
+    })
+}
+
+/// Whether a status code states a failure.
+///
+/// A code whose decimal form could not be determined is *not* treated as a
+/// failure: an uninterpretable token is missing evidence, not bad news.
+pub fn is_failure(code: &IntuneErrorCode) -> bool {
+    matches!(code.decimal, Some(value) if value != 0)
+}
+
+/// Whether the record's own timestamp can be compared with another record's.
+///
+/// Local and unspecified wall-clock stamps are rejected for comparison even
+/// though they are perfectly readable: without an offset there is no way to know
+/// whether a device stamp precedes a service stamp, and issue #363 forbids
+/// resolving a contradiction by recency without reliable provenance.
+pub fn timestamp_is_reliable(timestamp: Option<&IntuneTimestamp>) -> bool {
+    match timestamp {
+        None => true,
+        Some(stamp) => {
+            matches!(
+                stamp.kind,
+                IntuneTimestampKind::Utc | IntuneTimestampKind::Offset
+            ) && stamp.normalized_utc.is_some()
+        }
+    }
+}
+
+fn normalized_instant(context: &IntuneObservationContext) -> Option<String> {
+    context
+        .source_timestamp
+        .as_ref()
+        .and_then(|stamp| stamp.normalized_utc.clone())
+}
+
+fn is_uninterpretable(context: &IntuneObservationContext) -> bool {
+    matches!(
+        context.parse_state,
+        IntuneParseState::Malformed | IntuneParseState::Unsupported
+    )
+}
+
+/// Classify a recognized MDM Admin-channel event ID.
+pub fn classify_event(event: &NormalizedWindowsEvent) -> ConfigurationEventKind {
+    if !event
+        .provider
+        .eq_ignore_ascii_case(MDM_DIAGNOSTICS_PROVIDER)
+    {
+        return ConfigurationEventKind::Unrecognized;
+    }
+    match event.event_id {
+        EVENT_ID_COMMAND_FAILURE => ConfigurationEventKind::CommandFailure,
+        EVENT_ID_SET_POLICY_INT | EVENT_ID_SET_POLICY_STRING => ConfigurationEventKind::PolicySet,
+        EVENT_ID_DELETE_POLICY => ConfigurationEventKind::PolicyDeleted,
+        _ => ConfigurationEventKind::Unrecognized,
+    }
+}
+
+fn command_type_is_removal(command_type: Option<&str>) -> bool {
+    command_type.is_some_and(|value| {
+        let value = value.trim().trim_matches(['(', ')']);
+        value.eq_ignore_ascii_case("Delete") || value.eq_ignore_ascii_case("Remove")
+    })
+}
+
+/// Project one normalized event onto a configuration observation.
+///
+/// Returns `None` when the record names no CSP resource at all and therefore has
+/// nothing to say about configuration; such records are not evidence of anything
+/// here and inventing an identity for them would fabricate a transaction.
+pub fn observation_from_event(event: &NormalizedWindowsEvent) -> Option<ConfigurationObservation> {
+    let context = &event.context;
+    let event_kind = classify_event(event);
+    let message = event.message.as_deref().unwrap_or_default();
+
+    let uri = named(&event.named_data, &URI_KEYS)
+        .map(str::to_owned)
+        .or_else(|| csp_uri_from_message(message))
+        .or_else(|| {
+            // PolicyManager events name Policy/Area rather than a node path.
+            let scope = named(&event.named_data, &SCOPE_KEYS)
+                .map(ConfigurationScope::from_token)
+                .unwrap_or(ConfigurationScope::Device);
+            policy_uri_from_message(message, scope)
+        });
+
+    let setting_id = named(&event.named_data, &["SettingId"]).map(str::to_owned);
+    if uri.is_none() && setting_id.is_none() {
+        return None;
+    }
+
+    let identity = resolve_identity(&IdentityHints {
+        uri: uri.as_deref(),
+        setting_id: setting_id.as_deref(),
+        policy_id: named(&event.named_data, &SOURCE_ID_KEYS),
+        display_name: named(&event.named_data, &DISPLAY_NAME_KEYS),
+        scope_token: named(&event.named_data, &SCOPE_KEYS),
+        evidence_id: &context.evidence_ref.evidence_id,
+    });
+
+    let error = named(&event.named_data, &RESULT_KEYS)
+        .map(str::to_owned)
+        .or_else(|| result_token_from_message(message))
+        .as_deref()
+        .and_then(build_error_code);
+
+    let command_type = named(&event.named_data, &COMMAND_TYPE_KEYS).map(str::to_owned);
+    let uninterpretable = is_uninterpretable(context);
+
+    let disposition = if uninterpretable {
+        ConfigurationDisposition::Indeterminate
+    } else {
+        match event_kind {
+            // 404 is the failure event. Without a readable non-zero status the
+            // record still proves the CSP rejected something, but not what, so
+            // it stays indeterminate rather than asserting a rejection.
+            ConfigurationEventKind::CommandFailure => match error.as_ref() {
+                Some(code) if is_failure(code) => ConfigurationDisposition::Rejected,
+                _ => ConfigurationDisposition::Indeterminate,
+            },
+            ConfigurationEventKind::PolicySet => {
+                if command_type_is_removal(command_type.as_deref()) {
+                    ConfigurationDisposition::Removed
+                } else {
+                    ConfigurationDisposition::Applied
+                }
+            }
+            ConfigurationEventKind::PolicyDeleted => ConfigurationDisposition::Removed,
+            ConfigurationEventKind::Unrecognized => ConfigurationDisposition::Received,
+        }
+    };
+
+    Some(ConfigurationObservation {
+        evidence_ref: context.evidence_ref.clone(),
+        side: evidence_side(&context.provenance.source_kind),
+        source_kind: context.provenance.source_kind.clone(),
+        sensitivity: context.sensitivity.clone(),
+        identity,
+        disposition,
+        event_kind: Some(event_kind),
+        event_id: Some(event.event_id),
+        source_id: named(&event.named_data, &SOURCE_ID_KEYS)
+            .map(str::to_owned)
+            .or_else(|| source_id_from_message(message)),
+        enrollment_id: named(&event.named_data, &ENROLLMENT_KEYS).map(str::to_owned),
+        command_type,
+        value: named(&event.named_data, &VALUE_KEYS).map(str::to_owned),
+        error,
+        winning_source_id: named(&event.named_data, &WINNING_KEYS).map(str::to_owned),
+        superseded_by_source_id: named(&event.named_data, &SUPERSEDED_BY_KEYS).map(str::to_owned),
+        occurred_at_utc: normalized_instant(context),
+        time_is_reliable: timestamp_is_reliable(context.source_timestamp.as_ref()),
+        record_id: event.record_id,
+        is_uninterpretable: uninterpretable,
+        named_data: event.named_data.clone(),
+    })
+}
+
+/// Project one normalized report row onto a configuration observation.
+///
+/// Unlike events, a report row is always retained: the row exists because a
+/// report named the setting, and even an unidentified row is coverage that a
+/// reader needs to see. It keys on its own evidence id in that case.
+pub fn observation_from_report(report: &NormalizedSettingReport) -> ConfigurationObservation {
+    let context = &report.context;
+
+    let identity = resolve_identity(&IdentityHints {
+        uri: report.setting_uri.as_deref(),
+        setting_id: report.setting_id.as_deref(),
+        policy_id: report.policy_id.as_deref(),
+        display_name: report.display_name.as_deref(),
+        scope_token: named(&report.named_data, &SCOPE_KEYS),
+        evidence_id: &context.evidence_ref.evidence_id,
+    });
+
+    let command_type = named(&report.named_data, &COMMAND_TYPE_KEYS).map(str::to_owned);
+    let uninterpretable = is_uninterpretable(context);
+
+    let disposition = if uninterpretable {
+        ConfigurationDisposition::Indeterminate
+    } else {
+        match report.outcome {
+            NormalizedSettingOutcome::Applied => {
+                if command_type_is_removal(command_type.as_deref()) {
+                    ConfigurationDisposition::Removed
+                } else {
+                    ConfigurationDisposition::Applied
+                }
+            }
+            NormalizedSettingOutcome::Pending => ConfigurationDisposition::Pending,
+            NormalizedSettingOutcome::Failed => ConfigurationDisposition::Rejected,
+            NormalizedSettingOutcome::Conflict => ConfigurationDisposition::Conflict,
+            NormalizedSettingOutcome::Superseded => ConfigurationDisposition::Superseded,
+            NormalizedSettingOutcome::NotApplicable => ConfigurationDisposition::NotApplicable,
+            NormalizedSettingOutcome::Unknown => ConfigurationDisposition::Received,
+        }
+    };
+
+    let error = report
+        .error
+        .clone()
+        .or_else(|| named(&report.named_data, &RESULT_KEYS).and_then(build_error_code));
+
+    ConfigurationObservation {
+        evidence_ref: context.evidence_ref.clone(),
+        side: evidence_side(&context.provenance.source_kind),
+        source_kind: context.provenance.source_kind.clone(),
+        sensitivity: context.sensitivity.clone(),
+        identity,
+        disposition,
+        event_kind: None,
+        event_id: None,
+        source_id: report
+            .policy_id
+            .clone()
+            .or_else(|| named(&report.named_data, &SOURCE_ID_KEYS).map(str::to_owned)),
+        enrollment_id: named(&report.named_data, &ENROLLMENT_KEYS).map(str::to_owned),
+        command_type,
+        value: report
+            .value
+            .clone()
+            .or_else(|| named(&report.named_data, &VALUE_KEYS).map(str::to_owned)),
+        error,
+        winning_source_id: named(&report.named_data, &WINNING_KEYS).map(str::to_owned),
+        superseded_by_source_id: named(&report.named_data, &SUPERSEDED_BY_KEYS).map(str::to_owned),
+        occurred_at_utc: normalized_instant(context),
+        time_is_reliable: timestamp_is_reliable(context.source_timestamp.as_ref()),
+        record_id: context.provenance.record_number,
+        is_uninterpretable: uninterpretable,
+        named_data: report.named_data.clone(),
+    }
+}
+
+/// True when the observation was contributed by device-side evidence.
+pub fn is_device_side(observation: &ConfigurationObservation) -> bool {
+    observation.side == ConfigurationEvidenceSide::Device
+}
+
+/// True when the observation was contributed by imported service-side evidence.
+pub fn is_service_side(observation: &ConfigurationObservation) -> bool {
+    observation.side == ConfigurationEvidenceSide::Service
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_status_reports_both_the_hresult_and_its_signed_decimal() {
+        let code = build_error_code("(0x82B00006)").expect("hex token parses");
+        assert_eq!(code.raw, "0x82B00006");
+        assert_eq!(code.hex.as_deref(), Some("0x82B00006"));
+        assert_eq!(code.decimal, Some(-2102394874));
+        assert!(is_failure(&code));
+    }
+
+    #[test]
+    fn zero_status_is_not_a_failure() {
+        let code = build_error_code("0").expect("zero parses");
+        assert!(!is_failure(&code));
+    }
+
+    #[test]
+    fn an_unparseable_status_yields_no_code_rather_than_a_guess() {
+        assert!(build_error_code("not-a-code").is_none());
+        assert!(build_error_code("   ").is_none());
+    }
+
+    #[test]
+    fn a_negative_decimal_status_reports_its_hresult_form() {
+        let code = build_error_code("-2016281112").expect("decimal token parses");
+        assert_eq!(code.hex.as_deref(), Some("0x87D1FDE8"));
+    }
+
+    #[test]
+    fn local_wall_clock_timestamps_are_not_comparable() {
+        let stamp = IntuneTimestamp {
+            raw_text: "7/31/2026 1:00:00 PM".to_owned(),
+            original_offset: None,
+            normalized_utc: Some("2026-07-31T13:00:00Z".to_owned()),
+            kind: IntuneTimestampKind::Local,
+        };
+        assert!(!timestamp_is_reliable(Some(&stamp)));
+    }
+
+    #[test]
+    fn a_missing_timestamp_is_not_a_broken_timestamp() {
+        assert!(timestamp_is_reliable(None));
+    }
+
+    #[test]
+    fn named_lookup_is_case_insensitive_and_skips_blank_values() {
+        let data = vec![
+            IntuneNamedValue {
+                name: "nodeuri".to_owned(),
+                value: "   ".to_owned(),
+            },
+            IntuneNamedValue {
+                name: "SettingUri".to_owned(),
+                value: "./Device/Vendor/MSFT/Policy".to_owned(),
+            },
+        ];
+        assert_eq!(named(&data, &URI_KEYS), Some("./Device/Vendor/MSFT/Policy"));
+    }
+}

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/sources.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/sources.rs
@@ -173,12 +173,16 @@ pub fn is_unassessable_failure(observation: &ConfigurationObservation) -> bool {
         && observation.event_kind == Some(ConfigurationEventKind::CommandFailure)
 }
 
-/// Classify a recognized MDM Admin-channel event ID.
-pub fn classify_event(event: &NormalizedWindowsEvent) -> ConfigurationEventKind {
-    if !event
+/// Whether the record came from the provider whose vocabulary this build knows.
+pub fn is_mdm_diagnostics_provider(event: &NormalizedWindowsEvent) -> bool {
+    event
         .provider
         .eq_ignore_ascii_case(MDM_DIAGNOSTICS_PROVIDER)
-    {
+}
+
+/// Classify a recognized MDM Admin-channel event ID.
+pub fn classify_event(event: &NormalizedWindowsEvent) -> ConfigurationEventKind {
+    if !is_mdm_diagnostics_provider(event) {
         return ConfigurationEventKind::Unrecognized;
     }
     match event.event_id {
@@ -204,16 +208,29 @@ fn command_type_is_removal(command_type: Option<&str>) -> bool {
 pub fn observation_from_event(event: &NormalizedWindowsEvent) -> Option<ConfigurationObservation> {
     let context = &event.context;
     let event_kind = classify_event(event);
-    let message = event.message.as_deref().unwrap_or_default();
+
+    // Message scraping is gated on the provider for the same reason event ids are
+    // (see `classify_event`): `CSP URI: (…)` in some other provider's rendered
+    // text is that provider's vocabulary, and reading it here let any component's
+    // log line join a real MDM transaction. Named data is structured and stays
+    // trusted whoever wrote it.
+    let message = if is_mdm_diagnostics_provider(event) {
+        event.message.as_deref().unwrap_or_default()
+    } else {
+        ""
+    };
 
     let uri = named(&event.named_data, &URI_KEYS)
         .map(str::to_owned)
         .or_else(|| csp_uri_from_message(message))
         .or_else(|| {
-            // PolicyManager events name Policy/Area rather than a node path.
+            // PolicyManager events name Policy/Area rather than a node path. A
+            // record that never stated a scope keeps an unspecified one: inventing
+            // `Device` here manufactured a joinable device-scoped URI and merged
+            // the record into a transaction it may not belong to.
             let scope = named(&event.named_data, &SCOPE_KEYS)
                 .map(ConfigurationScope::from_token)
-                .unwrap_or(ConfigurationScope::Device);
+                .unwrap_or(ConfigurationScope::Unspecified);
             policy_uri_from_message(message, scope)
         });
 

--- a/crates/cmtraceopen-parser/src/intune/device/windows/configuration/sources.rs
+++ b/crates/cmtraceopen-parser/src/intune/device/windows/configuration/sources.rs
@@ -341,6 +341,25 @@ pub fn observation_from_report(report: &NormalizedSettingReport) -> Configuratio
     }
 }
 
+/// Whether two configuration source identifiers name the same source.
+///
+/// A source id is a GUID that different artifacts write differently: the MDM
+/// report writes it bare and lowercase, the event provider writes it braced and
+/// upper. Comparing the bytes made one policy look like two competing ones, which
+/// is enough to raise a conflict finding on its own.
+pub fn same_source_id(left: &str, right: &str) -> bool {
+    normalize_source_id(left) == normalize_source_id(right)
+}
+
+/// The comparison form of a configuration source identifier.
+pub fn normalize_source_id(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches(['{', '}'])
+        .trim()
+        .to_ascii_lowercase()
+}
+
 /// True when the observation was contributed by device-side evidence.
 pub fn is_device_side(observation: &ConfigurationObservation) -> bool {
     observation.side == ConfigurationEvidenceSide::Device

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/applied-from-csp-event/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/applied-from-csp-event/evidence/mdm-admin-channel/current/records.json
@@ -1,0 +1,67 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized MDM Admin channel events, no real device data",
+  "events": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-applied",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 101,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 813,
+            "recordId": 101
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 101,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"
+        },
+        {
+          "name": "Value",
+          "value": "1"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        },
+        {
+          "name": "EnrollmentId",
+          "value": "44444444-4444-4444-8444-444444444444"
+        },
+        {
+          "name": "Area",
+          "value": "Update"
+        }
+      ],
+      "message": "MDM PolicyManager: Set policy int, Policy: (AllowAutoUpdate), Area: (Update), EnrollmentID requesting merge: (44444444-4444-4444-8444-444444444444), Value: (1)"
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/applied-from-csp-event/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/applied-from-csp-event/expected.json
@@ -26,11 +26,16 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-applied"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-device-only-evidence": "high",
+    "configuration-applied": "high"
+  },
   "findingIds": [
     "configuration-device-only-evidence",
     "configuration-applied"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/applied-from-csp-event/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/applied-from-csp-event/expected.json
@@ -1,0 +1,42 @@
+{
+  "scenario": "applied-from-csp-event",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "1",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-applied"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-device-only-evidence",
+    "configuration-applied"
+  ],
+  "assertions": [
+    "a recognized set-policy event is device evidence that the CSP applied the value",
+    "service state stays noEvidence when no Intune report was imported"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/applied-from-csp-event/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/applied-from-csp-event/manifest.json
@@ -1,0 +1,27 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "applied-from-csp-event",
+  "workload": "device/windows/configuration",
+  "description": "A PolicyManager set-policy event proves the CSP wrote the value on the device.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "captured",
+      "payload": "events",
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-admin-channel/current/records.json",
+      "bytesCopied": 2219,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/cloud-success-local-terminal-error/evidence/intune-setting-report/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/cloud-success-local-terminal-error/evidence/intune-setting-report/current/records.json
@@ -1,0 +1,39 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized configuration report rows, no real device data",
+  "reports": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-service-success",
+          "sourceArtifactId": "intune-setting-report"
+        },
+        "provenance": {
+          "sourceKind": "graph",
+          "sourceArtifactId": "intune-setting-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:21:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:21:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "settingId": null,
+      "policyId": "11111111-1111-4111-8111-111111111111",
+      "displayName": null,
+      "outcome": "applied",
+      "value": "1",
+      "error": null,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/cloud-success-local-terminal-error/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/cloud-success-local-terminal-error/evidence/mdm-admin-channel/current/records.json
@@ -1,0 +1,46 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized MDM Admin channel events, no real device data",
+  "events": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-failure",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 130,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 404,
+            "recordId": 130
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:11:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:11:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 404,
+      "level": "error",
+      "task": null,
+      "keywords": null,
+      "recordId": 130,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [],
+      "message": "MDM ConfigurationManager: Command failure status. Configuration Source ID: (11111111-1111-4111-8111-111111111111), Enrollment Name: (MDMDeviceWithAAD), Provider Name: (Policy), Command Type: (Add), CSP URI: (./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate), Result: (0x82B00006)."
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/cloud-success-local-terminal-error/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/cloud-success-local-terminal-error/expected.json
@@ -1,0 +1,53 @@
+{
+  "scenario": "cloud-success-local-terminal-error",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "available"
+    },
+    {
+      "artifactId": "intune-setting-report",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "rejected",
+      "service": "reportedSuccess",
+      "resolution": "contradicted",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": "0x82B00006",
+      "serviceErrorHex": null,
+      "appliedValue": null,
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-failure",
+        "rpt-service-success"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-local-rejection",
+    "configuration-local-service-contradiction"
+  ],
+  "assertions": [
+    "a portal success does not erase a local CSP failure",
+    "the local rejection is still reported on its own evidence"
+  ],
+  "findingEvidence": {
+    "configuration-local-service-contradiction": [
+      "evt-failure",
+      "rpt-service-success"
+    ]
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/cloud-success-local-terminal-error/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/cloud-success-local-terminal-error/expected.json
@@ -30,12 +30,17 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-failure",
         "rpt-service-success"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-local-rejection": "high",
+    "configuration-local-service-contradiction": "high"
+  },
   "findingIds": [
     "configuration-local-rejection",
     "configuration-local-service-contradiction"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/cloud-success-local-terminal-error/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/cloud-success-local-terminal-error/manifest.json
@@ -1,0 +1,44 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "cloud-success-local-terminal-error",
+  "workload": "device/windows/configuration",
+  "description": "Intune reports success while the device's own CSP returned a terminal error.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "captured",
+      "payload": "events",
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-admin-channel/current/records.json",
+      "bytesCopied": 1827,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "intune-setting-report",
+      "family": "graph",
+      "sourceKind": "graph",
+      "captureState": "captured",
+      "payload": "reports",
+      "originalBasename": "settingStates.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/intune-setting-report/current/records.json",
+      "bytesCopied": 1178,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://intune-setting-report/settingStates.json",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/evidence/mdm-diagnostic-report/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/evidence/mdm-diagnostic-report/current/records.json
@@ -1,0 +1,79 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized configuration report rows, no real device data",
+  "reports": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-conflict-loser",
+          "sourceArtifactId": "mdm-diagnostic-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-diagnostic-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:05:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:05:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "settingId": null,
+      "policyId": "11111111-1111-4111-8111-111111111111",
+      "displayName": null,
+      "outcome": "conflict",
+      "value": null,
+      "error": null,
+      "namedData": [
+        {
+          "name": "WinningPolicyId",
+          "value": "22222222-2222-4222-8222-222222222222"
+        }
+      ]
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-conflict-winner",
+          "sourceArtifactId": "mdm-diagnostic-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-diagnostic-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 2,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:05:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:05:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "settingId": null,
+      "policyId": "22222222-2222-4222-8222-222222222222",
+      "displayName": null,
+      "outcome": "applied",
+      "value": "1",
+      "error": null,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/expected.json
@@ -1,0 +1,50 @@
+{
+  "scenario": "conflict-between-two-sources",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "conflicted",
+      "service": "noEvidence",
+      "resolution": "conflicted",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "1",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "rpt-conflict-loser",
+        "rpt-conflict-winner"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-conflict",
+    "configuration-device-only-evidence"
+  ],
+  "assertions": [
+    "a conflict is only claimed when both competing sources are in the bundle",
+    "the conflict finding cites the competing rows rather than asserting the conflict"
+  ],
+  "findingEvidence": {
+    "configuration-conflict": [
+      "rpt-conflict-loser",
+      "rpt-conflict-winner"
+    ]
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/expected.json
@@ -27,12 +27,17 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "rpt-conflict-loser",
         "rpt-conflict-winner"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-conflict": "high",
+    "configuration-device-only-evidence": "high"
+  },
   "findingIds": [
     "configuration-conflict",
     "configuration-device-only-evidence"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/expected.json
@@ -14,9 +14,9 @@
       "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
       "displayName": null,
       "receipt": "cspProcessed",
-      "local": "contested",
+      "local": "conflicted",
       "service": "noEvidence",
-      "resolution": "contradicted",
+      "resolution": "conflicted",
       "sourceIds": [
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222"
@@ -34,11 +34,18 @@
     }
   ],
   "findingIds": [
-    "configuration-contested-device-evidence",
+    "configuration-conflict",
     "configuration-device-only-evidence"
   ],
+  "findingEvidence": {
+    "configuration-conflict": [
+      "rpt-conflict-loser",
+      "rpt-conflict-winner"
+    ]
+  },
   "assertions": [
     "a conflict is only claimed when both competing sources are in the bundle",
-    "the conflict finding cites the competing rows rather than asserting the conflict"
+    "the conflict finding cites the competing rows rather than asserting the conflict",
+    "the losing row's explicit WinningPolicyId is what links the two, not the record order"
   ]
 }

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/expected.json
@@ -14,9 +14,9 @@
       "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
       "displayName": null,
       "receipt": "cspProcessed",
-      "local": "conflicted",
+      "local": "contested",
       "service": "noEvidence",
-      "resolution": "conflicted",
+      "resolution": "contradicted",
       "sourceIds": [
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222"
@@ -34,17 +34,11 @@
     }
   ],
   "findingIds": [
-    "configuration-conflict",
+    "configuration-contested-device-evidence",
     "configuration-device-only-evidence"
   ],
   "assertions": [
     "a conflict is only claimed when both competing sources are in the bundle",
     "the conflict finding cites the competing rows rather than asserting the conflict"
-  ],
-  "findingEvidence": {
-    "configuration-conflict": [
-      "rpt-conflict-loser",
-      "rpt-conflict-winner"
-    ]
-  }
+  ]
 }

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/conflict-between-two-sources/manifest.json
@@ -1,0 +1,27 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "conflict-between-two-sources",
+  "workload": "device/windows/configuration",
+  "description": "Two policies claim one node; the losing row names the winner and the winner's row is present.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "family": "diagnosticReport",
+      "sourceKind": "diagnosticReport",
+      "captureState": "captured",
+      "payload": "reports",
+      "originalBasename": "MDMDiagReport.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-diagnostic-report/current/records.json",
+      "bytesCopied": 2388,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-diagnostic-report/MDMDiagReport.json",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/csp-terminal-error/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/csp-terminal-error/evidence/mdm-admin-channel/current/records.json
@@ -1,0 +1,46 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized MDM Admin channel events, no real device data",
+  "events": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-failure",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 102,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 404,
+            "recordId": 102
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:01:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:01:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 404,
+      "level": "error",
+      "task": null,
+      "keywords": null,
+      "recordId": 102,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [],
+      "message": "MDM ConfigurationManager: Command failure status. Configuration Source ID: (11111111-1111-4111-8111-111111111111), Enrollment Name: (MDMDeviceWithAAD), Provider Name: (Policy), Command Type: (Add), CSP URI: (./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate), Result: (0x82B00006)."
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/csp-terminal-error/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/csp-terminal-error/expected.json
@@ -1,0 +1,42 @@
+{
+  "scenario": "csp-terminal-error",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "rejected",
+      "service": "noEvidence",
+      "resolution": "rejected",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": "0x82B00006",
+      "serviceErrorHex": null,
+      "appliedValue": null,
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-failure"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-local-rejection",
+    "configuration-device-only-evidence"
+  ],
+  "assertions": [
+    "event 404 with a non-zero status is a terminal local rejection",
+    "the CSP URI, configuration source, and status are recovered from the rendered message"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/csp-terminal-error/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/csp-terminal-error/expected.json
@@ -26,11 +26,16 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-failure"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-local-rejection": "high",
+    "configuration-device-only-evidence": "high"
+  },
   "findingIds": [
     "configuration-local-rejection",
     "configuration-device-only-evidence"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/csp-terminal-error/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/csp-terminal-error/manifest.json
@@ -1,0 +1,27 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "csp-terminal-error",
+  "workload": "device/windows/configuration",
+  "description": "A command-failure event carrying only a rendered message; identity and status are read from the text.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "captured",
+      "payload": "events",
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-admin-channel/current/records.json",
+      "bytesCopied": 1827,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/evidence/mdm-admin-channel/current/records.json
@@ -1,0 +1,134 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized MDM Admin channel events, no real device data",
+  "events": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-wallpaper",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 170,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 814,
+            "recordId": 170
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:18:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:18:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "sensitive",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 814,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 170,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Personalization/DesktopImageUrl"
+        },
+        {
+          "name": "Value",
+          "value": "D:\\Data\\wallpaper.png"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        },
+        {
+          "name": "EnrollmentId",
+          "value": "44444444-4444-4444-8444-444444444444"
+        },
+        {
+          "name": "TenantId",
+          "value": "55555555-5555-4555-8555-555555555555"
+        },
+        {
+          "name": "Upn",
+          "value": "synthetic.user@example.invalid"
+        },
+        {
+          "name": "Area",
+          "value": "Personalization"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-update",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 171,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 813,
+            "recordId": 171
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:19:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:19:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 171,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"
+        },
+        {
+          "name": "Value",
+          "value": "1"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        },
+        {
+          "name": "PreviousValue",
+          "value": "D:\\Data\\wallpaper.png"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/evidence/mdm-admin-channel/current/records.json
@@ -129,6 +129,61 @@
         }
       ],
       "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-identity-node",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 172,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 814,
+            "recordId": 172
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:20:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:20:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 814,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 172,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Accounts/synthetic.user@example.invalid/LocalUserGroup"
+        },
+        {
+          "name": "Value",
+          "value": "CONTOSO\\Helpdesk"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ],
+      "message": null
     }
   ]
 }

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/expected.json
@@ -95,17 +95,17 @@
   ],
   "redactedSettings": [
     {
-      "key": "device|uri:device/vendor/msft/accounts/[redacted:dcfe70dcbb35f268]/localusergroup",
-      "canonicalUri": "Device/Vendor/MSFT/Accounts/[redacted:dcfe70dcbb35f268]/LocalUserGroup",
-      "appliedValue": "[redacted:41c487e830eb6e34]",
+      "key": "device|uri:device/vendor/msft/accounts/[redacted:f7f12a6f659e1763]/localusergroup",
+      "canonicalUri": "Device/Vendor/MSFT/Accounts/[redacted:f7f12a6f659e1763]/LocalUserGroup",
+      "appliedValue": "[redacted:2a0b12d04bdd8d1b]",
       "namedData": [
         {
           "name": "NodeUri",
-          "value": "./Device/Vendor/MSFT/Accounts/[redacted:dcfe70dcbb35f268]/LocalUserGroup"
+          "value": "./Device/Vendor/MSFT/Accounts/[redacted:f7f12a6f659e1763]/LocalUserGroup"
         },
         {
           "name": "Value",
-          "value": "[redacted:41c487e830eb6e34]"
+          "value": "[redacted:2a0b12d04bdd8d1b]"
         },
         {
           "name": "ConfigurationSourceId",
@@ -116,7 +116,7 @@
     {
       "key": "device|uri:device/vendor/msft/personalization/desktopimageurl",
       "canonicalUri": "Device/Vendor/MSFT/Personalization/DesktopImageUrl",
-      "appliedValue": "[redacted:2db0cdb8f368add0]",
+      "appliedValue": "[redacted:e8d980ac53a3acc5]",
       "namedData": [
         {
           "name": "NodeUri",
@@ -124,7 +124,7 @@
         },
         {
           "name": "Value",
-          "value": "[redacted:2db0cdb8f368add0]"
+          "value": "[redacted:e8d980ac53a3acc5]"
         },
         {
           "name": "ConfigurationSourceId",
@@ -132,15 +132,15 @@
         },
         {
           "name": "EnrollmentId",
-          "value": "[redacted:9f537c69f47aac4f]"
+          "value": "[redacted:e056b9b044086234]"
         },
         {
           "name": "TenantId",
-          "value": "[redacted:18e8680b98fc84d5]"
+          "value": "[redacted:b908e25de120e3ce]"
         },
         {
           "name": "Upn",
-          "value": "[redacted:dcfe70dcbb35f268]"
+          "value": "[redacted:f7f12a6f659e1763]"
         },
         {
           "name": "Area",
@@ -151,7 +151,7 @@
     {
       "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
       "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
-      "appliedValue": "[redacted:187c4fa5b79764ea]",
+      "appliedValue": "[redacted:3e88aebf97f1124f]",
       "namedData": [
         {
           "name": "NodeUri",
@@ -159,7 +159,7 @@
         },
         {
           "name": "Value",
-          "value": "[redacted:187c4fa5b79764ea]"
+          "value": "[redacted:3e88aebf97f1124f]"
         },
         {
           "name": "ConfigurationSourceId",
@@ -167,10 +167,10 @@
         },
         {
           "name": "PreviousValue",
-          "value": "[redacted:2db0cdb8f368add0]"
+          "value": "[redacted:e8d980ac53a3acc5]"
         }
       ]
     }
   ],
-  "redactedEnrollmentId": "[redacted:9f537c69f47aac4f]"
+  "redactedEnrollmentId": "[redacted:e056b9b044086234]"
 }

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/expected.json
@@ -1,0 +1,124 @@
+{
+  "scenario": "deterministic-redaction",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/personalization/desktopimageurl",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Personalization/DesktopImageUrl",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "D:\\Data\\wallpaper.png",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-wallpaper"
+      ]
+    },
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "1",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-update"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-device-only-evidence",
+    "configuration-applied"
+  ],
+  "assertions": [
+    "every configuration value is tokenized in the default export",
+    "the same underlying value produces the same token in two different settings",
+    "the configuration source id survives redaction so the policy stays identifiable"
+  ],
+  "redactedSettings": [
+    {
+      "key": "device|uri:device/vendor/msft/personalization/desktopimageurl",
+      "appliedValue": "[redacted:71d0311ead4fbe6a]",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Personalization/DesktopImageUrl"
+        },
+        {
+          "name": "Value",
+          "value": "[redacted:71d0311ead4fbe6a]"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        },
+        {
+          "name": "EnrollmentId",
+          "value": "[redacted:ba71ea487f657435]"
+        },
+        {
+          "name": "TenantId",
+          "value": "[redacted:dd08d6c3590f892b]"
+        },
+        {
+          "name": "Upn",
+          "value": "[redacted:039bc27f8eb2856a]"
+        },
+        {
+          "name": "Area",
+          "value": "Personalization"
+        }
+      ]
+    },
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "appliedValue": "[redacted:af63ac4c86019afc]",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"
+        },
+        {
+          "name": "Value",
+          "value": "[redacted:af63ac4c86019afc]"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        },
+        {
+          "name": "PreviousValue",
+          "value": "[redacted:71d0311ead4fbe6a]"
+        }
+      ]
+    }
+  ],
+  "redactedEnrollmentId": "[redacted:ba71ea487f657435]"
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/expected.json
@@ -9,6 +9,28 @@
   ],
   "settings": [
     {
+      "key": "device|uri:device/vendor/msft/accounts/synthetic.user@example.invalid/localusergroup",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Accounts/synthetic.user@example.invalid/LocalUserGroup",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "CONTOSO\\Helpdesk",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-identity-node"
+      ]
+    },
+    {
       "key": "device|uri:device/vendor/msft/personalization/desktopimageurl",
       "scope": "device",
       "canonicalUri": "Device/Vendor/MSFT/Personalization/DesktopImageUrl",
@@ -58,14 +80,36 @@
     "configuration-applied"
   ],
   "assertions": [
-    "every configuration value is tokenized in the default export",
+    "every configuration value is tokenized in the export projection",
     "the same underlying value produces the same token in two different settings",
+    "an identity segment inside a node path is tokenized while the path survives",
+    "the lowercased dedupe key reuses the token its mixed-case URI produced",
     "the configuration source id survives redaction so the policy stays identifiable"
   ],
   "redactedSettings": [
     {
+      "key": "device|uri:device/vendor/msft/accounts/[redacted:dcfe70dcbb35f268]/localusergroup",
+      "canonicalUri": "Device/Vendor/MSFT/Accounts/[redacted:dcfe70dcbb35f268]/LocalUserGroup",
+      "appliedValue": "[redacted:41c487e830eb6e34]",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Accounts/[redacted:dcfe70dcbb35f268]/LocalUserGroup"
+        },
+        {
+          "name": "Value",
+          "value": "[redacted:41c487e830eb6e34]"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ]
+    },
+    {
       "key": "device|uri:device/vendor/msft/personalization/desktopimageurl",
-      "appliedValue": "[redacted:71d0311ead4fbe6a]",
+      "canonicalUri": "Device/Vendor/MSFT/Personalization/DesktopImageUrl",
+      "appliedValue": "[redacted:2db0cdb8f368add0]",
       "namedData": [
         {
           "name": "NodeUri",
@@ -73,7 +117,7 @@
         },
         {
           "name": "Value",
-          "value": "[redacted:71d0311ead4fbe6a]"
+          "value": "[redacted:2db0cdb8f368add0]"
         },
         {
           "name": "ConfigurationSourceId",
@@ -81,15 +125,15 @@
         },
         {
           "name": "EnrollmentId",
-          "value": "[redacted:ba71ea487f657435]"
+          "value": "[redacted:9f537c69f47aac4f]"
         },
         {
           "name": "TenantId",
-          "value": "[redacted:dd08d6c3590f892b]"
+          "value": "[redacted:18e8680b98fc84d5]"
         },
         {
           "name": "Upn",
-          "value": "[redacted:039bc27f8eb2856a]"
+          "value": "[redacted:dcfe70dcbb35f268]"
         },
         {
           "name": "Area",
@@ -99,7 +143,8 @@
     },
     {
       "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
-      "appliedValue": "[redacted:af63ac4c86019afc]",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "appliedValue": "[redacted:187c4fa5b79764ea]",
       "namedData": [
         {
           "name": "NodeUri",
@@ -107,7 +152,7 @@
         },
         {
           "name": "Value",
-          "value": "[redacted:af63ac4c86019afc]"
+          "value": "[redacted:187c4fa5b79764ea]"
         },
         {
           "name": "ConfigurationSourceId",
@@ -115,10 +160,10 @@
         },
         {
           "name": "PreviousValue",
-          "value": "[redacted:71d0311ead4fbe6a]"
+          "value": "[redacted:2db0cdb8f368add0]"
         }
       ]
     }
   ],
-  "redactedEnrollmentId": "[redacted:ba71ea487f657435]"
+  "redactedEnrollmentId": "[redacted:9f537c69f47aac4f]"
 }

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/expected.json
@@ -26,6 +26,7 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-identity-node"
       ]
@@ -48,6 +49,7 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-wallpaper"
       ]
@@ -70,11 +72,16 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-update"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-device-only-evidence": "high",
+    "configuration-applied": "high"
+  },
   "findingIds": [
     "configuration-device-only-evidence",
     "configuration-applied"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/manifest.json
@@ -15,7 +15,7 @@
       "originalBasename": "Admin.evtx",
       "capturedUtc": "2026-07-31T10:00:00Z",
       "relativePath": "evidence/mdm-admin-channel/current/records.json",
-      "bytesCopied": 4163,
+      "bytesCopied": 5966,
       "encoding": "utf-8",
       "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
       "rotation": {

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/deterministic-redaction/manifest.json
@@ -1,0 +1,27 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "deterministic-redaction",
+  "workload": "device/windows/configuration",
+  "description": "Identity and arbitrary values in the default export become stable tokens.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "captured",
+      "payload": "events",
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-admin-channel/current/records.json",
+      "bytesCopied": 4163,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/duplicate-display-name-different-csp-paths/evidence/mdm-diagnostic-report/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/duplicate-display-name-different-csp-paths/evidence/mdm-diagnostic-report/current/records.json
@@ -1,0 +1,74 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized configuration report rows, no real device data",
+  "reports": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-devicelock",
+          "sourceArtifactId": "mdm-diagnostic-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-diagnostic-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:14:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:14:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Config/DeviceLock/DevicePasswordEnabled",
+      "settingId": null,
+      "policyId": "11111111-1111-4111-8111-111111111111",
+      "displayName": "Require a password",
+      "outcome": "applied",
+      "value": "1",
+      "error": null,
+      "namedData": []
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-passport",
+          "sourceArtifactId": "mdm-diagnostic-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-diagnostic-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 2,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:14:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:14:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/PassportForWork/33333333-3333-4333-8333-333333333333/Policies/UsePassportForWork",
+      "settingId": null,
+      "policyId": "22222222-2222-4222-8222-222222222222",
+      "displayName": "Require a password",
+      "outcome": "applied",
+      "value": "1",
+      "error": null,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/duplicate-display-name-different-csp-paths/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/duplicate-display-name-different-csp-paths/expected.json
@@ -1,0 +1,65 @@
+{
+  "scenario": "duplicate-display-name-different-csp-paths",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/passportforwork/33333333-3333-4333-8333-333333333333/policies/usepassportforwork",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/PassportForWork/33333333-3333-4333-8333-333333333333/Policies/UsePassportForWork",
+      "displayName": "Require a password",
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "22222222-2222-4222-8222-222222222222"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "1",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "rpt-passport"
+      ]
+    },
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/devicelock/devicepasswordenabled",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/DeviceLock/DevicePasswordEnabled",
+      "displayName": "Require a password",
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "1",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "rpt-devicelock"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-duplicate-display-name",
+    "configuration-device-only-evidence",
+    "configuration-applied"
+  ],
+  "assertions": [
+    "a shared display name never merges two CSP identities",
+    "the duplicate name is surfaced so a portal comparison is not misread"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/duplicate-display-name-different-csp-paths/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/duplicate-display-name-different-csp-paths/expected.json
@@ -26,6 +26,7 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "rpt-passport"
       ]
@@ -48,11 +49,17 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "rpt-devicelock"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-duplicate-display-name": "high",
+    "configuration-device-only-evidence": "high",
+    "configuration-applied": "high"
+  },
   "findingIds": [
     "configuration-duplicate-display-name",
     "configuration-device-only-evidence",

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/duplicate-display-name-different-csp-paths/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/duplicate-display-name-different-csp-paths/manifest.json
@@ -1,0 +1,27 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "duplicate-display-name-different-csp-paths",
+  "workload": "device/windows/configuration",
+  "description": "One friendly name over two unrelated CSP nodes.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "family": "diagnosticReport",
+      "sourceKind": "diagnosticReport",
+      "captureState": "captured",
+      "payload": "reports",
+      "originalBasename": "MDMDiagReport.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-diagnostic-report/current/records.json",
+      "bytesCopied": 2339,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-diagnostic-report/MDMDiagReport.json",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/event-only-evidence/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/event-only-evidence/evidence/mdm-admin-channel/current/records.json
@@ -1,0 +1,59 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized MDM Admin channel events, no real device data",
+  "events": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-applied",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 140,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 814,
+            "recordId": 140
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:13:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:13:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 814,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 140,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/DeliveryOptimization/DODownloadMode"
+        },
+        {
+          "name": "Value",
+          "value": "2"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/event-only-evidence/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/event-only-evidence/expected.json
@@ -1,0 +1,47 @@
+{
+  "scenario": "event-only-evidence",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "status": "skipped"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/deliveryoptimization/dodownloadmode",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/DeliveryOptimization/DODownloadMode",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "2",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-applied"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-device-only-evidence",
+    "configuration-uncollected-artifacts",
+    "configuration-applied"
+  ],
+  "assertions": [
+    "a skipped artifact is a coverage gap, not an absence of the setting",
+    "event evidence alone is enough to state what the CSP did"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/event-only-evidence/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/event-only-evidence/expected.json
@@ -30,11 +30,17 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-applied"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-device-only-evidence": "high",
+    "configuration-uncollected-artifacts": "high",
+    "configuration-applied": "medium"
+  },
   "findingIds": [
     "configuration-device-only-evidence",
     "configuration-uncollected-artifacts",

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/event-only-evidence/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/event-only-evidence/manifest.json
@@ -1,0 +1,44 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "event-only-evidence",
+  "workload": "device/windows/configuration",
+  "description": "Only the Admin channel was collected; the diagnostic report was deliberately skipped.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "captured",
+      "payload": "events",
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-admin-channel/current/records.json",
+      "bytesCopied": 1887,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "family": "diagnosticReport",
+      "sourceKind": "diagnosticReport",
+      "captureState": "skipped",
+      "payload": null,
+      "originalBasename": "MDMDiagReport.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": null,
+      "bytesCopied": 0,
+      "encoding": null,
+      "sanitizedSourcePath": null,
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/incomplete-channel-coverage/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/incomplete-channel-coverage/evidence/mdm-admin-channel/current/records.json
@@ -1,0 +1,59 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized MDM Admin channel events, no real device data",
+  "events": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-applied",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 160,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 813,
+            "recordId": 160
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:17:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:17:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 160,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"
+        },
+        {
+          "name": "Value",
+          "value": "1"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/incomplete-channel-coverage/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/incomplete-channel-coverage/expected.json
@@ -34,11 +34,18 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-applied"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-device-only-evidence": "high",
+    "configuration-uncollected-artifacts": "high",
+    "configuration-truncated-artifacts": "high",
+    "configuration-applied": "medium"
+  },
   "findingIds": [
     "configuration-device-only-evidence",
     "configuration-uncollected-artifacts",

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/incomplete-channel-coverage/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/incomplete-channel-coverage/expected.json
@@ -1,0 +1,52 @@
+{
+  "scenario": "incomplete-channel-coverage",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "capped"
+    },
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "status": "permissionDenied"
+    },
+    {
+      "artifactId": "policy-manager-registry",
+      "status": "missing"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "1",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-applied"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-device-only-evidence",
+    "configuration-uncollected-artifacts",
+    "configuration-truncated-artifacts",
+    "configuration-applied"
+  ],
+  "assertions": [
+    "capped, permission-denied, and missing coverage produce distinct requests",
+    "a capped channel means absence of a setting proves nothing"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/incomplete-channel-coverage/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/incomplete-channel-coverage/manifest.json
@@ -1,0 +1,61 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "incomplete-channel-coverage",
+  "workload": "device/windows/configuration",
+  "description": "A capped channel, an inaccessible report, and a registry source that was never present.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "capped",
+      "payload": "events",
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-admin-channel/current/records.json",
+      "bytesCopied": 1874,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "family": "diagnosticReport",
+      "sourceKind": "diagnosticReport",
+      "captureState": "accessDenied",
+      "payload": null,
+      "originalBasename": "MDMDiagReport.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": null,
+      "bytesCopied": 0,
+      "encoding": null,
+      "sanitizedSourcePath": null,
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "policy-manager-registry",
+      "family": "registry",
+      "sourceKind": "registry",
+      "captureState": "absent",
+      "payload": null,
+      "originalBasename": "PolicyManager.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": null,
+      "bytesCopied": 0,
+      "encoding": null,
+      "sanitizedSourcePath": null,
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/invalid-offset-and-contradictory-ordering/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/invalid-offset-and-contradictory-ordering/evidence/mdm-admin-channel/current/records.json
@@ -1,0 +1,169 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized MDM Admin channel events, no real device data",
+  "events": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-later-record-earlier-time",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 201,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 813,
+            "recordId": 201
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:00:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:00:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 201,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"
+        },
+        {
+          "name": "Value",
+          "value": "1"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-earlier-record-later-time",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 200,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 813,
+            "recordId": 200
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:30:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:30:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 200,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"
+        },
+        {
+          "name": "Value",
+          "value": "1"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-invalid-offset",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 202,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 813,
+            "recordId": 202
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:10:00+25:00",
+          "originalOffset": "+25:00",
+          "normalizedUtc": null,
+          "kind": "invalid"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 202,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/DeliveryOptimization/DODownloadMode"
+        },
+        {
+          "name": "Value",
+          "value": "2"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/invalid-offset-and-contradictory-ordering/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/invalid-offset-and-contradictory-ordering/expected.json
@@ -26,6 +26,7 @@
       "timeIsReliable": false,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-invalid-offset"
       ]
@@ -48,12 +49,18 @@
       "timeIsReliable": true,
       "orderingIsContradictory": true,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-earlier-record-later-time",
         "evt-later-record-earlier-time"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-device-only-evidence": "high",
+    "configuration-unusable-ordering": "high",
+    "configuration-applied": "high"
+  },
   "findingIds": [
     "configuration-device-only-evidence",
     "configuration-unusable-ordering",

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/invalid-offset-and-contradictory-ordering/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/invalid-offset-and-contradictory-ordering/expected.json
@@ -1,0 +1,66 @@
+{
+  "scenario": "invalid-offset-and-contradictory-ordering",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/deliveryoptimization/dodownloadmode",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/DeliveryOptimization/DODownloadMode",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "2",
+      "timeIsReliable": false,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-invalid-offset"
+      ]
+    },
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "1",
+      "timeIsReliable": true,
+      "orderingIsContradictory": true,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-earlier-record-later-time",
+        "evt-later-record-earlier-time"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-device-only-evidence",
+    "configuration-unusable-ordering",
+    "configuration-applied"
+  ],
+  "assertions": [
+    "an unparseable offset makes the record's time unusable for comparison",
+    "record numbers that contradict timestamps are reported, not silently reordered"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/invalid-offset-and-contradictory-ordering/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/invalid-offset-and-contradictory-ordering/manifest.json
@@ -1,0 +1,27 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "invalid-offset-and-contradictory-ordering",
+  "workload": "device/windows/configuration",
+  "description": "Record numbers that disagree with timestamps, and a timestamp with an impossible offset.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "captured",
+      "payload": "events",
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-admin-channel/current/records.json",
+      "bytesCopied": 5451,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/local-success-cloud-failure/evidence/intune-setting-report/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/local-success-cloud-failure/evidence/intune-setting-report/current/records.json
@@ -1,0 +1,43 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized configuration report rows, no real device data",
+  "reports": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-service-failed",
+          "sourceArtifactId": "intune-setting-report"
+        },
+        "provenance": {
+          "sourceKind": "graph",
+          "sourceArtifactId": "intune-setting-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:20:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:20:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "settingId": null,
+      "policyId": "11111111-1111-4111-8111-111111111111",
+      "displayName": null,
+      "outcome": "failed",
+      "value": null,
+      "error": {
+        "raw": "-2016281112",
+        "decimal": -2016281112,
+        "hex": "0x87D1FDE8"
+      },
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/local-success-cloud-failure/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/local-success-cloud-failure/evidence/mdm-admin-channel/current/records.json
@@ -1,0 +1,59 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized MDM Admin channel events, no real device data",
+  "events": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-applied",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 120,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 813,
+            "recordId": 120
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:10:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:10:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 120,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"
+        },
+        {
+          "name": "Value",
+          "value": "1"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/local-success-cloud-failure/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/local-success-cloud-failure/expected.json
@@ -1,0 +1,52 @@
+{
+  "scenario": "local-success-cloud-failure",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "available"
+    },
+    {
+      "artifactId": "intune-setting-report",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "reportedFailure",
+      "resolution": "contradicted",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": "0x87D1FDE8",
+      "appliedValue": "1",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-applied",
+        "rpt-service-failed"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-local-service-contradiction"
+  ],
+  "assertions": [
+    "the newer service row does not overrule the device record",
+    "the contradiction cites both sides instead of choosing one"
+  ],
+  "findingEvidence": {
+    "configuration-local-service-contradiction": [
+      "evt-applied",
+      "rpt-service-failed"
+    ]
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/local-success-cloud-failure/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/local-success-cloud-failure/expected.json
@@ -30,12 +30,16 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-applied",
         "rpt-service-failed"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-local-service-contradiction": "high"
+  },
   "findingIds": [
     "configuration-local-service-contradiction"
   ],

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/local-success-cloud-failure/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/local-success-cloud-failure/manifest.json
@@ -1,0 +1,44 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "local-success-cloud-failure",
+  "workload": "device/windows/configuration",
+  "description": "The device says the CSP applied the value; the imported Intune row says it failed.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "captured",
+      "payload": "events",
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-admin-channel/current/records.json",
+      "bytesCopied": 1874,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "intune-setting-report",
+      "family": "graph",
+      "sourceKind": "graph",
+      "captureState": "captured",
+      "payload": "reports",
+      "originalBasename": "settingStates.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/intune-setting-report/current/records.json",
+      "bytesCopied": 1272,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://intune-setting-report/settingStates.json",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/malformed-mdm-report/evidence/mdm-diagnostic-report/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/malformed-mdm-report/evidence/mdm-diagnostic-report/current/records.json
@@ -1,0 +1,44 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized configuration report rows, no real device data",
+  "reports": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-malformed",
+          "sourceArtifactId": "mdm-diagnostic-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-diagnostic-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:15:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:15:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "malformed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "settingId": null,
+      "policyId": null,
+      "displayName": null,
+      "outcome": "unknown",
+      "value": null,
+      "error": null,
+      "namedData": [
+        {
+          "name": "RawFragment",
+          "value": "<TruncatedNode"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/malformed-mdm-report/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/malformed-mdm-report/expected.json
@@ -24,11 +24,16 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": true,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "rpt-malformed"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-uninterpretable-evidence": "high",
+    "configuration-unreadable-artifacts": "high"
+  },
   "findingIds": [
     "configuration-uninterpretable-evidence",
     "configuration-unreadable-artifacts"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/malformed-mdm-report/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/malformed-mdm-report/expected.json
@@ -33,6 +33,11 @@
     "configuration-uninterpretable-evidence",
     "configuration-unreadable-artifacts"
   ],
+  "findingEvidence": {
+    "configuration-uninterpretable-evidence": [
+      "rpt-malformed"
+    ]
+  },
   "assertions": [
     "a malformed row contributes no outcome but is still cited",
     "parseFailed coverage keeps the artifact distinct from a missing one"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/malformed-mdm-report/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/malformed-mdm-report/expected.json
@@ -1,0 +1,40 @@
+{
+  "scenario": "malformed-mdm-report",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "status": "parseFailed"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "commandReceived",
+      "local": "indeterminate",
+      "service": "noEvidence",
+      "resolution": "insufficientEvidence",
+      "sourceIds": [],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": null,
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": true,
+      "evidenceIds": [
+        "rpt-malformed"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-uninterpretable-evidence",
+    "configuration-unreadable-artifacts"
+  ],
+  "assertions": [
+    "a malformed row contributes no outcome but is still cited",
+    "parseFailed coverage keeps the artifact distinct from a missing one"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/malformed-mdm-report/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/malformed-mdm-report/manifest.json
@@ -1,0 +1,27 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "malformed-mdm-report",
+  "workload": "device/windows/configuration",
+  "description": "A collected report that could not be interpreted; the bytes are retained as evidence.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "family": "diagnosticReport",
+      "sourceKind": "diagnosticReport",
+      "captureState": "parseFailed",
+      "payload": "reports",
+      "originalBasename": "MDMDiagReport.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-diagnostic-report/current/records.json",
+      "bytesCopied": 1249,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-diagnostic-report/MDMDiagReport.json",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/not-applicable-setting/evidence/mdm-diagnostic-report/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/not-applicable-setting/evidence/mdm-diagnostic-report/current/records.json
@@ -1,0 +1,39 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized configuration report rows, no real device data",
+  "reports": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-na",
+          "sourceArtifactId": "mdm-diagnostic-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-diagnostic-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:04:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:04:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/BitLocker/RequireDeviceEncryption",
+      "settingId": null,
+      "policyId": "11111111-1111-4111-8111-111111111111",
+      "displayName": "Require device encryption",
+      "outcome": "notApplicable",
+      "value": null,
+      "error": null,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/not-applicable-setting/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/not-applicable-setting/expected.json
@@ -1,0 +1,42 @@
+{
+  "scenario": "not-applicable-setting",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/bitlocker/requiredeviceencryption",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/BitLocker/RequireDeviceEncryption",
+      "displayName": "Require device encryption",
+      "receipt": "cspProcessed",
+      "local": "notApplicable",
+      "service": "noEvidence",
+      "resolution": "notApplicable",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": null,
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "rpt-na"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-not-applicable",
+    "configuration-device-only-evidence"
+  ],
+  "assertions": [
+    "notApplicable is a terminal disposition, not missing evidence",
+    "no reason for inapplicability is inferred from the node name"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/not-applicable-setting/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/not-applicable-setting/expected.json
@@ -26,11 +26,16 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "rpt-na"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-not-applicable": "high",
+    "configuration-device-only-evidence": "high"
+  },
   "findingIds": [
     "configuration-not-applicable",
     "configuration-device-only-evidence"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/not-applicable-setting/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/not-applicable-setting/manifest.json
@@ -1,0 +1,27 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "not-applicable-setting",
+  "workload": "device/windows/configuration",
+  "description": "A local MDM diagnostic report row reporting the node as not applicable to this device.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "family": "diagnosticReport",
+      "sourceKind": "diagnosticReport",
+      "captureState": "captured",
+      "payload": "reports",
+      "originalBasename": "MDMDiagReport.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-diagnostic-report/current/records.json",
+      "bytesCopied": 1203,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-diagnostic-report/MDMDiagReport.json",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/removal-rollback/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/removal-rollback/evidence/mdm-admin-channel/current/records.json
@@ -1,0 +1,114 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized MDM Admin channel events, no real device data",
+  "events": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-applied",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 110,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 813,
+            "recordId": 110
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:08:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:08:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 110,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"
+        },
+        {
+          "name": "Value",
+          "value": "1"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-deleted",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 111,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 815,
+            "recordId": 111
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:09:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:09:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 815,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 111,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"
+        },
+        {
+          "name": "CommandType",
+          "value": "Delete"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/removal-rollback/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/removal-rollback/expected.json
@@ -26,12 +26,17 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-applied",
         "evt-deleted"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-removed": "high",
+    "configuration-device-only-evidence": "high"
+  },
   "findingIds": [
     "configuration-removed",
     "configuration-device-only-evidence"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/removal-rollback/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/removal-rollback/expected.json
@@ -1,0 +1,43 @@
+{
+  "scenario": "removal-rollback",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "removed",
+      "service": "noEvidence",
+      "resolution": "removed",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "1",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-applied",
+        "evt-deleted"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-removed",
+    "configuration-device-only-evidence"
+  ],
+  "assertions": [
+    "an application followed by a deletion is a lifecycle, not a contradiction",
+    "removal is the current fact once a delete is observed"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/removal-rollback/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/removal-rollback/manifest.json
@@ -1,0 +1,27 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "removal-rollback",
+  "workload": "device/windows/configuration",
+  "description": "A delete-policy event removes a previously applied node.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "captured",
+      "payload": "events",
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-admin-channel/current/records.json",
+      "bytesCopied": 3648,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/report-only-evidence/evidence/intune-setting-report/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/report-only-evidence/evidence/intune-setting-report/current/records.json
@@ -1,0 +1,39 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized configuration report rows, no real device data",
+  "reports": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-service-only",
+          "sourceArtifactId": "intune-setting-report"
+        },
+        "provenance": {
+          "sourceKind": "graph",
+          "sourceArtifactId": "intune-setting-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:22:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:22:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Config/DeliveryOptimization/DODownloadMode",
+      "settingId": null,
+      "policyId": "22222222-2222-4222-8222-222222222222",
+      "displayName": null,
+      "outcome": "applied",
+      "value": "2",
+      "error": null,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/report-only-evidence/evidence/mdm-diagnostic-report/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/report-only-evidence/evidence/mdm-diagnostic-report/current/records.json
@@ -1,0 +1,39 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized configuration report rows, no real device data",
+  "reports": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-local-applied",
+          "sourceArtifactId": "mdm-diagnostic-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-diagnostic-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:12:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:12:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "settingId": null,
+      "policyId": "11111111-1111-4111-8111-111111111111",
+      "displayName": null,
+      "outcome": "applied",
+      "value": "1",
+      "error": null,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/report-only-evidence/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/report-only-evidence/expected.json
@@ -1,0 +1,75 @@
+{
+  "scenario": "report-only-evidence",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "status": "available"
+    },
+    {
+      "artifactId": "intune-setting-report",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "missing"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/deliveryoptimization/dodownloadmode",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/DeliveryOptimization/DODownloadMode",
+      "displayName": null,
+      "receipt": "intended",
+      "local": "noEvidence",
+      "service": "reportedSuccess",
+      "resolution": "insufficientEvidence",
+      "sourceIds": [
+        "22222222-2222-4222-8222-222222222222"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": null,
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "rpt-service-only"
+      ]
+    },
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "1",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "rpt-local-applied"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-service-only-evidence",
+    "configuration-device-only-evidence",
+    "configuration-uncollected-artifacts",
+    "configuration-applied"
+  ],
+  "assertions": [
+    "an imported Intune row alone never resolves to applied",
+    "a local diagnostic report row is device evidence and does resolve",
+    "the absent event channel is an explicit next-artifact request"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/report-only-evidence/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/report-only-evidence/expected.json
@@ -34,6 +34,7 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "rpt-service-only"
       ]
@@ -56,11 +57,18 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "rpt-local-applied"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-service-only-evidence": "medium",
+    "configuration-device-only-evidence": "high",
+    "configuration-uncollected-artifacts": "high",
+    "configuration-applied": "medium"
+  },
   "findingIds": [
     "configuration-service-only-evidence",
     "configuration-device-only-evidence",

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/report-only-evidence/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/report-only-evidence/manifest.json
@@ -1,0 +1,61 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "report-only-evidence",
+  "workload": "device/windows/configuration",
+  "description": "No event channel at all: one local report row and one imported Intune row.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "family": "diagnosticReport",
+      "sourceKind": "diagnosticReport",
+      "captureState": "captured",
+      "payload": "reports",
+      "originalBasename": "MDMDiagReport.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-diagnostic-report/current/records.json",
+      "bytesCopied": 1187,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-diagnostic-report/MDMDiagReport.json",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "intune-setting-report",
+      "family": "graph",
+      "sourceKind": "graph",
+      "captureState": "captured",
+      "payload": "reports",
+      "originalBasename": "settingStates.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/intune-setting-report/current/records.json",
+      "bytesCopied": 1188,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://intune-setting-report/settingStates.json",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "absent",
+      "payload": null,
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": null,
+      "bytesCopied": 0,
+      "encoding": null,
+      "sanitizedSourcePath": null,
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/scope-mismatch-device-and-user/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/scope-mismatch-device-and-user/evidence/mdm-admin-channel/current/records.json
@@ -1,0 +1,114 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized MDM Admin channel events, no real device data",
+  "events": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-device-applied",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 103,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 813,
+            "recordId": 103
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:02:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:02:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 813,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 103,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/Start/HideRecentlyAddedApps"
+        },
+        {
+          "name": "Value",
+          "value": "1"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ],
+      "message": null
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-user-failed",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 104,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 404,
+            "recordId": 104
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:03:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:03:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 404,
+      "level": "error",
+      "task": null,
+      "keywords": null,
+      "recordId": 104,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./User/Vendor/MSFT/Policy/Config/Start/HideRecentlyAddedApps"
+        },
+        {
+          "name": "Result",
+          "value": "0x82B00006"
+        },
+        {
+          "name": "ConfigurationSourceId",
+          "value": "11111111-1111-4111-8111-111111111111"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/scope-mismatch-device-and-user/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/scope-mismatch-device-and-user/expected.json
@@ -26,6 +26,7 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-device-applied"
       ]
@@ -48,11 +49,18 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-user-failed"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-local-rejection": "high",
+    "configuration-scope-split": "high",
+    "configuration-device-only-evidence": "high",
+    "configuration-applied": "high"
+  },
   "findingIds": [
     "configuration-local-rejection",
     "configuration-scope-split",

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/scope-mismatch-device-and-user/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/scope-mismatch-device-and-user/expected.json
@@ -1,0 +1,66 @@
+{
+  "scenario": "scope-mismatch-device-and-user",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/start/hiderecentlyaddedapps",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Start/HideRecentlyAddedApps",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "applied",
+      "service": "noEvidence",
+      "resolution": "applied",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "1",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-device-applied"
+      ]
+    },
+    {
+      "key": "user|uri:user/vendor/msft/policy/config/start/hiderecentlyaddedapps",
+      "scope": "user",
+      "canonicalUri": "User/Vendor/MSFT/Policy/Config/Start/HideRecentlyAddedApps",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "rejected",
+      "service": "noEvidence",
+      "resolution": "rejected",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111"
+      ],
+      "localErrorHex": "0x82B00006",
+      "serviceErrorHex": null,
+      "appliedValue": null,
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "evt-user-failed"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-local-rejection",
+    "configuration-scope-split",
+    "configuration-device-only-evidence",
+    "configuration-applied"
+  ],
+  "assertions": [
+    "device and user scope of one node are two transactions with two outcomes",
+    "the shared resource path is what makes the scope split detectable without merging them"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/scope-mismatch-device-and-user/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/scope-mismatch-device-and-user/manifest.json
@@ -1,0 +1,27 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "scope-mismatch-device-and-user",
+  "workload": "device/windows/configuration",
+  "description": "The same CSP node targeted in both scopes; the user-scoped command failed.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "captured",
+      "payload": "events",
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-admin-channel/current/records.json",
+      "bytesCopied": 3660,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/evidence/mdm-diagnostic-report/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/evidence/mdm-diagnostic-report/current/records.json
@@ -1,0 +1,79 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized configuration report rows, no real device data",
+  "reports": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-superseded",
+          "sourceArtifactId": "mdm-diagnostic-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-diagnostic-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:06:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:06:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Config/DeliveryOptimization/DODownloadMode",
+      "settingId": null,
+      "policyId": "11111111-1111-4111-8111-111111111111",
+      "displayName": null,
+      "outcome": "superseded",
+      "value": null,
+      "error": null,
+      "namedData": [
+        {
+          "name": "SupersededBy",
+          "value": "22222222-2222-4222-8222-222222222222"
+        }
+      ]
+    },
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-replacement",
+          "sourceArtifactId": "mdm-diagnostic-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-diagnostic-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 2,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:07:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:07:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Config/DeliveryOptimization/DODownloadMode",
+      "settingId": null,
+      "policyId": "22222222-2222-4222-8222-222222222222",
+      "displayName": null,
+      "outcome": "applied",
+      "value": "2",
+      "error": null,
+      "namedData": []
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/expected.json
@@ -14,9 +14,9 @@
       "canonicalUri": "Device/Vendor/MSFT/Policy/Config/DeliveryOptimization/DODownloadMode",
       "displayName": null,
       "receipt": "cspProcessed",
-      "local": "contested",
+      "local": "superseded",
       "service": "noEvidence",
-      "resolution": "contradicted",
+      "resolution": "superseded",
       "sourceIds": [
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222"
@@ -34,11 +34,18 @@
     }
   ],
   "findingIds": [
-    "configuration-contested-device-evidence",
+    "configuration-superseded",
     "configuration-device-only-evidence"
   ],
+  "findingEvidence": {
+    "configuration-superseded": [
+      "rpt-replacement",
+      "rpt-superseded"
+    ]
+  },
   "assertions": [
     "supersedence is only claimed when the replacing source is observed",
-    "the replacing source is cited alongside the superseded row"
+    "the replacing source is cited alongside the superseded row",
+    "the superseded row's explicit SupersededBy is what links the two, not the record order"
   ]
 }

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/expected.json
@@ -27,12 +27,17 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": false,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "rpt-replacement",
         "rpt-superseded"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-superseded": "high",
+    "configuration-device-only-evidence": "high"
+  },
   "findingIds": [
     "configuration-superseded",
     "configuration-device-only-evidence"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/expected.json
@@ -1,0 +1,50 @@
+{
+  "scenario": "superseded-by-replacement-source",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "status": "available"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/deliveryoptimization/dodownloadmode",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/DeliveryOptimization/DODownloadMode",
+      "displayName": null,
+      "receipt": "cspProcessed",
+      "local": "superseded",
+      "service": "noEvidence",
+      "resolution": "superseded",
+      "sourceIds": [
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222"
+      ],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": "2",
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": false,
+      "evidenceIds": [
+        "rpt-replacement",
+        "rpt-superseded"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-superseded",
+    "configuration-device-only-evidence"
+  ],
+  "assertions": [
+    "supersedence is only claimed when the replacing source is observed",
+    "the replacing source is cited alongside the superseded row"
+  ],
+  "findingEvidence": {
+    "configuration-superseded": [
+      "rpt-replacement",
+      "rpt-superseded"
+    ]
+  }
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/expected.json
@@ -14,9 +14,9 @@
       "canonicalUri": "Device/Vendor/MSFT/Policy/Config/DeliveryOptimization/DODownloadMode",
       "displayName": null,
       "receipt": "cspProcessed",
-      "local": "superseded",
+      "local": "contested",
       "service": "noEvidence",
-      "resolution": "superseded",
+      "resolution": "contradicted",
       "sourceIds": [
         "11111111-1111-4111-8111-111111111111",
         "22222222-2222-4222-8222-222222222222"
@@ -34,17 +34,11 @@
     }
   ],
   "findingIds": [
-    "configuration-superseded",
+    "configuration-contested-device-evidence",
     "configuration-device-only-evidence"
   ],
   "assertions": [
     "supersedence is only claimed when the replacing source is observed",
     "the replacing source is cited alongside the superseded row"
-  ],
-  "findingEvidence": {
-    "configuration-superseded": [
-      "rpt-replacement",
-      "rpt-superseded"
-    ]
-  }
+  ]
 }

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/superseded-by-replacement-source/manifest.json
@@ -1,0 +1,27 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "superseded-by-replacement-source",
+  "workload": "device/windows/configuration",
+  "description": "A row reports supersedence and names the replacing source, which is itself present.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "family": "diagnosticReport",
+      "sourceKind": "diagnosticReport",
+      "captureState": "captured",
+      "payload": "reports",
+      "originalBasename": "MDMDiagReport.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-diagnostic-report/current/records.json",
+      "bytesCopied": 2405,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-diagnostic-report/MDMDiagReport.json",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/evidence/mdm-admin-channel/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/evidence/mdm-admin-channel/current/records.json
@@ -1,0 +1,55 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized MDM Admin channel events, no real device data",
+  "events": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "evt-unknown-id",
+          "sourceArtifactId": "mdm-admin-channel"
+        },
+        "provenance": {
+          "sourceKind": "eventLog",
+          "sourceArtifactId": "mdm-admin-channel",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 150,
+          "registry": null,
+          "event": {
+            "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+            "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+            "eventId": 1907,
+            "recordId": 150
+          }
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:16:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:16:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "parsed",
+        "accessState": "available"
+      },
+      "channel": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin",
+      "provider": "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider",
+      "eventId": 1907,
+      "level": "information",
+      "task": null,
+      "keywords": null,
+      "recordId": 150,
+      "activityId": "66666666-6666-4666-8666-666666666666",
+      "namedData": [
+        {
+          "name": "NodeUri",
+          "value": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate"
+        },
+        {
+          "name": "Detail",
+          "value": "future signal"
+        }
+      ],
+      "message": null
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/evidence/mdm-diagnostic-report/current/records.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/evidence/mdm-diagnostic-report/current/records.json
@@ -1,0 +1,44 @@
+{"_marker": "SYNTHETIC FIXTURE - normalized configuration report rows, no real device data",
+  "reports": [
+    {
+      "context": {
+        "evidenceRef": {
+          "evidenceId": "rpt-unsupported",
+          "sourceArtifactId": "mdm-diagnostic-report"
+        },
+        "provenance": {
+          "sourceKind": "diagnosticReport",
+          "sourceArtifactId": "mdm-diagnostic-report",
+          "filePath": null,
+          "lineNumber": null,
+          "recordNumber": 1,
+          "registry": null,
+          "event": null
+        },
+        "sourceTimestamp": {
+          "rawText": "2026-07-31T09:16:00Z",
+          "originalOffset": null,
+          "normalizedUtc": "2026-07-31T09:16:00Z",
+          "kind": "utc"
+        },
+        "observedAtUtc": "2026-07-31T10:00:00Z",
+        "sensitivity": "public",
+        "parseState": "unsupported",
+        "accessState": "available"
+      },
+      "settingUri": "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "settingId": null,
+      "policyId": null,
+      "displayName": null,
+      "outcome": "unknown",
+      "value": null,
+      "error": null,
+      "namedData": [
+        {
+          "name": "SchemaVersion",
+          "value": "9"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/expected.json
@@ -37,14 +37,17 @@
   ],
   "findingConfidence": {
     "configuration-uninterpretable-evidence": "high",
-    "configuration-unreadable-artifacts": "high"
+    "configuration-unreadable-artifacts": "high",
+    "configuration-artifact-without-usable-records": "high"
   },
   "findingIds": [
     "configuration-uninterpretable-evidence",
-    "configuration-unreadable-artifacts"
+    "configuration-unreadable-artifacts",
+    "configuration-artifact-without-usable-records"
   ],
   "assertions": [
     "an unrecognized event id names the resource without claiming an outcome",
-    "an unsupported schema is retained rather than discarded"
+    "an unsupported schema is retained rather than discarded",
+    "the event channel is reported as available-but-barren rather than left to read as clean"
   ]
 }

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/expected.json
@@ -1,0 +1,45 @@
+{
+  "scenario": "unknown-report-schema",
+  "workload": "device/windows/configuration",
+  "coverage": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "status": "available"
+    },
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "status": "unsupported"
+    }
+  ],
+  "settings": [
+    {
+      "key": "device|uri:device/vendor/msft/policy/config/update/allowautoupdate",
+      "scope": "device",
+      "canonicalUri": "Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      "displayName": null,
+      "receipt": "commandReceived",
+      "local": "indeterminate",
+      "service": "noEvidence",
+      "resolution": "insufficientEvidence",
+      "sourceIds": [],
+      "localErrorHex": null,
+      "serviceErrorHex": null,
+      "appliedValue": null,
+      "timeIsReliable": true,
+      "orderingIsContradictory": false,
+      "hasUninterpretableEvidence": true,
+      "evidenceIds": [
+        "evt-unknown-id",
+        "rpt-unsupported"
+      ]
+    }
+  ],
+  "findingIds": [
+    "configuration-uninterpretable-evidence",
+    "configuration-unreadable-artifacts"
+  ],
+  "assertions": [
+    "an unrecognized event id names the resource without claiming an outcome",
+    "an unsupported schema is retained rather than discarded"
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/expected.json
@@ -28,12 +28,17 @@
       "timeIsReliable": true,
       "orderingIsContradictory": false,
       "hasUninterpretableEvidence": true,
+      "hasUnassessableFailure": false,
       "evidenceIds": [
         "evt-unknown-id",
         "rpt-unsupported"
       ]
     }
   ],
+  "findingConfidence": {
+    "configuration-uninterpretable-evidence": "high",
+    "configuration-unreadable-artifacts": "high"
+  },
   "findingIds": [
     "configuration-uninterpretable-evidence",
     "configuration-unreadable-artifacts"

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/unknown-report-schema/manifest.json
@@ -1,0 +1,44 @@
+{
+  "intuneManifestVersion": 1,
+  "syntheticFixture": true,
+  "scenario": "unknown-report-schema",
+  "workload": "device/windows/configuration",
+  "description": "A report schema and an event id this build does not recognize.",
+  "generatedAtUtc": "2026-07-31T10:00:00Z",
+  "artifacts": [
+    {
+      "artifactId": "mdm-admin-channel",
+      "family": "eventLog",
+      "sourceKind": "eventLog",
+      "captureState": "captured",
+      "payload": "events",
+      "originalBasename": "Admin.evtx",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-admin-channel/current/records.json",
+      "bytesCopied": 1770,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-admin-channel/Admin.evtx",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    },
+    {
+      "artifactId": "mdm-diagnostic-report",
+      "family": "diagnosticReport",
+      "sourceKind": "diagnosticReport",
+      "captureState": "unsupported",
+      "payload": "reports",
+      "originalBasename": "MDMDiagReport.json",
+      "capturedUtc": "2026-07-31T10:00:00Z",
+      "relativePath": "evidence/mdm-diagnostic-report/current/records.json",
+      "bytesCopied": 1242,
+      "encoding": "utf-8",
+      "sanitizedSourcePath": "SYNTHETIC://mdm-diagnostic-report/MDMDiagReport.json",
+      "rotation": {
+        "kind": "current",
+        "fragmentComplete": true
+      }
+    }
+  ]
+}

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -61,7 +61,7 @@ const SCENARIOS: [&str; 17] = [
 ///
 /// A rule that invents an identifier outside this list has escaped review, and a
 /// consumer keying on identifiers would break silently.
-const FINDING_VOCABULARY: [&str; 20] = [
+const FINDING_VOCABULARY: [&str; 21] = [
     "configuration-applied",
     "configuration-conflict",
     "configuration-conflict-unsubstantiated",
@@ -77,6 +77,7 @@ const FINDING_VOCABULARY: [&str; 20] = [
     "configuration-superseded",
     "configuration-superseded-unsubstantiated",
     "configuration-truncated-artifacts",
+    "configuration-unassessable-failure",
     "configuration-unattributed-records",
     "configuration-uncollected-artifacts",
     "configuration-uninterpretable-evidence",
@@ -217,6 +218,7 @@ fn project(setting: &ConfigurationSetting) -> Value {
         "timeIsReliable": setting.time_is_reliable,
         "orderingIsContradictory": setting.ordering_is_contradictory,
         "hasUninterpretableEvidence": setting.has_uninterpretable_evidence,
+        "hasUnassessableFailure": setting.has_unassessable_failure,
         "evidenceIds": evidence_ids.into_iter().collect::<Vec<_>>(),
     })
 }
@@ -319,6 +321,21 @@ fn every_scenario_matches_its_expected_analysis() {
             json!(finding_ids(&snapshot)),
             expected["findingIds"],
             "{scenario}: finding identifiers, in rule order"
+        );
+
+        // Confidence is a claim about how far the evidence reaches, and ADR-001
+        // makes it a contract rather than a presentation detail. Pinning only the
+        // identifiers let a High-confidence success survive a bundle whose
+        // artifacts were capped, denied, and missing.
+        let actual_confidence = snapshot
+            .findings
+            .iter()
+            .map(|finding| (finding.finding_id.clone(), wire(&finding.confidence)))
+            .collect::<serde_json::Map<_, _>>();
+        assert_eq!(
+            Value::Object(actual_confidence),
+            expected["findingConfidence"],
+            "{scenario}: finding confidence"
         );
 
         let actual_coverage = snapshot
@@ -446,6 +463,7 @@ fn every_documented_finding_is_reachable_from_the_corpus_or_a_synthesized_case()
         analyze_configuration(&ordered_supersedence_input()),
         analyze_configuration(&unattributed_input()),
         analyze_configuration(&contested_device_input()),
+        analyze_configuration(&unassessable_failure_input()),
     ] {
         seen.extend(finding_ids(&snapshot));
     }
@@ -893,6 +911,81 @@ fn unattributed_input() -> ConfigurationInput {
     ])
 }
 
+/// A 404 command-failure event whose `Result:` token cannot be read.
+fn unreadable_failure_event(evidence_id: &str, record_id: u64) -> NormalizedWindowsEvent {
+    NormalizedWindowsEvent {
+        context: context(
+            evidence_id,
+            "mdm-admin-channel",
+            IntuneSourceKind::EventLog,
+            IntuneParseState::Parsed,
+        ),
+        channel: "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin"
+            .to_owned(),
+        provider: "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider".to_owned(),
+        event_id: 404,
+        event_version: None,
+        level: NormalizedEventLevel::Error,
+        task: None,
+        keywords: None,
+        record_id: Some(record_id),
+        activity_id: None,
+        named_data: vec![IntuneNamedValue {
+            name: "NodeUri".to_owned(),
+            value: NODE.to_owned(),
+        }],
+        message: Some(
+            "MDM ConfigurationManager: Command failure status. CSP URI: (./Device/Vendor/MSFT/\
+             Policy/Config/Update/AllowAutoUpdate), Result: (unreadable)."
+                .to_owned(),
+        ),
+    }
+}
+
+fn applied_event(evidence_id: &str, record_id: u64) -> NormalizedWindowsEvent {
+    NormalizedWindowsEvent {
+        context: context(
+            evidence_id,
+            "mdm-admin-channel",
+            IntuneSourceKind::EventLog,
+            IntuneParseState::Parsed,
+        ),
+        channel: "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin"
+            .to_owned(),
+        provider: "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider".to_owned(),
+        event_id: 813,
+        event_version: None,
+        level: NormalizedEventLevel::Information,
+        task: None,
+        keywords: None,
+        record_id: Some(record_id),
+        activity_id: None,
+        named_data: vec![
+            IntuneNamedValue {
+                name: "NodeUri".to_owned(),
+                value: NODE.to_owned(),
+            },
+            IntuneNamedValue {
+                name: "Value".to_owned(),
+                value: "1".to_owned(),
+            },
+        ],
+        message: None,
+    }
+}
+
+fn unassessable_failure_input() -> ConfigurationInput {
+    ConfigurationInput {
+        generated_at_utc: "2026-07-31T10:00:00Z".to_owned(),
+        events: vec![
+            applied_event("evt-applied", 1),
+            unreadable_failure_event("evt-unreadable-404", 2),
+        ],
+        reports: Vec::new(),
+        coverage: Vec::new(),
+    }
+}
+
 fn contested_device_input() -> ConfigurationInput {
     input_of(vec![
         row(
@@ -946,6 +1039,76 @@ fn records_with_no_identifier_are_never_merged_with_one_another() {
     );
     assert_eq!(snapshot.unattributed.len(), 2);
     assert!(finding_ids(&snapshot).contains(&"configuration-unattributed-records".to_owned()));
+}
+
+/// The Autopilot class: an 813 says the value was written and a 404 for the same
+/// node says a command failed, but its status is unreadable. Reporting a clean
+/// `configuration-applied` at High confidence with no mention of the failure is
+/// what this guards against.
+#[test]
+fn an_unreadable_failure_blocks_a_terminal_success_for_the_same_node() {
+    let snapshot = analyze_configuration(&unassessable_failure_input());
+    let setting = snapshot.settings.first().expect("one transaction");
+    assert!(
+        setting.has_unassessable_failure,
+        "the 404 must be recorded as a failure whose detail is unassessable"
+    );
+    assert_ne!(
+        wire(&setting.resolution),
+        json!("applied"),
+        "a success must not stand beside an unreadable failure for the same node"
+    );
+
+    let ids = finding_ids(&snapshot);
+    assert!(
+        ids.contains(&"configuration-unassessable-failure".to_owned()),
+        "the failure record must be reported, got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&"configuration-applied".to_owned()),
+        "got {ids:?}"
+    );
+}
+
+#[test]
+fn a_record_the_collector_could_not_fully_read_states_no_outcome() {
+    // `access_state` is the collector telling us the fields this analyzer keys on
+    // may be the ones it never read.
+    let mut input = unassessable_failure_input();
+    input.events = vec![applied_event("evt-partial", 1)];
+    input.events[0].context.access_state =
+        cmtraceopen_parser::intune::evidence::IntuneAccessState::Capped;
+
+    let snapshot = analyze_configuration(&input);
+    let setting = snapshot.settings.first().expect("one transaction");
+    assert!(setting.has_uninterpretable_evidence);
+    assert_eq!(wire(&setting.local), json!("indeterminate"));
+    assert!(!finding_ids(&snapshot).contains(&"configuration-applied".to_owned()));
+}
+
+/// ADR-001: coverage gaps cannot raise confidence, and a success claim rests
+/// partly on not having seen a failure.
+#[test]
+fn coverage_gaps_stop_a_success_being_stated_at_high_confidence() {
+    let snapshot = analyze_configuration(&load_input("incomplete-channel-coverage"));
+    let applied = snapshot
+        .findings
+        .iter()
+        .find(|finding| finding.finding_id == "configuration-applied")
+        .expect("the applied finding is present");
+    assert_eq!(wire(&applied.confidence), json!("medium"));
+    assert!(
+        !applied.coverage_gap_ids.is_empty(),
+        "the finding must name the gaps that cost it confidence"
+    );
+
+    let clean = analyze_configuration(&load_input("applied-from-csp-event"));
+    let clean_applied = clean
+        .findings
+        .iter()
+        .find(|finding| finding.finding_id == "configuration-applied")
+        .expect("the applied finding is present");
+    assert_eq!(wire(&clean_applied.confidence), json!("high"));
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -365,7 +365,7 @@ fn cited_evidence_matches_the_expectation_where_a_scenario_pins_it() {
             checked += 1;
         }
     }
-    assert!(checked >= 4, "expected several pinned citation sets");
+    assert!(checked >= 2, "expected several pinned citation sets");
 }
 
 #[test]
@@ -409,6 +409,8 @@ fn every_documented_finding_is_reachable_from_the_corpus_or_a_synthesized_case()
     for snapshot in [
         analyze_configuration(&unsubstantiated_conflict_input()),
         analyze_configuration(&unsubstantiated_supersedence_input()),
+        analyze_configuration(&ordered_conflict_input()),
+        analyze_configuration(&ordered_supersedence_input()),
         analyze_configuration(&unattributed_input()),
         analyze_configuration(&contested_device_input()),
     ] {
@@ -667,6 +669,54 @@ fn unsubstantiated_supersedence_input() -> ConfigurationInput {
         NormalizedSettingOutcome::Superseded,
         vec![("SupersededBy", POLICY_B)],
     )])
+}
+
+fn ordered_conflict_input() -> ConfigurationInput {
+    let mut applied = row(
+        "ordered-applied",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Applied,
+        Vec::new(),
+    );
+    applied.context.provenance.record_number = Some(1);
+    let mut conflict = row(
+        "ordered-conflict",
+        Some(NODE),
+        Some(POLICY_B),
+        NormalizedSettingOutcome::Conflict,
+        Vec::new(),
+    );
+    conflict.context.provenance.record_number = Some(2);
+    input_of(vec![applied, conflict])
+}
+
+fn ordered_supersedence_input() -> ConfigurationInput {
+    let mut applied = row(
+        "ordered-applied",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Applied,
+        Vec::new(),
+    );
+    applied.context.provenance.record_number = Some(1);
+    let mut superseded = row(
+        "ordered-superseded",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Superseded,
+        vec![("SupersededBy", POLICY_B)],
+    );
+    superseded.context.provenance.record_number = Some(2);
+    let mut replacement = row(
+        "ordered-replacement",
+        Some(NODE),
+        Some(POLICY_B),
+        NormalizedSettingOutcome::Applied,
+        Vec::new(),
+    );
+    replacement.context.provenance.record_number = Some(3);
+    input_of(vec![applied, superseded, replacement])
 }
 
 fn unattributed_input() -> ConfigurationInput {

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -110,6 +110,13 @@ fn load_input(scenario: &str) -> ConfigurationInput {
             .as_str()
             .expect("manifest declares generatedAtUtc")
             .to_owned(),
+        // The harness is the caller, so the harness owns analysis identity. The
+        // scenario name is this corpus's unique-per-analysis value, and naming it
+        // here rather than in the manifest keeps it what it is: a caller's
+        // contract input, not a property of the collected evidence. Most
+        // scenarios share `generatedAtUtc`, so the pinned tokens are proof the
+        // scope, not the timestamp, is what separates them.
+        analysis_scope: Some(format!("fixture:{scenario}")),
         ..ConfigurationInput::default()
     };
 
@@ -583,6 +590,7 @@ fn permutations_of(input: ConfigurationInput) -> Vec<ConfigurationInput> {
         for reports in orderings(&input.reports) {
             permutations.push(ConfigurationInput {
                 generated_at_utc: input.generated_at_utc.clone(),
+                analysis_scope: input.analysis_scope.clone(),
                 events: events.clone(),
                 reports,
                 coverage: input.coverage.clone(),
@@ -782,6 +790,124 @@ fn the_redaction_scenario_produces_the_pinned_tokens() {
         expected["redactedEnrollmentId"],
         "an enrollment id is tokenized rather than dropped"
     );
+}
+
+/// Two analyses that share a `generatedAtUtc` must not share a token.
+///
+/// The defect this pins reached the export, not just the hash helper: the token
+/// scope used to be the snapshot's `generatedAtUtc`, and the docs claimed no two
+/// exports could share it. A timestamp is not a nonce — these two bundles are
+/// byte-identical evidence captured under two different analyses at the same
+/// second, which is ordinary at second resolution — so every token matched and
+/// the cross-export join ADR-004 forbids worked exactly as before.
+#[test]
+fn two_analyses_with_the_same_generated_at_utc_export_no_shared_token() {
+    let mut first = load_input("deterministic-redaction");
+    let mut second = load_input("deterministic-redaction");
+    first.analysis_scope = Some("analysis-a".to_owned());
+    second.analysis_scope = Some("analysis-b".to_owned());
+    assert_eq!(
+        first.generated_at_utc, second.generated_at_utc,
+        "the whole point is that the instant is shared"
+    );
+
+    let tokens = |input: &ConfigurationInput| {
+        exported_tokens(&redacted_configuration_snapshot(&analyze_configuration(
+            input,
+        )))
+    };
+    let first_tokens = tokens(&first);
+    let second_tokens = tokens(&second);
+
+    assert!(
+        !first_tokens.is_empty(),
+        "the scenario must actually produce tokens or this proves nothing"
+    );
+    assert_eq!(
+        first_tokens.len(),
+        second_tokens.len(),
+        "the same evidence must still redact to the same *number* of tokens"
+    );
+    let shared = first_tokens
+        .intersection(&second_tokens)
+        .collect::<Vec<_>>();
+    assert!(
+        shared.is_empty(),
+        "two analyses sharing an instant must share no token, got {shared:?}"
+    );
+}
+
+/// One analysis keeps one token vocabulary, however many times it is projected.
+///
+/// The other half of the boundary: isolating exports is worthless if it also
+/// breaks the equality a conflict diagnosis is read from.
+#[test]
+fn one_analysis_scope_keeps_its_tokens_across_separate_runs() {
+    let input = load_input("deterministic-redaction");
+    let first = redacted_configuration_snapshot(&analyze_configuration(&input));
+    let second = redacted_configuration_snapshot(&analyze_configuration(&input));
+    assert_eq!(
+        wire(&first),
+        wire(&second),
+        "one analysis scope is one export vocabulary"
+    );
+    assert_eq!(
+        first.analysis_scope, second.analysis_scope,
+        "the scope digest is derived, not invented per run"
+    );
+    assert!(
+        first
+            .analysis_scope
+            .as_ref()
+            .is_some_and(|digest| !digest.contains("deterministic-redaction")),
+        "the caller's scope value must not be republished, got {:?}",
+        first.analysis_scope
+    );
+}
+
+/// An omitted scope is a declined boundary, and the export says so.
+///
+/// Pinned as a *disclaimer*, not a feature: with no caller-supplied scope the
+/// tokens fall back to `generatedAtUtc` alone and two analyses sharing that
+/// instant do collide. The snapshot reports `analysisScope: null` so a consumer
+/// can tell the difference between "isolated from other exports" and "no claim".
+#[test]
+fn an_omitted_analysis_scope_makes_no_isolation_claim() {
+    let mut input = load_input("deterministic-redaction");
+    input.analysis_scope = None;
+    let scopeless = redacted_configuration_snapshot(&analyze_configuration(&input));
+    assert_eq!(scopeless.analysis_scope, None);
+
+    let scoped = redacted_configuration_snapshot(&analyze_configuration(&load_input(
+        "deterministic-redaction",
+    )));
+    assert!(scoped.analysis_scope.is_some());
+    assert!(
+        exported_tokens(&scopeless).is_disjoint(&exported_tokens(&scoped)),
+        "declining the boundary must not silently join the export to a scoped one"
+    );
+}
+
+/// Every `[redacted:…]` token anywhere in an export.
+fn exported_tokens(snapshot: &ConfigurationSnapshot) -> BTreeSet<String> {
+    fn collect(value: &Value, into: &mut BTreeSet<String>) {
+        match value {
+            Value::String(text) => {
+                for candidate in text.split_inclusive(']') {
+                    if let Some(start) = candidate.find("[redacted:") {
+                        into.insert(candidate[start..].to_owned());
+                    }
+                }
+            }
+            Value::Array(items) => items.iter().for_each(|item| collect(item, into)),
+            Value::Object(fields) => fields.values().for_each(|field| collect(field, into)),
+            _ => {}
+        }
+    }
+
+    let mut tokens = BTreeSet::new();
+    collect(&wire(snapshot), &mut tokens);
+    tokens
 }
 
 #[test]
@@ -997,6 +1123,7 @@ fn row(
 fn input_of(reports: Vec<NormalizedSettingReport>) -> ConfigurationInput {
     ConfigurationInput {
         generated_at_utc: "2026-07-31T10:00:00Z".to_owned(),
+        analysis_scope: Some("synthesized".to_owned()),
         events: Vec::new(),
         reports,
         coverage: Vec::new(),
@@ -1160,6 +1287,7 @@ fn applied_event(evidence_id: &str, record_id: u64) -> NormalizedWindowsEvent {
 fn unassessable_failure_input() -> ConfigurationInput {
     ConfigurationInput {
         generated_at_utc: "2026-07-31T10:00:00Z".to_owned(),
+        analysis_scope: Some("synthesized".to_owned()),
         events: vec![
             applied_event("evt-applied", 1),
             unreadable_failure_event("evt-unreadable-404", 2),
@@ -1489,6 +1617,7 @@ fn the_shared_normalized_contract_is_the_one_this_leaf_was_built_against() {
 fn an_event_naming_no_resource_contributes_nothing() {
     let input = ConfigurationInput {
         generated_at_utc: "2026-07-31T10:00:00Z".to_owned(),
+        analysis_scope: Some("synthesized".to_owned()),
         events: vec![NormalizedWindowsEvent {
             context: context(
                 "evt-unrelated",
@@ -1535,6 +1664,7 @@ fn another_providers_message_text_never_joins_an_mdm_transaction() {
 
     let input = ConfigurationInput {
         generated_at_utc: "2026-07-31T10:00:00Z".to_owned(),
+        analysis_scope: Some("synthesized".to_owned()),
         events: vec![applied_event("evt-mdm", 2), event],
         reports: Vec::new(),
         coverage: Vec::new(),

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -368,6 +368,39 @@ fn cited_evidence_matches_the_expectation_where_a_scenario_pins_it() {
     assert!(checked >= 2, "expected several pinned citation sets");
 }
 
+/// `assertions` is prose, and prose is not a test.
+///
+/// Two of the flagship scenarios claimed "the conflict finding cites the
+/// competing rows" while emitting no such finding at all, because nothing ever
+/// compared the sentence with the output. A sentence that claims a citation must
+/// therefore be backed by a `findingEvidence` block, which
+/// `cited_evidence_matches_the_expectation_where_a_scenario_pins_it` does check.
+#[test]
+fn a_scenario_that_claims_a_citation_in_prose_must_pin_that_citation() {
+    for scenario in SCENARIOS {
+        let expected = load_json(&scenario_root(scenario).join("expected.json"));
+        let assertions = expected["assertions"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{scenario}: expected.json declares assertions"));
+        assert!(
+            !assertions.is_empty(),
+            "{scenario}: assertions must not be empty"
+        );
+
+        let claims_a_citation = assertions.iter().any(|assertion| {
+            let text = assertion.as_str().unwrap_or_default();
+            text.contains("cites") || text.contains("cited")
+        });
+        if claims_a_citation {
+            assert!(
+                expected["findingEvidence"].is_object(),
+                "{scenario}: an assertion claims a citation, so the scenario must pin \
+                 findingEvidence for it rather than leave the claim unchecked"
+            );
+        }
+    }
+}
+
 #[test]
 fn every_finding_cites_evidence_or_a_coverage_gap() {
     for scenario in SCENARIOS {
@@ -422,6 +455,61 @@ fn every_documented_finding_is_reachable_from_the_corpus_or_a_synthesized_case()
         .filter(|id| !seen.contains(**id))
         .collect::<Vec<_>>();
     assert!(missing.is_empty(), "unreachable finding rules: {missing:?}");
+}
+
+/// The record ordinals in a report snapshot describe the order rows were written
+/// into the file. They do not say which policy won an argument, and swapping them
+/// used to flip the two headline scenarios between `contested`/Error and
+/// `conflicted`/Warning.
+#[test]
+fn renumbering_the_rows_of_a_correlated_scenario_does_not_change_the_diagnosis() {
+    for scenario in [
+        "conflict-between-two-sources",
+        "superseded-by-replacement-source",
+    ] {
+        let baseline = analyze_configuration(&load_input(scenario));
+
+        // A consistent alternative history: the same rows, written to the report
+        // in the opposite order. Ordinals and timestamps move together, so the
+        // bundle stays internally coherent and the only thing that changed is
+        // which row the file happens to list first.
+        let mut swapped = load_input(scenario);
+        let positions = swapped
+            .reports
+            .iter()
+            .map(|report| {
+                (
+                    report.context.provenance.record_number,
+                    report.context.source_timestamp.clone(),
+                )
+            })
+            .rev()
+            .collect::<Vec<_>>();
+        for (report, (ordinal, timestamp)) in swapped.reports.iter_mut().zip(positions) {
+            report.context.provenance.record_number = ordinal;
+            report.context.source_timestamp = timestamp;
+        }
+
+        let renumbered = analyze_configuration(&swapped);
+        assert_eq!(
+            baseline
+                .settings
+                .iter()
+                .map(|setting| (wire(&setting.local), wire(&setting.resolution)))
+                .collect::<Vec<_>>(),
+            renumbered
+                .settings
+                .iter()
+                .map(|setting| (wire(&setting.local), wire(&setting.resolution)))
+                .collect::<Vec<_>>(),
+            "{scenario}: record numbers must not decide the outcome"
+        );
+        assert_eq!(
+            finding_ids(&baseline),
+            finding_ids(&renumbered),
+            "{scenario}: record numbers must not decide the findings"
+        );
+    }
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -61,8 +61,9 @@ const SCENARIOS: [&str; 17] = [
 ///
 /// A rule that invents an identifier outside this list has escaped review, and a
 /// consumer keying on identifiers would break silently.
-const FINDING_VOCABULARY: [&str; 21] = [
+const FINDING_VOCABULARY: [&str; 22] = [
     "configuration-applied",
+    "configuration-artifact-without-usable-records",
     "configuration-conflict",
     "configuration-conflict-unsubstantiated",
     "configuration-contested-device-evidence",
@@ -1306,6 +1307,83 @@ fn one_policy_in_two_casings_is_not_a_conflict() {
     assert!(
         !ids.contains(&"configuration-conflict".to_owned()),
         "got {ids:?}"
+    );
+}
+
+/// `Json` describes the encoding, not the origin. A portal export is JSON and so
+/// is a device-side agent state file; granting the kind device authority let the
+/// former resolve a setting the CSP was never shown to have applied.
+#[test]
+fn a_json_source_does_not_carry_device_authority() {
+    let mut report = row(
+        "rpt-json-export",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Applied,
+        Vec::new(),
+    );
+    report.context.provenance.source_kind = IntuneSourceKind::Json;
+    let snapshot = analyze_configuration(&input_of(vec![report]));
+    let setting = snapshot.settings.first().expect("one transaction");
+    assert_eq!(wire(&setting.local), json!("noEvidence"));
+    assert_ne!(wire(&setting.resolution), json!("applied"));
+}
+
+/// CSP node names are documented with specific casing but are not case-sensitive.
+/// Grouping the scope-split rule on the exact bytes meant a device `Start/…` and a
+/// user `start/…` never met, so the split went unreported.
+#[test]
+fn the_scope_split_rule_survives_a_casing_difference_between_the_two_scopes() {
+    let snapshot = analyze_configuration(&input_of(vec![
+        row(
+            "rpt-device-scope",
+            Some("./Device/Vendor/MSFT/Policy/Config/Start/HideRecentlyAddedApps"),
+            Some(POLICY_A),
+            NormalizedSettingOutcome::Applied,
+            Vec::new(),
+        ),
+        row(
+            "rpt-user-scope",
+            Some("./User/Vendor/MSFT/Policy/Config/start/hiderecentlyaddedapps"),
+            Some(POLICY_A),
+            NormalizedSettingOutcome::Applied,
+            Vec::new(),
+        ),
+    ]));
+    assert_eq!(snapshot.settings.len(), 2, "the two scopes stay separate");
+    assert!(
+        finding_ids(&snapshot).contains(&"configuration-scope-split".to_owned()),
+        "got {:?}",
+        finding_ids(&snapshot)
+    );
+}
+
+/// The service's own status code was populated and cited by no rule, so the code
+/// Intune reported never reached a reader of the contradiction finding.
+#[test]
+fn the_contradiction_finding_quotes_both_sides_status_codes() {
+    let snapshot = analyze_configuration(&load_input("cloud-success-local-terminal-error"));
+    let contradiction = snapshot
+        .findings
+        .iter()
+        .find(|finding| finding.finding_id == "configuration-local-service-contradiction")
+        .expect("the contradiction finding is present");
+    assert!(
+        contradiction.summary.contains("0x82B00006"),
+        "got {}",
+        contradiction.summary
+    );
+
+    let both = analyze_configuration(&load_input("local-success-cloud-failure"));
+    let with_service_code = both
+        .findings
+        .iter()
+        .find(|finding| finding.finding_id == "configuration-local-service-contradiction")
+        .expect("the contradiction finding is present");
+    assert!(
+        with_service_code.summary.contains("0x87D1FDE8"),
+        "the service-reported status must be quoted, got {}",
+        with_service_code.summary
     );
 }
 

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -469,6 +469,7 @@ fn the_redaction_scenario_produces_the_pinned_tokens() {
         .map(|setting| {
             json!({
                 "key": setting.identity.key,
+                "canonicalUri": setting.identity.canonical_uri,
                 "appliedValue": setting.applied_value,
                 "namedData": setting
                     .observations
@@ -501,10 +502,31 @@ fn redaction_preserves_the_diagnosis_and_is_deterministic() {
     let second = redacted_configuration_snapshot(&snapshot);
 
     assert_eq!(wire(&first), wire(&second), "redaction is deterministic");
+
+    // ADR-004's invariant is that redaction does not alter a *conclusion*. The
+    // conclusion is the identifier, severity, confidence, and citation set — not
+    // the prose, which is built from setting labels and therefore carries node
+    // paths. The previous expectation here compared whole findings and so pinned
+    // the leak in place: a node path embedding a SID reached the export through
+    // the summary, and any fix to that would have failed this test.
+    let conclusion = |findings: &[cmtraceopen_parser::intune::evidence::IntuneFinding]| {
+        findings
+            .iter()
+            .map(|finding| {
+                json!({
+                    "id": finding.finding_id,
+                    "severity": wire(&finding.severity),
+                    "confidence": wire(&finding.confidence),
+                    "evidence": wire(&finding.evidence),
+                    "coverageGapIds": finding.coverage_gap_ids,
+                })
+            })
+            .collect::<Vec<_>>()
+    };
     assert_eq!(
-        wire(&first.findings),
-        wire(&snapshot.findings),
-        "redaction must not change the findings"
+        conclusion(&first.findings),
+        conclusion(&snapshot.findings),
+        "redaction must not change what a finding concludes or cites"
     );
     assert_eq!(
         first
@@ -519,6 +541,51 @@ fn redaction_preserves_the_diagnosis_and_is_deterministic() {
             .collect::<Vec<_>>(),
         "redaction must not change any resolution"
     );
+}
+
+#[test]
+fn no_finding_or_coverage_text_carries_an_identity_the_settings_redacted() {
+    // The settings and the prose that describes them are one export. A node path
+    // scrubbed in `canonicalUri` and quoted verbatim in a finding summary is the
+    // same disclosure, reached by a different field.
+    for scenario in SCENARIOS {
+        let redacted =
+            redacted_configuration_snapshot(&analyze_configuration(&load_input(scenario)));
+        let mut prose = Vec::new();
+        for finding in &redacted.findings {
+            prose.push(finding.title.clone());
+            prose.push(finding.summary.clone());
+            prose.extend(finding.recommended_checks.iter().cloned());
+        }
+        prose.extend(redacted.coverage.iter().filter_map(|e| e.detail.clone()));
+
+        for text in prose {
+            let lowercased = text.to_ascii_lowercase();
+            assert!(
+                !lowercased.contains("s-1-"),
+                "{scenario}: a SID reached exported prose: {text}"
+            );
+            assert!(
+                !lowercased.contains("@example.invalid"),
+                "{scenario}: a UPN reached exported prose: {text}"
+            );
+        }
+    }
+}
+
+#[test]
+fn re_redacting_an_export_returns_it_unchanged() {
+    // Callers chain projections; a token that gets hashed a second time silently
+    // breaks the equality the first projection was there to preserve.
+    for scenario in SCENARIOS {
+        let once = redacted_configuration_snapshot(&analyze_configuration(&load_input(scenario)));
+        let twice = redacted_configuration_snapshot(&once);
+        assert_eq!(
+            wire(&once),
+            wire(&twice),
+            "{scenario}: redaction is idempotent"
+        );
+    }
 }
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -826,6 +826,7 @@ fn an_event_naming_no_resource_contributes_nothing() {
             provider: "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider"
                 .to_owned(),
             event_id: 208,
+            event_version: None,
             level: NormalizedEventLevel::Information,
             task: None,
             keywords: None,

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -1164,6 +1164,38 @@ fn an_event_naming_no_resource_contributes_nothing() {
     );
 }
 
+/// A record from another provider may legitimately name a CSP node in structured
+/// data, but its *rendered text* is its own vocabulary. Scraping `CSP URI: (…)`
+/// out of it let any component's log line join a real MDM transaction.
+#[test]
+fn another_providers_message_text_never_joins_an_mdm_transaction() {
+    let mut event = applied_event("evt-foreign", 1);
+    event.provider = "Contoso-Agent".to_owned();
+    event.named_data = Vec::new();
+    event.message = Some(format!(
+        "Contoso agent applied policy. CSP URI: ({NODE}), Result: (0)."
+    ));
+
+    let input = ConfigurationInput {
+        generated_at_utc: "2026-07-31T10:00:00Z".to_owned(),
+        events: vec![applied_event("evt-mdm", 2), event],
+        reports: Vec::new(),
+        coverage: Vec::new(),
+    };
+    let snapshot = analyze_configuration(&input);
+    let setting = snapshot.settings.first().expect("one transaction");
+    assert_eq!(
+        setting.evidence.len(),
+        1,
+        "only the MDM record may contribute, got {:?}",
+        setting.evidence
+    );
+    assert!(
+        snapshot.unattributed.is_empty(),
+        "a foreign record naming no resource is not configuration evidence at all"
+    );
+}
+
 #[test]
 fn expected_files_declare_the_workload_they_belong_to() {
     // Cheap guard against a scenario being copied into the wrong corpus.

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -1,0 +1,809 @@
+//! Contract tests for `intune::device::windows::configuration` (issue #363).
+//!
+//! The corpus under `tests/fixtures/intune/device/windows/configuration/` is the
+//! acceptance criteria for the issue's required fixture matrix. Each scenario is
+//! run end to end: the manifest is validated by the shared harness, the evidence
+//! files are decoded into the shared normalized inputs, the analyzer runs, and
+//! its per-setting states, finding vocabulary, and citations are compared with
+//! the hand-authored `expected.json`.
+//!
+//! Scenarios that would need a device to produce (an unsubstantiated conflict,
+//! records with no identifier at all) are exercised from synthesized inputs at
+//! the bottom of this file rather than by inflating the matrix.
+
+mod support;
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use serde_json::{json, Value};
+
+use cmtraceopen_parser::intune::device::windows::configuration::{
+    analyze_configuration, redacted_configuration_snapshot, ConfigurationInput,
+    ConfigurationSetting, ConfigurationSnapshot, INTUNE_CONFIGURATION_SCHEMA_VERSION,
+};
+use cmtraceopen_parser::intune::evidence::{
+    IntuneArtifactCoverage, IntuneArtifactStatus, IntuneEvidenceRef, IntuneNamedValue,
+    IntuneObservationContext, IntuneParseState, IntuneProvenance, IntuneSensitivity,
+    IntuneSourceKind, IntuneTimestamp, IntuneTimestampKind,
+};
+use cmtraceopen_parser::intune::normalized::{
+    NormalizedEventLevel, NormalizedSettingOutcome, NormalizedSettingReport,
+    NormalizedWindowsEvent, INTUNE_NORMALIZED_SCHEMA_VERSION,
+};
+use support::{load_json, mutated, scenario_names, validate_scenario, Failures};
+
+const CORPUS: &str = "device/windows/configuration";
+
+/// The required fixture matrix from issue #363, pinned so a scenario cannot be
+/// quietly dropped or renamed.
+const SCENARIOS: [&str; 17] = [
+    "applied-from-csp-event",
+    "cloud-success-local-terminal-error",
+    "conflict-between-two-sources",
+    "csp-terminal-error",
+    "deterministic-redaction",
+    "duplicate-display-name-different-csp-paths",
+    "event-only-evidence",
+    "incomplete-channel-coverage",
+    "invalid-offset-and-contradictory-ordering",
+    "local-success-cloud-failure",
+    "malformed-mdm-report",
+    "not-applicable-setting",
+    "removal-rollback",
+    "report-only-evidence",
+    "scope-mismatch-device-and-user",
+    "superseded-by-replacement-source",
+    "unknown-report-schema",
+];
+
+/// Every finding identifier this build is allowed to emit.
+///
+/// A rule that invents an identifier outside this list has escaped review, and a
+/// consumer keying on identifiers would break silently.
+const FINDING_VOCABULARY: [&str; 20] = [
+    "configuration-applied",
+    "configuration-conflict",
+    "configuration-conflict-unsubstantiated",
+    "configuration-contested-device-evidence",
+    "configuration-device-only-evidence",
+    "configuration-duplicate-display-name",
+    "configuration-local-rejection",
+    "configuration-local-service-contradiction",
+    "configuration-not-applicable",
+    "configuration-removed",
+    "configuration-scope-split",
+    "configuration-service-only-evidence",
+    "configuration-superseded",
+    "configuration-superseded-unsubstantiated",
+    "configuration-truncated-artifacts",
+    "configuration-unattributed-records",
+    "configuration-uncollected-artifacts",
+    "configuration-uninterpretable-evidence",
+    "configuration-unreadable-artifacts",
+    "configuration-unusable-ordering",
+];
+
+fn corpus_root() -> PathBuf {
+    support::corpus_root(CORPUS)
+}
+
+fn scenario_root(scenario: &str) -> PathBuf {
+    corpus_root().join(scenario)
+}
+
+// ── Loading ─────────────────────────────────────────────────────────────────
+
+/// Build the analyzer input from one scenario's manifest and evidence files.
+///
+/// This is the boundary a native adapter would occupy: it reads bytes and hands
+/// the pure crate the shared normalized types. The parser crate itself never
+/// touches the filesystem.
+fn load_input(scenario: &str) -> ConfigurationInput {
+    let root = scenario_root(scenario);
+    let manifest = load_json(&root.join("manifest.json"));
+
+    let mut input = ConfigurationInput {
+        generated_at_utc: manifest["generatedAtUtc"]
+            .as_str()
+            .expect("manifest declares generatedAtUtc")
+            .to_owned(),
+        ..ConfigurationInput::default()
+    };
+
+    for artifact in manifest["artifacts"]
+        .as_array()
+        .expect("manifest artifacts is an array")
+    {
+        let artifact_id = artifact["artifactId"]
+            .as_str()
+            .expect("artifact declares an id");
+        input.coverage.push(coverage_entry(artifact));
+
+        let Some(relative) = artifact["relativePath"].as_str() else {
+            continue;
+        };
+        let document = load_json(&root.join(relative));
+
+        match artifact["payload"].as_str() {
+            Some("events") => {
+                let events: Vec<NormalizedWindowsEvent> =
+                    serde_json::from_value(document["events"].clone()).unwrap_or_else(|error| {
+                        panic!("{scenario}/{artifact_id}: events decode: {error}")
+                    });
+                input.events.extend(events);
+            }
+            Some("reports") => {
+                let reports: Vec<NormalizedSettingReport> =
+                    serde_json::from_value(document["reports"].clone()).unwrap_or_else(|error| {
+                        panic!("{scenario}/{artifact_id}: reports decode: {error}")
+                    });
+                input.reports.extend(reports);
+            }
+            other => panic!("{scenario}/{artifact_id}: unknown payload kind {other:?}"),
+        }
+    }
+
+    input
+}
+
+fn coverage_entry(artifact: &Value) -> IntuneArtifactCoverage {
+    let capture_state = artifact["captureState"]
+        .as_str()
+        .expect("artifact declares a captureState");
+    IntuneArtifactCoverage {
+        artifact_id: artifact["artifactId"]
+            .as_str()
+            .expect("artifact declares an id")
+            .to_owned(),
+        family: artifact["family"].as_str().unwrap_or_default().to_owned(),
+        status: status_for(capture_state),
+        detail: None,
+        observed_at_utc: artifact["capturedUtc"]
+            .as_str()
+            .unwrap_or_default()
+            .to_owned(),
+        evidence: Vec::new(),
+    }
+}
+
+/// The manifest's capture state, mapped onto the shared coverage vocabulary.
+///
+/// Kept explicit rather than derived from the harness table so a drift in either
+/// direction is a compile-visible change here.
+fn status_for(capture_state: &str) -> IntuneArtifactStatus {
+    match capture_state {
+        "captured" => IntuneArtifactStatus::Available,
+        "capped" => IntuneArtifactStatus::Capped,
+        "absent" => IntuneArtifactStatus::Missing,
+        "accessDenied" => IntuneArtifactStatus::PermissionDenied,
+        "skipped" => IntuneArtifactStatus::Skipped,
+        "unsupported" => IntuneArtifactStatus::Unsupported,
+        "parseFailed" => IntuneArtifactStatus::ParseFailed,
+        other => panic!("unknown captureState {other:?}"),
+    }
+}
+
+fn wire<T: serde::Serialize>(value: &T) -> Value {
+    serde_json::to_value(value).expect("shared contract types serialize")
+}
+
+/// The semantic projection compared against `expected.json`.
+fn project(setting: &ConfigurationSetting) -> Value {
+    let source_ids = setting
+        .sources
+        .iter()
+        .filter_map(|statement| statement.source_id.clone())
+        .collect::<BTreeSet<_>>();
+    let evidence_ids = setting
+        .evidence
+        .iter()
+        .map(|reference| reference.evidence_id.clone())
+        .collect::<BTreeSet<_>>();
+
+    json!({
+        "key": setting.identity.key,
+        "scope": wire(&setting.identity.scope),
+        "canonicalUri": setting.identity.canonical_uri,
+        "displayName": setting.identity.display_name,
+        "receipt": wire(&setting.receipt),
+        "local": wire(&setting.local),
+        "service": wire(&setting.service),
+        "resolution": wire(&setting.resolution),
+        "sourceIds": source_ids.into_iter().collect::<Vec<_>>(),
+        "localErrorHex": setting.local_error.as_ref().and_then(|code| code.hex.clone()),
+        "serviceErrorHex": setting.service_error.as_ref().and_then(|code| code.hex.clone()),
+        "appliedValue": setting.applied_value,
+        "timeIsReliable": setting.time_is_reliable,
+        "orderingIsContradictory": setting.ordering_is_contradictory,
+        "hasUninterpretableEvidence": setting.has_uninterpretable_evidence,
+        "evidenceIds": evidence_ids.into_iter().collect::<Vec<_>>(),
+    })
+}
+
+fn finding_ids(snapshot: &ConfigurationSnapshot) -> Vec<String> {
+    snapshot
+        .findings
+        .iter()
+        .map(|finding| finding.finding_id.clone())
+        .collect()
+}
+
+// ── Corpus contract ─────────────────────────────────────────────────────────
+
+#[test]
+fn the_corpus_exposes_exactly_the_required_fixture_matrix() {
+    assert_eq!(
+        scenario_names(&corpus_root()),
+        SCENARIOS.map(str::to_owned).to_vec(),
+        "the corpus must match the fixture matrix required by issue #363"
+    );
+}
+
+#[test]
+fn every_scenario_satisfies_the_shared_fixture_contract() {
+    let mut failures = Failures::new();
+    for scenario in SCENARIOS {
+        let root = scenario_root(scenario);
+        let manifest = load_json(&root.join("manifest.json"));
+        let expected = load_json(&root.join("expected.json"));
+        failures.absorb(validate_scenario(scenario, &root, &manifest, &expected));
+    }
+    failures.assert_empty("configuration corpus");
+}
+
+#[test]
+fn every_evidence_file_is_decodable_and_carries_the_marker() {
+    for scenario in SCENARIOS {
+        let root = scenario_root(scenario);
+        let manifest = load_json(&root.join("manifest.json"));
+        for artifact in manifest["artifacts"].as_array().expect("artifacts array") {
+            let Some(relative) = artifact["relativePath"].as_str() else {
+                continue;
+            };
+            let document = load_json(&root.join(relative));
+            let marker = document["_marker"].as_str().unwrap_or_default();
+            assert!(
+                marker.contains(support::SYNTHETIC_MARKER),
+                "{scenario}: {relative} must carry the synthetic marker as its first key"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_corrupted_byte_count_is_rejected_for_this_corpus_too() {
+    // The shared harness owns this rule; asserting it here proves the corpus is
+    // actually wired into the validator rather than merely sitting next to it.
+    let scenario = "applied-from-csp-event";
+    let root = scenario_root(scenario);
+    let manifest = load_json(&root.join("manifest.json"));
+    let expected = load_json(&root.join("expected.json"));
+    let failures = validate_scenario(
+        scenario,
+        &root,
+        &mutated(&manifest, "/artifacts/0/bytesCopied", json!(1)),
+        &expected,
+    );
+    assert!(
+        failures
+            .entries()
+            .iter()
+            .any(|entry| entry.contains("bytesCopied")),
+        "a wrong byte count must be rejected, got {:?}",
+        failures.entries()
+    );
+}
+
+// ── Analysis contract ───────────────────────────────────────────────────────
+
+#[test]
+fn every_scenario_matches_its_expected_analysis() {
+    for scenario in SCENARIOS {
+        let expected = load_json(&scenario_root(scenario).join("expected.json"));
+        let snapshot = analyze_configuration(&load_input(scenario));
+
+        assert_eq!(
+            snapshot.schema_version, INTUNE_CONFIGURATION_SCHEMA_VERSION,
+            "{scenario}: snapshot schema version"
+        );
+
+        let actual_settings = snapshot.settings.iter().map(project).collect::<Vec<_>>();
+        assert_eq!(
+            Value::Array(actual_settings),
+            expected["settings"],
+            "{scenario}: per-setting states"
+        );
+
+        assert_eq!(
+            json!(finding_ids(&snapshot)),
+            expected["findingIds"],
+            "{scenario}: finding identifiers, in rule order"
+        );
+
+        let actual_coverage = snapshot
+            .coverage
+            .iter()
+            .map(|entry| json!({"artifactId": entry.artifact_id, "status": wire(&entry.status)}))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            Value::Array(actual_coverage),
+            expected["coverage"],
+            "{scenario}: coverage"
+        );
+    }
+}
+
+#[test]
+fn cited_evidence_matches_the_expectation_where_a_scenario_pins_it() {
+    // Conflict, supersedence, and contradiction findings are the ones issue #363
+    // requires to cite the competing evidence rather than assert an outcome, so
+    // those scenarios pin the exact citation set.
+    let mut checked = 0;
+    for scenario in SCENARIOS {
+        let expected = load_json(&scenario_root(scenario).join("expected.json"));
+        let Some(pinned) = expected["findingEvidence"].as_object() else {
+            continue;
+        };
+        let snapshot = analyze_configuration(&load_input(scenario));
+        for (finding_id, evidence_ids) in pinned {
+            let finding = snapshot
+                .findings
+                .iter()
+                .find(|finding| finding.finding_id == *finding_id)
+                .unwrap_or_else(|| panic!("{scenario}: expected finding {finding_id}"));
+            let actual = finding
+                .evidence
+                .iter()
+                .map(|reference| reference.evidence_id.clone())
+                .collect::<BTreeSet<_>>();
+            assert_eq!(
+                json!(actual.into_iter().collect::<Vec<_>>()),
+                *evidence_ids,
+                "{scenario}: {finding_id} must cite exactly the competing evidence"
+            );
+            checked += 1;
+        }
+    }
+    assert!(checked >= 4, "expected several pinned citation sets");
+}
+
+#[test]
+fn every_finding_cites_evidence_or_a_coverage_gap() {
+    for scenario in SCENARIOS {
+        let snapshot = analyze_configuration(&load_input(scenario));
+        for finding in &snapshot.findings {
+            assert!(
+                finding.is_evidence_backed(),
+                "{scenario}: finding {} cites neither evidence nor a coverage gap",
+                finding.finding_id
+            );
+        }
+    }
+}
+
+#[test]
+fn findings_come_only_from_the_documented_vocabulary() {
+    let vocabulary = FINDING_VOCABULARY.iter().copied().collect::<BTreeSet<_>>();
+    for scenario in SCENARIOS {
+        let snapshot = analyze_configuration(&load_input(scenario));
+        for finding in &snapshot.findings {
+            assert!(
+                vocabulary.contains(finding.finding_id.as_str()),
+                "{scenario}: undocumented finding id {}",
+                finding.finding_id
+            );
+        }
+    }
+}
+
+#[test]
+fn every_documented_finding_is_reachable_from_the_corpus_or_a_synthesized_case() {
+    // A vocabulary entry no fixture can produce is either dead code or an
+    // untested rule; both are worth failing over.
+    let mut seen = BTreeSet::new();
+    for scenario in SCENARIOS {
+        let snapshot = analyze_configuration(&load_input(scenario));
+        seen.extend(finding_ids(&snapshot));
+    }
+    for snapshot in [
+        analyze_configuration(&unsubstantiated_conflict_input()),
+        analyze_configuration(&unsubstantiated_supersedence_input()),
+        analyze_configuration(&unattributed_input()),
+        analyze_configuration(&contested_device_input()),
+    ] {
+        seen.extend(finding_ids(&snapshot));
+    }
+
+    let missing = FINDING_VOCABULARY
+        .iter()
+        .filter(|id| !seen.contains(**id))
+        .collect::<Vec<_>>();
+    assert!(missing.is_empty(), "unreachable finding rules: {missing:?}");
+}
+
+#[test]
+fn analysis_is_deterministic_across_repeated_runs() {
+    for scenario in SCENARIOS {
+        let input = load_input(scenario);
+        assert_eq!(
+            wire(&analyze_configuration(&input)),
+            wire(&analyze_configuration(&input)),
+            "{scenario}: analysis must be deterministic"
+        );
+    }
+}
+
+#[test]
+fn settings_are_ordered_by_canonical_identity_key() {
+    for scenario in SCENARIOS {
+        let snapshot = analyze_configuration(&load_input(scenario));
+        let keys = snapshot
+            .settings
+            .iter()
+            .map(|setting| setting.identity.key.clone())
+            .collect::<Vec<_>>();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(keys, sorted, "{scenario}: settings must be key-ordered");
+    }
+}
+
+// ── Redaction ───────────────────────────────────────────────────────────────
+
+#[test]
+fn the_redaction_scenario_produces_the_pinned_tokens() {
+    let scenario = "deterministic-redaction";
+    let expected = load_json(&scenario_root(scenario).join("expected.json"));
+    let snapshot = analyze_configuration(&load_input(scenario));
+    let redacted = redacted_configuration_snapshot(&snapshot);
+
+    assert!(!snapshot.redacted, "the reduced snapshot is not redacted");
+    assert!(redacted.redacted, "the export marks itself redacted");
+
+    let actual = redacted
+        .settings
+        .iter()
+        .map(|setting| {
+            json!({
+                "key": setting.identity.key,
+                "appliedValue": setting.applied_value,
+                "namedData": setting
+                    .observations
+                    .iter()
+                    .flat_map(|observation| observation.named_data.iter())
+                    .map(|entry| json!({"name": entry.name, "value": entry.value}))
+                    .collect::<Vec<_>>(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(Value::Array(actual), expected["redactedSettings"]);
+
+    let enrollment = redacted
+        .settings
+        .iter()
+        .flat_map(|setting| setting.observations.iter())
+        .find_map(|observation| observation.enrollment_id.clone());
+    assert_eq!(
+        json!(enrollment),
+        expected["redactedEnrollmentId"],
+        "an enrollment id is tokenized rather than dropped"
+    );
+}
+
+#[test]
+fn redaction_preserves_the_diagnosis_and_is_deterministic() {
+    let snapshot = analyze_configuration(&load_input("deterministic-redaction"));
+    let first = redacted_configuration_snapshot(&snapshot);
+    let second = redacted_configuration_snapshot(&snapshot);
+
+    assert_eq!(wire(&first), wire(&second), "redaction is deterministic");
+    assert_eq!(
+        wire(&first.findings),
+        wire(&snapshot.findings),
+        "redaction must not change the findings"
+    );
+    assert_eq!(
+        first
+            .settings
+            .iter()
+            .map(|setting| wire(&setting.resolution))
+            .collect::<Vec<_>>(),
+        snapshot
+            .settings
+            .iter()
+            .map(|setting| wire(&setting.resolution))
+            .collect::<Vec<_>>(),
+        "redaction must not change any resolution"
+    );
+}
+
+#[test]
+fn redaction_keeps_the_configuration_source_identifiable() {
+    let snapshot = analyze_configuration(&load_input("conflict-between-two-sources"));
+    let redacted = redacted_configuration_snapshot(&snapshot);
+    let sources = redacted
+        .settings
+        .iter()
+        .flat_map(|setting| setting.sources.iter())
+        .filter_map(|statement| statement.source_id.clone())
+        .collect::<BTreeSet<_>>();
+    assert!(
+        sources
+            .iter()
+            .all(|source| !source.starts_with("[redacted")),
+        "policy identifiers must survive redaction so the conflict stays actionable"
+    );
+    assert_eq!(sources.len(), 2);
+}
+
+#[test]
+fn identical_values_redact_to_identical_tokens_across_settings() {
+    let snapshot = analyze_configuration(&load_input("deterministic-redaction"));
+    let redacted = redacted_configuration_snapshot(&snapshot);
+    let wallpaper_value = redacted
+        .settings
+        .iter()
+        .find_map(|setting| {
+            setting
+                .identity
+                .canonical_uri
+                .as_deref()?
+                .contains("Personalization")
+                .then(|| setting.applied_value.clone())?
+        })
+        .expect("the personalization setting is present");
+    let previous_value = redacted
+        .settings
+        .iter()
+        .flat_map(|setting| setting.observations.iter())
+        .flat_map(|observation| observation.named_data.iter())
+        .find(|entry| entry.name == "PreviousValue")
+        .map(|entry| entry.value.clone())
+        .expect("the previous-value pair is present");
+
+    assert_eq!(
+        wallpaper_value, previous_value,
+        "the same underlying value must produce the same token"
+    );
+    assert!(wallpaper_value.starts_with("[redacted:"));
+}
+
+// ── Synthesized cases outside the fixture matrix ────────────────────────────
+
+fn context(
+    evidence_id: &str,
+    artifact: &str,
+    source_kind: IntuneSourceKind,
+    parse_state: IntuneParseState,
+) -> IntuneObservationContext {
+    IntuneObservationContext {
+        evidence_ref: IntuneEvidenceRef {
+            evidence_id: evidence_id.to_owned(),
+            source_artifact_id: artifact.to_owned(),
+        },
+        provenance: IntuneProvenance {
+            source_kind,
+            source_artifact_id: artifact.to_owned(),
+            file_path: None,
+            line_number: None,
+            record_number: None,
+            registry: None,
+            event: None,
+        },
+        source_timestamp: Some(IntuneTimestamp {
+            raw_text: "2026-07-31T09:00:00Z".to_owned(),
+            original_offset: None,
+            normalized_utc: Some("2026-07-31T09:00:00Z".to_owned()),
+            kind: IntuneTimestampKind::Utc,
+        }),
+        observed_at_utc: "2026-07-31T10:00:00Z".to_owned(),
+        sensitivity: IntuneSensitivity::Public,
+        parse_state,
+        access_state: cmtraceopen_parser::intune::evidence::IntuneAccessState::Available,
+    }
+}
+
+fn row(
+    evidence_id: &str,
+    uri: Option<&str>,
+    policy_id: Option<&str>,
+    outcome: NormalizedSettingOutcome,
+    named: Vec<(&str, &str)>,
+) -> NormalizedSettingReport {
+    NormalizedSettingReport {
+        context: context(
+            evidence_id,
+            "mdm-diagnostic-report",
+            IntuneSourceKind::DiagnosticReport,
+            IntuneParseState::Parsed,
+        ),
+        setting_uri: uri.map(str::to_owned),
+        setting_id: None,
+        policy_id: policy_id.map(str::to_owned),
+        display_name: None,
+        outcome,
+        value: None,
+        error: None,
+        named_data: named
+            .into_iter()
+            .map(|(name, value)| IntuneNamedValue {
+                name: name.to_owned(),
+                value: value.to_owned(),
+            })
+            .collect(),
+    }
+}
+
+fn input_of(reports: Vec<NormalizedSettingReport>) -> ConfigurationInput {
+    ConfigurationInput {
+        generated_at_utc: "2026-07-31T10:00:00Z".to_owned(),
+        events: Vec::new(),
+        reports,
+        coverage: Vec::new(),
+    }
+}
+
+const NODE: &str = "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate";
+const POLICY_A: &str = "11111111-1111-4111-8111-111111111111";
+const POLICY_B: &str = "22222222-2222-4222-8222-222222222222";
+
+fn unsubstantiated_conflict_input() -> ConfigurationInput {
+    input_of(vec![row(
+        "rpt-lonely-conflict",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Conflict,
+        Vec::new(),
+    )])
+}
+
+fn unsubstantiated_supersedence_input() -> ConfigurationInput {
+    input_of(vec![row(
+        "rpt-lonely-supersedence",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Superseded,
+        vec![("SupersededBy", POLICY_B)],
+    )])
+}
+
+fn unattributed_input() -> ConfigurationInput {
+    input_of(vec![
+        row(
+            "rpt-nameless-1",
+            None,
+            Some(POLICY_A),
+            NormalizedSettingOutcome::Applied,
+            Vec::new(),
+        ),
+        row(
+            "rpt-nameless-2",
+            None,
+            Some(POLICY_A),
+            NormalizedSettingOutcome::Applied,
+            Vec::new(),
+        ),
+    ])
+}
+
+fn contested_device_input() -> ConfigurationInput {
+    input_of(vec![
+        row(
+            "rpt-says-applied",
+            Some(NODE),
+            Some(POLICY_A),
+            NormalizedSettingOutcome::Applied,
+            Vec::new(),
+        ),
+        row(
+            "rpt-says-failed",
+            Some(NODE),
+            Some(POLICY_A),
+            NormalizedSettingOutcome::Failed,
+            Vec::new(),
+        ),
+    ])
+}
+
+#[test]
+fn a_conflict_without_an_observed_competing_source_is_not_claimed() {
+    let snapshot = analyze_configuration(&unsubstantiated_conflict_input());
+    let ids = finding_ids(&snapshot);
+    assert!(
+        ids.contains(&"configuration-conflict-unsubstantiated".to_owned()),
+        "expected the unsubstantiated variant, got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&"configuration-conflict".to_owned()),
+        "a conflict must not be asserted without the competing source"
+    );
+}
+
+#[test]
+fn a_supersedence_whose_replacement_was_never_collected_is_not_claimed() {
+    let snapshot = analyze_configuration(&unsubstantiated_supersedence_input());
+    let ids = finding_ids(&snapshot);
+    assert!(
+        ids.contains(&"configuration-superseded-unsubstantiated".to_owned()),
+        "expected the unsubstantiated variant, got {ids:?}"
+    );
+    assert!(!ids.contains(&"configuration-superseded".to_owned()));
+}
+
+#[test]
+fn records_with_no_identifier_are_never_merged_with_one_another() {
+    let snapshot = analyze_configuration(&unattributed_input());
+    assert!(
+        snapshot.settings.is_empty(),
+        "an unidentified record must not become a setting transaction"
+    );
+    assert_eq!(snapshot.unattributed.len(), 2);
+    assert!(finding_ids(&snapshot).contains(&"configuration-unattributed-records".to_owned()));
+}
+
+#[test]
+fn disagreeing_device_records_do_not_pick_a_winner() {
+    let snapshot = analyze_configuration(&contested_device_input());
+    let setting = snapshot.settings.first().expect("one transaction");
+    assert_eq!(wire(&setting.local), json!("contested"));
+    assert_eq!(wire(&setting.resolution), json!("contradicted"));
+    assert!(finding_ids(&snapshot).contains(&"configuration-contested-device-evidence".to_owned()));
+}
+
+#[test]
+fn the_shared_normalized_contract_is_the_one_this_leaf_was_built_against() {
+    // A bump here means the shared input shape moved and this leaf's fixtures
+    // need re-checking rather than silently decoding into different semantics.
+    assert_eq!(INTUNE_NORMALIZED_SCHEMA_VERSION, 1);
+    assert_eq!(INTUNE_CONFIGURATION_SCHEMA_VERSION, 1);
+}
+
+#[test]
+fn an_event_naming_no_resource_contributes_nothing() {
+    let input = ConfigurationInput {
+        generated_at_utc: "2026-07-31T10:00:00Z".to_owned(),
+        events: vec![NormalizedWindowsEvent {
+            context: context(
+                "evt-unrelated",
+                "mdm-admin-channel",
+                IntuneSourceKind::EventLog,
+                IntuneParseState::Parsed,
+            ),
+            channel: "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider/Admin"
+                .to_owned(),
+            provider: "Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-Provider"
+                .to_owned(),
+            event_id: 208,
+            level: NormalizedEventLevel::Information,
+            task: None,
+            keywords: None,
+            record_id: Some(1),
+            activity_id: None,
+            named_data: Vec::new(),
+            message: Some("MDM Session: OMA-DM session ended.".to_owned()),
+        }],
+        reports: Vec::new(),
+        coverage: Vec::new(),
+    };
+    let snapshot = analyze_configuration(&input);
+    assert!(snapshot.settings.is_empty());
+    assert!(
+        snapshot.unattributed.is_empty(),
+        "an event about no CSP node is not configuration evidence at all"
+    );
+}
+
+#[test]
+fn expected_files_declare_the_workload_they_belong_to() {
+    // Cheap guard against a scenario being copied into the wrong corpus.
+    for scenario in SCENARIOS {
+        let expected = load_json(&scenario_root(scenario).join("expected.json"));
+        assert_eq!(
+            expected["workload"].as_str(),
+            Some(CORPUS),
+            "{scenario}: expected.json workload"
+        );
+    }
+}

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -1670,6 +1670,16 @@ fn another_providers_message_text_never_joins_an_mdm_transaction() {
         coverage: Vec::new(),
     };
     let snapshot = analyze_configuration(&input);
+    assert_eq!(
+        snapshot.settings.len(),
+        1,
+        "the foreign record must not open a transaction of its own, got {:?}",
+        snapshot
+            .settings
+            .iter()
+            .map(|setting| setting.identity.key.clone())
+            .collect::<Vec<_>>()
+    );
     let setting = snapshot.settings.first().expect("one transaction");
     assert_eq!(
         setting.evidence.len(),

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -530,6 +530,188 @@ fn renumbering_the_rows_of_a_correlated_scenario_does_not_change_the_diagnosis()
     }
 }
 
+/// Every ordering of one bundle's sibling records must produce the same snapshot,
+/// byte for byte.
+///
+/// ADR-003's invariant: permuting non-ordered input does not change a result. The
+/// previous determinism test re-ran the *same* vector, which cannot see a
+/// first-wins field. `applied_value`, `terminal_error`, and the merged identity
+/// fields were all first-wins over the caller's vector, so two sources applying
+/// different values exported whichever the serializer emitted first.
+#[test]
+fn permuting_sibling_records_does_not_change_the_analysis() {
+    for scenario in SCENARIOS {
+        let baseline = wire(&analyze_configuration(&load_input(scenario)));
+
+        for permutation in permutations_of(load_input(scenario)) {
+            assert_eq!(
+                wire(&analyze_configuration(&permutation)),
+                baseline,
+                "{scenario}: input order must not change the analysis"
+            );
+        }
+    }
+}
+
+/// Every ordering of the events and reports, capped so a large bundle stays a
+/// test rather than a benchmark.
+fn permutations_of(input: ConfigurationInput) -> Vec<ConfigurationInput> {
+    fn orderings<T: Clone>(items: &[T]) -> Vec<Vec<T>> {
+        if items.len() <= 1 {
+            return vec![items.to_vec()];
+        }
+        if items.len() > 4 {
+            let mut reversed = items.to_vec();
+            reversed.reverse();
+            return vec![items.to_vec(), reversed];
+        }
+        let mut result = Vec::new();
+        for index in 0..items.len() {
+            let mut rest = items.to_vec();
+            let head = rest.remove(index);
+            for mut tail in orderings(&rest) {
+                tail.insert(0, head.clone());
+                result.push(tail);
+            }
+        }
+        result
+    }
+
+    let mut permutations = Vec::new();
+    for events in orderings(&input.events) {
+        for reports in orderings(&input.reports) {
+            permutations.push(ConfigurationInput {
+                generated_at_utc: input.generated_at_utc.clone(),
+                events: events.clone(),
+                reports,
+                coverage: input.coverage.clone(),
+            });
+        }
+    }
+    permutations
+}
+
+/// Two sources writing different values to one node. Exporting one of them would
+/// be a coin flip on the caller's vector order.
+#[test]
+fn two_sources_applying_different_values_export_neither() {
+    let mut applied_one = row(
+        "rpt-value-one",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Applied,
+        Vec::new(),
+    );
+    applied_one.value = Some("1".to_owned());
+    let mut applied_two = row(
+        "rpt-value-two",
+        Some(NODE),
+        Some(POLICY_B),
+        NormalizedSettingOutcome::Applied,
+        Vec::new(),
+    );
+    applied_two.value = Some("2".to_owned());
+
+    let forward = analyze_configuration(&input_of(vec![applied_one.clone(), applied_two.clone()]));
+    let reverse = analyze_configuration(&input_of(vec![applied_two, applied_one]));
+
+    assert_eq!(
+        forward.settings[0].applied_value, None,
+        "a disagreement is not a value"
+    );
+    assert_eq!(wire(&forward), wire(&reverse));
+}
+
+/// A setting whose display name is stated by one record and not another must not
+/// depend on which record the caller listed first: the duplicate-display-name
+/// rule keys on it.
+#[test]
+fn a_merged_identity_field_does_not_follow_caller_order() {
+    let mut named = row(
+        "rpt-named",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Applied,
+        Vec::new(),
+    );
+    named.display_name = Some("Zebra policy".to_owned());
+    let mut also_named = row(
+        "rpt-also-named",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Applied,
+        Vec::new(),
+    );
+    also_named.display_name = Some("Alpha policy".to_owned());
+
+    let forward = analyze_configuration(&input_of(vec![named.clone(), also_named.clone()]));
+    let reverse = analyze_configuration(&input_of(vec![also_named, named]));
+    assert_eq!(
+        forward.settings[0].identity.display_name,
+        reverse.settings[0].identity.display_name
+    );
+}
+
+/// Two records reporting different terminal codes must not flip which HRESULT the
+/// rejection finding quotes.
+#[test]
+fn two_terminal_codes_do_not_flip_with_caller_order() {
+    let failure = |evidence_id: &str, raw: &str, decimal: i64, hex: &str| {
+        let mut report = row(
+            evidence_id,
+            Some(NODE),
+            Some(POLICY_A),
+            NormalizedSettingOutcome::Failed,
+            Vec::new(),
+        );
+        report.error = Some(cmtraceopen_parser::intune::evidence::IntuneErrorCode {
+            raw: raw.to_owned(),
+            decimal: Some(decimal),
+            hex: Some(hex.to_owned()),
+        });
+        report
+    };
+    let first = failure("rpt-first-code", "0x82B00006", -2102394874, "0x82B00006");
+    let second = failure("rpt-second-code", "0x87D1FDE8", -2016281112, "0x87D1FDE8");
+
+    let forward = analyze_configuration(&input_of(vec![first.clone(), second.clone()]));
+    let reverse = analyze_configuration(&input_of(vec![second, first]));
+    assert_eq!(
+        forward.settings[0].local_error,
+        reverse.settings[0].local_error
+    );
+    assert_eq!(wire(&forward), wire(&reverse));
+}
+
+/// The same record collected twice must not change the analysis either.
+#[test]
+fn a_duplicated_record_does_not_change_the_analysis() {
+    let once = analyze_configuration(&load_input("removal-rollback"));
+
+    let mut doubled = load_input("removal-rollback");
+    let mut copies = doubled.events.clone();
+    for (index, event) in copies.iter_mut().enumerate() {
+        event.context.evidence_ref.evidence_id =
+            format!("{}-again-{index}", event.context.evidence_ref.evidence_id);
+    }
+    doubled.events.extend(copies);
+
+    let twice = analyze_configuration(&doubled);
+    assert_eq!(
+        once.settings
+            .iter()
+            .map(|setting| (wire(&setting.local), wire(&setting.resolution)))
+            .collect::<Vec<_>>(),
+        twice
+            .settings
+            .iter()
+            .map(|setting| (wire(&setting.local), wire(&setting.resolution)))
+            .collect::<Vec<_>>(),
+        "re-collecting the same records must not change the diagnosis"
+    );
+    assert_eq!(finding_ids(&once), finding_ids(&twice));
+}
+
 #[test]
 fn analysis_is_deterministic_across_repeated_runs() {
     for scenario in SCENARIOS {

--- a/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_configuration.rs
@@ -1030,6 +1030,103 @@ fn a_supersedence_whose_replacement_was_never_collected_is_not_claimed() {
     assert!(!ids.contains(&"configuration-superseded".to_owned()));
 }
 
+/// ADR-002: an untyped local field may not be promoted into shared semantic
+/// authority. `Command: Delete` beside a typed `Applied` outcome was turning a
+/// stated application into a removal.
+#[test]
+fn free_text_command_never_overrides_a_typed_outcome() {
+    let snapshot = analyze_configuration(&input_of(vec![row(
+        "rpt-applied-with-delete-command",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Applied,
+        vec![("Command", "Delete")],
+    )]));
+    let setting = snapshot.settings.first().expect("one transaction");
+    assert_eq!(wire(&setting.local), json!("applied"));
+    assert_eq!(
+        setting
+            .observations
+            .first()
+            .and_then(|observation| observation.command_type.clone()),
+        Some("Delete".to_owned()),
+        "the command verb is still retained as evidence"
+    );
+}
+
+/// A row naming a winner that is not in the bundle substantiates nothing. This
+/// used to produce `configuration-conflict` at Warning/High from one source.
+#[test]
+fn a_named_winner_that_was_never_collected_does_not_substantiate_a_conflict() {
+    let snapshot = analyze_configuration(&input_of(vec![row(
+        "rpt-names-an-absent-winner",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Conflict,
+        vec![("WinningProvider", "GPO")],
+    )]));
+    let ids = finding_ids(&snapshot);
+    assert!(
+        ids.contains(&"configuration-conflict-unsubstantiated".to_owned()),
+        "got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&"configuration-conflict".to_owned()),
+        "got {ids:?}"
+    );
+}
+
+#[test]
+fn a_record_naming_itself_as_its_own_replacement_does_not_substantiate_supersedence() {
+    let snapshot = analyze_configuration(&input_of(vec![row(
+        "rpt-self-superseding",
+        Some(NODE),
+        Some(POLICY_A),
+        NormalizedSettingOutcome::Superseded,
+        vec![("SupersededBy", POLICY_A)],
+    )]));
+    let ids = finding_ids(&snapshot);
+    assert!(
+        ids.contains(&"configuration-superseded-unsubstantiated".to_owned()),
+        "got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&"configuration-superseded".to_owned()),
+        "got {ids:?}"
+    );
+}
+
+/// One policy id written braced and upper by one artifact and bare and lower by
+/// another is one source, not two competing ones.
+#[test]
+fn one_policy_in_two_casings_is_not_a_conflict() {
+    let snapshot = analyze_configuration(&input_of(vec![
+        row(
+            "rpt-braced",
+            Some(NODE),
+            Some(&format!("{{{}}}", POLICY_A.to_ascii_uppercase())),
+            NormalizedSettingOutcome::Conflict,
+            Vec::new(),
+        ),
+        row(
+            "rpt-bare",
+            Some(NODE),
+            Some(POLICY_A),
+            NormalizedSettingOutcome::Conflict,
+            Vec::new(),
+        ),
+    ]));
+    let ids = finding_ids(&snapshot);
+    assert!(
+        ids.contains(&"configuration-conflict-unsubstantiated".to_owned()),
+        "one source in two spellings must not become two, got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&"configuration-conflict".to_owned()),
+        "got {ids:?}"
+    );
+}
+
 #[test]
 fn records_with_no_identifier_are_never_merged_with_one_another() {
     let snapshot = analyze_configuration(&unattributed_input());


### PR DESCRIPTION
Implements `cmtraceopen_parser::intune::device::windows::configuration`: a pure, wasm-clean lane that explains whether an Intune/MDM configuration setting was delivered, processed by its CSP, applied, rejected, conflicted, superseded, removed, or left unresolved.

## What is done

- **Module layout** under `crates/cmtraceopen-parser/src/intune/device/windows/configuration/`:
  - `identity.rs`: canonical CSP/OMA-URI identity (`canonicalize_uri`, `resolve_identity`). Settings with the same display name but different CSP paths, policy source IDs, scopes, or configuration sources stay separate transactions.
  - `sources.rs`: typed observations from normalized `DeviceManagement-Enterprise-Diagnostics-Provider/Admin` events and MDM Diagnostic report / Intune setting-report rows. Preserves OMA-URI, policy source ID, setting name, scope, command/action, result code, activity ID, enrollment ID.
  - `models.rs`: serialized contract (`INTUNE_CONFIGURATION_SCHEMA_VERSION = 1`, camelCase, deterministic ordering). The answer keeps three axes separate: receipt (`ConfigurationReceiptState`), local CSP outcome (`ConfigurationLocalState`), service reporting (`ConfigurationServiceState`), then one `ConfigurationResolution`.
  - `reducer.rs`: one transaction per canonical identity; cloud reporting is supplemental to local CSP evidence; device/service disagreement resolves to `Contradicted` with both statements cited, never newest-wins.
  - `rules.rs`: evidence-backed findings, including explicit next-artifact requests when event/report/registry evidence is missing.
  - `redaction.rs`: default export redacts synthetic identity, user/device/tenant values, and custom setting payloads deterministically.
- **Focused suite** `crates/cmtraceopen-parser/tests/intune_windows_configuration.rs` (22 tests) plus 17 fixture scenarios under `crates/cmtraceopen-parser/tests/fixtures/intune/device/windows/configuration/`, all synthetic and marked `SYNTHETIC FIXTURE`, matching the compliance lane's manifest/expected conventions.

## Fixture matrix (all 17 required scenarios)

| # | Issue scenario | Fixture |
|---|---|---|
| 1 | received and applied | `applied-from-csp-event` |
| 2 | CSP terminal error | `csp-terminal-error` |
| 3 | user/device scope mismatch | `scope-mismatch-device-and-user` |
| 4 | unsupported/not applicable | `not-applicable-setting` |
| 5 | conflict between two sources | `conflict-between-two-sources` |
| 6 | superseded/replaced | `superseded-by-replacement-source` |
| 7 | removal/rollback | `removal-rollback` |
| 8 | local success, cloud mismatch | `local-success-cloud-failure` |
| 9 | cloud success, local terminal error | `cloud-success-local-terminal-error` |
| 10 | report-only evidence | `report-only-evidence` |
| 11 | event-only evidence | `event-only-evidence` |
| 12 | duplicate display name, different CSP paths | `duplicate-display-name-different-csp-paths` |
| 13 | malformed MDM report | `malformed-mdm-report` |
| 14 | unknown event/report schema | `unknown-report-schema` |
| 15 | incomplete channel/report coverage | `incomplete-channel-coverage` |
| 16 | invalid offset and contradictory ordering | `invalid-offset-and-contradictory-ordering` |
| 17 | deterministic redaction | `deterministic-redaction` |

## Shared model impact

`NormalizedWindowsEvent` / `NormalizedSettingReport` in `src/intune/normalized.rs` were **not** modified. This lane only consumes them. Rebasing onto current main picked up the additive `event_version: Option<u32>` field the Autopilot lane appended; the one struct literal in this suite now initializes it to `None` (own commit, test-only).

## Deliberately not done

- **Native Windows adapter tests** (EVTX/HTML report/registry normalization into these facts): no native configuration adapter exists in `src-tauri` yet, so there is nothing to test. That is native-side work outside the pure-lane scope of this PR and will land with the adapter.
- No CSP-specific remediation advice (issue non-goal).
- Compliance evaluation untouched (tracked separately).

## Assumptions

- Fixture root follows the sibling lanes at `tests/fixtures/intune/device/windows/configuration/` (the issue body's shorthand omitted `device/`).
- Event IDs modeled (813/814 policy set, 815 delete, 404 command failure) follow the documented DeviceManagement-Enterprise-Diagnostics-Provider/Admin semantics; unknown IDs and unknown report schemas degrade to explicit unknown-schema coverage, never to fabricated states.
- Timestamps without reliable provenance cannot order contradictory statements; scenario 16 pins that behavior.
- `cargo fmt --check --all` currently reports pre-existing diffs on files this PR does not touch (local rustfmt drift also present on main); no files owned by this PR are flagged, and none were reformatted.

## Verification (from the worktree root)

- `cargo test --locked -p cmtraceopen-parser --test intune_windows_configuration`: 22 passed, 0 failed
- `cargo test --locked -p cmtraceopen-parser`: 2171 passed, 0 failed across all suites
- `cargo clippy --locked -p cmtraceopen-parser --all-targets -- -D warnings`: clean
- `cargo check --workspace`: clean
- `cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown`: clean
- `git diff --check`: clean

## Charter fix round

Eight commits addressing the 10 ranked finding clusters from the charter review
(`cmtraceopen-code-review`, three layers: contract / adversarial / mechanical) plus
all 11 CodeRabbit threads. Every behavioural fix is TDD'd; every changed fixture
expectation states why the previous one was unsafe.

| Finding | Fix | Commit |
|---|---|---|
| 1. Redaction violates ADR-004 on five fronts | One `RedactionScope` choke point; per-analysis token scope; case-insensitive identity detection; `Sensitive` handled; idempotent; consumes the family's `redact_text` | `1a40c04e` |
| 2. Headline scenarios pin the wrong story | Explicit `WinningPolicyId` / `SupersededBy` linkage (ADR-002) settles the node before any reading of order | `3b4bfd5d` |
| 3. No direction-aware assessability gate | Unreadable failure-shaped records block terminal success; `access_state` made load-bearing; coverage gaps gate High confidence | `20b29acf` |
| 4. Lifecycle uses first-occurrence position | Last terminal disposition, lifecycle dispositions only | `3b4bfd5d` |
| 5. Scope fabrication | No default-to-`Device`; unspecified keeps its own key; message scraping provider-gated | `31085935` |
| 6. Untyped `named_data` drives typed conclusions | Typed outcome wins over `Command`; named winner must be observed; self-reference guard | `0a7dc57b` |
| 7. Order dependence with no permutation test | Canonical observation order; agree-or-none values; deterministic code and identity selection; permutation test restored | `c461fc8f` |
| 8. Duplicate observation escalates severity | Dedupe by artifact and ordinal before the ordering guard | `3b4bfd5d` |
| 9. Conflict gate compares source ids byte-exact | Normalized (case- and brace-insensitive) comparison throughout | `0a7dc57b` |
| 10. Minors | `Json` loses device authority; `Removed`/`ReportedSuccess` becomes `Contradicted`; `service_error` cited; coverage honesty rule; re-exports pruned; CSP URI period; `resource_path` casing | `8325b9b8`, `3a0b174d` |

### Charter fix round 2 — Hermes P1

One blocking finding from the Hermes charter review at `3a0b174d`: the per-analysis
token scope was salted with `generatedAtUtc` and the docs claimed no two exports
could share it. A timestamp is not a nonce — two independent analyses can carry the
same second-resolution instant (the fixtures already do), so identical values minted
identical tokens and the cross-export join ADR-004 forbids still worked.

| Finding | Fix | Commit |
|---|---|---|
| P1. `generatedAtUtc` is not a per-analysis identity | Token scope bound to caller-supplied `ConfigurationInput::analysis_scope`, digested onto `ConfigurationSnapshot::analysis_scope`; docs restated as a conditional guarantee with explicit disclaimers | `ef9e199d` |

RED first: `two_analyses_that_share_a_generated_at_utc_do_not_share_a_token` failed
against the old scope with `left: "[redacted:50aa2e930aca3c17]" == right:
"[redacted:50aa2e930aca3c17]"`. Green after the fix, alongside four new pins —
`one_analysis_split_across_two_projections_keeps_its_tokens` (within-analysis
equality is not collateral damage), `an_omitted_scope_is_documented_as_no_boundary_at_all`
and `the_scope_digest_does_not_republish_the_callers_scope_value`, plus the
contract-level `two_analyses_with_the_same_generated_at_utc_export_no_shared_token`,
`one_analysis_scope_keeps_its_tokens_across_separate_runs`, and
`an_omitted_analysis_scope_makes_no_isolation_claim` over a real scenario's whole
export. The existing within-export equality and idempotence tests are unchanged and
green; the `deterministic-redaction` fixture's pinned tokens moved because the salt
did, and nothing else in the corpus changed.

Considered and rejected: a process-generated nonce (option b) — a counter restarts
at zero every run, so in the realistic deployment of one analysis per app launch it
would isolate nothing while costing purity and reproducibility, i.e. exactly the
overclaiming-by-mechanism the finding was about. A composite of `generatedAtUtc`
plus other snapshot material (option c) — the uniqueness argument would have been
hand-wavy, and the instruction was not to ship it on those terms.

### ADR-004 decision, and what is routed rather than answered

ADR-004 records the redaction token algorithm, caller-supplied key, and equality
scope as **provisional** and assigns them to the Store pilot. This lane therefore
**scoped equality per analysis** rather than inventing a keyed-token API, and takes
the identity of that analysis from the caller: `ConfigurationInput::analysis_scope`.
Equality holds within one scope — which is what makes a conflict legible after
redaction — and two analyses that supply different scope values share no token
vocabulary. `redaction_token` is no longer public; tokens are only reachable
through a scope a caller cannot construct without an analysis.

The scope is the caller's because nothing else can be: this crate is pure and
`wasm32-unknown-unknown` clean, with no clock, no entropy source, and no state
surviving a restart from which to mint a unique identifier. The reducer digests the
caller's value onto `ConfigurationSnapshot::analysis_scope`, so the caller's own
identifier (which may be a serial number or a case title) never reaches the export,
while the export can still name the scope its tokens belong to.

The docs state precisely what this **does** guarantee (equal values inside one
scope produce equal tokens; two differently-scoped analyses never share a token for
the same value) and what it **does not** (uniqueness is the caller's obligation and
is not checked here; omitting the scope falls back to `generatedAtUtc` alone and
buys no isolation at all, which the snapshot reports as `analysisScope: null`; the
token is still unkeyed and no defense against enumeration inside one export).

**Routed to the Store pilot / framework owner, not decided here:**

1. **A keyed token API.** The per-analysis salt travels with the export, so it does
   not defend against an attacker who can enumerate candidate values and confirm a
   match *within* one export. Closing that needs a caller-supplied secret and a
   documented equality scope, which is ADR-004's stated owner.
2. **Two token vocabularies in one export.** SIDs and UPNs are tokenized in this
   analysis's scope; user-profile paths and inline credentials keep the family's
   globally stable `[user:…]` / `[command:…]` tokens from
   `apps::windows::common::redact_text`. Unifying them is a family-wide change.
3. **`#[non_exhaustive]`** (CodeRabbit thread 6) — rejected here as a lane change;
   the family has zero instances and a change should be family-wide or not at all.

### Contract changes worth a second look

- `resolve(Removed, ReportedSuccess)` is now `Contradicted` rather than `Removed`.
  The old precedence assumed Intune reports a completed delete as a success; no
  documented contract says so, and ADR-003 requires an unresolved authoritative
  contradiction to stay conservative. This is the one line to change if that
  vocabulary is ever written down.
- `expected.json` gained `findingConfidence` and per-setting `hasUnassessableFailure`,
  both now compared by the harness. Confidence was previously unpinned, which is how
  a High-confidence success survived a bundle with three incomplete artifacts.
- New finding id `configuration-artifact-without-usable-records` (coverage honesty:
  an artifact read in full that settled nothing) and
  `configuration-unassessable-failure` (a command failure whose status is unreadable).
  Vocabulary is 22 entries.

### Gates (re-run after every slice)

Re-run at `ef9e199d`:

- `cargo test -p cmtraceopen-parser`: 2219 passed, 0 failed (45 in
  `intune_windows_configuration`, 18 in the redaction unit module)
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo check --workspace`: clean
- `cargo check -p cmtraceopen-parser --target wasm32-unknown-unknown`: clean
  (the fix adds no OS-entropy or clock dependency)
- `npx tsc --noEmit`: clean (no frontend surface touched)

All 11 CodeRabbit threads have a reply naming the fix commit or the rejection
reasoning, and are resolved.

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows Intune configuration analysis with normalized settings, scopes, outcomes, findings, evidence, and coverage details.
  * Added detection for applied, rejected, removed, superseded, conflicting, not-applicable, and indeterminate settings.
  * Added deterministic redaction that protects sensitive values while preserving useful configuration context.
  * Added support for incomplete, malformed, unsupported, and contradictory evidence without discarding available details.

* **Tests**
  * Added end-to-end scenarios covering configuration outcomes, evidence sources, conflicts, scope mismatches, redaction, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

