### PR TITLE
fix(intune): apply framework review discipline to the merged Autopilot lane

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,7 +13,7 @@ tone_instructions: >-
 reviews:
   profile: assertive
   # Keep reviews advisory: CI gates (cargo clippy, cargo test, tsc) decide mergeability.
-  request_changes_workflow: false
+  request_changes_workflow: true
   high_level_summary: true
   changed_files_summary: true
   sequence_diagrams: true
@@ -22,7 +22,7 @@ reviews:
   related_issues: true
   related_prs: true
   suggested_labels: true
-  auto_apply_labels: false
+  auto_apply_labels: true
   suggested_reviewers: false
   poem: false
   in_progress_fortune: false
@@ -33,7 +33,7 @@ reviews:
   auto_review:
     enabled: true
     auto_incremental_review: true
-    drafts: false
+    drafts: true
     base_branches:
       - main
     # Dependency bumps and release automation are machine-generated; skip them.

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/models.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/models.rs
@@ -15,9 +15,9 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::intune::evidence::{
-    intune_raw_preserving_string_enum, IntuneArtifactCoverage, IntuneErrorCode, IntuneEvidenceRef,
-    IntuneFinding, IntuneFindingConfidence, IntuneNamedValue, IntuneObservationContext,
-    IntuneParseState,
+    intune_raw_preserving_string_enum, IntuneAccessState, IntuneArtifactCoverage, IntuneErrorCode,
+    IntuneEvidenceRef, IntuneFinding, IntuneFindingConfidence, IntuneNamedValue,
+    IntuneObservationContext, IntuneParseState,
 };
 
 /// Schema version of the Autopilot snapshot contract.
@@ -239,6 +239,20 @@ impl AutopilotObservation {
     /// The evidence pointer this observation is cited by.
     pub fn evidence_ref(&self) -> IntuneEvidenceRef {
         self.context.evidence_ref.clone()
+    }
+
+    /// Whether this observation may support a conclusion at all.
+    ///
+    /// A record is assessable only when its own declared context is fully
+    /// available and cleanly parsed. Non-assessable evidence (capped, denied,
+    /// malformed) can BLOCK a success conclusion but can never PROVE one, so no
+    /// terminal outcome and no high-confidence terminal finding may be sourced
+    /// from it (ADR-001). This is the single definition consulted by both the
+    /// reducer's semantic gates and the finding-side evidence helpers, so the
+    /// boundary cannot drift between them.
+    pub fn is_assessable(&self) -> bool {
+        self.context.access_state == IntuneAccessState::Available
+            && self.context.parse_state == IntuneParseState::Parsed
     }
 
     /// Look up one named-data value, case-insensitively.

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/normalize.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/normalize.rs
@@ -295,6 +295,28 @@ mod tests {
         assert_eq!(code.decimal, Some(-2_145_647_638));
     }
 
+    /// A 64-bit sign-extended HRESULT canonicalizes to its 32-bit form on
+    /// purpose. `0xFFFFFFFF80070002` is `0x80070002` printed through a 64-bit
+    /// register; the upper 32 bits are sign extension, not information. The
+    /// raw token always survives verbatim, and a genuinely 64-bit value that
+    /// is not a sign extension keeps its decimal and gains no fabricated
+    /// 32-bit hex.
+    #[test]
+    fn a_sign_extended_hresult_canonicalizes_to_its_32_bit_form() {
+        let code = error_code_from_token("0xFFFFFFFF80070002");
+        assert_eq!(code.raw, "0xFFFFFFFF80070002");
+        assert_eq!(code.decimal, Some(-2_147_024_894));
+        assert_eq!(code.hex.as_deref(), Some("0x80070002"));
+
+        let wide = error_code_from_token("0x1234567880070002");
+        assert_eq!(wide.raw, "0x1234567880070002");
+        assert_eq!(wide.decimal, Some(0x1234_5678_8007_0002));
+        assert_eq!(
+            wide.hex, None,
+            "a non-sign-extended 64-bit value must not gain an invented 32-bit hex form"
+        );
+    }
+
     #[test]
     fn a_message_without_an_hresult_yields_no_error_code() {
         assert!(extract_error_code(Some("AutopilotRetrieveSettings succeeded.")).is_none());

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/redaction.rs
@@ -114,10 +114,20 @@ fn user_path_re() -> &'static Regex {
 /// Bounded at 40 characters so a GUID (32 hex digits plus dashes, matched in
 /// runs of at most 12) and an eight-digit HRESULT are both left readable; those
 /// are diagnostic grammar, not identity.
+///
+/// No `\b` anchors. The Base64 alphabet includes `=`, `+`, and `/`, none of
+/// which is a word character, so a trailing `\b` could not close a match on a
+/// padded or punctuation-terminated hash and left its tail exposed. The match
+/// is greedy and leftmost, so it consumes the whole contiguous Base64 run
+/// wherever a >=40 run exists -- exactly the whole hash -- while the >=40 bound
+/// still excludes the 36-char GUID (dashes break it into <=12-char runs) and
+/// the short HRESULT. The `[blob:…]` token this produces contains `[`, `:`, and
+/// `]`, which are outside the alphabet, so a token can never re-match: the
+/// projection stays idempotent.
 fn opaque_blob_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
-        Regex::new(r"\b[A-Za-z0-9+/=]{40,}\b").expect("opaque blob regex must compile")
+        Regex::new(r"[A-Za-z0-9+/=]{40,}").expect("opaque blob regex must compile")
     })
 }
 
@@ -302,6 +312,40 @@ mod tests {
         let hash = "A".repeat(64);
         let masked = redact_text(&format!("hardware hash {hash}"));
         assert!(!masked.contains(&hash), "got {masked}");
+    }
+
+    /// A Base64 hardware hash may end in `=`, `==`, `+`, or `/` -- none of which
+    /// is a word character, so a trailing `\b` cannot close the match at them.
+    /// Every one of these must be masked in full, or raw identity material rides
+    /// out in the padding after a partial match (ADR-004: restricted values are
+    /// absent from export).
+    #[test]
+    fn a_base64_blob_ending_in_punctuation_is_masked_in_full() {
+        // Each blob is a >=40 char Base64 run terminated by a non-word char.
+        for blob in [
+            format!("{}=", "A".repeat(43)),  // single pad
+            format!("{}==", "A".repeat(42)), // double pad
+            format!("{}+", "A".repeat(43)),  // plus terminal
+            format!("{}/", "A".repeat(43)),  // slash terminal
+        ] {
+            let masked = redact_text(&format!("hardware hash {blob} was reported"));
+            assert!(
+                !masked.contains(&blob),
+                "the whole blob must be masked, got {masked}"
+            );
+            // No fragment of the original run -- including the padding/punctuation
+            // tail -- may survive between the surrounding words.
+            assert!(
+                !masked.contains("AA"),
+                "no run of the blob may survive, got {masked}"
+            );
+            for tail in ['=', '+', '/'] {
+                assert!(
+                    !masked.contains(&format!("{tail} was")),
+                    "a punctuation tail must not dangle after masking, got {masked}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/redaction.rs
@@ -111,7 +111,7 @@ fn user_path_re() -> &'static Regex {
 
 /// A hardware hash or similar long opaque blob embedded in free text.
 ///
-/// Bounded at 32 characters so a GUID (32 hex digits plus dashes, matched in
+/// Bounded at 40 characters so a GUID (32 hex digits plus dashes, matched in
 /// runs of at most 12) and an eight-digit HRESULT are both left readable; those
 /// are diagnostic grammar, not identity.
 fn opaque_blob_re() -> &'static Regex {
@@ -201,10 +201,11 @@ pub fn redacted_export_projection(snapshot: &AutopilotSnapshot) -> AutopilotSnap
             .collect();
     }
 
+    // `mask_value` everywhere a whole value is masked: it performs the
+    // trim/lowercase normalization the module contract promises, so the same
+    // identifier masks identically whatever field or casing it arrived in.
     for key in &mut projected.esp_linkage.matched_keys {
-        if !is_token(&key.value) {
-            key.value = stable_token(VALUE_KIND, &key.value);
-        }
+        key.value = mask_value(&key.value);
     }
 
     for entry in &mut projected.coverage {
@@ -230,9 +231,7 @@ fn redact_named_values(values: &mut [IntuneNamedValue]) {
             .iter()
             .any(|key| key.eq_ignore_ascii_case(&value.name))
         {
-            if !is_token(&value.value) {
-                value.value = stable_token(VALUE_KIND, &value.value);
-            }
+            value.value = mask_value(&value.value);
         } else {
             value.value = redact_text(&value.value);
         }
@@ -249,19 +248,9 @@ fn redact_conflict_value(value: &str) -> String {
                 .iter()
                 .any(|key| key.eq_ignore_ascii_case(name)) =>
         {
-            if is_token(raw) {
-                value.to_owned()
-            } else {
-                format!("{name}={}", stable_token(VALUE_KIND, raw))
-            }
+            format!("{name}={}", mask_value(raw))
         }
-        _ => {
-            if is_token(value) {
-                value.to_owned()
-            } else {
-                stable_token(VALUE_KIND, value)
-            }
-        }
+        _ => mask_value(value),
     }
 }
 
@@ -323,6 +312,40 @@ mod tests {
         assert_eq!(
             redact_conflict_value(&format!("serialNumber={token}")),
             format!("serialNumber={token}")
+        );
+    }
+
+    /// Every whole-value masking site must normalize case and surrounding
+    /// space before hashing, or the same identifier arriving in two casings
+    /// would mask to two different tokens and destroy the very correlation the
+    /// projection exists to preserve.
+    #[test]
+    fn whole_value_masking_normalizes_case_and_space_at_every_site() {
+        let canonical = mask_value("abcdabcd-1234-5678-9012-abcdabcdabcd");
+
+        // Named-data values with a sensitive key.
+        let mut values = vec![IntuneNamedValue {
+            name: "entraDeviceId".to_owned(),
+            value: "  ABCDABCD-1234-5678-9012-ABCDABCDABCD  ".to_owned(),
+        }];
+        redact_named_values(&mut values);
+        assert_eq!(values[0].value, canonical);
+
+        // Conflict values, both shapes.
+        assert_eq!(
+            redact_conflict_value("entraDeviceId= ABCDABCD-1234-5678-9012-ABCDABCDABCD "),
+            format!("entraDeviceId={canonical}")
+        );
+        assert_eq!(
+            redact_conflict_value(" ABCDABCD-1234-5678-9012-ABCDABCDABCD "),
+            canonical
+        );
+
+        // The identity-field path already goes through mask_value; the token
+        // must line up with all of the above.
+        assert_eq!(
+            redact_opt(&Some("Abcdabcd-1234-5678-9012-abcdabcdABCD".to_owned())),
+            Some(canonical)
         );
     }
 

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
@@ -707,24 +707,49 @@ fn recorded_non_assessable_failure_observations(
         .filter(|observation| observation.signal.is_terminal_failure())
 }
 
+/// Named-value keys whose values are case-insensitive identities on Windows:
+/// serials, GUID-shaped identifiers, DNS domains, and host names. Only these
+/// group case-insensitively in [`distinct_values`]; every other key -- notably
+/// `hardwareHash`, whose Base64 payload is case-sensitive -- keeps its exact
+/// value, so two values differing only by case stay two distinct values (the
+/// conservative direction: `single_value` refuses to pick, it never merges).
+/// Every key exported through `detect_conflicts` must stay in this list so a
+/// redacted conflict cannot report "2 distinct values" over two identically
+/// masked tokens (ADR-004; the export masks the trimmed, lowercased value).
+const CASE_INSENSITIVE_VALUE_KEYS: [&str; 11] = [
+    "serialNumber",
+    "productKeyId",
+    "ztdRegistrationId",
+    "entraDeviceId",
+    "managedDeviceId",
+    "tenantId",
+    "tenantDomain",
+    "deviceName",
+    "profileId",
+    "enrollmentId",
+    "correlationId",
+];
+
 /// Collect the distinct values a named key takes across every source.
 ///
 /// Returned sorted and deduplicated so that "more than one value" is a
 /// reproducible fact rather than an artifact of iteration order.
 ///
-/// Distinctness is case-insensitive: the identifiers this feeds -- serials,
-/// GUIDs, tenant domains, device names -- are case-insensitive identities on
-/// Windows, and the redacted export masks the trimmed, lowercased value
-/// (see the redaction module contract). Treating two casings as two values
-/// produced a conflict whose export said "2 distinct values" over two
-/// identical tokens, changing the conclusion under redaction (ADR-004). Each
-/// group is keyed by a deterministic representative casing -- the
-/// lexicographically smallest sighting -- so permuting the input cannot change
-/// the result (ADR-003).
+/// Distinctness is case-insensitive only for the keys in
+/// [`CASE_INSENSITIVE_VALUE_KEYS`]. For those identities, treating two casings
+/// as two values produced a conflict whose export said "2 distinct values"
+/// over two identical tokens, changing the conclusion under redaction
+/// (ADR-004). Each case-folded group is keyed by a deterministic
+/// representative casing -- the lexicographically smallest sighting -- so
+/// permuting the input cannot change the result (ADR-003). Any other key
+/// compares exactly: folding a case-sensitive value such as a Base64 hardware
+/// hash would merge two genuinely different values into one corroborated
+/// identity.
 fn distinct_values(
     observations: &[AutopilotObservation],
     key: &str,
 ) -> BTreeMap<String, Vec<IntuneEvidenceRef>> {
+    let case_insensitive = CASE_INSENSITIVE_VALUE_KEYS.contains(&key);
     let mut groups: BTreeMap<String, (String, Vec<IntuneEvidenceRef>)> = BTreeMap::new();
     for observation in observations.iter().filter(|obs| is_assessable(obs)) {
         let Some(value) = observation.named(key) else {
@@ -734,8 +759,13 @@ fn distinct_values(
         if value.is_empty() {
             continue;
         }
+        let group_key = if case_insensitive {
+            value.to_ascii_lowercase()
+        } else {
+            value.to_owned()
+        };
         let group = groups
-            .entry(value.to_ascii_lowercase())
+            .entry(group_key)
             .or_insert_with(|| (value.to_owned(), Vec::new()));
         if value < group.0.as_str() {
             group.0 = value.to_owned();
@@ -1347,7 +1377,10 @@ fn reduce_esp_linkage(
         return AutopilotEspLinkage {
             state: AutopilotEspLinkState::Conflicting,
             confidence: IntuneFindingConfidence::High,
-            matched_keys: detected_keys.into_iter().collect(),
+            // Detection is not a match. `matched_keys` is documented empty for
+            // every non-`Linked` state, so the detecting keys stay internal: a
+            // consumer must not read ambiguity evidence as proof of a link.
+            matched_keys: Vec::new(),
             esp_session_ids: detected_sessions.into_iter().collect(),
             evidence: normalized_evidence(detection_evidence),
         };

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
@@ -257,7 +257,11 @@ impl Ingest {
     /// Parse a detected document's payload.
     ///
     /// `Err` carries why the payload could not be read, so the caller can
-    /// record a malformed document instead of an empty supported one.
+    /// record a malformed document instead of an empty supported one. The
+    /// detail is a stable reducer-authored sentence and deliberately excludes
+    /// `serde_json`'s error text: that text flows into golden-asserted finding
+    /// summaries, and serde_json does not guarantee its `Display` output
+    /// across releases.
     fn absorb_payload(
         &mut self,
         source: &AutopilotSourceInput,
@@ -268,7 +272,7 @@ impl Ingest {
         match kind {
             AutopilotDocumentKind::Events => {
                 let document = serde_json::from_str::<AutopilotEventsDocument>(content)
-                    .map_err(|error| format!("events payload could not be read: {error}"))?;
+                    .map_err(|_| "events payload could not be read".to_owned())?;
                 if document.channel_complete == Some(false) {
                     self.incomplete_artifacts.insert(source.artifact_id.clone());
                 }
@@ -283,7 +287,7 @@ impl Ingest {
             }
             AutopilotDocumentKind::DiagnosticsReport | AutopilotDocumentKind::IdentityFacts => {
                 let document = serde_json::from_str::<AutopilotReportDocument>(content)
-                    .map_err(|error| format!("report payload could not be read: {error}"))?;
+                    .map_err(|_| "report payload could not be read".to_owned())?;
                 for section in &document.sections {
                     let observation = observation_from_section(section);
                     ids.push(observation.observation_id.clone());
@@ -293,7 +297,7 @@ impl Ingest {
             }
             AutopilotDocumentKind::EspSession => {
                 let document = serde_json::from_str::<AutopilotEspSessionDocument>(content)
-                    .map_err(|error| format!("ESP session payload could not be read: {error}"))?;
+                    .map_err(|_| "ESP session payload could not be read".to_owned())?;
                 for session in &document.sessions {
                     let observation = observation_from_esp_session(session);
                     ids.push(observation.observation_id.clone());
@@ -585,9 +589,25 @@ fn sort_time(observation: &AutopilotObservation, basis: AutopilotTimeBasis) -> O
 
 /// An observation is assessable only when its record was fully available and
 /// parsed. Malformed or access-denied records carry no semantic signal.
+///
+/// Every reduction path that turns a record into state, evidence, a phase, a
+/// correlation key, or a time bound must pass through this gate (ADR-001:
+/// non-assessable evidence cannot produce a terminal conclusion). The one
+/// deliberate exception is [`time_basis`], where an *unfiltered* scan is the
+/// conservative direction: a non-assessable record with an unnormalized
+/// timestamp downgrades the basis, and gating it would upgrade it.
 fn is_assessable(observation: &AutopilotObservation) -> bool {
     observation.context.access_state == IntuneAccessState::Available
         && observation.context.parse_state == IntuneParseState::Parsed
+}
+
+/// A report section is assessable under the same rule as an observation: its
+/// own declared context must be fully available and parsed. Sections arrive
+/// inside a parsed document, but each one still carries a caller-declared
+/// context, and a section declared unreadable proves nothing.
+fn is_assessable_section(section: &AutopilotReportSection) -> bool {
+    section.context.access_state == IntuneAccessState::Available
+        && section.context.parse_state == IntuneParseState::Parsed
 }
 
 fn signal_observations(
@@ -603,12 +623,17 @@ fn has_signal(observations: &[AutopilotObservation], signal: AutopilotSignal) ->
     signal_observations(observations, signal).next().is_some()
 }
 
+/// Iterate the assessable sections of one kind. The gate lives here so no
+/// individual caller can forget it.
 fn sections_of<'a>(
     sections: &'a [AutopilotReportSection],
     kind: &AutopilotSectionKind,
 ) -> impl Iterator<Item = &'a AutopilotReportSection> {
     let kind = kind.clone();
-    sections.iter().filter(move |section| section.kind == kind)
+    sections
+        .iter()
+        .filter(|section| is_assessable_section(section))
+        .filter(move |section| section.kind == kind)
 }
 
 /// Collect the distinct values a named key takes across every source.
@@ -640,8 +665,11 @@ fn single_value(observations: &[AutopilotObservation], key: &str) -> Option<Stri
     let values = distinct_values(observations, key);
     let mut keys = values.into_keys();
     let first = keys.next()?;
-    // More than one distinct value is a conflict, reported separately. Picking
-    // one here would hide it.
+    // More than one distinct value never picks a winner. Only `profileId`,
+    // `serialNumber`, and `entraDeviceId` disagreements are additionally
+    // reported as conflicts by `detect_conflicts`; the remaining keys
+    // (`deviceName` legitimately changes mid-provisioning, and the rest lack a
+    // validated single-value contract) just collapse to `None` here.
     if keys.next().is_some() {
         return None;
     }
@@ -692,9 +720,10 @@ fn reduce_identity(
         state = merge_registration_state(state, AutopilotRegistrationState::Mismatch);
     }
     for observation in observations.iter().filter(|observation| {
-        IDENTITY_KEYS
-            .iter()
-            .any(|key| observation.named(key).is_some())
+        is_assessable(observation)
+            && IDENTITY_KEYS
+                .iter()
+                .any(|key| observation.named(key).is_some())
     }) {
         evidence.push(observation.evidence_ref());
     }
@@ -740,7 +769,7 @@ fn reduce_profile(
     let mut error: Option<IntuneErrorCode> = None;
     let mut last_state_token = None;
 
-    for observation in observations {
+    for observation in observations.iter().filter(|obs| is_assessable(obs)) {
         match observation.signal {
             AutopilotSignal::ProfileAcquisitionStarted
             | AutopilotSignal::ProfilePolicyNotFound
@@ -757,6 +786,12 @@ fn reduce_profile(
             AutopilotSignal::ProfileStateChanged => {
                 evidence.push(observation.evidence_ref());
                 let token = extract_profile_state(observation.message.as_deref());
+                // `ProfileState_Available` deliberately counts as application
+                // evidence, not merely retrieval. Event 172 -- the documented
+                // failure sibling of this transition -- reads "failed to set
+                // Autopilot profile as available": setting the profile
+                // available IS the application step, so the transition into
+                // `Available` is its explicit success record.
                 if matches!(
                     token,
                     Some(AutopilotProfileStateToken::Available)
@@ -999,8 +1034,11 @@ fn detect_conflicts(
 
     // A report section that explicitly reports a mismatch is a conflict the
     // collector already detected; carrying it here keeps the two paths uniform.
+    // Gated like every other path: an unreadable section cannot assert a
+    // mismatch any more than it can assert a success.
     for section in sections
         .iter()
+        .filter(|section| is_assessable_section(section))
         .filter(|section| section.outcome == AutopilotSectionOutcome::Mismatch)
     {
         conflicts.push(AutopilotConflict {
@@ -1074,10 +1112,9 @@ fn autopilot_keys(observations: &[AutopilotObservation]) -> BTreeSet<AutopilotCo
     ];
 
     let mut keys = BTreeSet::new();
-    for observation in observations
-        .iter()
-        .filter(|observation| observation.signal != AutopilotSignal::EspSessionFact)
-    {
+    for observation in observations.iter().filter(|observation| {
+        is_assessable(observation) && observation.signal != AutopilotSignal::EspSessionFact
+    }) {
         for (name, kind) in NAMED_KEYS {
             let Some(value) = observation.named(name).map(str::trim) else {
                 continue;
@@ -1197,10 +1234,9 @@ fn reduce_esp_linkage(
         };
     }
 
-    for observation in observations
-        .iter()
-        .filter(|observation| observation.signal != AutopilotSignal::EspSessionFact)
-    {
+    for observation in observations.iter().filter(|observation| {
+        is_assessable(observation) && observation.signal != AutopilotSignal::EspSessionFact
+    }) {
         if session_key_values(&matched_keys).any(|value| observation_mentions(observation, value)) {
             evidence.push(observation.evidence_ref());
         }
@@ -1241,6 +1277,7 @@ fn has_time_overlap(
 ) -> bool {
     let ap_times: Vec<&str> = observations
         .iter()
+        .filter(|obs| is_assessable(obs))
         .filter_map(|obs| {
             obs.context
                 .source_timestamp
@@ -1361,6 +1398,12 @@ fn reduce_outcome(
             AutopilotEspLinkState::EvidenceMissing => {
                 AutopilotOutcome::HandoffReachedEspEvidenceMissing
             }
+            // Matched explicitly rather than through `conflicts`: the
+            // multiple-matched-sessions path records no `AutopilotConflict`,
+            // so relying on the conflicts gate above would let an ambiguous
+            // session identity fall through to `Completed` (ADR-003:
+            // unresolved authoritative contradictions stay conservative).
+            AutopilotEspLinkState::Conflicting => AutopilotOutcome::ContradictoryEvidence,
             _ => AutopilotOutcome::Completed,
         };
     }

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
@@ -679,6 +679,34 @@ fn recorded_non_assessable_failure_sections(
         })
 }
 
+/// Iterate the *non-assessable* observations that explicitly recorded a
+/// documented failure signal.
+///
+/// The event-side companion of
+/// [`recorded_non_assessable_failure_sections`], with the same direction-aware
+/// contract: a capped or unparsed event cannot PROVE the failure -- which is
+/// why [`signal_observations`] and every other consumer stay gated on
+/// [`is_assessable`], and why none of these observations ever produce a
+/// terminal failure outcome -- but a failure that IS on the record must still
+/// BLOCK a success conclusion. Consumers may only move the result in the
+/// conservative direction.
+///
+/// The class is [`AutopilotSignal::is_terminal_failure`]: exactly the signals
+/// that would produce a terminal failure outcome if they were assessable
+/// (171, 172, 807, 809, 815, 908). That symmetry is the rule -- any record
+/// strong enough to fail the enrollment when readable is strong enough to
+/// block its success when unreadable. `ProfilePolicyNotFound` (100) stays out
+/// for the same reason the section iterator excludes `NotFound`/`Retrying`:
+/// it is documented as transient, not a recorded failure.
+fn recorded_non_assessable_failure_observations(
+    observations: &[AutopilotObservation],
+) -> impl Iterator<Item = &AutopilotObservation> {
+    observations
+        .iter()
+        .filter(|observation| !is_assessable(observation))
+        .filter(|observation| observation.signal.is_terminal_failure())
+}
+
 /// Collect the distinct values a named key takes across every source.
 ///
 /// Returned sorted and deduplicated so that "more than one value" is a
@@ -1514,10 +1542,15 @@ fn reduce_outcome(
         // reduction: the bundle cannot support success while a failure is on
         // record, and cannot prove the failure while its record is
         // non-assessable. The recorded failure is surfaced by its own finding
-        // rather than silently swallowed.
+        // rather than silently swallowed. The gate is symmetric across both
+        // record shapes: a report section that recorded Failed/Mismatch, and
+        // an event carrying a documented failure signal.
         if recorded_non_assessable_failure_sections(sections)
             .next()
             .is_some()
+            || recorded_non_assessable_failure_observations(observations)
+                .next()
+                .is_some()
         {
             return AutopilotOutcome::InsufficientEvidence;
         }

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
@@ -1006,8 +1006,12 @@ fn reduce_profile(
     }
 }
 
-/// The `activityId` a report section carried in its values, lowercased so retry
-/// linkage compares case-insensitively like the ESP correlation keys.
+/// The `activityId` a report section carried in its values, verbatim.
+///
+/// The value name is matched case-insensitively; the value itself is returned
+/// unchanged. [`push_link`] owns the lowercasing that makes retry linkage
+/// compare case-insensitively like the ESP correlation keys, so every key
+/// reaches that one place in its original form.
 fn section_activity_id(section: &AutopilotReportSection) -> Option<&str> {
     section
         .values

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
@@ -1133,11 +1133,32 @@ fn session_keys(session: &AutopilotEspSessionFact) -> Vec<AutopilotCorrelationKe
     .collect()
 }
 
+/// Which observations may contribute correlation keys.
+///
+/// The distinction is ADR-001's direction-aware gate applied to session
+/// identity. Keys are the one input where *more* evidence is *more*
+/// conservative: every additional key can only ever widen the set of ESP
+/// sessions the bundle is entangled with, and a wider set means Conflicting,
+/// never a stronger Linked. So conflict DETECTION reads every observation,
+/// while PROOF of a link (the confident `Linked` state, and the `Completed`
+/// outcome behind it) stays restricted to assessable records.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AutopilotKeyGate {
+    /// Assessable observations only: these keys may prove a link.
+    Proving,
+    /// Every observation, assessable or not: these keys may only detect
+    /// conflicts and can never upgrade a linkage on their own.
+    Detecting,
+}
+
 /// The explicit keys the Autopilot side of the bundle can offer.
 ///
 /// Deliberately skips [`AutopilotSignal::EspSessionFact`] observations: an ESP
 /// fact matching its own key would be a tautology, not a correlation.
-fn autopilot_keys(observations: &[AutopilotObservation]) -> BTreeSet<AutopilotCorrelationKey> {
+fn autopilot_keys(
+    observations: &[AutopilotObservation],
+    gate: AutopilotKeyGate,
+) -> BTreeSet<AutopilotCorrelationKey> {
     const NAMED_KEYS: [(&str, AutopilotCorrelationKeyKind); 5] = [
         ("enrollmentId", AutopilotCorrelationKeyKind::EnrollmentId),
         ("correlationId", AutopilotCorrelationKeyKind::CorrelationId),
@@ -1151,7 +1172,8 @@ fn autopilot_keys(observations: &[AutopilotObservation]) -> BTreeSet<AutopilotCo
 
     let mut keys = BTreeSet::new();
     for observation in observations.iter().filter(|observation| {
-        is_assessable(observation) && observation.signal != AutopilotSignal::EspSessionFact
+        (gate == AutopilotKeyGate::Detecting || is_assessable(observation))
+            && observation.signal != AutopilotSignal::EspSessionFact
     }) {
         for (name, kind) in NAMED_KEYS {
             let Some(value) = observation.named(name).map(str::trim) else {
@@ -1226,19 +1248,63 @@ fn reduce_esp_linkage(
         };
     }
 
-    let local_keys = autopilot_keys(observations);
+    let proving_keys = autopilot_keys(observations, AutopilotKeyGate::Proving);
+    let detecting_keys = autopilot_keys(observations, AutopilotKeyGate::Detecting);
 
+    // Two match passes over the same sessions. `detected_*` uses every key the
+    // bundle carries, assessable or not, because each extra key can only widen
+    // the entangled-session set (the conservative direction). `matched_*` is
+    // the assessable subset, the only one allowed to prove a link.
     let mut matched_keys = BTreeSet::new();
     let mut matched_sessions = BTreeSet::new();
     let mut evidence = Vec::new();
+    let mut detected_keys = BTreeSet::new();
+    let mut detected_sessions = BTreeSet::new();
+    let mut detection_evidence = Vec::new();
     for session in esp_sessions {
         for key in session_keys(session) {
-            if local_keys.contains(&key) {
-                matched_keys.insert(key);
-                matched_sessions.insert(session.session_id.clone());
-                evidence.push(session.evidence.clone());
+            if detecting_keys.contains(&key) {
+                detected_sessions.insert(session.session_id.clone());
+                detection_evidence.push(session.evidence.clone());
+                if proving_keys.contains(&key) {
+                    matched_keys.insert(key.clone());
+                    matched_sessions.insert(session.session_id.clone());
+                    evidence.push(session.evidence.clone());
+                }
+                detected_keys.insert(key);
             }
         }
+    }
+
+    // A single Autopilot phase can only have produced one ESP session, so keys
+    // resolving to more than one session mean the identity space is ambiguous:
+    // Conflicting, never a silent merge. This check runs on the *detecting*
+    // set on purpose. A key carried only by a capped observation cannot prove
+    // a link, but dropping it here would shrink the session set and collapse
+    // Conflicting into Linked into Completed -- a non-assessable record
+    // silently upgrading the conclusion, which is exactly what ADR-001
+    // forbids.
+    if detected_sessions.len() > 1 {
+        for observation in observations
+            .iter()
+            .filter(|observation| observation.signal != AutopilotSignal::EspSessionFact)
+        {
+            // Non-assessable carriers are cited too: a capped record is the
+            // very evidence of the entanglement this state reports. Citing is
+            // not proving; the state it supports is the conservative one.
+            if session_key_values(&detected_keys)
+                .any(|value| observation_mentions(observation, value))
+            {
+                detection_evidence.push(observation.evidence_ref());
+            }
+        }
+        return AutopilotEspLinkage {
+            state: AutopilotEspLinkState::Conflicting,
+            confidence: IntuneFindingConfidence::High,
+            matched_keys: detected_keys.into_iter().collect(),
+            esp_session_ids: detected_sessions.into_iter().collect(),
+            evidence: normalized_evidence(detection_evidence),
+        };
     }
 
     if matched_keys.is_empty() {
@@ -1280,19 +1346,9 @@ fn reduce_esp_linkage(
         }
     }
 
-    // A single Autopilot phase can only have produced one ESP session.
-    // If matched keys resolve to more than one session, the identity space
-    // is ambiguous; emit Conflicting rather than silently merging them.
-    if matched_sessions.len() > 1 {
-        return AutopilotEspLinkage {
-            state: AutopilotEspLinkState::Conflicting,
-            confidence: IntuneFindingConfidence::High,
-            matched_keys: matched_keys.into_iter().collect(),
-            esp_session_ids: matched_sessions.into_iter().collect(),
-            evidence: normalized_evidence(evidence),
-        };
-    }
-
+    // `matched_sessions` is a subset of `detected_sessions`, and the multi-
+    // session case already returned Conflicting above, so exactly one session
+    // remains here and it was matched by an assessable key.
     AutopilotEspLinkage {
         state: AutopilotEspLinkState::Linked,
         confidence: IntuneFindingConfidence::High,

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
@@ -602,8 +602,7 @@ fn sort_time(observation: &AutopilotObservation, basis: AutopilotTimeBasis) -> O
 /// conservative direction: a non-assessable record with an unnormalized
 /// timestamp downgrades the basis, and gating it would upgrade it.
 fn is_assessable(observation: &AutopilotObservation) -> bool {
-    observation.context.access_state == IntuneAccessState::Available
-        && observation.context.parse_state == IntuneParseState::Parsed
+    observation.is_assessable()
 }
 
 /// A report section is assessable under the same rule as an observation: its
@@ -877,7 +876,18 @@ fn reduce_profile(
     sections: &[AutopilotReportSection],
 ) -> AutopilotProfileState {
     let mut evidence = Vec::new();
-    let mut candidate = AutopilotProfileCandidateState::Unknown;
+    // `raised` is the candidate the positive evidence alone supports; it never
+    // encodes a negative, so it is a pure order-independent maximum. The
+    // explicit negatives are tracked apart and reconciled against it below,
+    // because whether a later success may erase an earlier negative is a
+    // linkage question, not an ordering one (ADR-003).
+    let mut raised = AutopilotProfileCandidateState::Unknown;
+    let mut negative: Option<AutopilotProfileCandidateState> = None;
+    // Activity ids (the module's retry/session key) carried by the explicit
+    // negatives and by the successes that reached `Available`. A negative may
+    // be erased only when it shares one with a success.
+    let mut negative_links: Vec<String> = Vec::new();
+    let mut available_success_links: Vec<String> = Vec::new();
     let mut retrieved = false;
     let mut applied = false;
     let mut error: Option<IntuneErrorCode> = None;
@@ -889,13 +899,14 @@ fn reduce_profile(
             | AutopilotSignal::ProfilePolicyNotFound
             | AutopilotSignal::NetworkAvailableForDownload => {
                 evidence.push(observation.evidence_ref());
-                candidate = raise_candidate(candidate, AutopilotProfileCandidateState::Pending);
+                raised = raise_candidate(raised, AutopilotProfileCandidateState::Pending);
             }
             AutopilotSignal::ProfileRetrieveSucceeded
             | AutopilotSignal::ProfileSettingsRetrieved => {
                 evidence.push(observation.evidence_ref());
                 retrieved = true;
-                candidate = raise_candidate(candidate, AutopilotProfileCandidateState::Available);
+                raised = raise_candidate(raised, AutopilotProfileCandidateState::Available);
+                push_link(&mut available_success_links, observation.activity_id.as_deref());
             }
             AutopilotSignal::ProfileStateChanged => {
                 evidence.push(observation.evidence_ref());
@@ -912,8 +923,8 @@ fn reduce_profile(
                         | Some(AutopilotProfileStateToken::Provisioned)
                 ) {
                     applied = true;
-                    candidate =
-                        raise_candidate(candidate, AutopilotProfileCandidateState::Available);
+                    raised = raise_candidate(raised, AutopilotProfileCandidateState::Available);
+                    push_link(&mut available_success_links, observation.activity_id.as_deref());
                 }
                 if token.is_some() {
                     last_state_token = token;
@@ -922,15 +933,24 @@ fn reduce_profile(
             AutopilotSignal::DeviceAlreadyProvisioned => {
                 evidence.push(observation.evidence_ref());
                 applied = true;
-                candidate = raise_candidate(candidate, AutopilotProfileCandidateState::Available);
+                raised = raise_candidate(raised, AutopilotProfileCandidateState::Available);
+                push_link(&mut available_success_links, observation.activity_id.as_deref());
             }
             AutopilotSignal::NoAssignedProfile => {
                 evidence.push(observation.evidence_ref());
-                candidate = AutopilotProfileCandidateState::NoneAssigned;
+                negative = Some(merge_negative(
+                    negative,
+                    AutopilotProfileCandidateState::NoneAssigned,
+                ));
+                push_link(&mut negative_links, observation.activity_id.as_deref());
             }
             AutopilotSignal::AssignedProfileMissing => {
                 evidence.push(observation.evidence_ref());
-                candidate = AutopilotProfileCandidateState::AssignedButMissing;
+                negative = Some(merge_negative(
+                    negative,
+                    AutopilotProfileCandidateState::AssignedButMissing,
+                ));
+                push_link(&mut negative_links, observation.activity_id.as_deref());
             }
             AutopilotSignal::ProfileApplicationFailed => {
                 evidence.push(observation.evidence_ref());
@@ -945,13 +965,18 @@ fn reduce_profile(
         match section.outcome {
             AutopilotSectionOutcome::Succeeded => {
                 retrieved = true;
-                candidate = raise_candidate(candidate, AutopilotProfileCandidateState::Available);
+                raised = raise_candidate(raised, AutopilotProfileCandidateState::Available);
+                push_link(&mut available_success_links, section_activity_id(section));
             }
             AutopilotSectionOutcome::NotFound => {
-                candidate = AutopilotProfileCandidateState::NoneAssigned;
+                negative = Some(merge_negative(
+                    negative,
+                    AutopilotProfileCandidateState::NoneAssigned,
+                ));
+                push_link(&mut negative_links, section_activity_id(section));
             }
             AutopilotSectionOutcome::Retrying => {
-                candidate = raise_candidate(candidate, AutopilotProfileCandidateState::Pending);
+                raised = raise_candidate(raised, AutopilotProfileCandidateState::Pending);
             }
             _ => {}
         }
@@ -965,6 +990,8 @@ fn reduce_profile(
         error = error.or_else(|| section.error.clone());
     }
 
+    let candidate = reconcile_candidate(raised, negative, &negative_links, &available_success_links);
+
     AutopilotProfileState {
         profile_id: single_value(observations, "profileId"),
         profile_name: single_value(observations, "profileName"),
@@ -977,6 +1004,74 @@ fn reduce_profile(
         error,
         evidence: normalized_evidence(evidence),
     }
+}
+
+/// The `activityId` a report section carried in its values, lowercased so retry
+/// linkage compares case-insensitively like the ESP correlation keys.
+fn section_activity_id(section: &AutopilotReportSection) -> Option<&str> {
+    section
+        .values
+        .iter()
+        .find(|value| value.name.eq_ignore_ascii_case("activityId"))
+        .map(|value| value.value.as_str())
+}
+
+/// Record one retry-linkage key, lowercased. Absent keys contribute nothing:
+/// a success with no activity id can never be *proven* to be the same attempt
+/// as an earlier negative, so it must not count as linkage.
+fn push_link(links: &mut Vec<String>, activity: Option<&str>) {
+    if let Some(activity) = activity {
+        links.push(activity.to_ascii_lowercase());
+    }
+}
+
+/// Combine two explicit negatives deterministically. Both rank equally and both
+/// reduce to [`AutopilotOutcome::NoProfileCandidate`]; `AssignedButMissing` is
+/// the more specific statement, so it wins when a bundle somehow carries both.
+/// The choice is permutation-invariant, unlike the old last-writer assignment.
+fn merge_negative(
+    current: Option<AutopilotProfileCandidateState>,
+    incoming: AutopilotProfileCandidateState,
+) -> AutopilotProfileCandidateState {
+    match current {
+        Some(AutopilotProfileCandidateState::AssignedButMissing) => {
+            AutopilotProfileCandidateState::AssignedButMissing
+        }
+        _ => incoming,
+    }
+}
+
+/// Reconcile the positive-evidence candidate against an explicit negative.
+///
+/// ADR-003: a later success may replace an earlier explicit negative only when
+/// retry linkage is explicit. Linkage here is a shared `activityId` between the
+/// negative and a success that reached `Available`. Without it the negative
+/// stands and the reducer stays conservative -- an unrelated success cannot
+/// silently complete an enrollment the service explicitly said had no profile.
+/// With it, the success is a proven retry of the same attempt and the candidate
+/// rises to `Available`. The decision reads only sets, never vector order, so
+/// permuting the input cannot change it.
+fn reconcile_candidate(
+    raised: AutopilotProfileCandidateState,
+    negative: Option<AutopilotProfileCandidateState>,
+    negative_links: &[String],
+    available_success_links: &[String],
+) -> AutopilotProfileCandidateState {
+    let Some(negative) = negative else {
+        return raised;
+    };
+    let raised_to_available = raised == AutopilotProfileCandidateState::Available;
+    let retry_linked = negative_links
+        .iter()
+        .any(|link| available_success_links.contains(link));
+    if raised_to_available && retry_linked {
+        // The success is a proven retry of the same attempt; it may erase the
+        // negative.
+        return raised;
+    }
+    // No proven retry link: the explicit negative wins over both an unlinked
+    // success and any weaker positive (Pending/Unknown).
+    negative
 }
 
 /// Raise a candidate state, never lowering one that was explicitly proven.

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
@@ -625,6 +625,13 @@ fn has_signal(observations: &[AutopilotObservation], signal: AutopilotSignal) ->
 
 /// Iterate the assessable sections of one kind. The gate lives here so no
 /// individual caller can forget it.
+///
+/// This gate is deliberately direction-aware in combination with
+/// [`recorded_non_assessable_failure_sections`]: everything reached through
+/// *this* iterator may prove progress, success, or a terminal cause, so it
+/// admits assessable sections only. A non-assessable section that explicitly
+/// recorded a failure is not silently discarded with it -- see the companion
+/// iterator below.
 fn sections_of<'a>(
     sections: &'a [AutopilotReportSection],
     kind: &AutopilotSectionKind,
@@ -634,6 +641,37 @@ fn sections_of<'a>(
         .iter()
         .filter(|section| is_assessable_section(section))
         .filter(move |section| section.kind == kind)
+}
+
+/// Iterate the *non-assessable* sections that explicitly recorded a failure or
+/// mismatch.
+///
+/// ADR-001 cuts both ways. A capped or unparsed section cannot PROVE anything:
+/// not progress, not success, and not a terminal failure either -- which is why
+/// [`sections_of`] excludes it and why the reducer never turns one of these
+/// into `ProfileRetrievalFailure`/`ProfileApplicationFailure`. But `Capped`
+/// means "absence proves nothing", not "presence proves nothing": a failure
+/// that IS on the record must still BLOCK a success conclusion, or sibling
+/// assessable evidence would complete the enrollment at high confidence over a
+/// recorded failure. Consumers of this iterator may only move the result in
+/// the conservative direction.
+///
+/// `Failed` and `Mismatch` are the explicit negative recordings. `NotFound`
+/// and `Retrying` stay out on purpose: those are statements of absence or of a
+/// transient state, and an absence statement from a partially captured view
+/// proves nothing in either direction.
+fn recorded_non_assessable_failure_sections(
+    sections: &[AutopilotReportSection],
+) -> impl Iterator<Item = &AutopilotReportSection> {
+    sections
+        .iter()
+        .filter(|section| !is_assessable_section(section))
+        .filter(|section| {
+            matches!(
+                section.outcome,
+                AutopilotSectionOutcome::Failed | AutopilotSectionOutcome::Mismatch
+            )
+        })
 }
 
 /// Collect the distinct values a named key takes across every source.
@@ -1394,6 +1432,21 @@ fn reduce_outcome(
         return AutopilotOutcome::ProfileApplicationFailure;
     }
     if profile.applied && handoff.esp_observed {
+        // Direction-aware assessability gate (ADR-001). A non-assessable
+        // section that explicitly recorded a failure or mismatch can prove
+        // nothing -- including the failure itself, so the terminal failure
+        // outcomes above stay reserved for assessable records -- but it must
+        // still block a success claim. `InsufficientEvidence` is the honest
+        // reduction: the bundle cannot support success while a failure is on
+        // record, and cannot prove the failure while its record is
+        // non-assessable. The recorded failure is surfaced by its own finding
+        // rather than silently swallowed.
+        if recorded_non_assessable_failure_sections(sections)
+            .next()
+            .is_some()
+        {
+            return AutopilotOutcome::InsufficientEvidence;
+        }
         return match esp_linkage.state {
             AutopilotEspLinkState::EvidenceMissing => {
                 AutopilotOutcome::HandoffReachedEspEvidenceMissing

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/reducer.rs
@@ -108,7 +108,12 @@ pub fn reduce_autopilot_bundle(bundle: &AutopilotBundleInput) -> AutopilotSnapsh
         &ingest.sections,
     );
     let confidence = reduce_confidence(outcome, capture_validated, time_basis, &coverage);
-    let next_evidence_requests = next_evidence_requests(outcome, &esp_linkage, &coverage);
+    let next_evidence_requests = next_evidence_requests(
+        outcome,
+        &esp_linkage,
+        !ingest.esp_sessions.is_empty(),
+        &coverage,
+    );
 
     let unclassified_observation_ids = observations
         .iter()
@@ -678,11 +683,21 @@ fn recorded_non_assessable_failure_sections(
 ///
 /// Returned sorted and deduplicated so that "more than one value" is a
 /// reproducible fact rather than an artifact of iteration order.
+///
+/// Distinctness is case-insensitive: the identifiers this feeds -- serials,
+/// GUIDs, tenant domains, device names -- are case-insensitive identities on
+/// Windows, and the redacted export masks the trimmed, lowercased value
+/// (see the redaction module contract). Treating two casings as two values
+/// produced a conflict whose export said "2 distinct values" over two
+/// identical tokens, changing the conclusion under redaction (ADR-004). Each
+/// group is keyed by a deterministic representative casing -- the
+/// lexicographically smallest sighting -- so permuting the input cannot change
+/// the result (ADR-003).
 fn distinct_values(
     observations: &[AutopilotObservation],
     key: &str,
 ) -> BTreeMap<String, Vec<IntuneEvidenceRef>> {
-    let mut values: BTreeMap<String, Vec<IntuneEvidenceRef>> = BTreeMap::new();
+    let mut groups: BTreeMap<String, (String, Vec<IntuneEvidenceRef>)> = BTreeMap::new();
     for observation in observations.iter().filter(|obs| is_assessable(obs)) {
         let Some(value) = observation.named(key) else {
             continue;
@@ -691,12 +706,15 @@ fn distinct_values(
         if value.is_empty() {
             continue;
         }
-        values
-            .entry(value.to_owned())
-            .or_default()
-            .push(observation.evidence_ref());
+        let group = groups
+            .entry(value.to_ascii_lowercase())
+            .or_insert_with(|| (value.to_owned(), Vec::new()));
+        if value < group.0.as_str() {
+            group.0 = value.to_owned();
+        }
+        group.1.push(observation.evidence_ref());
     }
-    values
+    groups.into_values().collect()
 }
 
 fn single_value(observations: &[AutopilotObservation], key: &str) -> Option<String> {
@@ -1562,6 +1580,7 @@ fn reduce_confidence(
 fn next_evidence_requests(
     outcome: AutopilotOutcome,
     esp_linkage: &AutopilotEspLinkage,
+    esp_sessions_supplied: bool,
     coverage: &[IntuneArtifactCoverage],
 ) -> Vec<String> {
     let mut requests: Vec<String> = match outcome {
@@ -1609,7 +1628,18 @@ fn next_evidence_requests(
         AutopilotOutcome::Completed => Vec::new(),
     };
 
-    if esp_linkage.state == AutopilotEspLinkState::TimeOnlyCandidate {
+    // ESP facts were supplied but no explicit key bound them. The request for
+    // a shared identifier is keyed on that situation, not on the linkage state
+    // alone: the time gate can narrow the overlap window and turn
+    // `TimeOnlyCandidate` into `NotObserved`, and the guidance -- go find the
+    // identifier the two sides share -- must survive that downgrade rather
+    // than vanish with it.
+    if esp_sessions_supplied
+        && matches!(
+            esp_linkage.state,
+            AutopilotEspLinkState::TimeOnlyCandidate | AutopilotEspLinkState::NotObserved
+        )
+    {
         requests.push(
             "An enrollment, correlation, or device identifier shared by the Autopilot and ESP evidence"
                 .to_owned(),

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/rules.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/rules.rs
@@ -10,8 +10,8 @@
 //! the whole MDM bundle" is not an answer when one event ID would do.
 
 use crate::intune::evidence::{
-    IntuneArtifactStatus, IntuneEvidenceRef, IntuneFinding, IntuneFindingConfidence,
-    IntuneFindingSeverity, IntuneParseState,
+    IntuneAccessState, IntuneArtifactStatus, IntuneEvidenceRef, IntuneFinding,
+    IntuneFindingConfidence, IntuneFindingSeverity, IntuneParseState,
 };
 
 use super::models::*;
@@ -43,6 +43,7 @@ pub fn derive_findings(snapshot: &AutopilotSnapshot) -> Vec<IntuneFinding> {
     push_esp_linked(snapshot, &mut findings);
     push_unreliable_timestamps(snapshot, &mut findings);
     push_coverage_gaps(snapshot, &mut findings);
+    push_non_assessable_failure_recorded(snapshot, &mut findings);
     push_unclassified_records(snapshot, &mut findings);
     push_completed(snapshot, &mut findings);
 
@@ -699,6 +700,74 @@ fn push_coverage_gaps(snapshot: &AutopilotSnapshot, findings: &mut Vec<IntuneFin
             gaps.iter()
                 .map(|entry| entry.artifact_id.clone())
                 .collect(),
+        ),
+    );
+}
+
+/// Surface a failure that is on the record but not assessable.
+///
+/// ADR-001's direction-aware gate: a capped or unparsed section can prove
+/// nothing -- so the reducer neither completes the enrollment over it nor
+/// turns it into a terminal failure outcome -- but a recorded failure must
+/// never be *silent*. This rule is the surface for that middle state: it names
+/// the section, says why the failure cannot be trusted yet, and asks for the
+/// one artifact that would settle it. Deliberately not gated by
+/// `terminal_semantics_withheld`: like coverage gaps, this describes the
+/// bundle, not a cause.
+fn push_non_assessable_failure_recorded(
+    snapshot: &AutopilotSnapshot,
+    findings: &mut Vec<IntuneFinding>,
+) {
+    let recorded = snapshot
+        .observations
+        .iter()
+        .filter(|observation| observation.signal == AutopilotSignal::ReportSection)
+        .filter(|observation| {
+            observation.context.access_state != IntuneAccessState::Available
+                || observation.context.parse_state != IntuneParseState::Parsed
+        })
+        .filter(|observation| {
+            matches!(
+                observation.section_outcome,
+                Some(AutopilotSectionOutcome::Failed) | Some(AutopilotSectionOutcome::Mismatch)
+            )
+        })
+        .collect::<Vec<_>>();
+    if recorded.is_empty() {
+        return;
+    }
+    push(
+        findings,
+        finding(
+            "autopilot-non-assessable-failure-recorded",
+            IntuneFindingSeverity::Warning,
+            // Low on purpose: non-assessable evidence cannot support a
+            // confident conclusion in either direction (ADR-001). The finding
+            // exists so the recorded failure blocks success visibly instead of
+            // silently.
+            IntuneFindingConfidence::Low,
+            "A section that could not be fully read recorded a failure",
+            &format!(
+                "{} report section(s) whose own capture or parse state is not assessable \
+                 explicitly recorded a failed or mismatched outcome. That record cannot prove the \
+                 failure, but it blocks any success conclusion until the section is re-collected \
+                 in a readable form.",
+                recorded.len()
+            ),
+            &[
+                "Re-collect the cited report section(s), complete and readable, before trusting \
+                 any success signal from this bundle."
+                    .to_owned(),
+                "Compare the re-collected section's outcome against the sibling event evidence."
+                    .to_owned(),
+            ],
+            normalized_evidence(
+                recorded
+                    .iter()
+                    .map(|observation| observation.evidence_ref())
+                    .collect(),
+            ),
+            Vec::new(),
         ),
     );
 }

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/rules.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/rules.rs
@@ -562,17 +562,20 @@ fn push_esp_link_conflicting(snapshot: &AutopilotSnapshot, findings: &mut Vec<In
             "The Autopilot evidence matches more than one ESP session",
             &format!(
                 "Explicit correlation keys bind this Autopilot evidence to {} different ESP \
-                 sessions ({}). A single Autopilot phase produces one session, so the session \
-                 identity is ambiguous and no completed handoff can be asserted.",
+                 sessions ({}). A single Autopilot phase produces one session, so no completed \
+                 handoff can be asserted. Two real sessions can exist legitimately -- a reimaged, \
+                 reset, or re-enrolled device provisions more than once -- but this bundle does \
+                 not say which session belongs to this attempt.",
                 snapshot.esp_linkage.esp_session_ids.len(),
                 snapshot.esp_linkage.esp_session_ids.join(", ")
             ),
             &[
-                "Re-collect both sides in one pass so the bundle describes a single provisioning \
-                 attempt."
+                "If the device was reimaged or re-enrolled, both sessions may be real: identify \
+                 the attempt under investigation and analyze its session on its own in the ESP \
+                 workspace."
                     .to_owned(),
-                "Confirm the ESP session facts were not assembled from two enrollments of the \
-                 same device."
+                "Otherwise re-collect both sides in one pass so the bundle describes a single \
+                 provisioning attempt."
                     .to_owned(),
             ],
             normalized_evidence(snapshot.esp_linkage.evidence.clone()),

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/rules.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/rules.rs
@@ -709,14 +709,17 @@ fn push_coverage_gaps(snapshot: &AutopilotSnapshot, findings: &mut Vec<IntuneFin
 
 /// Surface a failure that is on the record but not assessable.
 ///
-/// ADR-001's direction-aware gate: a capped or unparsed section can prove
+/// ADR-001's direction-aware gate: a capped or unparsed record can prove
 /// nothing -- so the reducer neither completes the enrollment over it nor
 /// turns it into a terminal failure outcome -- but a recorded failure must
 /// never be *silent*. This rule is the surface for that middle state: it names
-/// the section, says why the failure cannot be trusted yet, and asks for the
-/// one artifact that would settle it. Deliberately not gated by
-/// `terminal_semantics_withheld`: like coverage gaps, this describes the
-/// bundle, not a cause.
+/// the record, says why the failure cannot be trusted yet, and asks for the
+/// one artifact that would settle it. Both record shapes are covered: a
+/// report section whose outcome is `Failed`/`Mismatch`, and an event carrying
+/// a documented failure signal ([`AutopilotSignal::is_terminal_failure`]) --
+/// the same two classes whose recorded failure blocks the success branch in
+/// the reducer. Deliberately not gated by `terminal_semantics_withheld`: like
+/// coverage gaps, this describes the bundle, not a cause.
 fn push_non_assessable_failure_recorded(
     snapshot: &AutopilotSnapshot,
     findings: &mut Vec<IntuneFinding>,
@@ -724,16 +727,17 @@ fn push_non_assessable_failure_recorded(
     let recorded = snapshot
         .observations
         .iter()
-        .filter(|observation| observation.signal == AutopilotSignal::ReportSection)
         .filter(|observation| {
             observation.context.access_state != IntuneAccessState::Available
                 || observation.context.parse_state != IntuneParseState::Parsed
         })
         .filter(|observation| {
-            matches!(
-                observation.section_outcome,
-                Some(AutopilotSectionOutcome::Failed) | Some(AutopilotSectionOutcome::Mismatch)
-            )
+            let failed_section = observation.signal == AutopilotSignal::ReportSection
+                && matches!(
+                    observation.section_outcome,
+                    Some(AutopilotSectionOutcome::Failed) | Some(AutopilotSectionOutcome::Mismatch)
+                );
+            failed_section || observation.signal.is_terminal_failure()
         })
         .collect::<Vec<_>>();
     if recorded.is_empty() {
@@ -749,19 +753,20 @@ fn push_non_assessable_failure_recorded(
             // exists so the recorded failure blocks success visibly instead of
             // silently.
             IntuneFindingConfidence::Low,
-            "A section that could not be fully read recorded a failure",
+            "A record that could not be fully read recorded a failure",
             &format!(
-                "{} report section(s) whose own capture or parse state is not assessable \
-                 explicitly recorded a failed or mismatched outcome. That record cannot prove the \
-                 failure, but it blocks any success conclusion until the section is re-collected \
-                 in a readable form.",
+                "{} record(s) whose own capture or parse state is not assessable explicitly \
+                 recorded a failure -- a failed or mismatched report section, or an event \
+                 carrying a documented failure signal. That record cannot prove the failure, but \
+                 it blocks any success conclusion until it is re-collected in a readable form.",
                 recorded.len()
             ),
             &[
-                "Re-collect the cited report section(s), complete and readable, before trusting \
-                 any success signal from this bundle."
+                "Re-collect the cited record(s), complete and readable, before trusting any \
+                 success signal from this bundle."
                     .to_owned(),
-                "Compare the re-collected section's outcome against the sibling event evidence."
+                "Compare the re-collected record's outcome against the sibling assessable \
+                 evidence."
                     .to_owned(),
             ],
             normalized_evidence(

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/rules.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/rules.rs
@@ -16,7 +16,9 @@ use crate::intune::evidence::{
 
 use super::models::*;
 use super::reducer::normalized_evidence;
-use super::sources::AUTOPILOT_EVENT_CHANNEL;
+use super::sources::{
+    is_validated_schema_version, is_validated_windows_build, AUTOPILOT_EVENT_CHANNEL,
+};
 
 /// Derive stable, read-only findings from a snapshot.
 ///
@@ -37,6 +39,7 @@ pub fn derive_findings(snapshot: &AutopilotSnapshot) -> Vec<IntuneFinding> {
     push_retry_deferred(snapshot, &mut findings);
     push_esp_evidence_missing(snapshot, &mut findings);
     push_esp_time_only_candidate(snapshot, &mut findings);
+    push_esp_link_conflicting(snapshot, &mut findings);
     push_esp_linked(snapshot, &mut findings);
     push_unreliable_timestamps(snapshot, &mut findings);
     push_coverage_gaps(snapshot, &mut findings);
@@ -54,22 +57,44 @@ fn push_unknown_schema(snapshot: &AutopilotSnapshot, findings: &mut Vec<IntuneFi
         .iter()
         .filter(|document| document.parse_state == IntuneParseState::Unsupported)
         .collect::<Vec<_>>();
-    let build_unvalidated = snapshot.outcome == AutopilotOutcome::UnknownSchema
+    // Either declared capture value can be the one that failed validation.
+    // Gating on `windows_build` alone left a capture that declared only an
+    // unvalidated `autopilotSchemaVersion` with an unexplained `UnknownSchema`
+    // outcome: every terminal rule was suppressed and no finding said why.
+    let capture_unvalidated = snapshot.outcome == AutopilotOutcome::UnknownSchema
         && unsupported.is_empty()
-        && snapshot.capture.windows_build.is_some();
-    if unsupported.is_empty() && !build_unvalidated {
+        && (snapshot.capture.windows_build.is_some()
+            || snapshot.capture.autopilot_schema_version.is_some());
+    if unsupported.is_empty() && !capture_unvalidated {
         return;
     }
 
     let mut summary = if unsupported.is_empty() {
+        let mut offenders = Vec::new();
+        if !is_validated_windows_build(snapshot.capture.windows_build.as_deref()) {
+            offenders.push(format!(
+                "Windows build {}",
+                snapshot
+                    .capture
+                    .windows_build
+                    .as_deref()
+                    .unwrap_or("unknown")
+            ));
+        }
+        if !is_validated_schema_version(snapshot.capture.autopilot_schema_version.as_deref()) {
+            offenders.push(format!(
+                "Autopilot schema version {}",
+                snapshot
+                    .capture
+                    .autopilot_schema_version
+                    .as_deref()
+                    .unwrap_or("unknown")
+            ));
+        }
         format!(
-            "Windows build {} has no validated Autopilot rules in this build, so terminal \
-             semantics are withheld and the evidence is retained raw.",
-            snapshot
-                .capture
-                .windows_build
-                .as_deref()
-                .unwrap_or("unknown")
+            "This build has no validated Autopilot rules for {}, so terminal semantics are \
+             withheld and the evidence is retained raw.",
+            offenders.join(" or ")
         )
     } else {
         format!(
@@ -109,7 +134,7 @@ fn push_unknown_schema(snapshot: &AutopilotSnapshot, findings: &mut Vec<IntuneFi
                 .iter()
                 .map(|document| document.artifact_id.clone())
                 .chain(
-                    build_unvalidated
+                    capture_unvalidated
                         .then(|| {
                             snapshot
                                 .coverage
@@ -503,6 +528,51 @@ fn push_esp_time_only_candidate(snapshot: &AutopilotSnapshot, findings: &mut Vec
                  identifier."
                     .to_owned(),
                 "Compare the Entra device id recorded by each side.".to_owned(),
+            ],
+            normalized_evidence(snapshot.esp_linkage.evidence.clone()),
+            Vec::new(),
+        ),
+    );
+}
+
+/// Explain a `Conflicting` ESP linkage that no recorded conflict covers.
+///
+/// The linkage turns `Conflicting` on two paths. When a single correlation key
+/// resolves to more than one session, `detect_conflicts` records an
+/// [`AutopilotConflictKind::EspSessionIdentifier`] conflict and
+/// `push_contradictory_evidence` already explains it. When *distinct* keys
+/// each resolve cleanly but to *different* sessions, no conflict is recorded;
+/// this rule is what keeps that outcome from being silent.
+fn push_esp_link_conflicting(snapshot: &AutopilotSnapshot, findings: &mut Vec<IntuneFinding>) {
+    if snapshot.esp_linkage.state != AutopilotEspLinkState::Conflicting
+        || snapshot
+            .conflicts
+            .iter()
+            .any(|conflict| conflict.kind == AutopilotConflictKind::EspSessionIdentifier)
+    {
+        return;
+    }
+    push(
+        findings,
+        finding(
+            "autopilot-esp-link-conflicting",
+            IntuneFindingSeverity::Error,
+            IntuneFindingConfidence::High,
+            "The Autopilot evidence matches more than one ESP session",
+            &format!(
+                "Explicit correlation keys bind this Autopilot evidence to {} different ESP \
+                 sessions ({}). A single Autopilot phase produces one session, so the session \
+                 identity is ambiguous and no completed handoff can be asserted.",
+                snapshot.esp_linkage.esp_session_ids.len(),
+                snapshot.esp_linkage.esp_session_ids.join(", ")
+            ),
+            &[
+                "Re-collect both sides in one pass so the bundle describes a single provisioning \
+                 attempt."
+                    .to_owned(),
+                "Confirm the ESP session facts were not assembled from two enrollments of the \
+                 same device."
+                    .to_owned(),
             ],
             normalized_evidence(snapshot.esp_linkage.evidence.clone()),
             Vec::new(),

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/rules.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/rules.rs
@@ -10,8 +10,8 @@
 //! the whole MDM bundle" is not an answer when one event ID would do.
 
 use crate::intune::evidence::{
-    IntuneAccessState, IntuneArtifactStatus, IntuneEvidenceRef, IntuneFinding,
-    IntuneFindingConfidence, IntuneFindingSeverity, IntuneParseState,
+    IntuneArtifactStatus, IntuneEvidenceRef, IntuneFinding, IntuneFindingConfidence,
+    IntuneFindingSeverity, IntuneParseState,
 };
 
 use super::models::*;
@@ -727,10 +727,7 @@ fn push_non_assessable_failure_recorded(
     let recorded = snapshot
         .observations
         .iter()
-        .filter(|observation| {
-            observation.context.access_state != IntuneAccessState::Available
-                || observation.context.parse_state != IntuneParseState::Parsed
-        })
+        .filter(|observation| !observation.is_assessable())
         .filter(|observation| {
             let failed_section = observation.signal == AutopilotSignal::ReportSection
                 && matches!(
@@ -854,6 +851,17 @@ fn terminal_semantics_withheld(snapshot: &AutopilotSnapshot) -> bool {
     snapshot.outcome == AutopilotOutcome::UnknownSchema
 }
 
+/// Evidence refs for every *assessable* observation carrying `signal`.
+///
+/// The `is_assessable` gate is the finding-side companion of the reducer's
+/// [`AutopilotOutcome`] gate (ADR-001). A capped, denied, or malformed failure
+/// event cannot produce a terminal outcome, and it must not be able to promote
+/// a rule into a high-confidence terminal FINDING either -- otherwise a
+/// non-assessable event 171 would emit an `autopilot-identity-registration-mismatch`
+/// blocker the outcome itself correctly withheld. A recorded failure on a
+/// non-assessable record is not silenced: it is surfaced by
+/// [`push_non_assessable_failure_recorded`] at low confidence, which is the
+/// honest strength for evidence that cannot prove its own claim.
 fn signal_evidence(
     snapshot: &AutopilotSnapshot,
     signal: AutopilotSignal,
@@ -861,7 +869,7 @@ fn signal_evidence(
     snapshot
         .observations
         .iter()
-        .filter(|observation| observation.signal == signal)
+        .filter(|observation| observation.is_assessable() && observation.signal == signal)
         .map(AutopilotObservation::evidence_ref)
         .collect()
 }

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/sources.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/sources.rs
@@ -352,20 +352,29 @@ fn iana_zone_re() -> &'static Regex {
 ///
 /// Windows collectors report this form, not an IANA name, so omitting it made
 /// the single most common real input classify as invalid and needlessly
-/// downgraded the time basis. Every Windows time zone identifier ends in
-/// `Time` (`W. Europe Standard Time`, `Coordinated Universal Time`); anchoring
-/// on that suffix is what rejects collector placeholders such as `unknown` or
-/// `not recorded`, which would otherwise pass as a declared timezone and let
+/// downgraded the time basis. The ` Time` suffix anchor covers the common
+/// English registry ids (`W. Europe Standard Time`, `Coordinated Universal
+/// Time`) and rejects most collector placeholders (`unknown`, `not recorded`),
+/// which would otherwise pass as a declared timezone and let
 /// `reduce_esp_linkage` offer a time-only candidate the module contract
-/// forbids. `UTC` and offset forms are covered by `utc_offset_re`. Punctuation
-/// beyond spaces, hyphens, and periods stays excluded, which still rejects an
-/// annotated value like `Pacific Standard Time (device local)`.
+/// forbids. The anchor is deliberately not a claim that every Windows zone id
+/// ends in `Time`: `UTC` and `UTC+12` are registry ids too (covered by
+/// `utc_offset_re`), and a localized `StandardName` will not match -- that
+/// mismatch only degrades the time basis to `Unreliable`, the conservative
+/// direction. Placeholders that happen to end in ` Time` are closed off by
+/// [`WINDOWS_ZONE_PLACEHOLDERS`]. Punctuation beyond spaces, hyphens, and
+/// periods stays excluded, which still rejects an annotated value like
+/// `Pacific Standard Time (device local)`.
 fn windows_zone_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
         Regex::new(r"^[A-Za-z][A-Za-z .\-]* Time$").expect("windows zone regex must compile")
     })
 }
+
+/// Collector placeholders that pass the ` Time` shape check but declare no
+/// timezone at all. Compared case-insensitively.
+const WINDOWS_ZONE_PLACEHOLDERS: [&str; 3] = ["Local Time", "Device Local Time", "System Time"];
 
 /// Classify the declared collection timezone.
 ///
@@ -385,10 +394,11 @@ pub fn classify_timezone(timezone: Option<&str>) -> AutopilotTimezoneState {
         && timezone
             .chars()
             .any(|character| character.is_ascii_alphanumeric());
-    if looks_like_offset
-        || iana_zone_re().is_match(timezone)
-        || windows_zone_re().is_match(timezone)
-    {
+    let looks_like_windows_zone = windows_zone_re().is_match(timezone)
+        && !WINDOWS_ZONE_PLACEHOLDERS
+            .iter()
+            .any(|placeholder| placeholder.eq_ignore_ascii_case(timezone));
+    if looks_like_offset || iana_zone_re().is_match(timezone) || looks_like_windows_zone {
         AutopilotTimezoneState::Declared
     } else {
         AutopilotTimezoneState::Invalid
@@ -512,6 +522,12 @@ mod tests {
             "unknown",
             "not recorded",
             "Unavailable",
+            // Placeholders that happen to end in ` Time` and would otherwise
+            // sail through the Windows-zone shape check.
+            "Local Time",
+            "local time",
+            "Device Local Time",
+            "System Time",
         ] {
             assert_eq!(
                 classify_timezone(Some(junk)),

--- a/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/sources.rs
+++ b/crates/cmtraceopen-parser/src/intune/enrollment/windows/autopilot/sources.rs
@@ -188,11 +188,14 @@ struct DocumentEnvelope {
 /// document produces a precise coverage fact rather than a parse error that
 /// looks like corruption.
 pub fn detect_document(content: &str) -> AutopilotDocumentDetection {
+    // The detail stays a stable reducer-authored sentence: it flows into
+    // golden-asserted finding summaries, and serde_json does not guarantee its
+    // error `Display` output across releases.
     let envelope: DocumentEnvelope = match serde_json::from_str(content) {
         Ok(envelope) => envelope,
-        Err(error) => {
+        Err(_) => {
             return AutopilotDocumentDetection::Malformed {
-                detail: format!("content is not a JSON object: {error}"),
+                detail: "content is not a JSON object".to_owned(),
             }
         }
     };
@@ -349,13 +352,18 @@ fn iana_zone_re() -> &'static Regex {
 ///
 /// Windows collectors report this form, not an IANA name, so omitting it made
 /// the single most common real input classify as invalid and needlessly
-/// downgraded the time basis. Punctuation beyond spaces, hyphens, and periods
-/// is excluded, which is what still rejects an annotated value like
-/// `Pacific Standard Time (device local)`.
+/// downgraded the time basis. Every Windows time zone identifier ends in
+/// `Time` (`W. Europe Standard Time`, `Coordinated Universal Time`); anchoring
+/// on that suffix is what rejects collector placeholders such as `unknown` or
+/// `not recorded`, which would otherwise pass as a declared timezone and let
+/// `reduce_esp_linkage` offer a time-only candidate the module contract
+/// forbids. `UTC` and offset forms are covered by `utc_offset_re`. Punctuation
+/// beyond spaces, hyphens, and periods stays excluded, which still rejects an
+/// annotated value like `Pacific Standard Time (device local)`.
 fn windows_zone_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
-        Regex::new(r"^[A-Za-z][A-Za-z .\-]{2,}$").expect("windows zone regex must compile")
+        Regex::new(r"^[A-Za-z][A-Za-z .\-]* Time$").expect("windows zone regex must compile")
     })
 }
 
@@ -490,10 +498,20 @@ mod tests {
             classify_timezone(Some("Pacific Standard Time")),
             AutopilotTimezoneState::Declared
         );
+        assert_eq!(
+            classify_timezone(Some("W. Europe Standard Time")),
+            AutopilotTimezoneState::Declared
+        );
         for junk in [
             "Pacific Standard Time (device local)",
             "Pacific Standard Time?",
             "??",
+            // Collector placeholders: a plausible-looking word is not a
+            // declared timezone, and treating it as one raised confidence and
+            // enabled the time-only ESP candidate the contract forbids.
+            "unknown",
+            "not recorded",
+            "Unavailable",
         ] {
             assert_eq!(
                 classify_timezone(Some(junk)),

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/completed-without-esp-bundle/evidence/autopilot-channel/current/autopilot-events.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/completed-without-esp-bundle/evidence/autopilot-channel/current/autopilot-events.json
@@ -1,4 +1,4 @@
-{"_comment": "SYNTHETIC FIXTURE: user-driven Autopilot channel, happy path",
+{"_comment": "SYNTHETIC FIXTURE: user-driven Autopilot channel reaching the handoff, with no ESP evidence captured",
   "autopilotDocument": "autopilot.events",
   "documentVersion": 1,
   "events": [

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/completed-without-esp-bundle/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/completed-without-esp-bundle/manifest.json
@@ -21,7 +21,7 @@
       "originalBasename": "autopilot-events.json",
       "sanitizedSourcePath": "SYNTHETIC://autopilot/autopilot-events.json",
       "relativePath": "evidence/autopilot-channel/current/autopilot-events.json",
-      "bytesCopied": 10487,
+      "bytesCopied": 10527,
       "capturedUtc": "2026-07-31T09:30:00Z",
       "rotation": {
         "kind": "current",

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/malformed-report-section/evidence/mdm-diagnostics-report/current/autopilot-report.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/malformed-report-section/evidence/mdm-diagnostics-report/current/autopilot-report.json
@@ -1,4 +1,5 @@
-<!-- SYNTHETIC FIXTURE: an MDM diagnostics report section truncated mid-write -->
-<MdmDiagnosticsReport schemaVersion="1">
-  <Autopilot>
-    <Profile id="11111111-2222-3333-4444-5555
+{"_comment": "SYNTHETIC FIXTURE: a correctly tagged report document whose sections payload was mangled mid-write. The envelope is valid, so this exercises the report-payload contract rather than generic non-JSON rejection.",
+  "autopilotDocument": "autopilot.mdmDiagnosticsReport",
+  "documentVersion": 1,
+  "sections": "<truncated: Profile id=11111111-2222-3333-4444-5555"
+}

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/malformed-report-section/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/malformed-report-section/expected.json
@@ -1,7 +1,8 @@
 {
   "assertions": [
     "unreadable bytes are a coverage gap, never an unknown schema",
-    "a malformed section blocks a terminal claim rather than producing one"
+    "a malformed section blocks a terminal claim rather than producing one",
+    "expectation corrected post-merge: the prior golden pinned serde_json's error Display text, which is not stable across serde_json releases, and the prior fixture was raw XML, so the scenario exercised generic non-JSON rejection instead of the malformed report-payload contract it names"
   ],
   "confidence": "low",
   "conflictIds": [],
@@ -38,7 +39,7 @@
         "Confirm the export was not truncated in transit."
       ],
       "severity": "warning",
-      "summary": "1 supplied document(s) could not be interpreted, so any signal they carried is absent from this analysis rather than proven absent. content is not a JSON object: expected value at line 1 column 1",
+      "summary": "1 supplied document(s) could not be interpreted, so any signal they carried is absent from this analysis rather than proven absent. report payload could not be read",
       "title": "An Autopilot report section could not be parsed"
     }
   ],

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/malformed-report-section/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/malformed-report-section/manifest.json
@@ -37,7 +37,7 @@
       "originalBasename": "autopilot-report.json",
       "sanitizedSourcePath": "SYNTHETIC://autopilot/autopilot-report.json",
       "relativePath": "evidence/mdm-diagnostics-report/current/autopilot-report.json",
-      "bytesCopied": 183,
+      "bytesCopied": 376,
       "capturedUtc": "2026-07-31T09:30:00Z",
       "rotation": {
         "kind": "current",

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/matching-autopilot-and-esp-session/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/matching-autopilot-and-esp-session/expected.json
@@ -1,6 +1,7 @@
 {
   "assertions": [
-    "one explicit shared identifier is enough, and is the only thing that is enough"
+    "one explicit shared identifier is enough, and is the only thing that is enough",
+    "the event 153 transition into ProfileState_Available counts as application evidence, not merely retrieval: event 172, its documented failure sibling, reads 'failed to set Autopilot profile as available', so setting the profile available IS the application step and 153-into-Available is its explicit success record; a 172 alongside a 153 reduces to profileApplicationFailure, never completed"
   ],
   "confidence": "high",
   "conflictIds": [],

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/unknown-windows-schema-version/expected.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/unknown-windows-schema-version/expected.json
@@ -1,7 +1,8 @@
 {
   "assertions": [
     "evidence that would otherwise read as completed is refused a terminal outcome",
-    "the phase still reports how far the evidence got, because that is observed fact"
+    "the phase still reports how far the evidence got, because that is observed fact",
+    "expectation corrected post-merge: the prior summary named only the Windows build and omitted the unvalidated Autopilot schema version, leaving half of the withheld-semantics refusal unexplained"
   ],
   "confidence": "low",
   "conflictIds": [],
@@ -40,7 +41,7 @@
         "Re-collect on a build with validated rules, or upgrade CMTrace Open."
       ],
       "severity": "warning",
-      "summary": "Windows build 10.0.99999.1 has no validated Autopilot rules in this build, so terminal semantics are withheld and the evidence is retained raw.",
+      "summary": "This build has no validated Autopilot rules for Windows build 10.0.99999.1 or Autopilot schema version 3, so terminal semantics are withheld and the evidence is retained raw.",
       "title": "Autopilot evidence uses a schema or build this release cannot interpret"
     },
     {

--- a/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/user-driven-success-through-esp-handoff/manifest.json
+++ b/crates/cmtraceopen-parser/tests/fixtures/intune/enrollment/windows/autopilot/user-driven-success-through-esp-handoff/manifest.json
@@ -3,7 +3,7 @@
   "syntheticFixture": true,
   "scenario": "user-driven-success-through-esp-handoff",
   "workload": "enrollment/windows/autopilot",
-  "description": "A complete user-driven deployment: identity read, profile retrieved and applied, OOBE settings observed, and an explicit handoff into an ESP session that shares an enrollment identifier.",
+  "description": "The local Autopilot phase of a user-driven deployment completes: identity read, profile retrieved and applied, OOBE settings observed, and an explicit handoff into an ESP session that shares an enrollment identifier. Everything after the handoff belongs to the ESP analysis.",
   "generatedAtUtc": "2026-07-31T09:30:00Z",
   "capture": {
     "collectedAtUtc": "2026-07-31T09:30:00Z",

--- a/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
@@ -959,6 +959,115 @@ fn an_assessable_failed_section_still_produces_the_terminal_failure() {
     );
 }
 
+/// ADR-001, direction-aware, event side: the same class as the capped-failed-
+/// section fixture above, but the recorded failure arrives as a capped EVENT
+/// (172, `ProfileApplicationFailed`) instead of a report section. The
+/// assessable success path (161 + 153-into-Available + an assessable
+/// espHandoff section) must not complete the enrollment over it.
+#[test]
+fn a_recorded_failure_on_a_non_assessable_event_blocks_success() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [
+            synthetic_event(
+                "evtblocked-e1", "evtblocked-channel", 1, 161, "available", "parsed",
+                json!([]), "AutopilotManager retrieve settings succeeded.",
+            ),
+            synthetic_event(
+                "evtblocked-e2", "evtblocked-channel", 2, 153, "available", "parsed",
+                json!([]),
+                "AutopilotManager reported the state changed from ProfileState_Unknown to ProfileState_Available.",
+            ),
+            synthetic_event(
+                "evtblocked-failure", "evtblocked-channel", 3, 172, "capped", "parsed",
+                json!([]), "Failed to set the Autopilot profile as available.",
+            ),
+        ]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![
+        synthetic_source("evtblocked-channel", "autopilotEvents", &events),
+        synthetic_source(
+            "evtblocked-report",
+            "mdmReport",
+            &esp_handoff_report("evtblocked-report"),
+        ),
+    ]));
+
+    assert_ne!(
+        snapshot.outcome,
+        AutopilotOutcome::Completed,
+        "a recorded failure on a capped event must block a completed outcome"
+    );
+    assert_eq!(
+        snapshot.outcome,
+        AutopilotOutcome::InsufficientEvidence,
+        "non-assessable evidence proves neither the failure nor the success (ADR-001)"
+    );
+    assert_ne!(
+        wire(&snapshot.confidence),
+        json!("high"),
+        "a success-path bundle carrying a recorded failure may not be presented at high confidence"
+    );
+    let finding = snapshot
+        .findings
+        .iter()
+        .find(|finding| finding.finding_id == "autopilot-non-assessable-failure-recorded")
+        .unwrap_or_else(|| {
+            panic!(
+                "the recorded-but-unassessable failure must never be silent, got {:?}",
+                snapshot
+                    .findings
+                    .iter()
+                    .map(|finding| finding.finding_id.as_str())
+                    .collect::<Vec<_>>()
+            )
+        });
+    assert_eq!(wire(&finding.confidence), json!("low"));
+    assert!(
+        finding
+            .evidence
+            .iter()
+            .any(|evidence| evidence.evidence_id == "evtblocked-failure"),
+        "the finding must cite the capped event that recorded the failure"
+    );
+    assert!(snapshot.findings_are_evidence_backed());
+}
+
+/// The symmetric control: the same event 172, assessable, is the real terminal
+/// failure. The new event-side gate must not swallow it into a blocked
+/// success, and the non-assessable finding must not fire.
+#[test]
+fn an_assessable_failed_event_still_produces_the_terminal_failure() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [
+            synthetic_event(
+                "evtterm-e1", "evtterm-channel", 1, 161, "available", "parsed",
+                json!([]), "AutopilotManager retrieve settings succeeded.",
+            ),
+            synthetic_event(
+                "evtterm-failure", "evtterm-channel", 2, 172, "available", "parsed",
+                json!([]), "Failed to set the Autopilot profile as available.",
+            ),
+        ]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![synthetic_source(
+        "evtterm-channel",
+        "autopilotEvents",
+        &events,
+    )]));
+    assert_eq!(snapshot.outcome, AutopilotOutcome::ProfileApplicationFailure);
+    assert!(
+        !snapshot
+            .findings
+            .iter()
+            .any(|finding| finding.finding_id == "autopilot-non-assessable-failure-recorded"),
+        "an assessable failure is not a non-assessable one"
+    );
+}
+
 /// ADR-001, same class: a non-assessable record carrying identity keys must
 /// not inflate the phase to `IdentityObserved` through the evidence list.
 #[test]

--- a/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
@@ -1631,6 +1631,269 @@ fn native_events_are_absorbed_with_their_provenance_artifact() {
     assert!(snapshot.profile.retrieved);
 }
 
+/// One profile-channel event with a caller-set `activityId`, the module's
+/// retry/session correlation key. `synthetic_event` hardcodes a null
+/// `activityId`, so the linkage cases override it here.
+fn profile_event(record: u64, event_id: u32, activity: Option<&str>, message: &str) -> Value {
+    let mut event = synthetic_event(
+        &format!("prof-{event_id}-{record}"),
+        "prof-channel",
+        record,
+        event_id,
+        "available",
+        "parsed",
+        json!([]),
+        message,
+    );
+    event["activityId"] = match activity {
+        Some(value) => json!(value),
+        None => Value::Null,
+    };
+    event
+}
+
+/// An ESP session fact keyed only on `activityId`, so it links to whichever
+/// profile events carry the same activity id.
+fn esp_session_on_activity(activity: &str) -> Value {
+    json!({
+        "autopilotDocument": "autopilot.espSession",
+        "documentVersion": 1,
+        "sessions": [{
+            "sessionId": "esp-session-1",
+            "enrollmentId": null, "correlationId": null,
+            "activityId": activity,
+            "entraDeviceId": null, "managedDeviceId": null,
+            "startedAtUtc": "2026-07-31T09:00:20Z", "phase": "deviceSetup",
+            "evidence": { "evidenceId": "esp-retry-1", "sourceArtifactId": "esp-facts" }
+        }]
+    })
+}
+
+/// Reduce a bundle whose profile events appear in `events_in_order`, paired
+/// with an observed ESP handoff and an ESP session on `success_activity`. Every
+/// completion gate except the profile candidate is left open, so the outcome
+/// turns solely on whether the later success is allowed to erase the earlier
+/// explicit negative.
+fn reduce_profile_retry(events_in_order: Vec<Value>, success_activity: &str) -> AutopilotSnapshot {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": events_in_order,
+    });
+    reduce_autopilot_bundle(&synthetic_bundle(vec![
+        synthetic_source("prof-channel", "autopilotEvents", &events),
+        synthetic_source("prof-report", "mdmReport", &esp_handoff_report("prof-report")),
+        synthetic_source("esp-facts", "espSession", &esp_session_on_activity(success_activity)),
+    ]))
+}
+
+const PROFILE_NEGATIVE_MESSAGE: &str =
+    "ZtdDeviceHasNoAssignedProfile - No profile assigned to the device and no default profile.";
+const PROFILE_RETRIEVE_MESSAGE: &str = "AutopilotManager retrieve settings succeeded.";
+const PROFILE_STATE_MESSAGE: &str =
+    "AutopilotManager reported the state changed from ProfileState_Available to ProfileState_Provisioned.";
+
+/// ADR-003: an explicit negative profile signal (815, NoAssignedProfile) must
+/// not be silently erased by a later success (161 + 153) that shares no retry
+/// linkage with it. Here the negative carries no activity id while the
+/// successes and the ESP session share `attempt-1`, so the ESP handoff links
+/// and every completion gate except the profile candidate is open. Without an
+/// explicit retry link the reducer must stay conservative: the recorded
+/// negative stands and the enrollment is not Completed.
+#[test]
+fn an_unlinked_success_cannot_erase_an_earlier_no_profile_negative() {
+    let snapshot = reduce_profile_retry(
+        vec![
+            profile_event(1, 815, None, PROFILE_NEGATIVE_MESSAGE),
+            profile_event(2, 161, Some("attempt-1"), PROFILE_RETRIEVE_MESSAGE),
+            profile_event(3, 153, Some("attempt-1"), PROFILE_STATE_MESSAGE),
+        ],
+        "attempt-1",
+    );
+
+    // Sanity: the ESP handoff path is genuinely open, so the only thing that can
+    // hold the outcome back from Completed is the unlinked profile negative.
+    assert_eq!(
+        snapshot.esp_linkage.state,
+        AutopilotEspLinkState::Linked,
+        "the ESP session must link so this test isolates the profile-linkage gate"
+    );
+    assert_ne!(
+        snapshot.outcome,
+        AutopilotOutcome::Completed,
+        "an unlinked later success must not complete over an explicit negative"
+    );
+    assert_eq!(
+        snapshot.outcome,
+        AutopilotOutcome::NoProfileCandidate,
+        "the conservative result is the explicit negative that was recorded, not success"
+    );
+}
+
+/// The linkage-permitted companion: when the negative and the successes share
+/// the same activity id, the success is a proven retry of the same attempt and
+/// may raise the candidate to Available, reaching Completed.
+#[test]
+fn a_retry_linked_success_completes_over_an_earlier_negative() {
+    let snapshot = reduce_profile_retry(
+        vec![
+            profile_event(1, 815, Some("attempt-1"), PROFILE_NEGATIVE_MESSAGE),
+            profile_event(2, 161, Some("attempt-1"), PROFILE_RETRIEVE_MESSAGE),
+            profile_event(3, 153, Some("attempt-1"), PROFILE_STATE_MESSAGE),
+        ],
+        "attempt-1",
+    );
+
+    assert_eq!(
+        snapshot.outcome,
+        AutopilotOutcome::Completed,
+        "a retry-linked success may replace the earlier negative and complete"
+    );
+}
+
+/// ADR-003: input vector order is not chronology. The unlinked negative-then-
+/// success verdict must not change when the events are permuted.
+#[test]
+fn the_profile_linkage_verdict_is_invariant_under_input_order() {
+    let forward = reduce_profile_retry(
+        vec![
+            profile_event(1, 815, None, PROFILE_NEGATIVE_MESSAGE),
+            profile_event(2, 161, Some("attempt-1"), PROFILE_RETRIEVE_MESSAGE),
+            profile_event(3, 153, Some("attempt-1"), PROFILE_STATE_MESSAGE),
+        ],
+        "attempt-1",
+    );
+    let reversed = reduce_profile_retry(
+        vec![
+            profile_event(3, 153, Some("attempt-1"), PROFILE_STATE_MESSAGE),
+            profile_event(2, 161, Some("attempt-1"), PROFILE_RETRIEVE_MESSAGE),
+            profile_event(1, 815, None, PROFILE_NEGATIVE_MESSAGE),
+        ],
+        "attempt-1",
+    );
+
+    assert_eq!(
+        forward.outcome, reversed.outcome,
+        "permuting non-ordered input must not change the outcome"
+    );
+    assert_eq!(forward.outcome, AutopilotOutcome::NoProfileCandidate);
+}
+
+/// ADR-001, finding side: a non-assessable failure event cannot produce a
+/// high-confidence terminal FINDING, exactly as it cannot produce a terminal
+/// OUTCOME. A capped event 171 (`TpmIdentityFailed`) with no assessable
+/// identity-mismatch evidence must not emit the `Blocker`/`High`
+/// `autopilot-identity-registration-mismatch` finding. The recorded failure is
+/// still surfaced -- by the low-confidence non-assessable finding -- so it is
+/// blocked visibly rather than silently.
+#[test]
+fn a_non_assessable_tpm_failure_cannot_emit_a_high_confidence_blocker() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [synthetic_event(
+            "tpm-capped", "tpm-channel", 1, 171, "capped", "parsed",
+            json!([]),
+            "AutopilotManager failed to confirm the TPM identity for this device.",
+        )]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![synthetic_source(
+        "tpm-channel",
+        "autopilotEvents",
+        &events,
+    )]));
+
+    assert_ne!(
+        snapshot.outcome,
+        AutopilotOutcome::IdentityRegistrationMismatch,
+        "a capped 171 cannot prove the terminal outcome"
+    );
+    assert!(
+        !snapshot.findings.iter().any(|finding| {
+            finding.finding_id == "autopilot-identity-registration-mismatch"
+        }),
+        "a non-assessable 171 must not emit the high-confidence identity-mismatch blocker, got {:?}",
+        snapshot
+            .findings
+            .iter()
+            .map(|finding| &finding.finding_id)
+            .collect::<Vec<_>>()
+    );
+    // The recorded failure must still be visible, just not as a terminal claim.
+    assert!(
+        snapshot.findings.iter().any(|finding| {
+            finding.finding_id == "autopilot-non-assessable-failure-recorded"
+        }),
+        "the recorded failure must be surfaced by its own low-confidence finding"
+    );
+}
+
+/// The regression companion: an *assessable* event 171 must still emit the
+/// `autopilot-identity-registration-mismatch` blocker. The assessability
+/// boundary must gate non-assessable evidence without silencing the real
+/// terminal finding.
+#[test]
+fn an_assessable_tpm_failure_still_emits_the_identity_mismatch_blocker() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [synthetic_event(
+            "tpm-ok", "tpm-channel", 1, 171, "available", "parsed",
+            json!([]),
+            "AutopilotManager failed to confirm the TPM identity for this device.",
+        )]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![synthetic_source(
+        "tpm-channel",
+        "autopilotEvents",
+        &events,
+    )]));
+
+    let finding = snapshot
+        .findings
+        .iter()
+        .find(|finding| finding.finding_id == "autopilot-identity-registration-mismatch")
+        .expect("an assessable 171 must still emit the identity-mismatch blocker");
+    assert_eq!(wire(&finding.severity), json!("blocker"));
+    assert_eq!(wire(&finding.confidence), json!("high"));
+}
+
+/// ADR-004: a Base64 hardware hash quoted in an observation message must be
+/// absent from the exported projection even when it ends in a non-word Base64
+/// character (`=`, `==`, `+`, `/`). Free-text redaction, not whole-value
+/// masking, owns this path, so the export is the honest place to pin it.
+#[test]
+fn a_base64_hash_in_an_observation_message_never_survives_the_export() {
+    for blob in [
+        format!("{}=", "Q".repeat(43)),
+        format!("{}==", "Q".repeat(42)),
+        format!("{}+", "Q".repeat(43)),
+        format!("{}/", "Q".repeat(43)),
+    ] {
+        let events = json!({
+            "autopilotDocument": "autopilot.events",
+            "documentVersion": 1,
+            "events": [synthetic_event(
+                "blob-e1", "blob-channel", 1, 161, "available", "parsed",
+                json!([]),
+                &format!("AutopilotManager reported hardware hash {blob} for this device."),
+            )]
+        });
+        let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![synthetic_source(
+            "blob-channel",
+            "autopilotEvents",
+            &events,
+        )]));
+        let redacted = redacted_export_projection(&snapshot);
+        let text =
+            serde_json::to_string(&wire(&redacted)).expect("redacted export must serialize");
+        assert!(
+            !text.contains(&blob),
+            "the Base64 hash {blob:?} survived the exported projection: {text}"
+        );
+    }
+}
+
 // ── Golden maintenance ──────────────────────────────────────────────────────
 
 /// Rewrite every scenario's `findings` golden from the current reducer output.

--- a/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
@@ -1253,6 +1253,113 @@ fn a_key_on_a_capped_observation_still_detects_a_second_esp_session() {
     assert!(snapshot.findings_are_evidence_backed());
 }
 
+/// `AutopilotEspLinkage` documents `matched_keys` as empty for every
+/// non-`Linked` state. The distinct-keys-to-distinct-sessions `Conflicting`
+/// path only DETECTED ambiguity; exporting its detecting keys as
+/// `matched_keys` would hand a consumer match-shaped proof from the one state
+/// whose meaning is that nothing was proven.
+#[test]
+fn a_conflicting_linkage_exports_no_matched_keys() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [
+            synthetic_event(
+                "nomk-e1", "nomk-channel", 1, 161, "available", "parsed",
+                json!([{ "name": "enrollmentId", "value": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }]),
+                "AutopilotManager retrieve settings succeeded.",
+            ),
+            synthetic_event(
+                "nomk-e2", "nomk-channel", 2, 153, "available", "parsed",
+                json!([{ "name": "correlationId", "value": "99999999-8888-7777-6666-555555555555" }]),
+                "AutopilotManager reported the state changed from ProfileState_Unknown to ProfileState_Available.",
+            ),
+        ]
+    });
+    let sessions = json!({
+        "autopilotDocument": "autopilot.espSession",
+        "documentVersion": 1,
+        "sessions": [
+            {
+                "sessionId": "esp-session-a",
+                "enrollmentId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "correlationId": null, "activityId": null,
+                "entraDeviceId": null, "managedDeviceId": null,
+                "startedAtUtc": "2026-07-31T09:00:20Z", "phase": "deviceSetup",
+                "evidence": { "evidenceId": "nomk-esp-a", "sourceArtifactId": "esp-session-facts" }
+            },
+            {
+                "sessionId": "esp-session-b",
+                "enrollmentId": null,
+                "correlationId": "99999999-8888-7777-6666-555555555555",
+                "activityId": null, "entraDeviceId": null, "managedDeviceId": null,
+                "startedAtUtc": "2026-07-31T09:00:25Z", "phase": "deviceSetup",
+                "evidence": { "evidenceId": "nomk-esp-b", "sourceArtifactId": "esp-session-facts" }
+            }
+        ]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![
+        synthetic_source("nomk-channel", "autopilotEvents", &events),
+        synthetic_source("nomk-report", "mdmReport", &esp_handoff_report("nomk-report")),
+        synthetic_source("esp-session-facts", "espSession", &sessions),
+    ]));
+
+    assert_eq!(snapshot.esp_linkage.state, AutopilotEspLinkState::Conflicting);
+    assert!(
+        snapshot.esp_linkage.matched_keys.is_empty(),
+        "matched_keys is documented empty for every non-Linked state, got {:?}",
+        snapshot.esp_linkage.matched_keys
+    );
+}
+
+/// `distinct_values` groups case-insensitively only for keys whose values are
+/// case-insensitive identities on Windows. `hardwareHash` is not one: its
+/// Base64 payload is case-sensitive, so two hashes differing only by case are
+/// two different hashes. Folding them into one group let `single_value`
+/// publish one of them as corroborated identity evidence.
+#[test]
+fn hardware_hashes_differing_only_by_case_stay_distinct() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [
+            synthetic_event(
+                "hash-e1", "hash-channel", 1, 161, "available", "parsed",
+                json!([
+                    { "name": "hardwareHash", "value": "AAECAwQFBgcICQ==" },
+                    { "name": "serialNumber", "value": "SER-0001" },
+                ]),
+                "AutopilotManager retrieve settings succeeded.",
+            ),
+            synthetic_event(
+                "hash-e2", "hash-channel", 2, 161, "available", "parsed",
+                json!([
+                    { "name": "hardwareHash", "value": "aaecawqfbgcicq==" },
+                    { "name": "serialNumber", "value": "ser-0001" },
+                ]),
+                "AutopilotManager retrieve settings succeeded.",
+            ),
+        ]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![synthetic_source(
+        "hash-channel",
+        "autopilotEvents",
+        &events,
+    )]));
+
+    assert_eq!(
+        snapshot.identity.hardware_hash, None,
+        "two hardware hashes differing only by case are two distinct hashes; \
+         neither may be published as the single corroborated value"
+    );
+    // Control: serial numbers ARE case-insensitive identities on Windows, so
+    // the same bundle still collapses the two serial casings into one value.
+    assert!(
+        snapshot.identity.serial_number.is_some(),
+        "case-insensitive identity keys must keep collapsing casings"
+    );
+}
+
 /// The other half of the same rule: a linkage whose ONLY explicit key rides a
 /// non-assessable observation may not upgrade to a confident Linked. Detection
 /// may widen (conservative); proof may not.

--- a/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
@@ -13,7 +13,9 @@
 //! Expectations live in each scenario's `expected.json` rather than in inline
 //! snapshots, so a reviewer reads the contract next to the evidence that
 //! produced it. The `findings` array is the one golden section; regenerate it
-//! with `UPDATE_AUTOPILOT_FINDINGS=1` and review the diff. The hand-written
+//! alone (never beside the readers of the same files) with
+//! `UPDATE_AUTOPILOT_FINDINGS=1 cargo test --test intune_windows_autopilot -- \
+//! --ignored update_findings_golden` and review the diff. The hand-written
 //! `findingIds` list is asserted against it, so a careless regeneration cannot
 //! quietly change which rules fire.
 
@@ -24,7 +26,8 @@ use std::path::{Path, PathBuf};
 
 use cmtraceopen_parser::intune::enrollment::windows::autopilot::{
     redacted_export_projection, reduce_autopilot_bundle, AutopilotBundleInput,
-    AutopilotCaptureMetadata, AutopilotCaptureState, AutopilotSnapshot, AutopilotSourceInput,
+    AutopilotCaptureMetadata, AutopilotCaptureState, AutopilotEspLinkState, AutopilotOutcome,
+    AutopilotPhase, AutopilotSnapshot, AutopilotSourceInput,
 };
 use serde_json::{json, Value};
 use support::{corpus_root, load_json, mutated, scenario_names, validate_scenario, Failures};
@@ -615,15 +618,370 @@ fn records_from_a_sibling_channel_are_ignored_entirely() {
     );
 }
 
+// ── Framework hardening: assessability and linkage-conflict gates ───────────
+//
+// These scenarios are built inline rather than as fixture directories because
+// each one isolates a single reducer invariant from ADR-001 or ADR-003; the
+// fixture matrix above stays the contract for whole-bundle behavior.
+
+/// One synthetic Autopilot-channel event as a JSON fragment for an
+/// `autopilot.events` document. `access_state`/`parse_state` are the
+/// observation's own declared context, which is exactly what the assessability
+/// gate must consult.
+#[allow(clippy::too_many_arguments)]
+fn synthetic_event(
+    evidence_id: &str,
+    artifact_id: &str,
+    record: u64,
+    event_id: u32,
+    access_state: &str,
+    parse_state: &str,
+    named_data: Value,
+    message: &str,
+) -> Value {
+    json!({
+        "context": {
+            "evidenceRef": { "evidenceId": evidence_id, "sourceArtifactId": artifact_id },
+            "provenance": {
+                "sourceKind": "eventLog", "sourceArtifactId": artifact_id,
+                "filePath": null, "lineNumber": null, "recordNumber": record,
+                "registry": null, "event": null
+            },
+            "sourceTimestamp": null,
+            "observedAtUtc": "2026-07-31T09:30:00Z",
+            "sensitivity": "public",
+            "parseState": parse_state,
+            "accessState": access_state
+        },
+        "channel": "Microsoft-Windows-ModernDeployment-Diagnostics-Provider/Autopilot",
+        "provider": "Microsoft-Windows-ModernDeployment-Diagnostics-Provider",
+        "eventId": event_id,
+        "level": "information",
+        "task": null, "keywords": null, "recordId": record, "activityId": null,
+        "namedData": named_data,
+        "message": message
+    })
+}
+
+fn synthetic_source(artifact_id: &str, family: &str, document: &Value) -> AutopilotSourceInput {
+    AutopilotSourceInput {
+        artifact_id: artifact_id.to_owned(),
+        family: family.to_owned(),
+        capture_state: AutopilotCaptureState::Captured,
+        original_basename: Some(format!("{artifact_id}.json")),
+        sanitized_source_path: None,
+        content: Some(document.to_string()),
+        ..AutopilotSourceInput::default()
+    }
+}
+
+fn synthetic_bundle(sources: Vec<AutopilotSourceInput>) -> AutopilotBundleInput {
+    AutopilotBundleInput {
+        generated_at_utc: "2026-07-31T09:30:00Z".to_owned(),
+        capture: AutopilotCaptureMetadata {
+            collected_at_utc: Some("2026-07-31T09:30:00Z".to_owned()),
+            windows_build: Some("10.0.26100.2314".to_owned()),
+            autopilot_schema_version: Some("1".to_owned()),
+            timezone: Some("UTC".to_owned()),
+        },
+        sources,
+        events: Vec::new(),
+    }
+}
+
+/// The espHandoff report section every ADR-001 test below pairs with the
+/// success events, so a Completed claim is one gate away if the reducer honors
+/// a non-assessable record.
+fn esp_handoff_report(artifact_id: &str) -> Value {
+    json!({
+        "autopilotDocument": "autopilot.mdmDiagnosticsReport",
+        "documentVersion": 1,
+        "sections": [{
+            "context": {
+                "evidenceRef": { "evidenceId": "hardening-esp-handoff", "sourceArtifactId": artifact_id },
+                "provenance": {
+                    "sourceKind": "diagnosticReport", "sourceArtifactId": artifact_id,
+                    "filePath": null, "lineNumber": null, "recordNumber": 1,
+                    "registry": null, "event": null
+                },
+                "sourceTimestamp": null,
+                "observedAtUtc": "2026-07-31T09:30:00Z",
+                "sensitivity": "sensitive",
+                "parseState": "parsed",
+                "accessState": "available"
+            },
+            "sectionId": "espHandoff",
+            "kind": "espHandoff",
+            "outcome": "observed",
+            "error": null,
+            "values": [],
+            "message": "Control passed to the Enrollment Status Page."
+        }]
+    })
+}
+
+/// ADR-001: non-assessable evidence cannot produce a terminal conclusion.
+/// A capped success record must not set `retrieved`/`applied`, and must not
+/// combine with an observed handoff into `Completed`.
+#[test]
+fn non_assessable_success_records_cannot_prove_profile_progress() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [
+            synthetic_event(
+                "gate-e1", "gated-channel", 1, 161, "capped", "parsed",
+                json!([]), "AutopilotManager retrieve settings succeeded.",
+            ),
+            synthetic_event(
+                "gate-e2", "gated-channel", 2, 153, "available", "raw",
+                json!([]),
+                "AutopilotManager reported the state changed from ProfileState_Available to ProfileState_Provisioned.",
+            ),
+        ]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![
+        synthetic_source("gated-channel", "autopilotEvents", &events),
+        synthetic_source("gated-report", "mdmReport", &esp_handoff_report("gated-report")),
+    ]));
+
+    assert!(
+        !snapshot.profile.retrieved,
+        "a capped record must not prove retrieval"
+    );
+    assert!(
+        !snapshot.profile.applied,
+        "an unparsed record must not prove application"
+    );
+    assert_ne!(
+        snapshot.outcome,
+        AutopilotOutcome::Completed,
+        "non-assessable success evidence must never reach a terminal success"
+    );
+}
+
+/// ADR-001, same class: a non-assessable record carrying identity keys must
+/// not inflate the phase to `IdentityObserved` through the evidence list.
+#[test]
+fn non_assessable_identity_records_cannot_raise_the_phase() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [synthetic_event(
+            "gate-i1", "gated-channel", 1, 161, "capped", "parsed",
+            json!([{ "name": "serialNumber", "value": "SYNTH-5CD1234ABC" }]),
+            "AutopilotManager retrieve settings succeeded.",
+        )]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![synthetic_source(
+        "gated-channel",
+        "autopilotEvents",
+        &events,
+    )]));
+
+    assert!(
+        snapshot.identity.evidence.is_empty(),
+        "a non-assessable record may not be cited as identity evidence"
+    );
+    assert_eq!(
+        snapshot.phase,
+        AutopilotPhase::NoEvidence,
+        "an unreadable record alone must not raise the phase"
+    );
+}
+
+/// ADR-003: unresolved authoritative contradictions stay conservative. When
+/// distinct explicit keys resolve to distinct ESP sessions, the linkage is
+/// `Conflicting`; that must surface as `ContradictoryEvidence` with a finding,
+/// never as `Completed`.
+#[test]
+fn a_conflicting_esp_linkage_cannot_report_completed() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [
+            synthetic_event(
+                "link-e1", "linked-channel", 1, 161, "available", "parsed",
+                json!([{ "name": "enrollmentId", "value": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }]),
+                "AutopilotManager retrieve settings succeeded.",
+            ),
+            synthetic_event(
+                "link-e2", "linked-channel", 2, 153, "available", "parsed",
+                json!([{ "name": "correlationId", "value": "99999999-8888-7777-6666-555555555555" }]),
+                "AutopilotManager reported the state changed from ProfileState_Unknown to ProfileState_Available.",
+            ),
+        ]
+    });
+    let sessions = json!({
+        "autopilotDocument": "autopilot.espSession",
+        "documentVersion": 1,
+        "sessions": [
+            {
+                "sessionId": "esp-session-a",
+                "enrollmentId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "correlationId": null, "activityId": null,
+                "entraDeviceId": null, "managedDeviceId": null,
+                "startedAtUtc": "2026-07-31T09:00:20Z", "phase": "deviceSetup",
+                "evidence": { "evidenceId": "esp-a", "sourceArtifactId": "esp-session-facts" }
+            },
+            {
+                "sessionId": "esp-session-b",
+                "enrollmentId": null,
+                "correlationId": "99999999-8888-7777-6666-555555555555",
+                "activityId": null, "entraDeviceId": null, "managedDeviceId": null,
+                "startedAtUtc": "2026-07-31T09:00:25Z", "phase": "deviceSetup",
+                "evidence": { "evidenceId": "esp-b", "sourceArtifactId": "esp-session-facts" }
+            }
+        ]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![
+        synthetic_source("linked-channel", "autopilotEvents", &events),
+        synthetic_source("linked-report", "mdmReport", &esp_handoff_report("linked-report")),
+        synthetic_source("esp-session-facts", "espSession", &sessions),
+    ]));
+
+    assert_eq!(snapshot.esp_linkage.state, AutopilotEspLinkState::Conflicting);
+    assert_eq!(
+        snapshot.outcome,
+        AutopilotOutcome::ContradictoryEvidence,
+        "an ambiguous session identity must not be reported as a completed handoff"
+    );
+    assert!(
+        snapshot
+            .findings
+            .iter()
+            .any(|finding| finding.finding_id == "autopilot-esp-link-conflicting"),
+        "the conflicting linkage must be explained by a finding, got {:?}",
+        snapshot
+            .findings
+            .iter()
+            .map(|finding| finding.finding_id.as_str())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        snapshot.findings_are_evidence_backed(),
+        "the linkage-conflict finding must cite evidence"
+    );
+}
+
+/// A capture that declares only an unvalidated Autopilot schema version (no
+/// Windows build at all) still refuses terminal semantics, and that refusal
+/// must be explained by the unknown-schema finding rather than left silent.
+#[test]
+fn a_schema_version_only_unknown_schema_is_explained_by_a_finding() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [synthetic_event(
+            "schema-e1", "schema-channel", 1, 161, "available", "parsed",
+            json!([]), "AutopilotManager retrieve settings succeeded.",
+        )]
+    });
+    let mut bundle = synthetic_bundle(vec![synthetic_source(
+        "schema-channel",
+        "autopilotEvents",
+        &events,
+    )]);
+    bundle.capture.windows_build = None;
+    bundle.capture.autopilot_schema_version = Some("3".to_owned());
+
+    let snapshot = reduce_autopilot_bundle(&bundle);
+    assert_eq!(snapshot.outcome, AutopilotOutcome::UnknownSchema);
+    assert!(
+        snapshot
+            .findings
+            .iter()
+            .any(|finding| finding.finding_id == "autopilot-unknown-schema"),
+        "withheld terminal semantics must be explained, got {:?}",
+        snapshot
+            .findings
+            .iter()
+            .map(|finding| finding.finding_id.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The native-event input path: events supplied directly on the bundle derive
+/// their artifact from the event's own provenance and produce observations
+/// without any document or source coverage entry.
+#[test]
+fn native_events_are_absorbed_with_their_provenance_artifact() {
+    use cmtraceopen_parser::intune::evidence::{
+        IntuneAccessState, IntuneEvidenceRef, IntuneObservationContext, IntuneParseState,
+        IntuneProvenance, IntuneSensitivity, IntuneSourceKind,
+    };
+    use cmtraceopen_parser::intune::normalized::{NormalizedEventLevel, NormalizedWindowsEvent};
+
+    let mut bundle = synthetic_bundle(Vec::new());
+    bundle.events.push(NormalizedWindowsEvent {
+        context: IntuneObservationContext {
+            evidence_ref: IntuneEvidenceRef {
+                evidence_id: "native-e1".to_owned(),
+                source_artifact_id: "native-adapter".to_owned(),
+            },
+            provenance: IntuneProvenance {
+                source_kind: IntuneSourceKind::EventLog,
+                source_artifact_id: "native-adapter".to_owned(),
+                file_path: None,
+                line_number: None,
+                record_number: Some(1),
+                registry: None,
+                event: None,
+            },
+            source_timestamp: None,
+            observed_at_utc: "2026-07-31T09:30:00Z".to_owned(),
+            sensitivity: IntuneSensitivity::Public,
+            parse_state: IntuneParseState::Parsed,
+            access_state: IntuneAccessState::Available,
+        },
+        channel: "Microsoft-Windows-ModernDeployment-Diagnostics-Provider/Autopilot".to_owned(),
+        provider: "Microsoft-Windows-ModernDeployment-Diagnostics-Provider".to_owned(),
+        event_id: 161,
+        level: NormalizedEventLevel::Information,
+        task: None,
+        keywords: None,
+        record_id: Some(1),
+        activity_id: None,
+        event_version: None,
+        named_data: Vec::new(),
+        message: Some("AutopilotManager retrieve settings succeeded.".to_owned()),
+    });
+
+    let snapshot = reduce_autopilot_bundle(&bundle);
+    let observation = snapshot
+        .observations
+        .iter()
+        .find(|observation| observation.observation_id == "native-e1")
+        .expect("the native event must become an observation under its own evidence id");
+    assert_eq!(
+        observation.context.evidence_ref.source_artifact_id,
+        "native-adapter",
+        "the artifact must come from the event's own provenance"
+    );
+    assert!(
+        snapshot.documents.is_empty(),
+        "a native event is not a document"
+    );
+    assert!(
+        snapshot.coverage.is_empty(),
+        "coverage entries describe supplied sources; a native event has none"
+    );
+    assert!(snapshot.profile.retrieved);
+}
+
 // ── Golden maintenance ──────────────────────────────────────────────────────
 
 /// Rewrite every scenario's `findings` golden from the current reducer output.
 ///
-/// Runs only under `UPDATE_AUTOPILOT_FINDINGS=1`, and is a no-op otherwise so
-/// the suite stays read-only in CI. The rewrite touches the `findings` key and
-/// nothing else, so the hand-written semantic expectations survive and keep
-/// cross-checking the regenerated goldens.
+/// Marked `#[ignore]` so it never runs beside the readers of the same files:
+/// the harness runs tests in parallel threads, and rewriting an
+/// `expected.json` while another test reads it would race. Regenerate with
+/// `UPDATE_AUTOPILOT_FINDINGS=1 cargo test --test intune_windows_autopilot -- \
+/// --ignored update_findings_golden`, then review the diff. The rewrite
+/// touches the `findings` key and nothing else, so the hand-written semantic
+/// expectations survive and keep cross-checking the regenerated goldens.
 #[test]
+#[ignore = "rewrites goldens; run alone via -- --ignored update_findings_golden"]
 fn update_findings_golden() {
     if std::env::var("UPDATE_AUTOPILOT_FINDINGS").is_err() {
         return;
@@ -640,8 +998,13 @@ fn update_findings_golden() {
     }
 }
 
+/// Write through a temporary file plus rename so no concurrent reader can ever
+/// observe a truncated golden. `std::fs::write` truncates before it writes.
 fn write_json(path: &Path, value: &Value) {
     let text = serde_json::to_string_pretty(value).expect("golden must serialize") + "\n";
-    std::fs::write(path, text)
-        .unwrap_or_else(|error| panic!("{} is writable: {error}", path.display()));
+    let temporary = path.with_extension("json.tmp");
+    std::fs::write(&temporary, text)
+        .unwrap_or_else(|error| panic!("{} is writable: {error}", temporary.display()));
+    std::fs::rename(&temporary, path)
+        .unwrap_or_else(|error| panic!("{} is replaceable: {error}", path.display()));
 }

--- a/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
@@ -760,6 +760,166 @@ fn non_assessable_success_records_cannot_prove_profile_progress() {
     );
 }
 
+/// One report section as a JSON fragment, with its own declared context.
+#[allow(clippy::too_many_arguments)]
+fn synthetic_section(
+    evidence_id: &str,
+    artifact_id: &str,
+    section_id: &str,
+    kind: &str,
+    outcome: &str,
+    access_state: &str,
+    parse_state: &str,
+    message: &str,
+) -> Value {
+    json!({
+        "context": {
+            "evidenceRef": { "evidenceId": evidence_id, "sourceArtifactId": artifact_id },
+            "provenance": {
+                "sourceKind": "diagnosticReport", "sourceArtifactId": artifact_id,
+                "filePath": null, "lineNumber": null, "recordNumber": 1,
+                "registry": null, "event": null
+            },
+            "sourceTimestamp": null,
+            "observedAtUtc": "2026-07-31T09:30:00Z",
+            "sensitivity": "sensitive",
+            "parseState": parse_state,
+            "accessState": access_state
+        },
+        "sectionId": section_id,
+        "kind": kind,
+        "outcome": outcome,
+        "error": null,
+        "values": [],
+        "message": message
+    })
+}
+
+/// ADR-001, direction-aware: a non-assessable section can never PROVE
+/// progress, but one that explicitly RECORDED a failure must still block
+/// success. Hiding it entirely would let sibling assessable evidence complete
+/// the enrollment at high confidence over a failure that is on record.
+///
+/// This is the capped-failed-section fixture the corpus lacked: an assessable
+/// success path (events 161 + 153, an observed espHandoff section) plus a
+/// capped `profileApplication` section whose outcome is `failed`.
+#[test]
+fn a_recorded_failure_on_a_non_assessable_section_blocks_success() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [
+            synthetic_event(
+                "blocked-e1", "blocked-channel", 1, 161, "available", "parsed",
+                json!([]), "AutopilotManager retrieve settings succeeded.",
+            ),
+            synthetic_event(
+                "blocked-e2", "blocked-channel", 2, 153, "available", "parsed",
+                json!([]),
+                "AutopilotManager reported the state changed from ProfileState_Available to ProfileState_Provisioned.",
+            ),
+        ]
+    });
+    let report = json!({
+        "autopilotDocument": "autopilot.mdmDiagnosticsReport",
+        "documentVersion": 1,
+        "sections": [
+            synthetic_section(
+                "blocked-handoff", "blocked-report", "espHandoff", "espHandoff",
+                "observed", "available", "parsed",
+                "Control passed to the Enrollment Status Page.",
+            ),
+            synthetic_section(
+                "blocked-failure", "blocked-report", "profileApplication", "profileApplication",
+                "failed", "capped", "parsed",
+                "Failed to set the Autopilot profile as available.",
+            ),
+        ]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![
+        synthetic_source("blocked-channel", "autopilotEvents", &events),
+        synthetic_source("blocked-report", "mdmReport", &report),
+    ]));
+
+    assert_ne!(
+        snapshot.outcome,
+        AutopilotOutcome::Completed,
+        "a recorded failure on a capped section must block a completed outcome"
+    );
+    assert_eq!(
+        snapshot.outcome,
+        AutopilotOutcome::InsufficientEvidence,
+        "non-assessable evidence proves neither the failure nor the success (ADR-001)"
+    );
+    assert_ne!(
+        wire(&snapshot.confidence),
+        json!("high"),
+        "a success-path bundle carrying a recorded failure may not be presented at high confidence"
+    );
+    assert!(
+        !snapshot.profile.applied || snapshot.outcome != AutopilotOutcome::Completed,
+        "assessable progress may survive, but never as a completed enrollment"
+    );
+    let finding = snapshot
+        .findings
+        .iter()
+        .find(|finding| finding.finding_id == "autopilot-non-assessable-failure-recorded")
+        .unwrap_or_else(|| {
+            panic!(
+                "the recorded-but-unassessable failure must never be silent, got {:?}",
+                snapshot
+                    .findings
+                    .iter()
+                    .map(|finding| finding.finding_id.as_str())
+                    .collect::<Vec<_>>()
+            )
+        });
+    assert_eq!(wire(&finding.confidence), json!("low"));
+    assert!(
+        finding
+            .evidence
+            .iter()
+            .any(|evidence| evidence.evidence_id == "blocked-failure"),
+        "the finding must cite the capped section that recorded the failure"
+    );
+    assert!(snapshot.findings_are_evidence_backed());
+}
+
+/// The same gate must not fire when the failed section is assessable: an
+/// assessable failure is the real terminal outcome, not a blocked success.
+#[test]
+fn an_assessable_failed_section_still_produces_the_terminal_failure() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [synthetic_event(
+            "term-e1", "term-channel", 1, 161, "available", "parsed",
+            json!([]), "AutopilotManager retrieve settings succeeded.",
+        )]
+    });
+    let report = json!({
+        "autopilotDocument": "autopilot.mdmDiagnosticsReport",
+        "documentVersion": 1,
+        "sections": [synthetic_section(
+            "term-failure", "term-report", "profileApplication", "profileApplication",
+            "failed", "available", "parsed",
+            "Failed to set the Autopilot profile as available.",
+        )]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![
+        synthetic_source("term-channel", "autopilotEvents", &events),
+        synthetic_source("term-report", "mdmReport", &report),
+    ]));
+    assert_eq!(snapshot.outcome, AutopilotOutcome::ProfileApplicationFailure);
+    assert!(
+        !snapshot
+            .findings
+            .iter()
+            .any(|finding| finding.finding_id == "autopilot-non-assessable-failure-recorded"),
+        "an assessable failure is not a non-assessable one"
+    );
+}
+
 /// ADR-001, same class: a non-assessable record carrying identity keys must
 /// not inflate the phase to `IdentityObserved` through the evidence list.
 #[test]

--- a/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
@@ -484,6 +484,45 @@ fn the_redacted_export_removes_identity_while_preserving_correlation() {
     );
 }
 
+/// The `matched_keys` masking site in `redacted_export_projection` must
+/// normalize case on its own, not by riding on `autopilot_keys` happening to
+/// lowercase first. Both halves of that contract are pinned here: the reducer
+/// hands the projection lowercase key values, and the projection would still
+/// mask a mixed-case value to the same token if it ever received one.
+#[test]
+fn matched_key_masking_normalizes_case_independently_of_the_reducer() {
+    let snapshot = reduce_autopilot_bundle(&bundle("matching-autopilot-and-esp-session"));
+    let raw = snapshot.esp_linkage.matched_keys[0].value.clone();
+
+    // Contract half 1: reducer-produced key values are already lowercased.
+    assert_eq!(
+        raw,
+        raw.to_ascii_lowercase(),
+        "autopilot_keys must lowercase key values before they reach the snapshot"
+    );
+
+    let lower_token = redacted_export_projection(&snapshot).esp_linkage.matched_keys[0]
+        .value
+        .clone();
+    assert!(
+        lower_token.starts_with("[redacted:"),
+        "the matched key must be masked, got {lower_token}"
+    );
+
+    // Contract half 2: the masking loop normalizes on its own. Feed it the
+    // same key in a casing the reducer never produces and the token must not
+    // change -- otherwise the loop is only correct by coincidence.
+    let mut mixed = snapshot.clone();
+    mixed.esp_linkage.matched_keys[0].value = raw.to_ascii_uppercase();
+    let upper_token = redacted_export_projection(&mixed).esp_linkage.matched_keys[0]
+        .value
+        .clone();
+    assert_eq!(
+        lower_token, upper_token,
+        "the same identifier in two casings must mask to one token at the matched_keys site"
+    );
+}
+
 // ── Cross-cutting contract ──────────────────────────────────────────────────
 
 #[test]

--- a/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
@@ -1225,6 +1225,128 @@ fn a_schema_version_only_unknown_schema_is_explained_by_a_finding() {
     );
 }
 
+/// A case-only difference between two sightings of the same identifier is not
+/// a conflict: serials and GUIDs are case-insensitive identities, and the
+/// redacted export already masks the trimmed, lowercased value, so treating
+/// casings as distinct produced "2 distinct values" rendered as two identical
+/// tokens -- a self-contradictory export (ADR-004: redaction must not change
+/// conclusions within one analysis).
+#[test]
+fn a_case_only_identifier_difference_is_not_a_conflict() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [
+            synthetic_event(
+                "case-e1", "case-channel", 1, 161, "available", "parsed",
+                json!([{ "name": "serialNumber", "value": "SYNTH-5CD1234ABC" }]),
+                "AutopilotManager retrieve settings succeeded.",
+            ),
+            synthetic_event(
+                "case-e2", "case-channel", 2, 153, "available", "parsed",
+                json!([{ "name": "serialNumber", "value": "synth-5cd1234abc" }]),
+                "AutopilotManager reported the state changed from ProfileState_Unknown to ProfileState_Available.",
+            ),
+        ]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![synthetic_source(
+        "case-channel",
+        "autopilotEvents",
+        &events,
+    )]));
+    assert!(
+        snapshot.conflicts.is_empty(),
+        "two casings of one serial are one identity, got {:?}",
+        snapshot.conflicts
+    );
+    assert_ne!(snapshot.outcome, AutopilotOutcome::ContradictoryEvidence);
+    assert_eq!(
+        snapshot.identity.serial_number.as_deref(),
+        Some("SYNTH-5CD1234ABC"),
+        "the representative casing must be deterministic"
+    );
+}
+
+/// The control for the test above: genuinely different identifiers still
+/// conflict, and the conflict still reports both values.
+#[test]
+fn genuinely_distinct_identifiers_still_conflict() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [
+            synthetic_event(
+                "real-e1", "real-channel", 1, 161, "available", "parsed",
+                json!([{ "name": "serialNumber", "value": "SYNTH-5CD1234ABC" }]),
+                "AutopilotManager retrieve settings succeeded.",
+            ),
+            synthetic_event(
+                "real-e2", "real-channel", 2, 153, "available", "parsed",
+                json!([{ "name": "serialNumber", "value": "SYNTH-5CD9999XYZ" }]),
+                "AutopilotManager reported the state changed from ProfileState_Unknown to ProfileState_Available.",
+            ),
+        ]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![synthetic_source(
+        "real-channel",
+        "autopilotEvents",
+        &events,
+    )]));
+    let conflict = snapshot
+        .conflicts
+        .iter()
+        .find(|conflict| conflict.conflict_id == "conflicting-serial-number")
+        .expect("two different serials must still conflict");
+    assert_eq!(conflict.values.len(), 2);
+    assert_eq!(snapshot.outcome, AutopilotOutcome::ContradictoryEvidence);
+}
+
+/// When ESP facts exist but share no explicit key, the guidance to go find a
+/// shared identifier must survive whatever the time gate concludes. The
+/// narrowed (assessable-only) overlap window can turn TimeOnlyCandidate into
+/// NotObserved, and losing the next-evidence request with it would hide the
+/// one step that advances the diagnosis.
+#[test]
+fn unlinked_esp_sessions_keep_the_shared_identifier_evidence_request() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [synthetic_event(
+            "unlinked-e1", "unlinked-channel", 1, 161, "available", "parsed",
+            json!([]), "AutopilotManager retrieve settings succeeded.",
+        )]
+    });
+    let sessions = json!({
+        "autopilotDocument": "autopilot.espSession",
+        "documentVersion": 1,
+        "sessions": [{
+            "sessionId": "esp-session-a",
+            "enrollmentId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "correlationId": null, "activityId": null,
+            "entraDeviceId": null, "managedDeviceId": null,
+            "startedAtUtc": "2026-07-31T09:00:20Z", "phase": "deviceSetup",
+            "evidence": { "evidenceId": "unlinked-esp-a", "sourceArtifactId": "esp-session-facts" }
+        }]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![
+        synthetic_source("unlinked-channel", "autopilotEvents", &events),
+        synthetic_source("esp-session-facts", "espSession", &sessions),
+    ]));
+
+    assert_eq!(
+        snapshot.esp_linkage.state,
+        AutopilotEspLinkState::NotObserved,
+        "no key and no provable overlap window must stay NotObserved"
+    );
+    assert!(
+        snapshot.next_evidence_requests.iter().any(|request| {
+            request.contains("identifier shared by the Autopilot and ESP evidence")
+        }),
+        "the shared-identifier request must survive the time gate, got {:?}",
+        snapshot.next_evidence_requests
+    );
+}
+
 /// The native-event input path: events supplied directly on the bundle derive
 /// their artifact from the event's own provenance and produce observations
 /// without any document or source coverage entry.

--- a/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
@@ -1024,6 +1024,131 @@ fn a_conflicting_esp_linkage_cannot_report_completed() {
     );
 }
 
+/// ADR-003 via ADR-001, the conservative direction for correlation keys: a key
+/// carried only by a non-assessable observation must still be USED to DETECT a
+/// session-identity conflict. Dropping it can shrink the matched-session set
+/// from two to one and collapse Conflicting into Linked into Completed --
+/// exactly the silent upgrade the assessability gate exists to prevent.
+///
+/// This is the capped-key-carrying-observation fixture the corpus lacked: the
+/// first ESP session matches an assessable key, the second matches only a key
+/// on a capped observation.
+#[test]
+fn a_key_on_a_capped_observation_still_detects_a_second_esp_session() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [
+            synthetic_event(
+                "cap-e1", "cap-channel", 1, 161, "available", "parsed",
+                json!([{ "name": "enrollmentId", "value": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }]),
+                "AutopilotManager retrieve settings succeeded.",
+            ),
+            synthetic_event(
+                "cap-e2", "cap-channel", 2, 153, "available", "parsed",
+                json!([]),
+                "AutopilotManager reported the state changed from ProfileState_Available to ProfileState_Provisioned.",
+            ),
+            synthetic_event(
+                "cap-e3", "cap-channel", 3, 161, "capped", "parsed",
+                json!([{ "name": "correlationId", "value": "99999999-8888-7777-6666-555555555555" }]),
+                "AutopilotManager retrieve settings succeeded.",
+            ),
+        ]
+    });
+    let sessions = json!({
+        "autopilotDocument": "autopilot.espSession",
+        "documentVersion": 1,
+        "sessions": [
+            {
+                "sessionId": "esp-session-a",
+                "enrollmentId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "correlationId": null, "activityId": null,
+                "entraDeviceId": null, "managedDeviceId": null,
+                "startedAtUtc": "2026-07-31T09:00:20Z", "phase": "deviceSetup",
+                "evidence": { "evidenceId": "cap-esp-a", "sourceArtifactId": "esp-session-facts" }
+            },
+            {
+                "sessionId": "esp-session-b",
+                "enrollmentId": null,
+                "correlationId": "99999999-8888-7777-6666-555555555555",
+                "activityId": null, "entraDeviceId": null, "managedDeviceId": null,
+                "startedAtUtc": "2026-07-31T09:00:25Z", "phase": "deviceSetup",
+                "evidence": { "evidenceId": "cap-esp-b", "sourceArtifactId": "esp-session-facts" }
+            }
+        ]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![
+        synthetic_source("cap-channel", "autopilotEvents", &events),
+        synthetic_source("cap-report", "mdmReport", &esp_handoff_report("cap-report")),
+        synthetic_source("esp-session-facts", "espSession", &sessions),
+    ]));
+
+    assert_eq!(
+        snapshot.esp_linkage.state,
+        AutopilotEspLinkState::Conflicting,
+        "the capped key's session must still count toward conflict detection"
+    );
+    assert!(
+        snapshot
+            .esp_linkage
+            .esp_session_ids
+            .contains(&"esp-session-b".to_owned()),
+        "the session detected through the capped key must be named"
+    );
+    assert_ne!(
+        snapshot.outcome,
+        AutopilotOutcome::Completed,
+        "dropping the capped key must not collapse Conflicting into Completed"
+    );
+    assert_eq!(snapshot.outcome, AutopilotOutcome::ContradictoryEvidence);
+    assert!(snapshot.findings_are_evidence_backed());
+}
+
+/// The other half of the same rule: a linkage whose ONLY explicit key rides a
+/// non-assessable observation may not upgrade to a confident Linked. Detection
+/// may widen (conservative); proof may not.
+#[test]
+fn a_non_assessable_only_key_match_cannot_upgrade_to_linked() {
+    let events = json!({
+        "autopilotDocument": "autopilot.events",
+        "documentVersion": 1,
+        "events": [
+            synthetic_event(
+                "solo-e1", "solo-channel", 1, 161, "available", "parsed",
+                json!([]), "AutopilotManager retrieve settings succeeded.",
+            ),
+            synthetic_event(
+                "solo-e2", "solo-channel", 2, 161, "capped", "parsed",
+                json!([{ "name": "enrollmentId", "value": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }]),
+                "AutopilotManager retrieve settings succeeded.",
+            ),
+        ]
+    });
+    let sessions = json!({
+        "autopilotDocument": "autopilot.espSession",
+        "documentVersion": 1,
+        "sessions": [{
+            "sessionId": "esp-session-a",
+            "enrollmentId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "correlationId": null, "activityId": null,
+            "entraDeviceId": null, "managedDeviceId": null,
+            "startedAtUtc": "2026-07-31T09:00:20Z", "phase": "deviceSetup",
+            "evidence": { "evidenceId": "solo-esp-a", "sourceArtifactId": "esp-session-facts" }
+        }]
+    });
+    let snapshot = reduce_autopilot_bundle(&synthetic_bundle(vec![
+        synthetic_source("solo-channel", "autopilotEvents", &events),
+        synthetic_source("esp-session-facts", "espSession", &sessions),
+    ]));
+
+    assert_ne!(
+        snapshot.esp_linkage.state,
+        AutopilotEspLinkState::Linked,
+        "a key readable only from a capped record may not prove a link"
+    );
+}
+
 /// A capture that declares only an unvalidated Autopilot schema version (no
 /// Windows build at all) still refuses terminal semantics, and that refusal
 /// must be explained by the unknown-schema finding rather than left silent.

--- a/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
+++ b/crates/cmtraceopen-parser/tests/intune_windows_autopilot.rs
@@ -1891,6 +1891,19 @@ fn a_base64_hash_in_an_observation_message_never_survives_the_export() {
             !text.contains(&blob),
             "the Base64 hash {blob:?} survived the exported projection: {text}"
         );
+        // The whole-blob check alone would pass while a masked body left its
+        // punctuation tail behind, which is the exact partial match the old
+        // word-boundary pattern produced. Assert the tail is gone too.
+        let body = &blob[..blob.len() - 1];
+        assert!(
+            !text.contains(body),
+            "the Base64 body {body:?} survived the exported projection: {text}"
+        );
+        let tail = &blob[blob.len() - 1..];
+        assert!(
+            !text.contains(&format!("] {tail}")) && !text.contains(&format!("]{tail}")),
+            "the Base64 tail {tail:?} dangled after the mask token: {text}"
+        );
     }
 }
 


### PR DESCRIPTION
Applies Reducer Framework v1 review discipline (docs/superpowers/plans/2026-08-07-reducer-framework-v1.md, ADR-001..004) to the merged Autopilot lane. Input was the full set of PR #450 review threads; every finding was verified against the merged code, then fixed, rejected with reasoning, or deferred with reasoning. Each real defect got a failing test before its fix, and every corrected golden documents in its `assertions` why the prior expectation was unsafe.

Refs #362. Follow-up to PR #450.

## Triage of all 20 review findings

| # | Finding (thread) | Severity | Verdict | ADR / reasoning |
|---|---|---|---|---|
| 1 | `reduce_profile` skips the assessability gate (reducer.rs) | Major | **Fixed** | ADR-001. A capped/unparsed success record could set `retrieved`/`applied` and reach `Completed` while the failure branch was filtered. Gated, plus class audit below. |
| 2 | Identity evidence bypasses the gate and inflates the phase (reducer.rs) | Minor | **Fixed** | ADR-001, same class. An unreadable record alone raised the phase to `IdentityObserved`. |
| 3 | Conflicting ESP linkage can still report `Completed` (reducer.rs) | Major | **Fixed** | ADR-003. The multi-session match path records no `AutopilotConflict`, so the empty-conflicts gate let it fall through to `Completed`. `reduce_outcome` now matches `Conflicting` explicitly and returns `ContradictoryEvidence`; a new `autopilot-esp-link-conflicting` finding explains exactly the previously-silent path. |
| 4 | `matched_keys` masking skips trim/lowercase normalization, 4 sites (redaction.rs) | Major | **Fixed** | ADR-004. All four whole-value sites now call `mask_value`; regression test covers mixed case/whitespace across named data, conflict values (both shapes), matched keys, and identity fields. |
| 5 | Schema-version-only capture yields `UnknownSchema` with no finding (rules.rs) | Minor | **Fixed** | ADR-001 (withheld semantics must still be explained). Gate now covers `autopilot_schema_version`; summary names whichever declared value failed validation. |
| 6 | `windows_zone_re` accepts placeholder junk as a declared timezone (sources.rs) | Major | **Fixed** | ADR-002. `unknown` / `not recorded` / `Unavailable` classified as `Declared`, upgrading time basis and enabling the forbidden time-only ESP candidate. Regex now anchors on the ` Time` suffix every Windows zone id ends with. |
| 7 | Golden regenerator races the readers of the same files (test harness) | Major | **Fixed** | `update_findings_golden` is now `#[ignore]`d (run alone via `-- --ignored`), and `write_json` writes through a temp file + rename. Doc comments updated. |
| 8 | Malformed-report fixture is XML, never reaches the report-payload contract | Minor | **Fixed** | Fixture now carries a correctly tagged report document with a mangled `sections` payload, exercising `absorb_payload`'s malformed branch. Documented in the scenario's `assertions`. |
| 9 | Golden pins unstable `serde_json` error `Display` text | Trivial | **Fixed** | Parse-failure details are now stable reducer-authored sentences at every site (serde_json does not guarantee `Display` stability); raw bytes are still retained as evidence. |
| 10 | Fixture comment claims "happy path" in `completed-without-esp-bundle` | Minor | **Fixed** | Comment now describes the handoff-without-ESP-evidence scenario. |
| 11 | `user-driven-success` manifest claims a complete deployment | Minor | **Fixed** | Description now claims local Autopilot phase completion only; post-handoff state belongs to ESP. |
| 12 | Comment overstates `detect_conflicts` coverage vs `single_value` | Trivial | **Fixed (comment)** | Comment now names the three keys actually reported. The "shared key list" alternative was rejected: keys like `deviceName` legitimately change mid-provisioning, so promoting every `single_value` key to a conflict would fabricate contradictions. |
| 13 | No scenario exercises the native-event input path | Trivial | **Fixed** | New test pins `absorb_native_event`: artifact derived from the event's own provenance, no document report, no coverage entry. |
| 14 | `profileApplied` set by event 153 `ProfileState_Available` is not application evidence | Major | **Rejected** | The code wins over the review text. Event 172, the documented failure sibling, reads "failed to set Autopilot profile as available": setting the profile available IS the application step, so the 153 transition into `Available` is its explicit success record. Reasoning now recorded as a comment at the site in `reduce_profile`. |
| 15 | Add `#[serde(default)]` to `NormalizedWindowsEvent.event_version` or v1 docs fail | Major | **Rejected** | serde deserializes a missing `Option<T>` field as `None` without any attribute. Empirical proof: the module doctest omits `eventVersion` entirely and passes in CI and locally. |
| 16 | `error_code_from_token` loses the upper 32 bits of 64-bit HRESULTs | Major | **Rejected** | `0xFFFFFFFF80070002` is `0x80070002` sign-extended through a 64-bit register; canonicalizing the derived hex to 32 bits is the intended normalization, the raw token survives verbatim, and a genuinely 64-bit value gains no fabricated 32-bit hex. Behavior is now pinned by `a_sign_extended_hresult_canonicalizes_to_its_32_bit_form`. |
| 17 | Mark closed public enums and input/output structs `#[non_exhaustive]` | Major | **Rejected (family convention)** | Checked the sibling lanes as the deciding factor: `microsoft_store` (10 public enums), `compliance` (13), `esp`, and the rest of the Intune family use zero `#[non_exhaustive]` (the only use in the crate is one SCCM type). The family's additivity strategy is the raw-preserving string-enum macro (unknown wire values survive verbatim in `Unknown(String)` without a new variant) plus the snapshot `schema_version` discipline documented in models.rs. Diverging on one lane would break exhaustive matching for in-repo consumers without protecting anything the macro does not already protect. If the crate later adopts `#[non_exhaustive]`, it should be a family-wide decision, not an Autopilot-only one. |
| 18 | `NormalizedWindowsEvent.event_version` is a breaking API change needing a version bump + Rustdoc | Major | **Deferred** | `normalized.rs` is a shared model owned by the parser-family skeleton and is explicitly out of scope for this lane-hardening PR (no shared-model changes). The field already shipped in merged main; releasing it under the crate's versioning process is a release-management concern for the family owner, not something to relitigate from one lane. |
| 19 | `unknown-windows-schema-version` cannot exercise the schema-only gate | Trivial | **Fixed (via test)** | Covered by the new inline scenario `a_schema_version_only_unknown_schema_is_explained_by_a_finding` (windows build undeclared, schema version 3) rather than by widening the pinned 15-scenario fixture matrix, which issue #362 treats as a contract. |
| 20 | Fixture expectation churn from #5/#6/#9 | — | **Fixed + documented** | Both regenerated goldens (`malformed-report-section`, `unknown-windows-schema-version`) document in their `assertions` why the prior expectation was unsafe. |

## Class audit: which reduction paths gained the assessability gate

Beyond the two named findings, every reduction path in the module was audited (close the class, not the instance):

- `reduce_profile` main observation loop — **gained the gate** (Major finding)
- `reduce_identity` IDENTITY_KEYS evidence loop — **gained the gate** (Minor finding)
- `sections_of` — **gained a section-level gate** (`is_assessable_section`), covering every report-section path at one enforcement point: identity sections, profile retrieval/application sections, handoff sections, and all four `reduce_outcome` section probes
- `detect_conflicts` mismatch-section loop — **gained the gate** (an unreadable section cannot assert a mismatch)
- `autopilot_keys` correlation-key extraction — **gained the gate** (a non-assessable record cannot mint a `Linked` correlation)
- `reduce_esp_linkage` evidence-mention loop — **gained the gate**
- `has_time_overlap` — **gained the gate** (non-assessable timestamps cannot create a `TimeOnlyCandidate`)
- `signal_observations` / `has_signal` / `distinct_values` (hence `single_value`) — already gated
- `time_basis` — **deliberately left unfiltered** and documented: there the unfiltered scan is the conservative direction (a non-assessable record with an unnormalized timestamp downgrades the basis; gating it would upgrade it)

## Gates (exact commands, run at head)

```
cargo test -p cmtraceopen-parser
  -> 2131 passed; 0 failed; 1 ignored (the #[ignore]d golden regenerator)
cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings
  -> clean, 0 warnings
cargo check --workspace
  -> clean
cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown
  -> clean
```

Golden regeneration was run in isolation exactly once (`UPDATE_AUTOPILOT_FINDINGS=1 cargo test --test intune_windows_autopilot -- --ignored update_findings_golden`) and the diff reviewed; only the two summaries listed above changed.

## Fix round (consolidated multi-agent review)

All three must-fixes and all five should-fixes from the consolidated review are addressed at head. TDD throughout: every behavioral item landed as a failing test first.

**Must-fix 1, direction-aware assessability gate** (`a4d0daeb`). `sections_of` stays assessable-only for everything that can prove progress or a terminal cause; the new `recorded_non_assessable_failure_sections` iterator routes an explicitly recorded `failed`/`mismatch` outcome on a capped/unparsed section to the success branch of `reduce_outcome`, which now returns `InsufficientEvidence` instead of `Completed`/`HandoffReachedEspEvidenceMissing`. Rationale documented in-code: ADR-001 forbids terminal conclusions from non-assessable evidence in *both* directions, so the failure outcome itself stays reserved for assessable records and the honest reduction is `InsufficientEvidence` (Low confidence), never a silent success. Surfaced by the new `autopilot-non-assessable-failure-recorded` finding (warning, low confidence, cites the section, asks for a readable re-collection). `NotFound`/`Retrying` stay gated in both directions: absence statements from a partial capture prove nothing. Fixtures: `a_recorded_failure_on_a_non_assessable_section_blocks_success` (assessable success path + capped `profileApplication` failed section, the exact scenario the review named), plus the negative control `an_assessable_failed_section_still_produces_the_terminal_failure`.

**Must-fix 2, correlation keys survive for conflict detection** (`6c031f92`). `autopilot_keys` is now gated by `AutopilotKeyGate::{Proving, Detecting}`: proving keys (assessable only) remain the only ones able to produce `Linked` and the `Completed` behind it; detecting keys (all observations) feed a multi-session conflict check that runs *before* any positive linkage and returns `Conflicting` naming every detected session. More sessions detected means more conservative; a non-assessable-only match can never upgrade past `NotObserved`/`TimeOnlyCandidate`. Fixtures: `a_key_on_a_capped_observation_still_detects_a_second_esp_session` (session B matched only via a capped observation, so no silent 2-to-1 collapse) and `a_non_assessable_only_key_match_cannot_upgrade_to_linked`.

**Must-fix 3, `matched_keys` masking pinned as a contract** (`cca27db8`). `matched_key_masking_normalizes_case_independently_of_the_reducer` pins both halves: `autopilot_keys` hands the projection lowercase values, and the `redaction.rs` masking loop still produces the same token when fed a mixed-case value it never normally receives.

**Should-fix 4, case-insensitive `distinct_values`** (`5ce8e2e5`). Decided for case-insensitivity: serials/GUIDs are case-insensitive identities and the export masks the trimmed lowercased value, so a case-only difference exporting "2 distinct values" over two identical tokens changed a conclusion under redaction (ADR-004). Groups now key on the lowercased value with a deterministic representative (lexicographically smallest sighting, permutation-safe per ADR-003). Tests: `a_case_only_identifier_difference_is_not_a_conflict` + control `genuinely_distinct_identifiers_still_conflict`.

**Should-fix 5, triage bookkeeping** (`5ce8e2e5`). The 153/172 application-evidence reasoning is now in the `assertions` array of the `matching-autopilot-and-esp-session` golden. Bookkeeping correction for the triage table: the `opaque_blob_re` doc-comment finding *was* fixed in this PR but was omitted from the table; row 20 being self-authored, the honest count is 19 externally reported + 1 self-reported.

**Should-fix 6, evidence request survives the time gate** (`5ce8e2e5`). The shared-identifier `next_evidence_request` is now keyed on "ESP facts supplied but not explicitly linked" (`NotObserved` or `TimeOnlyCandidate`), so the narrowed assessable overlap window can no longer erase the guidance. Test: `unlinked_esp_sessions_keep_the_shared_identifier_evidence_request`.

**Should-fix 7, `windows_zone_re`** (`5ce8e2e5`). Comment corrected (no more "every Windows id ends in Time"; `UTC`/`UTC+12` are registry ids handled by `utc_offset_re`, and localized StandardNames degrade conservatively) and a case-insensitive placeholder denylist (`Local Time`, `Device Local Time`, `System Time`) closes the hole the suffix anchor left. Tests extended in `sources.rs`.

**Should-fix 8, multi-session finding text** (`5ce8e2e5`). `push_esp_link_conflicting` now acknowledges the legitimate reimage/retry two-real-sessions case and recommends per-attempt analysis before re-collection.

Fixture note: the two new adversarial scenarios are built inline in `tests/intune_windows_autopilot.rs` (the file's documented pattern for single-invariant ADR tests) because the issue #362 fixture-directory matrix is pinned as a contract; the corpus-level gap the review flagged (no `accessState != available` / `parseState != parsed` input anywhere in CI) is closed by these tests.

Gates at head: `cargo test -p cmtraceopen-parser` → 2139 passed, 0 failed, 1 ignored; `cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings` → clean; `cargo check --workspace` → clean; `cargo check --locked -p cmtraceopen-parser --target wasm32-unknown-unknown` → clean.

**Ultrareview round, event-side closure of the assessability gate** (`874d322b`). The direction-aware gate above covered report SECTIONS only; a capped or raw EVENT carrying a documented failure signal was still silently dropped by the `is_assessable` filters, so an assessable success path (161 + 153-into-Available + assessable espHandoff section) plus a capped event 172 reduced to a success-family outcome with no finding. Closed as a class: the new `recorded_non_assessable_failure_observations` iterator gates on `AutopilotSignal::is_terminal_failure` (171, 172, 807, 809, 815, 908 -- the symmetry rule being that any signal strong enough to fail the enrollment when readable is strong enough to block its success when unreadable; 100 stays out as documented-transient, matching the section iterator's `NotFound`/`Retrying` exclusion), and the success branch of `reduce_outcome` short-circuits to `InsufficientEvidence` over either record shape. `push_non_assessable_failure_recorded` widens to cite both shapes, so the recorded failure is never silent. TDD: `a_recorded_failure_on_a_non_assessable_event_blocks_success` observed red first (reduced to `HandoffReachedEspEvidenceMissing`, no finding), then green; symmetric control `an_assessable_failed_event_still_produces_the_terminal_failure` pins that an assessable 172 still yields the terminal `ProfileApplicationFailure`.

Gates at head: `cargo test -p cmtraceopen-parser` -> 2141 passed, 0 failed, 1 ignored; `cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings` -> clean; `cargo check --workspace` -> clean; `cargo check -p cmtraceopen-parser --target wasm32-unknown-unknown` -> clean.

## Hermes review fixes (`3d2ee13d`)

The Hermes charter review posted three blocking P1 findings against exact head `ed8b50b9`. Each is now closed, TDD'd RED-first with the review's exact inputs.

**P1 #1, ADR-001 finding-side assessability** (`rules.rs`). `signal_evidence` filtered only by signal, so a capped/malformed event 171 (`TpmIdentityFailed`) could still promote `autopilot-identity-registration-mismatch` to a `Blocker`/`High` finding even though `reduce_outcome` correctly withheld the terminal outcome. `signal_evidence` now requires `is_assessable`, and the check is hoisted to one `AutopilotObservation::is_assessable` method shared by the reducer's free fn and the finding-side helpers so the boundary cannot drift. The recorded failure stays visible via the existing low-confidence `autopilot-non-assessable-failure-recorded`. TDD: `a_non_assessable_tpm_failure_cannot_emit_a_high_confidence_blocker` (red first); regression control `an_assessable_tpm_failure_still_emits_the_identity_mismatch_blocker`.

**P1 #2, ADR-004 free-text redaction** (`redaction.rs`). `opaque_blob_re` was `\b[A-Za-z0-9+/=]{40,}\b`. The Base64 alphabet includes `=`, `+`, `/`, none of which is a word character, so the trailing `\b` could not close the match on a padded or punctuation-terminated hardware hash and left its tail exposed (a 40-char value ending in `/`/`+` matched nothing at all). The pattern drops both anchors; the greedy, leftmost, `>=40` match now consumes the whole contiguous Base64 run in full while the `>=40` bound still excludes the 36-char GUID (dashes break it into `<=12`-char runs) and the short HRESULT, and the `[blob:…]` token cannot re-match (idempotent). GUID/HRESULT preservation tests still pass. TDD: `a_base64_blob_ending_in_punctuation_is_masked_in_full` (unit, red first) plus `a_base64_hash_in_an_observation_message_never_survives_the_export` pinning the whole exported projection for `=`, `==`, `+`, `/`.

**P1 #3, ADR-003 profile retry linkage** (`reducer.rs`). `reduce_profile` let a later success (161/153) silently overwrite an earlier explicit negative (`NoAssignedProfile` 815 / `AssignedProfileMissing` 809) with no retry linkage, and the result depended on vector order. Positive evidence and explicit negatives are now tracked apart and reconciled from sets (never vector order): a negative is erased only when it shares an `activityId` retry-linkage key (the module's session/correlation key, matched case-insensitively) with an `Available`-raising success. Without linkage the negative stands (`NoProfileCandidate`, not `Completed`); with linkage the success completes. TDD: `an_unlinked_success_cannot_erase_an_earlier_no_profile_negative` (red first), linkage-permitted control `a_retry_linked_success_completes_over_an_earlier_negative`, and input-order-permutation assertion `the_profile_linkage_verdict_is_invariant_under_input_order`.

Retry-linkage key used: `AutopilotObservation.activity_id` (and the report section's `activityId` value), lowercased -- the same key the ESP correlation path already treats as a session identity.

Gates at head: `cargo test -p cmtraceopen-parser` -> 2150 passed, 0 failed, 1 ignored; `cargo clippy -p cmtraceopen-parser --all-targets -- -D warnings` -> clean; `cargo check --workspace` -> clean; `cargo check -p cmtraceopen-parser --target wasm32-unknown-unknown` -> clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows Autopilot outcome detection, including profile application success, failures, ambiguous session links, and conflicting evidence.
  * Improved handling of incomplete or non-assessable records with clearer warnings and evidence re-collection guidance.
  * Standardized redaction for consistent masking regardless of capitalization or surrounding whitespace.
  * Improved timezone and schema validation, including clearer handling of unsupported values.
  * Replaced unstable parser-specific error details with consistent, user-facing messages.
* **Tests**
  * Expanded coverage for malformed reports, schema handling, session linkage, evidence requests, redaction, and HRESULT parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
