### PR TITLE
fix(intune): stop writing an app inventory to TEMP on every analysis run

### DIFF
--- a/src-tauri/src/commands/intune.rs
+++ b/src-tauri/src/commands/intune.rs
@@ -98,13 +98,31 @@ impl GuidDiagLog {
     }
 
     /// A path no other analysis will pick, in the system temp directory.
+    ///
+    /// The sequence number is what makes that true rather than likely. Two analyses in the same
+    /// process can land inside one clock tick, and a clock can move backwards, either of which
+    /// would repeat a timestamp; because the file is opened exclusively, a repeat does not
+    /// overwrite anything but does lose the trace the operator asked for.
     fn trace_path() -> std::path::PathBuf {
         let stamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|elapsed| elapsed.as_nanos())
             .unwrap_or_default();
+        Self::trace_path_for(stamp)
+    }
+
+    /// The naming, with the clock supplied.
+    ///
+    /// Split so the sequence's contribution can be proved: a test that only calls `trace_path`
+    /// passes whether or not the sequence exists, because successive clock reads on a fast machine
+    /// happen to differ anyway. Holding the stamp fixed is the only way to show the collision case
+    /// is handled.
+    fn trace_path_for(stamp: u128) -> std::path::PathBuf {
+        static SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+        let sequence = SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         std::env::temp_dir().join(format!(
-            "cmtrace-guid-diag-{}-{stamp}.log",
+            "cmtrace-guid-diag-{}-{stamp}-{sequence}.log",
             std::process::id()
         ))
     }
@@ -1602,6 +1620,18 @@ mod guid_diag_tests {
             assert_eq!(mode & 0o777, 0o600, "got {:o}", mode & 0o777);
             let _ = fs::remove_file(&path);
         });
+    }
+
+    #[test]
+    fn every_trace_path_is_distinct_even_within_one_clock_tick() {
+        // The stamp is held fixed, which is the whole point: two analyses in one process can land
+        // inside a single tick, and a clock can move backwards. Either repeats a timestamp, and
+        // because the file is opened exclusively a repeat does not overwrite anything but does
+        // lose the trace that was asked for. Calling trace_path in a loop would pass whether or
+        // not the sequence existed, because successive clock reads happen to differ.
+        let paths: std::collections::HashSet<_> =
+            (0..256).map(|_| GuidDiagLog::trace_path_for(42)).collect();
+        assert_eq!(paths.len(), 256, "one clock tick must still give distinct paths");
     }
 
     #[test]

--- a/src-tauri/src/commands/intune.rs
+++ b/src-tauri/src/commands/intune.rs
@@ -94,18 +94,43 @@ impl GuidDiagLog {
     /// directory is world-writable, so a fixed name there is the classic clobber target — and this
     /// trace is opt-in precisely because its contents are sensitive.
     fn create_file(&self) -> std::io::Result<(std::path::PathBuf, fs::File)> {
+        Self::create_file_at(Self::trace_path())
+    }
+
+    /// A path no other analysis will pick, in the system temp directory.
+    fn trace_path() -> std::path::PathBuf {
         let stamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|elapsed| elapsed.as_nanos())
             .unwrap_or_default();
-        let path = std::env::temp_dir().join(format!(
+        std::env::temp_dir().join(format!(
             "cmtrace-guid-diag-{}-{stamp}.log",
             std::process::id()
-        ));
-        let file = fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)?;
+        ))
+    }
+
+    /// Creates `path` exclusively, readable only by the user who ran the analysis.
+    ///
+    /// Split from [`create_file`](Self::create_file) so the exclusive-open behaviour can be
+    /// exercised against a path that already exists, which is the case that matters and which a
+    /// test calling the composed function cannot reach.
+    fn create_file_at(
+        path: std::path::PathBuf,
+    ) -> std::io::Result<(std::path::PathBuf, fs::File)> {
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+
+        // The default umask leaves this world-readable, and the temp directory is shared. The
+        // trace holds the app inventory this whole change exists to stop leaking, so on the one
+        // path that does write it, only the owner may read it. Windows inherits the directory
+        // ACL, which is already per-user for the profile temp directory.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        let file = options.open(&path)?;
         Ok((path, file))
     }
 }
@@ -412,10 +437,18 @@ fn analyze_intune_logs_blocking(
         );
         if let Some(contents) = diag_buffer.contents() {
             match diag_buffer.create_file() {
-                Ok((diag_path, mut file)) => {
-                    let _ = file.write_all(contents.as_bytes());
-                    log::info!("event=guid_diag_written path=\"{}\"", diag_path.display());
-                }
+                // Reported only once the bytes are actually down. Discarding the write result
+                // logged success over a partial file, which is the same "looks fine, is not"
+                // shape this change is about.
+                Ok((diag_path, mut file)) => match file.write_all(contents.as_bytes()) {
+                    Ok(()) => {
+                        log::info!("event=guid_diag_written path=\"{}\"", diag_path.display())
+                    }
+                    Err(error) => log::warn!(
+                        "event=guid_diag_write_failed path=\"{}\" error=\"{error}\"",
+                        diag_path.display()
+                    ),
+                },
                 Err(error) => log::warn!("event=guid_diag_write_failed error=\"{error}\""),
             }
         }
@@ -1554,6 +1587,23 @@ mod guid_diag_tests {
         });
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn the_trace_file_is_readable_only_by_its_owner() {
+        // The temp directory is shared and the default umask leaves new files world-readable.
+        // This trace holds the app inventory the whole change exists to stop leaking, so on the
+        // one path that does write it, nobody else on the machine may read it.
+        use std::os::unix::fs::PermissionsExt;
+
+        with_var(Some("1"), || {
+            let log = GuidDiagLog::from_env();
+            let (path, _file) = log.create_file().expect("creates");
+            let mode = fs::metadata(&path).expect("stat").permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "got {:o}", mode & 0o777);
+            let _ = fs::remove_file(&path);
+        });
+    }
+
     #[test]
     fn the_trace_file_refuses_to_write_through_something_that_exists() {
         // The system temp directory is world-writable, so a fixed name there is the classic
@@ -1568,12 +1618,14 @@ mod guid_diag_tests {
             let (second_path, _second) = log.create_file().expect("creates");
             assert_ne!(first_path, second_path);
 
-            // And re-opening an existing path is refused rather than truncating it.
-            let existing = fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&first_path);
-            assert!(existing.is_err(), "create_new must refuse an existing path");
+            // The helper itself is asked to open a path that already exists. Asserting on
+            // OpenOptions directly would have proved only that the standard library works, and
+            // would still pass if the helper dropped create_new.
+            let refused = GuidDiagLog::create_file_at(first_path.clone());
+            assert!(
+                refused.is_err(),
+                "create_file_at must refuse a path that already exists"
+            );
 
             let _ = fs::remove_file(&first_path);
             let _ = fs::remove_file(&second_path);

--- a/src-tauri/src/commands/intune.rs
+++ b/src-tauri/src/commands/intune.rs
@@ -85,6 +85,29 @@ impl GuidDiagLog {
     fn contents(&self) -> Option<&str> {
         self.0.as_deref().filter(|trace| !trace.is_empty())
     }
+
+    /// Creates the trace file, refusing to write through anything that already exists.
+    ///
+    /// The name carries the process id and a monotonic stamp, and the file is opened with
+    /// `create_new`, so two analyses cannot overwrite each other and the call fails rather than
+    /// following a symlink an unprivileged user planted at a guessable path. The system temp
+    /// directory is world-writable, so a fixed name there is the classic clobber target — and this
+    /// trace is opt-in precisely because its contents are sensitive.
+    fn create_file(&self) -> std::io::Result<(std::path::PathBuf, fs::File)> {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_nanos())
+            .unwrap_or_default();
+        let path = std::env::temp_dir().join(format!(
+            "cmtrace-guid-diag-{}-{stamp}.log",
+            std::process::id()
+        ));
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)?;
+        Ok((path, file))
+    }
 }
 
 impl FmtWrite for GuidDiagLog {
@@ -388,10 +411,12 @@ fn analyze_intune_logs_blocking(
             guid_registry.len(), enriched_events, missed_events, enriched_downloads, missed_downloads, all_downloads.len()
         );
         if let Some(contents) = diag_buffer.contents() {
-            let diag_path = std::env::temp_dir().join("cmtrace-guid-diag.log");
-            if let Ok(mut f) = fs::File::create(&diag_path) {
-                let _ = f.write_all(contents.as_bytes());
-                log::info!("event=guid_diag_written path=\"{}\"", diag_path.display());
+            match diag_buffer.create_file() {
+                Ok((diag_path, mut file)) => {
+                    let _ = file.write_all(contents.as_bytes());
+                    log::info!("event=guid_diag_written path=\"{}\"", diag_path.display());
+                }
+                Err(error) => log::warn!("event=guid_diag_write_failed error=\"{error}\""),
             }
         }
     }
@@ -1443,22 +1468,44 @@ fn download_signal_rank(state: DownloadSignalState) -> u8 {
 mod guid_diag_tests {
     use super::GuidDiagLog;
     use std::fmt::Write as _;
+    use std::fs;
 
     /// Serializes the env-var mutation these tests share; cargo runs them on threads.
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// Restores the variable on drop, so a failing assertion cannot leak the mutation.
+    ///
+    /// A plain restore after `body()` is skipped while unwinding, which would leave the trace
+    /// enabled for every test that ran afterwards and turn one real failure into a cascade of
+    /// unrelated ones.
+    struct EnvRestore {
+        previous: Option<std::ffi::OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(previous) => std::env::set_var("CMTRACE_INTUNE_GUID_DIAG", previous),
+                None => std::env::remove_var("CMTRACE_INTUNE_GUID_DIAG"),
+            }
+        }
+    }
+
     fn with_var<T>(value: Option<&str>, body: impl FnOnce() -> T) -> T {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        let previous = std::env::var_os("CMTRACE_INTUNE_GUID_DIAG");
+        let lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let restore = EnvRestore {
+            previous: std::env::var_os("CMTRACE_INTUNE_GUID_DIAG"),
+            _lock: lock,
+        };
         match value {
             Some(value) => std::env::set_var("CMTRACE_INTUNE_GUID_DIAG", value),
             None => std::env::remove_var("CMTRACE_INTUNE_GUID_DIAG"),
         }
         let outcome = body();
-        match previous {
-            Some(previous) => std::env::set_var("CMTRACE_INTUNE_GUID_DIAG", previous),
-            None => std::env::remove_var("CMTRACE_INTUNE_GUID_DIAG"),
-        }
+        drop(restore);
         outcome
     }
 
@@ -1497,12 +1544,39 @@ mod guid_diag_tests {
     }
 
     #[test]
-    fn an_enabled_but_unused_trace_writes_no_file() {
-        // contents() is what gates the write, so an enabled run that logged nothing must still
-        // produce no file rather than an empty one sitting in TEMP.
+    fn an_enabled_trace_that_collected_nothing_reports_no_contents() {
+        // Deliberately a statement about the sink, not about the file. In the real analysis the
+        // pipeline summary always writes once the trace is on, so an enabled run does produce a
+        // file; claiming otherwise here would be a test passing for a reason its name denies.
         with_var(Some("1"), || {
             let log = GuidDiagLog::from_env();
             assert!(log.contents().is_none());
+        });
+    }
+
+    #[test]
+    fn the_trace_file_refuses_to_write_through_something_that_exists() {
+        // The system temp directory is world-writable, so a fixed name there is the classic
+        // clobber and symlink-follow target, and this trace is opt-in precisely because its
+        // contents are sensitive.
+        with_var(Some("1"), || {
+            let log = GuidDiagLog::from_env();
+            let (first_path, _first) = log.create_file().expect("creates");
+            assert!(first_path.exists());
+
+            // A second call must not reuse the name, so no analysis can truncate another's trace.
+            let (second_path, _second) = log.create_file().expect("creates");
+            assert_ne!(first_path, second_path);
+
+            // And re-opening an existing path is refused rather than truncating it.
+            let existing = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&first_path);
+            assert!(existing.is_err(), "create_new must refuse an existing path");
+
+            let _ = fs::remove_file(&first_path);
+            let _ = fs::remove_file(&second_path);
         });
     }
 }

--- a/src-tauri/src/commands/intune.rs
+++ b/src-tauri/src/commands/intune.rs
@@ -56,6 +56,46 @@ struct IntuneAnalysisProgressPayload {
     total_files: Option<usize>,
 }
 
+/// Sink for the verbose GUID-enrichment trace, off unless explicitly asked for.
+///
+/// The detail this carries is an organisation's app inventory: every registry
+/// GUID with its application name, every enriched event name, and every download
+/// name and content id. It was written to `%TEMP%/cmtrace-guid-diag.log` on every
+/// analysis run, without the operator asking, and never cleaned up.
+///
+/// Nobody chose that. It is developer instrumentation for diagnosing GUID
+/// enrichment, and the summary an operator actually needs already goes to the
+/// application log. Set `CMTRACE_INTUNE_GUID_DIAG` to collect the verbose trace
+/// while debugging; leave it unset and nothing is written to disk.
+///
+/// Implements `fmt::Write` so the existing `writeln!` call sites are unchanged
+/// and discard when the trace is off.
+struct GuidDiagLog(Option<String>);
+
+impl GuidDiagLog {
+    fn from_env() -> Self {
+        Self(
+            std::env::var_os("CMTRACE_INTUNE_GUID_DIAG")
+                .filter(|value| !value.is_empty())
+                .map(|_| String::new()),
+        )
+    }
+
+    /// The collected trace, or `None` when collection was off.
+    fn contents(&self) -> Option<&str> {
+        self.0.as_deref().filter(|trace| !trace.is_empty())
+    }
+}
+
+impl FmtWrite for GuidDiagLog {
+    fn write_str(&mut self, text: &str) -> std::fmt::Result {
+        if let Some(trace) = &mut self.0 {
+            trace.push_str(text);
+        }
+        Ok(())
+    }
+}
+
 /// Analyze Intune Management Extension logs and return structured results.
 ///
 /// Supports either:
@@ -236,7 +276,7 @@ fn analyze_intune_logs_blocking(
     }
 
     // Enrich event and download names using the global GUID registry
-    let mut diag_buffer = String::new();
+    let mut diag_buffer = GuidDiagLog::from_env();
     let mut enriched_events = 0u32;
     let mut enriched_downloads = 0u32;
     let mut missed_events = 0u32;
@@ -347,10 +387,12 @@ fn analyze_intune_logs_blocking(
             "event=guid_enrichment_summary registry={} enriched_events={} missed_events={} enriched_downloads={} missed_downloads={} total_downloads={}",
             guid_registry.len(), enriched_events, missed_events, enriched_downloads, missed_downloads, all_downloads.len()
         );
-        let diag_path = std::env::temp_dir().join("cmtrace-guid-diag.log");
-        if let Ok(mut f) = fs::File::create(&diag_path) {
-            let _ = f.write_all(diag_buffer.as_bytes());
-            log::info!("event=guid_diag_written path=\"{}\"", diag_path.display());
+        if let Some(contents) = diag_buffer.contents() {
+            let diag_path = std::env::temp_dir().join("cmtrace-guid-diag.log");
+            if let Ok(mut f) = fs::File::create(&diag_path) {
+                let _ = f.write_all(contents.as_bytes());
+                log::info!("event=guid_diag_written path=\"{}\"", diag_path.display());
+            }
         }
     }
 
@@ -1394,6 +1436,74 @@ fn download_signal_rank(state: DownloadSignalState) -> u8 {
         DownloadSignalState::InProgress => 1,
         DownloadSignalState::Success => 2,
         DownloadSignalState::Failed => 3,
+    }
+}
+
+#[cfg(test)]
+mod guid_diag_tests {
+    use super::GuidDiagLog;
+    use std::fmt::Write as _;
+
+    /// Serializes the env-var mutation these tests share; cargo runs them on threads.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_var<T>(value: Option<&str>, body: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = std::env::var_os("CMTRACE_INTUNE_GUID_DIAG");
+        match value {
+            Some(value) => std::env::set_var("CMTRACE_INTUNE_GUID_DIAG", value),
+            None => std::env::remove_var("CMTRACE_INTUNE_GUID_DIAG"),
+        }
+        let outcome = body();
+        match previous {
+            Some(previous) => std::env::set_var("CMTRACE_INTUNE_GUID_DIAG", previous),
+            None => std::env::remove_var("CMTRACE_INTUNE_GUID_DIAG"),
+        }
+        outcome
+    }
+
+    #[test]
+    fn collects_nothing_when_the_trace_was_not_asked_for() {
+        // The trace carries an organisation's app inventory. Unset means nothing is retained, so
+        // there is nothing for the caller to write to disk.
+        with_var(None, || {
+            let mut log = GuidDiagLog::from_env();
+            let name = "Contoso Payroll";
+            let _ = writeln!(log, "guid=abc name=\"{name}\"");
+            assert!(log.contents().is_none(), "no trace may be retained");
+        });
+    }
+
+    #[test]
+    fn an_empty_value_does_not_enable_it() {
+        // CMTRACE_INTUNE_GUID_DIAG= in a shell profile is not a request for the trace.
+        with_var(Some(""), || {
+            let mut log = GuidDiagLog::from_env();
+            let name = "Contoso Payroll";
+            let _ = writeln!(log, "guid=abc name=\"{name}\"");
+            assert!(log.contents().is_none());
+        });
+    }
+
+    #[test]
+    fn collects_the_trace_when_asked_for() {
+        with_var(Some("1"), || {
+            let mut log = GuidDiagLog::from_env();
+            let name = "Contoso Payroll";
+            let _ = writeln!(log, "guid=abc name=\"{name}\"");
+            let trace = log.contents().expect("the trace was requested");
+            assert!(trace.contains("Contoso Payroll"), "got {trace:?}");
+        });
+    }
+
+    #[test]
+    fn an_enabled_but_unused_trace_writes_no_file() {
+        // contents() is what gates the write, so an enabled run that logged nothing must still
+        // produce no file rather than an empty one sitting in TEMP.
+        with_var(Some("1"), || {
+            let log = GuidDiagLog::from_env();
+            assert!(log.contents().is_none());
+        });
     }
 }
 


### PR DESCRIPTION
Refs #549 — the one item in its "related, same root cause" list that needs no ADR-004 ruling.

## The leak

Every Intune analysis wrote `%TEMP%/cmtrace-guid-diag.log`. Unconditionally, with no operator action, never cleaned up, never redacted.

What it carried:

- every GUID registry entry with its **application name**
- every event name enriched or missed, with its GUID
- every download name with its content id and size

That is an organisation's app inventory — the same class of identifier the Intune lanes mask everywhere else — in cleartext, in a directory other users on the machine can read.

## Why this one does not wait on the ADR

#549 and #556 are export-boundary questions: a value that *should* be projected reaches a user-chosen file. Ruling 1 in #550 decides where that projection binds, so fixing them now would front-run the decision.

This is not that. It is a write nobody requested. No ruling in the draft would sanction it, and the fix is not "project it" but "do not write it".

## The fix

Developer instrumentation for diagnosing GUID enrichment. The summary an operator actually needs already goes to the application log via `log::info!`; only the verbose per-entry trace went to the file. It is now collected only when `CMTRACE_INTUNE_GUID_DIAG` is set to a non-empty value.

Implemented as a sink implementing `fmt::Write` that discards when off, so the eleven `writeln!` call sites are untouched and stay interleaved with the enrichment logic they describe — the writes are woven through `event.name = enriched` and the counters, so deleting blocks was not an option.

An empty env value does not enable it (a stray `CMTRACE_INTUNE_GUID_DIAG=` in a shell profile is not a request), and an enabled run that logged nothing writes no file rather than leaving an empty one in TEMP.

## Verification

Mutation-checked rather than assumed: making the sink always collect fails two of the four tests.

`src-tauri` suite and clippy `-D warnings` clean. One file, no formatting churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in diagnostic tracing for Intune GUID operations through the `CMTRACE_INTUNE_GUID_DIAG` setting.
  * Diagnostic files now use unique paths and are created only when trace content is available.

* **Bug Fixes**
  * Prevented empty diagnostic files when tracing is disabled or unused.
  * Improved diagnostic file security and reporting of creation or write failures.

* **Tests**
  * Added coverage for environment handling, trace collection, file permissions, unique paths, and existing-file protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->