### PR TITLE
ci(release): build every platform and carry shortlinks into release notes

### DIFF
--- a/.github/agents/release.agent.md
+++ b/.github/agents/release.agent.md
@@ -101,9 +101,12 @@ instead created by `codesign.yml`'s manual-dispatch path, GitHub suppresses the
 tag push event because the ref was created with `GITHUB_TOKEN`, and only the
 Windows half of the release is built. That is how v1.5.2 shipped Windows-only.
 Whenever `codesign.yml` is dispatched manually, dispatch `cmtrace-release.yml`
-with the same version afterwards:
+with the same version afterwards. Wait for the codesign run to have created the
+tag first, because `cmtrace-release.yml` checks out `refs/tags/vX.Y.Z` and fails
+immediately if the tag does not exist yet:
 
 ```bash
+git fetch --tags && git rev-parse "refs/tags/vX.Y.Z"
 gh workflow run cmtrace-release.yml --ref main -f version=X.Y.Z
 ```
 

--- a/.github/agents/release.agent.md
+++ b/.github/agents/release.agent.md
@@ -96,6 +96,36 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 
 This triggers `.github/workflows/cmtrace-release.yml` for macOS and Linux artifacts and `.github/workflows/codesign.yml` for signed Windows x64 and arm64 artifacts.
 
+Pushing the tag from a workstation is what fires both workflows. If the tag is
+instead created by `codesign.yml`'s manual-dispatch path, GitHub suppresses the
+tag push event because the ref was created with `GITHUB_TOKEN`, and only the
+Windows half of the release is built. That is how v1.5.2 shipped Windows-only.
+Whenever `codesign.yml` is dispatched manually, dispatch `cmtrace-release.yml`
+with the same version afterwards:
+
+```bash
+gh workflow run cmtrace-release.yml --ref main -f version=X.Y.Z
+```
+
+### 6a. Confirm the release is complete
+
+Before announcing the release, verify every platform actually landed:
+
+```bash
+gh release view vX.Y.Z --json assets --jq '[.assets[].name]'
+```
+
+Expect Windows `.msi` / `.exe` / `-setup.exe` for both arches, the macOS `.dmg`
+and `.app.tar.gz`, the Linux `.AppImage` / `.deb` / `.rpm`, both SBOMs, and
+`latest.json`. Then confirm `latest.json` carries every updater target:
+
+```bash
+curl -sL https://github.com/adamgell/cmtraceopen/releases/download/vX.Y.Z/latest.json | jq '.platforms | keys'
+```
+
+A missing `windows-aarch64` or `darwin-aarch64` key means those users get no
+update prompt at all, which is silent and easy to miss.
+
 ### 7. Confirm with a release summary
 
 After the push and tag succeed, print a concise formatted summary that includes:
@@ -126,6 +156,20 @@ Release: https://github.com/adamgell/cmtraceopen/releases/tag/vX.Y.Z
 ```
 
 Omit any empty changelog section from the summary.
+
+## Release Notes
+
+Both release workflows seed the GitHub release body from
+`.github/release-notes/template.md`, so a release created by either half starts
+with the same notes. Whenever the notes are rewritten by hand afterwards, keep
+the `### Download shortlinks` table. Those `*.cmtrace.net` hosts resolve to the
+current stable release rather than to a pinned version, so they keep working in
+tickets and runbooks after the release scrolls out of view, and they are the
+links the project hands out. Every release note must carry them.
+
+Re-running `cmtrace-release.yml` against an existing release reads the published
+body back and hands it to `tauri-action` unchanged, so hand-written notes survive
+a rebuild. Edit the release body, not the workflow, to correct published notes.
 
 ## Important Notes
 

--- a/.github/release-notes/template.md
+++ b/.github/release-notes/template.md
@@ -1,0 +1,34 @@
+Stable downloads: https://download.cmtraceopen.com/?source=github-release
+
+## CMTrace Open {{TAG}}
+
+Open-source CMTrace log viewer with built-in Intune diagnostics.
+
+### Download shortlinks
+
+Each shortlink always resolves to the current stable release, so it stays valid in
+tickets, runbooks, and slides long after this page scrolls out of view.
+
+| Platform | Shortlink |
+|----------|-----------|
+| Windows x64, portable EXE | https://win.cmtrace.net |
+| Windows ARM64, portable EXE | https://winarm.cmtrace.net |
+| Windows x64, Lite portable EXE | https://lite.cmtrace.net |
+| Windows x64, MSI installer | https://msi.cmtrace.net |
+| macOS Apple silicon, DMG | https://mac.cmtrace.net |
+| Linux x64, AppImage | https://linux.cmtrace.net |
+
+Nightly channel: https://nightly.cmtrace.net
+
+### Artifacts in {{TAG}}
+
+| Platform | Files |
+|----------|-------|
+| Windows x64 and ARM64 | signed `.msi`, signed portable `.exe` (Full and Lite), signed `-setup.exe` |
+| macOS Apple silicon | signed and notarized `.dmg`, plus the `.app.tar.gz` updater archive |
+| Linux x64 | `.AppImage`, `.deb`, `.rpm` |
+
+The MSI installs both the Full and Lite editions. Portable EXEs require no installation.
+
+CycloneDX SBOMs (`sbom-rust.cdx.json`, `sbom-npm.cdx.json`) and build provenance
+attestations are published alongside the binaries.

--- a/.github/workflows/cmtrace-release.yml
+++ b/.github/workflows/cmtrace-release.yml
@@ -61,8 +61,11 @@ jobs:
             version="${REF_NAME#v}"
           fi
 
-          if [ -z "$version" ]; then
-            echo "::error::Could not determine a release version."
+          # Without this a tag like v1.6.0-rc.1 would build, publish with
+          # prerelease: false, and overwrite the stable updater manifest that
+          # every installed copy polls.
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Expected a stable MAJOR.MINOR.PATCH version, got '$version'. This workflow publishes stable releases only."
             exit 1
           fi
 
@@ -112,9 +115,17 @@ jobs:
           fi
 
           echo "draft=$draft" >> "$GITHUB_OUTPUT"
+
+          # The closing delimiter has to start its own line, but normalizing the
+          # body itself would edit the notes on the way back to the release, so
+          # only add the newline when one is genuinely missing.
+          if [ -n "$(tail -c 1 release-notes.md)" ]; then
+            printf '\n' >> release-notes.md
+          fi
+
           {
             echo "body<<CMTRACE_RELEASE_BODY_EOF"
-            printf '%s\n' "$(cat release-notes.md)"
+            cat release-notes.md
             echo "CMTRACE_RELEASE_BODY_EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/cmtrace-release.yml
+++ b/.github/workflows/cmtrace-release.yml
@@ -6,6 +6,18 @@ on:
       - "v*"
       - "[0-9]*.[0-9]*.[0-9]*"
       - "!*.*.*.*"
+  # codesign.yml can be dispatched manually, and its "Create release tag for
+  # manual dispatch" step pushes the tag with GITHUB_TOKEN. GitHub suppresses
+  # workflow triggers for refs created by GITHUB_TOKEN, so that path publishes
+  # Windows artifacts without ever firing the tag push this workflow listens
+  # for, and the release ships Windows-only (v1.5.2). Dispatch lets the macOS
+  # and Linux half be run against a tag that already exists.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to build macOS and Linux artifacts for (for example 1.5.2 or v1.5.2). The tag must already exist.
+        required: true
+        type: string
 
 permissions: {}
 
@@ -29,7 +41,82 @@ jobs:
     runs-on: ${{ matrix.os }}
     environment: codesigning
     steps:
+      - name: Resolve release tag
+        id: resolve
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            version="${INPUT_VERSION#v}"
+            tag_name="v$version"
+          else
+            # The tag filters accept both "v1.5.2" and "1.5.2", so the pushed tag
+            # is authoritative and only the version string gets normalized.
+            tag_name="$REF_NAME"
+            version="${REF_NAME#v}"
+          fi
+
+          if [ -z "$version" ]; then
+            echo "::error::Could not determine a release version."
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag_name=$tag_name" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # On a dispatch the workflow ref is a branch, so the tag has to be
+          # named explicitly or the build would package the wrong commit.
+          ref: refs/tags/${{ steps.resolve.outputs.tag_name }}
+
+      - name: Resolve release notes
+        id: notes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.resolve.outputs.tag_name }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # tauri-action calls updateRelease on a published release with whatever
+          # body it is handed, so a re-run against an existing release would
+          # replace hand-written notes with the template. Read the published body
+          # back and feed it straight through instead.
+          draft=""
+          if gh release view "$TAG_NAME" --json body,isDraft > release-state.json 2>/dev/null; then
+            jq -r '.body // ""' release-state.json > release-notes.md
+            draft="$(jq -r '.isDraft' release-state.json)"
+          fi
+
+          if [ ! -s release-notes.md ]; then
+            template=".github/release-notes/template.md"
+            if [ ! -f "$template" ]; then
+              echo "::error::No release notes exist for $TAG_NAME and $template is missing from that tag."
+              exit 1
+            fi
+            sed -e "s|{{TAG}}|$TAG_NAME|g" -e "s|{{VERSION}}|$VERSION|g" "$template" > release-notes.md
+          fi
+
+          # tauri-action finds a draft by scanning the release list but a published
+          # one by tag lookup. The wrong flag sends it down the create path for a
+          # tag that already exists, which the API rejects.
+          if [ -z "$draft" ]; then
+            draft="true"
+          fi
+
+          echo "draft=$draft" >> "$GITHUB_OUTPUT"
+          {
+            echo "body<<CMTRACE_RELEASE_BODY_EOF"
+            printf '%s\n' "$(cat release-notes.md)"
+            echo "CMTRACE_RELEASE_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Import Apple Developer Certificate
         if: runner.os == 'macOS'
@@ -110,22 +197,10 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           projectPath: .
-          tagName: ${{ github.ref_name }}
-          releaseName: "CMTrace Open ${{ github.ref_name }}"
-          releaseBody: |
-            Stable downloads: https://download.cmtraceopen.com/?source=github-release
-
-            ## CMTrace Open ${{ github.ref_name }}
-
-            Open-source CMTrace log viewer with built-in Intune diagnostics.
-
-            ### Downloads
-            | Platform | File |
-            |----------|------|
-            | Windows (x64 / arm64) | signed `.msi` / signed `.exe` |
-            | macOS (ARM) | signed + notarized `.dmg` disk image |
-            | Linux (x64) | `.deb` / `.AppImage` |
-          releaseDraft: true
+          tagName: ${{ steps.resolve.outputs.tag_name }}
+          releaseName: "CMTrace Open ${{ steps.resolve.outputs.tag_name }}"
+          releaseBody: ${{ steps.notes.outputs.body }}
+          releaseDraft: ${{ steps.notes.outputs.draft }}
           prerelease: false
           args: --target ${{ matrix.target }}
 
@@ -140,8 +215,9 @@ jobs:
       - name: Upload SBOMs to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.resolve.outputs.tag_name }}
         run: |
-          gh release upload "${{ github.ref_name }}" \
+          gh release upload "$TAG_NAME" \
             sbom-rust.cdx.json \
             sbom-npm.cdx.json \
             --clobber

--- a/.github/workflows/codesign.yml
+++ b/.github/workflows/codesign.yml
@@ -447,8 +447,28 @@ jobs:
 
           gh release upload "$TAG_NAME" latest.json --clobber
 
+          # cmtrace-release.yml publishes the macOS and Linux entries from a
+          # separate workflow run, so a write there can still land between the
+          # read above and this upload. tauri-action merges rather than
+          # replaces, so the usual outcome is a complete manifest, but read the
+          # published file back rather than assuming: a Windows entry that lost
+          # the race would otherwise leave those users with no update prompt and
+          # nothing in the logs to say so.
+          gh release download "$TAG_NAME" --pattern latest.json --dir published --clobber
+          missing=""
+          for platform_key in windows-x86_64 windows-aarch64; do
+            if ! jq -e --arg key "$platform_key" '.platforms | has($key)' published/latest.json > /dev/null; then
+              missing="$missing $platform_key"
+            fi
+          done
+
           {
             echo "### Updater manifest"
             echo ""
-            jq -r '.platforms | keys[] | "- `\(.)`"' latest.json
+            jq -r '.platforms | keys[] | "- `\(.)`"' published/latest.json
           } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -n "$missing" ]; then
+            echo "::error::Published latest.json is missing:$missing. A concurrent manifest write clobbered it; re-run this job."
+            exit 1
+          fi

--- a/.github/workflows/codesign.yml
+++ b/.github/workflows/codesign.yml
@@ -395,17 +395,26 @@ jobs:
           # and the loser's platform vanished, which is how v1.5.2 shipped with a
           # windows-x86_64 entry and no windows-aarch64 one. Both arches are now
           # merged by a single writer once the matrix has finished.
-          if ! gh release download "$TAG_NAME" --pattern latest.json --dir . --clobber 2>/dev/null; then
+          # Ask whether the manifest exists before downloading it. Treating any
+          # download failure as "no manifest yet" would turn a transient API
+          # error into a Windows-only manifest that deletes the macOS and Linux
+          # entries, which is the exact failure this job exists to prevent.
+          published_assets="$(gh release view "$TAG_NAME" --json assets --jq '.assets[].name')"
+          if printf '%s\n' "$published_assets" | grep -qx 'latest.json'; then
+            gh release download "$TAG_NAME" --pattern latest.json --dir . --clobber
+          else
             echo '{}' > latest.json
           fi
 
           # macOS and Linux entries arrive from cmtrace-release.yml, so anything
-          # already in platforms is carried across untouched.
+          # already in platforms is carried across untouched. Merge onto the
+          # existing object rather than rebuilding it so unrecognized top-level
+          # metadata survives too.
           jq \
             --arg version "v$VERSION" \
             --arg notes "CMTrace Open v$VERSION" \
             --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '{
+            '. + {
                version: $version,
                notes: $notes,
                pub_date: (.pub_date // $now),

--- a/.github/workflows/codesign.yml
+++ b/.github/workflows/codesign.yml
@@ -121,22 +121,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.resolve_version.outputs.tag_name }}
+          VERSION: ${{ steps.resolve_version.outputs.version }}
         run: |
           $releaseTitle = "CMTrace Open $env:TAG_NAME"
-          $releaseNotes = @"
-          Stable downloads: https://download.cmtraceopen.com/?source=github-release
-
-          ## CMTrace Open $env:TAG_NAME
-
-          Open-source CMTrace log viewer with built-in Intune diagnostics.
-
-          ### Windows Downloads
-          | File | Description |
-          |------|-------------|
-          | `CMTrace-Open_VERSION_ARCH.msi` | MSI installer (includes Full + Lite) |
-          | `CMTrace-Open_VERSION_ARCH.exe` | Standalone full edition |
-          | `CMTrace-Open-Lite_VERSION_ARCH.exe` | Standalone lite edition |
-          "@
 
           $releaseExists = $false
           for ($attempt = 1; $attempt -le 12; $attempt++) {
@@ -150,7 +137,20 @@ jobs:
           }
 
           if (-not $releaseExists) {
-            gh release create $env:TAG_NAME --draft --title $releaseTitle --notes $releaseNotes *> $null
+            # Shared with cmtrace-release.yml so that whichever half of the
+            # release gets there first seeds the same notes, including the
+            # cmtrace.net download shortlinks.
+            $templatePath = ".github/release-notes/template.md"
+            if (-not (Test-Path $templatePath)) {
+              throw "Release notes template not found at $templatePath."
+            }
+
+            $releaseNotes = Get-Content $templatePath -Raw
+            $releaseNotes = $releaseNotes.Replace("{{TAG}}", $env:TAG_NAME)
+            $releaseNotes = $releaseNotes.Replace("{{VERSION}}", $env:VERSION)
+            Set-Content -Path release-notes.md -Value $releaseNotes -Encoding utf8
+
+            gh release create $env:TAG_NAME --draft --title $releaseTitle --notes-file release-notes.md *> $null
             if ($LASTEXITCODE -ne 0) {
               gh release view $env:TAG_NAME *> $null
               if ($LASTEXITCODE -ne 0) {
@@ -349,6 +349,7 @@ jobs:
             ${{ steps.stage_artifacts.outputs.lite_exe_path }}
             ${{ steps.verify_msi.outputs.msi_path }}
             ${{ steps.stage_artifacts.outputs.nsis_path }}
+            ${{ steps.stage_artifacts.outputs.nsis_path }}.sig
           if-no-files-found: error
 
       - name: Publish signed Windows assets to GitHub Release
@@ -362,58 +363,83 @@ jobs:
         run: |
           gh release upload $env:TAG_NAME $env:FULL_EXE_PATH $env:LITE_EXE_PATH $env:MSI_PATH $env:NSIS_PATH --clobber
 
-      - name: Update latest.json with Windows platform entry
-        shell: pwsh
+  finalize-updater-manifest:
+    name: Finalize updater manifest
+    needs:
+      - prepare-windows-release
+      - windows-signed-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.prepare-windows-release.outputs.version }}
+      TAG_NAME: ${{ needs.prepare-windows-release.outputs.tag_name }}
+
+    steps:
+      - name: Download signed Windows artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: release-artifacts
+          merge-multiple: true
+
+      - name: Merge Windows platform entries into latest.json
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NSIS_PATH: ${{ steps.stage_artifacts.outputs.nsis_path }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          $nsisFileName = Split-Path $env:NSIS_PATH -Leaf
-          $sigContent = Get-Content "$env:NSIS_PATH.sig" -Raw
-          $downloadUrl = "https://github.com/${{ github.repository }}/releases/download/$env:TAG_NAME/$nsisFileName"
+          set -euo pipefail
 
-          # Map artifact suffix to Tauri platform key
-          $platformKey = if ("${{ matrix.artifact_suffix }}" -eq "x64") { "windows-x86_64" } else { "windows-aarch64" }
+          # The x64 and arm64 jobs each used to download, patch, and re-upload
+          # latest.json. With nothing having seeded the file the two reads raced
+          # and the loser's platform vanished, which is how v1.5.2 shipped with a
+          # windows-x86_64 entry and no windows-aarch64 one. Both arches are now
+          # merged by a single writer once the matrix has finished.
+          if ! gh release download "$TAG_NAME" --pattern latest.json --dir . --clobber 2>/dev/null; then
+            echo '{}' > latest.json
+          fi
 
-          $platformEntry = @{
-            signature = $sigContent.Trim()
-            url       = $downloadUrl
-            version   = "v$env:VERSION"
-          }
+          # macOS and Linux entries arrive from cmtrace-release.yml, so anything
+          # already in platforms is carried across untouched.
+          jq \
+            --arg version "v$VERSION" \
+            --arg notes "CMTrace Open v$VERSION" \
+            --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{
+               version: $version,
+               notes: $notes,
+               pub_date: (.pub_date // $now),
+               platforms: (.platforms // {})
+             }' latest.json > latest.json.next
+          mv latest.json.next latest.json
 
-          # Try to download existing latest.json from the release (may have been uploaded by macOS/Linux workflow)
-          $latestJsonPath = Join-Path $PWD "latest.json"
-          $existing = $null
+          for entry in x64:windows-x86_64 arm64:windows-aarch64; do
+            suffix="${entry%%:*}"
+            platform_key="${entry##*:}"
+            installer="CMTrace-Open_${VERSION}_${suffix}-setup.exe"
+            signature_path="release-artifacts/${installer}.sig"
 
-          for ($attempt = 1; $attempt -le 6; $attempt++) {
-            try {
-              gh release download $env:TAG_NAME --pattern "latest.json" --dir $PWD --clobber 2>$null
-              if (Test-Path $latestJsonPath) {
-                $existing = Get-Content $latestJsonPath -Raw | ConvertFrom-Json
-                break
-              }
-            } catch { }
-            Start-Sleep -Seconds 10
-          }
+            if [ ! -f "$signature_path" ]; then
+              echo "::error::Updater signature missing for ${installer}."
+              exit 1
+            fi
 
-          if (-not $existing) {
-            # Create new latest.json
-            $existing = [PSCustomObject]@{
-              version   = "v$env:VERSION"
-              notes     = "CMTrace Open v$env:VERSION"
-              pub_date  = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-              platforms = @{}
-            }
-          }
+            # The signature is produced on a Windows runner, so strip CR as well
+            # as LF before it is embedded in JSON.
+            jq \
+              --arg key "$platform_key" \
+              --arg signature "$(tr -d '\r\n' < "$signature_path")" \
+              --arg url "https://github.com/${REPOSITORY}/releases/download/${TAG_NAME}/${installer}" \
+              --arg version "v$VERSION" \
+              '.platforms[$key] = {signature: $signature, url: $url, version: $version}' \
+              latest.json > latest.json.next
+            mv latest.json.next latest.json
+          done
 
-          # Ensure platforms is a hashtable we can add to
-          if ($existing.platforms -is [PSCustomObject]) {
-            $platformsHash = @{}
-            $existing.platforms.PSObject.Properties | ForEach-Object { $platformsHash[$_.Name] = $_.Value }
-            $existing.platforms = $platformsHash
-          }
+          gh release upload "$TAG_NAME" latest.json --clobber
 
-          $existing.platforms[$platformKey] = $platformEntry
-          $existing | ConvertTo-Json -Depth 10 | Set-Content $latestJsonPath -Encoding utf8
-
-          gh release upload $env:TAG_NAME $latestJsonPath --clobber
+          {
+            echo "### Updater manifest"
+            echo ""
+            jq -r '.platforms | keys[] | "- `\(.)`"' latest.json
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

`v1.5.2` shipped **Windows-only**. It was cut by dispatching `codesign.yml`, whose manual-dispatch path pushes the tag with `GITHUB_TOKEN`. GitHub suppresses workflow triggers for refs created by that token, so the `push: tags` event `cmtrace-release.yml` listens for never fired. The release is missing:

- `.dmg` and `.app.tar.gz` (macOS arm64)
- `.AppImage`, `.deb`, `.rpm` (Linux x64)
- `sbom-rust.cdx.json` and `sbom-npm.cdx.json`
- the `windows-aarch64` key in `latest.json`, which leaves Windows ARM64 users with no update prompt at all

`cmtrace-release.yml` had no `workflow_dispatch` trigger, so it could not be run for the existing tag to repair any of this.

## What changed

**`cmtrace-release.yml`**
- `workflow_dispatch` with a `version` input, so the macOS/Linux half can be run against a tag that already exists.
- Checkout pinned to `refs/tags/<tag>`, so a dispatch from a branch still packages the tagged commit rather than the branch tip.
- A notes step that reads an existing release body back and feeds it to `tauri-action` unchanged. `tauri-action` calls `updateRelease` with whatever body it is handed, so without this a re-run replaces hand-written release notes with the template. It also resolves the correct `releaseDraft` value, because `tauri-action` finds a draft by scanning the release list but a published release by tag lookup, and the wrong flag sends it down the create path for a tag that already exists.

**`codesign.yml`**
- The per-job `latest.json` patch is replaced by one `finalize-updater-manifest` job that runs after the matrix. Previously the x64 and arm64 jobs each downloaded, patched, and re-uploaded the file; with nothing having seeded it the two reads raced, which is how `v1.5.2` ended up with `windows-x86_64` and no `windows-aarch64`. The NSIS `.sig` is now kept as a workflow artifact so the single writer can assemble both entries.
- Release notes come from the shared template.

**`.github/release-notes/template.md`** (new)
Shared body rendered by both workflows, so whichever half creates the release seeds the same notes. Carries the `*.cmtrace.net` download shortlinks, which resolve to the current stable release rather than a pinned version and so stay valid in tickets and runbooks.

**`.github/agents/release.agent.md`**
Documents the `GITHUB_TOKEN` trigger trap, the dispatch recovery command, a post-release completeness check, and the requirement that release notes keep the shortlink table.

## Verification

- `actionlint` clean on both workflows; the two remaining `SC2086` infos are pre-existing and untouched.
- Notes preservation exercised against the real published `v1.5.2` body: round-trips byte-identical and resolves `draft=false`.
- Manifest merge exercised against the real `v1.5.1` and `v1.5.2` manifests: all 8 platform keys preserved, `pub_date` preserved, CRLF stripped from the Windows-generated signature.
- `tauri-action@1deb371` source read to confirm `uploadVersionJSON` merges into an existing `latest.json` rather than replacing it, so the macOS/Linux run will not drop the existing `windows-x86_64` entry.

Running the two halves in order (macOS/Linux, then Windows) reproduces exactly the manifest shape `v1.5.1` has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent release notes with platform download links, installation guidance, artifact details, and build-provenance information.
  * Improved release publishing for manually initiated builds across macOS, Linux, and Windows.
  * Windows releases now include updater signatures and consolidated update metadata for supported architectures.

* **Bug Fixes**
  * Improved preservation and validation of release content and platform update information during rebuilds.
  * Added checks to help ensure downloadable artifacts and updater targets are complete and correctly signed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->