### PR TITLE
fix(scripts): let the Windows prereq installer run at all on PowerShell 5.1

### DIFF
--- a/scripts/Install-CMTraceOpenBuildPrereqs.ps1
+++ b/scripts/Install-CMTraceOpenBuildPrereqs.ps1
@@ -7,11 +7,20 @@ param(
     [switch]$InstallRepoDependencies,
     [switch]$SkipValidation,
 
-    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+    [string]$RepoRoot
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+# Resolved here rather than as a param default. Windows PowerShell 5.1 leaves $PSScriptRoot empty
+# while evaluating defaults on an advanced script, which this is because of the CmdletBinding
+# attribute above, so the default threw before the script could run at all. Verified on 5.1: the
+# same default works without CmdletBinding and fails with it. pwsh 7 populates it either way, which
+# is why this survived.
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = Split-Path -Parent $PSScriptRoot
+}
 
 function Write-Step {
     param(


### PR DESCRIPTION
## The documented Windows setup command could never have worked

From `CLAUDE.md` and the README:

```
powershell -ExecutionPolicy Bypass -File .\scripts\Install-CMTraceOpenBuildPrereqs.ps1
```

It fails immediately, before installing anything:

```
Split-Path : Cannot bind argument to parameter 'Path' because it is an empty string.
At ...\Install-CMTraceOpenBuildPrereqs.ps1:10 char:45
+     [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
```

## Root cause, isolated rather than guessed

`$RepoRoot` defaulted to `(Split-Path -Parent $PSScriptRoot)`. **Windows PowerShell 5.1 leaves `$PSScriptRoot` empty while evaluating parameter defaults on an *advanced* script**, and this script is advanced because of its `[CmdletBinding(SupportsShouldProcess = $true)]` attribute.

Confirmed on Windows 11 build 26200 with three minimal scripts differing only in that attribute:

| Script | `$PSScriptRoot` in param default |
|---|---|
| plain `param()` | populated, works |
| **+ `[CmdletBinding(SupportsShouldProcess=$true)]`** | **empty, throws** |
| + CmdletBinding + `Set-StrictMode` | empty, throws |

`pwsh` 7 populates it either way, which is why this survived: anyone testing under PowerShell 7 sees it work. 5.1 is the default shell on Windows and the one the documented command invokes.

## Fix

`RepoRoot` is resolved in the script body, where `$PSScriptRoot` is populated. An explicitly passed `-RepoRoot` still wins.

## Class, not instance

Checked every `.ps1` in the repository for the same shape. This is the only one that reads `$PSScriptRoot` inside a `param()` default, so the class is closed rather than just this occurrence.

## How it was found

While installing the toolchain on the lab host in order to verify the event log work in #539 against real Windows. The installer is confirmed to progress past this point and install Node, VS Build Tools, and WebView2 once the argument is supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prerequisite installation script failures in Windows PowerShell 5.1.
  * The repository path is now resolved reliably at runtime when no path is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->