### PR TITLE
fix(clipboard): prepare v1.5.2 maintenance release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.2] - 2026-08-11
+
+### Fixed
+
+- **Windows clipboard history (#520)**: Info-pane copies now register in Windows clipboard history, and Ctrl+C preserves a selected text range instead of copying the entire log entry.
+
 ## [1.5.1] - 2026-08-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "cmtrace-open"
-version = "1.5.0"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "base64 0.23.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cmtrace-open",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cmtrace-open",
-      "version": "1.5.0",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-charts": "^9.3.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmtrace-open",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "description": "Free, open-source CMTrace replacement: Windows log viewer with ConfigMgr/SCCM, Intune, and Autopilot ESP diagnostics",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 # Cargo.toml); the single Cargo.lock lives at the workspace root.
 [package]
 name = "cmtrace-open"
-version = "1.5.1"
+version = "1.5.2"
 description = "Free, open-source CMTrace replacement: Windows log viewer with ConfigMgr/SCCM, Intune, and Autopilot ESP diagnostics, DSRegCmd triage, and real-time tailing."
 authors = ["Adam Gell"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CMTrace Open",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "com.cmtrace.open",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -36,6 +36,7 @@ import { useFileWatcher } from "../../hooks/use-file-watcher";
 import { useIntuneAnalysisProgress } from "../../workspaces/intune/use-intune-analysis-progress";
 import { useSysmonAnalysisProgress } from "../../workspaces/sysmon/use-sysmon-analysis-progress";
 import { useKeyboard } from "../../hooks/use-keyboard";
+import { useClipboardHistoryMirror } from "../../hooks/use-clipboard-history-mirror";
 import { useDragDrop } from "../../hooks/use-drag-drop";
 import { useFileAssociation } from "../../hooks/use-file-association";
 import { useFileAssociationPrompt } from "../../hooks/use-file-association-prompt";
@@ -291,6 +292,9 @@ export function AppShell() {
   useIntuneAnalysisProgress();
   useSysmonAnalysisProgress();
   useKeyboard();
+  // Re-write native WebView copies through the clipboard plugin so they
+  // register in Windows clipboard history (#520)
+  useClipboardHistoryMirror();
   useDragDrop();
   // Handle file path passed via OS file association at startup
   useFileAssociation();

--- a/src/hooks/use-clipboard-copy.test.tsx
+++ b/src/hooks/use-clipboard-copy.test.tsx
@@ -109,7 +109,6 @@ beforeEach(() => {
     showSettingsDialog: false,
     showEvidenceBundleDialog: false,
     showFileAssociationPrompt: false,
-    elevationPrompt: null,
   });
   useLogStore.getState().clear();
   useLogStore

--- a/src/hooks/use-clipboard-copy.test.tsx
+++ b/src/hooks/use-clipboard-copy.test.tsx
@@ -1,0 +1,221 @@
+import { cleanup, fireEvent, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLogStore } from "../stores/log-store";
+import { useUiStore } from "../stores/ui-store";
+import type { LogEntry, WorkspaceId } from "../types/log";
+import { useKeyboard } from "./use-keyboard";
+import { useClipboardHistoryMirror } from "./use-clipboard-history-mirror";
+
+const clipboardMocks = vi.hoisted(() => ({
+  writeText: vi.fn(async () => undefined),
+}));
+
+const actionMocks = vi.hoisted(() => ({
+  current: {
+    commandState: {
+      canOpenSources: true,
+      canOpenKnownSources: true,
+      canPauseResume: true,
+      canFind: true,
+      hasFindSession: false,
+      canFilter: true,
+      canRefresh: true,
+      canToggleSidebar: true,
+      canToggleDetailsPane: true,
+      canToggleInfoPane: true,
+      canAdjustTextSize: true,
+      canShowEvidenceBundle: false,
+      canSaveSession: false,
+      canCollectDiagnostics: true,
+      isLoading: false,
+      isPaused: false,
+      hasActiveSource: true,
+      isSidebarVisible: true,
+      isDetailsVisible: true,
+      isInfoPaneVisible: true,
+      activeFilterCount: 0,
+      isFiltering: false,
+      filterError: null as string | null,
+      activeWorkspace: "log" as WorkspaceId,
+      openFileLabel: "Open file…",
+      openFolderLabel: "Open folder…",
+    },
+    openSourceFileDialog: vi.fn(async () => undefined),
+    openSourceFolderDialog: vi.fn(async () => undefined),
+    openKnownSourceCatalogAction: vi.fn(async () => undefined),
+    showFindBar: vi.fn(),
+    findNext: vi.fn(),
+    findPrevious: vi.fn(),
+    showFilterDialog: vi.fn(),
+    showErrorLookupDialog: vi.fn(),
+    showEvidenceBundleDialog: vi.fn(),
+    showAboutDialog: vi.fn(),
+    showSettingsDialog: vi.fn(),
+    togglePauseResume: vi.fn(),
+    refreshActiveSource: vi.fn(async () => undefined),
+    toggleSidebar: vi.fn(),
+    toggleDetailsPane: vi.fn(),
+    toggleInfoPane: vi.fn(),
+    increaseLogListTextSize: vi.fn(),
+    decreaseLogListTextSize: vi.fn(),
+    resetLogListTextSize: vi.fn(),
+    switchWorkspace: vi.fn(),
+    dismissTransientDialogs: vi.fn(),
+    openRecentEntry: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: clipboardMocks.writeText,
+}));
+
+vi.mock("./use-app-actions", () => ({
+  useAppActions: () => actionMocks.current,
+}));
+
+function makeEntry(overrides: Partial<LogEntry> & { id: number }): LogEntry {
+  return {
+    lineNumber: overrides.id,
+    message: `message ${overrides.id}`,
+    component: null,
+    timestamp: null,
+    timestampDisplay: null,
+    severity: "Info",
+    thread: null,
+    threadDisplay: null,
+    sourceFile: null,
+    format: "Plain",
+    filePath: "/test.log",
+    timezoneOffset: null,
+    ...overrides,
+  };
+}
+
+function stubSelection(text: string) {
+  vi.spyOn(window, "getSelection").mockReturnValue({
+    toString: () => text,
+  } as Selection);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stubSelection("");
+  useUiStore.setState({
+    currentPlatform: "windows",
+    showFindBar: false,
+    showFilterDialog: false,
+    showErrorLookupDialog: false,
+    showAboutDialog: false,
+    showSettingsDialog: false,
+    showEvidenceBundleDialog: false,
+    showFileAssociationPrompt: false,
+    elevationPrompt: null,
+  });
+  useLogStore.getState().clear();
+  useLogStore
+    .getState()
+    .setEntries([
+      makeEntry({ id: 1, message: "alpha beta gamma", component: "CcmExec" }),
+    ]);
+  useLogStore.getState().selectEntry(1);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useKeyboard Ctrl+C fallback (#520)", () => {
+  it("copies the whole selected entry when no text is selected", () => {
+    renderHook(() => useKeyboard());
+
+    const notPrevented = fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+
+    expect(notPrevented).toBe(false);
+    expect(clipboardMocks.writeText).toHaveBeenCalledWith(
+      "alpha beta gamma\tCcmExec\t\t"
+    );
+  });
+
+  it("steps aside for a live text selection so the native copy takes it", () => {
+    stubSelection("beta");
+    renderHook(() => useKeyboard());
+
+    const notPrevented = fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+
+    // Default must NOT be prevented: the WebView's own copy handles the
+    // selection, and the history mirror re-writes it through the plugin.
+    expect(notPrevented).toBe(true);
+    expect(clipboardMocks.writeText).not.toHaveBeenCalled();
+  });
+
+  it("still copies the whole entry when the selection is only whitespace", () => {
+    stubSelection("   ");
+    renderHook(() => useKeyboard());
+
+    fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+
+    expect(clipboardMocks.writeText).toHaveBeenCalledWith(
+      "alpha beta gamma\tCcmExec\t\t"
+    );
+  });
+});
+
+describe("useClipboardHistoryMirror (#520)", () => {
+  it("mirrors a native copy of a DOM selection through the clipboard plugin", () => {
+    stubSelection("part of the message");
+    renderHook(() => useClipboardHistoryMirror());
+
+    fireEvent.copy(document.body);
+
+    expect(clipboardMocks.writeText).toHaveBeenCalledWith("part of the message");
+  });
+
+  it("mirrors the selected range of an input element", () => {
+    renderHook(() => useClipboardHistoryMirror());
+
+    const input = document.createElement("input");
+    input.value = "search term";
+    document.body.appendChild(input);
+    input.setSelectionRange(0, 6);
+
+    fireEvent.copy(input);
+
+    expect(clipboardMocks.writeText).toHaveBeenCalledWith("search");
+    input.remove();
+  });
+
+  it("leaves copies alone when an app handler already owns the event", () => {
+    stubSelection("owned elsewhere");
+    renderHook(() => useClipboardHistoryMirror());
+
+    // jsdom has no ClipboardEvent constructor; the handler only reads
+    // defaultPrevented and target, so a plain Event exercises the same path.
+    const event = new Event("copy", {
+      bubbles: true,
+      cancelable: true,
+    });
+    event.preventDefault();
+    document.body.dispatchEvent(event);
+
+    expect(clipboardMocks.writeText).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when nothing is selected", () => {
+    renderHook(() => useClipboardHistoryMirror());
+
+    fireEvent.copy(document.body);
+
+    expect(clipboardMocks.writeText).not.toHaveBeenCalled();
+  });
+
+  it("is inert off Windows, where no clipboard history consumes the mirror", () => {
+    useUiStore.setState({ currentPlatform: "macos" });
+    stubSelection("mac selection");
+    renderHook(() => useClipboardHistoryMirror());
+
+    fireEvent.copy(document.body);
+
+    expect(clipboardMocks.writeText).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-clipboard-history-mirror.ts
+++ b/src/hooks/use-clipboard-history-mirror.ts
@@ -1,0 +1,76 @@
+import { useEffect } from "react";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { useUiStore } from "../stores/ui-store";
+
+function copiedTextFrom(event: ClipboardEvent): string {
+  const target = event.target;
+
+  if (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement
+  ) {
+    const { selectionStart, selectionEnd, value } = target;
+
+    if (
+      selectionStart !== null &&
+      selectionEnd !== null &&
+      selectionEnd > selectionStart
+    ) {
+      return value.slice(selectionStart, selectionEnd);
+    }
+
+    return "";
+  }
+
+  return window.getSelection()?.toString() ?? "";
+}
+
+/**
+ * Mirrors native WebView copies through the Tauri clipboard plugin so they
+ * register in Windows clipboard history (Win+V).
+ *
+ * Copies the WebView performs itself — the built-in context menu over the
+ * Info pane, Ctrl+C on a text selection — reach the OS clipboard but are not
+ * captured by clipboard history, while copies written through the plugin are
+ * (#520). Re-writing the same text through the plugin after the native copy
+ * makes every copy land in history; the content is identical, so the extra
+ * write is otherwise invisible.
+ *
+ * Windows-only: no other platform has a history consumer, and skipping the
+ * mirror elsewhere avoids replacing rich clipboard content with plain text.
+ */
+export function useClipboardHistoryMirror() {
+  const isWindows = useUiStore(
+    (state) => state.currentPlatform === "windows"
+  );
+
+  useEffect(() => {
+    if (!isWindows) {
+      return;
+    }
+
+    const handleCopy = (event: ClipboardEvent) => {
+      // An app handler that prevented default owns this copy and has already
+      // written the clipboard through the plugin itself.
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      const text = copiedTextFrom(event);
+
+      if (text.length === 0) {
+        return;
+      }
+
+      writeText(text).catch((error) => {
+        console.error(
+          "[clipboard] failed to mirror copy into clipboard history",
+          { error }
+        );
+      });
+    };
+
+    document.addEventListener("copy", handleCopy);
+    return () => document.removeEventListener("copy", handleCopy);
+  }, [isWindows]);
+}

--- a/src/hooks/use-keyboard.ts
+++ b/src/hooks/use-keyboard.ts
@@ -258,6 +258,16 @@ export function useKeyboard() {
           return;
         }
 
+        // A live text selection (e.g. in the Info pane) wins over the
+        // whole-entry fallback: leave the event alone so the WebView's native
+        // copy takes the selection. The clipboard-history mirror re-writes it
+        // through the clipboard plugin so it still reaches Windows clipboard
+        // history (#520).
+        const selectionText = window.getSelection()?.toString().trim() ?? "";
+        if (selectionText.length > 0) {
+          return;
+        }
+
         event.preventDefault();
         const state = useLogStore.getState();
 


### PR DESCRIPTION
## Summary
- Backports the Windows clipboard-history fix for issue #520 onto the v1.5.1 maintenance line.
- Bumps application/package versions to 1.5.2.
- Documents the fix in the changelog.

## Validation
- `npx tsc --noEmit`
- `npm test -- --run src/hooks/use-clipboard-copy.test.tsx` (8 tests passed)
- Windows acceptance testing completed manually against the supplied test build.

Fixes #520