### PR TITLE
fix(clipboard): repair deferred mirror tests

### DIFF
--- a/src/hooks/use-clipboard-copy.test.tsx
+++ b/src/hooks/use-clipboard-copy.test.tsx
@@ -162,11 +162,23 @@ describe("useKeyboard Ctrl+C fallback (#520)", () => {
 });
 
 describe("useClipboardHistoryMirror (#520)", () => {
+  // The hook defers its write with setTimeout so the native copy lands first, so the two tests
+  // that assert a write have to let that timer run. The negative cases below need no timer: they
+  // assert the write never happens, and a pending timer would not change that.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("mirrors a native copy of a DOM selection through the clipboard plugin", () => {
     stubSelection("part of the message");
     renderHook(() => useClipboardHistoryMirror());
 
     fireEvent.copy(document.body);
+    vi.runAllTimers();
 
     expect(clipboardMocks.writeText).toHaveBeenCalledWith("part of the message");
   });
@@ -180,6 +192,7 @@ describe("useClipboardHistoryMirror (#520)", () => {
     input.setSelectionRange(0, 6);
 
     fireEvent.copy(input);
+    vi.runAllTimers();
 
     expect(clipboardMocks.writeText).toHaveBeenCalledWith("search");
     input.remove();


### PR DESCRIPTION
## Summary
- Fixes the two failing `useClipboardHistoryMirror` tests tracked by #559.
- Uses fake timers only within the mirror test group.
- Advances the deferred write timer before asserting the clipboard plugin call.
- Leaves the production hook unchanged.

## Validation
- `npm test -- --run src/hooks/use-clipboard-copy.test.tsx` — 8 passed
- `npx tsc --noEmit` — passed
- `npm test` — 54 files, 739 tests passed

Fixes #559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved clipboard history tests by accounting for delayed clipboard writes and timer behavior.
  * Added coverage for both DOM and input text selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->