### PR TITLE
chore(release): prepare v1.5.2 after #559

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.2] - 2026-08-11
+
+### Fixed
+
+- **Windows clipboard history (#520)**: Info-pane copies now register in Windows clipboard history, and Ctrl+C preserves a selected text range instead of copying the entire log entry.
+
 ## [Unreleased]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "cmtrace-open"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "base64 0.23.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cmtrace-open",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cmtrace-open",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-charts": "^9.3.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmtrace-open",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "description": "Free, open-source CMTrace replacement: Windows log viewer with ConfigMgr/SCCM, Intune, and Autopilot ESP diagnostics",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 # Cargo.toml); the single Cargo.lock lives at the workspace root.
 [package]
 name = "cmtrace-open"
-version = "1.5.1"
+version = "1.5.2"
 description = "Free, open-source CMTrace replacement: Windows log viewer with ConfigMgr/SCCM, Intune, and Autopilot ESP diagnostics, DSRegCmd triage, and real-time tailing."
 authors = ["Adam Gell"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CMTrace Open",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "com.cmtrace.open",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Align package, Cargo, Tauri, and lockfile versions at 1.5.2.
- Restore the v1.5.2 changelog entry for the clipboard fix after #559 landed.

## Validation
- Clipboard tests: 8 passed
- `npx tsc --noEmit`: passed

This prepares the corrected v1.5.2 release after #559.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Copied text from the Info pane is now added to Windows clipboard history.
  * Pressing Ctrl+C preserves the selected text range instead of copying the entire log entry.

* **Chores**
  * Updated the application version to 1.5.2.
  * Added release notes for the latest fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->