### PR TITLE
ci(release): give the manifest finalizer an explicit repository

### DIFF
--- a/.github/workflows/codesign.yml
+++ b/.github/workflows/codesign.yml
@@ -386,6 +386,11 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job deliberately skips actions/checkout, since it only needs the
+          # build artifacts and the release API. Without a working tree gh has no
+          # git remote to infer the repository from and every call fails with
+          # "not a git repository", so name it explicitly.
+          GH_REPO: ${{ github.repository }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## The bug

`finalize-updater-manifest` (added in #566) deliberately skips `actions/checkout`, because it only needs the build artifacts and the release API. But without a working tree the `gh` CLI has no git remote to infer the repository from, so its very first call failed:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1
```

## How it surfaced

On the v1.5.2 Windows rebuild ([run 31732298463](https://github.com/adamgell/cmtraceopen/actions/runs/31732298463)):

| Job | Result |
|---|---|
| Prepare Windows Release | success |
| Signed Windows Release (Windows-x64) | success |
| Signed Windows Release (Windows-arm64) | success |
| Finalize updater manifest | **failure** |

Both signed builds published their binaries, then the finalizer died before merging, leaving `windows-aarch64` out of `latest.json` — the exact entry that rebuild existed to restore.

The failure is at least loud: the job goes red rather than publishing a partial manifest.

## The fix

Set `GH_REPO` rather than adding a checkout, since nothing else in the job wants a working tree.

## v1.5.2

Already completed by hand from the run's artifacts, so no second rebuild was needed. That was only possible because #566 added the NSIS `.sig` to the uploaded artifacts. Before checking anything else I verified the artifact installers were byte-identical to the published release assets, so the signatures correspond to what users actually download:

```
MATCH  x64    8e2a90f8a2e92496f613bd77b940a5a02b8cdbb465f87562be8848edbc55a0c2
MATCH  arm64  48eed37c0c8d64f1310c68e69f303f3006e4990b6c669300fbd0b21f23516adf
```

and confirmed each signature's trusted comment names the right file:

```
windows-x86_64  -> trusted comment: timestamp:1786647973  file:CMTrace-Open_1.5.2_x64-setup.exe
windows-aarch64 -> trusted comment: timestamp:1786647999  file:CMTrace-Open_1.5.2_arm64-setup.exe
```

`v1.5.2` now publishes all 20 artifacts and all 8 updater platform keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation so release commands work reliably without requiring a repository checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->