### PR TITLE
fix(redaction): mask lowercase SIDs, and let the fixture scanner ask the masker

### DIFF
--- a/crates/cmtraceopen-parser/src/intune/apps/windows/common/mod.rs
+++ b/crates/cmtraceopen-parser/src/intune/apps/windows/common/mod.rs
@@ -7,4 +7,4 @@
 
 mod redaction;
 
-pub use redaction::redact_text;
+pub use redaction::{redact_text, sid_occurrences};

--- a/crates/cmtraceopen-parser/src/intune/apps/windows/common/redaction.rs
+++ b/crates/cmtraceopen-parser/src/intune/apps/windows/common/redaction.rs
@@ -185,11 +185,30 @@ fn tenant_field_re() -> &'static Regex {
 ///
 /// The `S-1-…` shape is unambiguous enough to mask without an anchor, and a
 /// SID identifies a user or machine exactly as strongly as a UPN does.
+///
+/// Case-insensitive like every other rule in this file. Windows itself emits the
+/// uppercase form, but third-party logs and JSON round-trips lowercase
+/// identifiers, and a `s-1-5-21-…` exporting verbatim while the uppercase form
+/// masked was an inconsistency nothing in the code or the docs intended.
 fn sid_re() -> &'static Regex {
     static CELL: OnceLock<Regex> = OnceLock::new();
     CELL.get_or_init(|| {
-        Regex::new(r"\bS-1-\d+(?:-\d+){2,}").expect("sid regex must compile")
+        Regex::new(r"(?i)\bS-1-\d+(?:-\d+){2,}").expect("sid regex must compile")
     })
+}
+
+/// Every Windows SID in `text`, as `(byte offset, matched text)`.
+///
+/// Public so anything needing to *find* SIDs — the fixture privacy scanner most
+/// of all — asks this grammar instead of restating the shape. A detector that
+/// re-implements what the masker matches will drift from it, and drift in a
+/// safety net is invisible by construction: the check whose job is catching a
+/// leak is the one place a mismatch goes unnoticed.
+pub fn sid_occurrences(text: &str) -> Vec<(usize, &str)> {
+    sid_re()
+        .find_iter(text)
+        .map(|found| (found.start(), found.as_str()))
+        .collect()
 }
 
 /// Whether `kind:hash` is a well-formed token body — the one validity rule
@@ -342,14 +361,18 @@ pub fn redact_text(value: &str) -> String {
 
     sid_re()
         .replace_all(&masked, |caps: &regex::Captures<'_>| {
-            stable_token("sid", &caps[0])
+            // Hashed from the uppercase form. A SID is case-insensitive, so the
+            // two spellings name one identity and must reach one token; hashing
+            // the text as written would hand an analyst two tokens for the same
+            // account and break the correlation these tokens exist to provide.
+            stable_token("sid", &caps[0].to_ascii_uppercase())
         })
         .into_owned()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::redact_text;
+    use super::{redact_text, sid_occurrences};
 
     #[test]
     fn a_json_escaped_windows_path_is_masked() {
@@ -494,6 +517,44 @@ mod tests {
         assert!(!escaped.contains("John"), "got {escaped:?}");
         assert!(!escaped.contains("Doe"), "got {escaped:?}");
         assert!(escaped.contains("AppData"), "got {escaped:?}");
+    }
+
+    #[test]
+    fn a_lowercase_sid_masks_to_the_same_token_as_the_uppercase_form() {
+        // Every other rule in this file is case-insensitive; this one was not, so a
+        // lowercase identifier from a third-party log or a JSON round-trip exported
+        // verbatim while the uppercase form masked.
+        let upper = redact_text("owner S-1-5-21-397955417-626881126-188441444-1010 end");
+        let lower = redact_text("owner s-1-5-21-397955417-626881126-188441444-1010 end");
+
+        assert!(!lower.contains("397955417"), "got {lower:?}");
+        // One identity, one token. Hashing the text as written would hand an analyst
+        // two tokens for the same account.
+        assert_eq!(upper, lower, "case must not change the masked result");
+    }
+
+    #[test]
+    fn sid_occurrences_finds_what_the_masker_masks() {
+        // The fixture privacy scanner uses this, so anything it fails to find is
+        // material the masker would have hidden and the guard would have waved past.
+        for text in [
+            "S-1-5-21-397955417-626881126-188441444-1010",
+            "s-1-5-21-397955417-626881126-188441444-1010",
+            // A trailing separator: the re-implementation this replaced required the
+            // candidate to end in a digit, so this passed the scan while the masker
+            // masked it.
+            "S-1-5-21-1-2-3-",
+            "\"S-1-5-21-1-2-3\"",
+        ] {
+            assert!(
+                !sid_occurrences(text).is_empty(),
+                "the scanner must see {text:?}"
+            );
+            assert_ne!(redact_text(text), text, "the masker must mask {text:?}");
+        }
+
+        // Below the sub-authority threshold, both agree it identifies nobody.
+        assert!(sid_occurrences("running as S-1-5-18").is_empty());
     }
 
     #[test]

--- a/crates/cmtraceopen-parser/tests/support/mod.rs
+++ b/crates/cmtraceopen-parser/tests/support/mod.rs
@@ -23,6 +23,7 @@
 //! `src-tauri/tests/common/mod.rs` sets the same precedent.
 #![allow(dead_code)]
 
+use cmtraceopen_parser::intune::apps::windows::common::sid_occurrences;
 use cmtraceopen_parser::intune::evidence::{
     access_state_for_artifact_status, IntuneAccessState, IntuneArtifactStatus,
 };
@@ -883,19 +884,22 @@ pub fn privacy_problems_excluding_probes(
 }
 
 /// Every `S-1-…` SID with at least three sub-authorities, with its byte offset.
+///
+/// Delegates to the owner grammar rather than restating the shape. This is the
+/// guard that fails the build when a fixture carries an unmasked SID, so a
+/// divergence from what the masker matches is a hole in the safety net, and a
+/// hole there is invisible by construction: the check whose job is catching a
+/// leak is the one place a mismatch goes unnoticed.
+///
+/// The re-implementation this replaced had two such holes. It was
+/// case-sensitive, so a lowercase `s-1-5-21-…` passed; and it required the
+/// candidate to end in a digit, so `S-1-5-21-1010-` passed while the masker
+/// would have masked it.
 fn windows_sid_occurrences(contents: &str) -> Vec<(usize, String)> {
-    let mut occurrences = Vec::new();
-    for (index, _) in contents.match_indices("S-1-") {
-        let candidate = contents[index..]
-            .split(|c: char| !(c.is_ascii_digit() || c == '-' || c == 'S'))
-            .next()
-            .unwrap_or_default();
-        if candidate.matches('-').count() >= 4 && candidate.ends_with(|c: char| c.is_ascii_digit())
-        {
-            occurrences.push((index, candidate.to_owned()));
-        }
-    }
-    occurrences
+    sid_occurrences(contents)
+        .into_iter()
+        .map(|(offset, found)| (offset, found.to_owned()))
+        .collect()
 }
 
 /// Find an email address, ignoring the reserved `.invalid` and `.example` TLDs


### PR DESCRIPTION
Closes #547.

Two defects from the issue, plus a third the first fix surfaced.

## The owner grammar was case-sensitive for SIDs only

`sid_re` was the one pattern in `redaction.rs` without `(?i)` — the profile-path, inline-credential, account-field, device-name and tenant-id rules all have it. So `s-1-5-21-...` exported verbatim while the uppercase form masked. Windows emits uppercase, but third-party logs and JSON round-trips do not.

## The fixture privacy scanner restated the shape instead of asking the grammar

It now calls a shared `sid_occurrences`. This matters more than the duplication suggests: it is the guard that fails the build when a fixture carries an unmasked SID, so any divergence from what the masker matches is a hole in the safety net — and a hole there is invisible by construction, because the check whose job is catching a leak is the one place a mismatch goes unnoticed.

**The issue's diagnosis of this one was not quite right, so recording what the divergence actually was.** The dash threshold is equivalent to the grammar's sub-authority count; `S-1-5-21-1010` was found by both. Measured against the grammar:

| input | masker | old scanner | |
|---|---|---|---|
| `S-1-5-21-1010` | masks | finds | agree — the issue's example was not a hole |
| `s-1-5-21-...` | *missed* | *missed* | both blind (defect 1) |
| `S-1-5-21-1010-` | masks | **misses** | real hole: candidate had to end in a digit |
| `userS-1-5-21-1010` | no match | finds | scanner stricter; harmless |

**Re-ran the full corpus against the tightened scanner. Nothing newly fails**, so no committed fixture was hiding a SID behind either hole — which was the check the issue asked for.

## A third defect the first fix exposed

Making the rule case-insensitive made the lowercase form mask — to a *different token*. The token is hashed from the matched text, so two spellings of one SID produced two tokens. That defeats the correlation a stable token exists to provide: an analyst following one account across a bundle would see it as two identities. The hash is now taken from the uppercase form.

## Verification

Mutation-checked rather than assumed:

- dropping `(?i)` → 3 tests fail
- hashing the text as written → 1 test fails

Parser suite, clippy `-D warnings`, wasm32, and the `src-tauri` suite all clean.

## Note on scope

Three files, no formatting churn. `cargo fmt --all` reflows ~20 unrelated files in this repo because no CI job enforces formatting, so only the edited lines are here.

Next in the cluster: #549 (ESP export never calls its own projection) and #556 (DsRegCmd has no projection at all), both of which want the ADR-004 boundary ruling in #550 first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Windows security identifiers (SIDs) are now recognized regardless of letter casing.
  - Equivalent SID spellings produce consistent redaction tokens.
  - SID detection is now consistent across redaction and privacy scanning.
- **Tests**
  - Added coverage for lowercase SIDs, consistent token generation, and matching scanner behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->