### PR TITLE
ci(release): publish latest.json from the release's own signatures

### DIFF
--- a/.github/actions/publish-updater-manifest/action.yml
+++ b/.github/actions/publish-updater-manifest/action.yml
@@ -1,0 +1,81 @@
+name: Publish updater manifest
+description: >-
+  Rebuild latest.json from the release's own signature assets and publish it.
+  Safe to run from either release workflow, in any order, concurrently.
+
+inputs:
+  version:
+    description: Release version without the leading v, for example 1.5.3
+    required: true
+  tag-name:
+    description: Release tag, for example v1.5.3
+    required: true
+  github-token:
+    description: Token used to read and write release assets
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Publish updater manifest
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        # Composite steps get no working tree of their own, and the checkout
+        # above is the caller's repo, so name the repository explicitly rather
+        # than letting gh infer it from a git remote that may not be there.
+        GH_REPO: ${{ github.repository }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        VERSION: ${{ inputs.version }}
+        TAG_NAME: ${{ inputs.tag-name }}
+      run: |
+        set -euo pipefail
+
+        # Both release workflows run this. The manifest is derived from the
+        # release's assets rather than from the platform this job happens to
+        # have built, so whichever workflow finishes last sees everything and
+        # publishes a complete file. Publishers that overlap compute identical
+        # bytes, and a publisher that runs early carries forward the entries it
+        # cannot see yet, so a concurrent write can only ever add keys.
+        for attempt in 1 2 3; do
+          rm -rf signatures published latest.json
+          mkdir -p signatures published
+
+          # No signatures yet is a legitimate state on the very first publisher.
+          gh release download "$TAG_NAME" --pattern '*.sig' --dir signatures --clobber 2>/dev/null || true
+          gh release download "$TAG_NAME" --pattern latest.json --dir published --clobber 2>/dev/null || true
+
+          published_manifest=""
+          if [ -f published/latest.json ]; then
+            published_manifest="published/latest.json"
+          fi
+
+          PUBLISHED_MANIFEST="$published_manifest" \
+          SIGNATURE_DIR=signatures \
+          OUTPUT_PATH=latest.json \
+            node .github/scripts/updater-manifest.mjs | tee build.log
+
+          gh release upload "$TAG_NAME" latest.json --clobber
+
+          # Read back what actually landed. Another publisher may have written
+          # between this run's read and its upload, and the loser of that race
+          # is exactly the silent data loss this action exists to prevent.
+          rm -rf verify && mkdir -p verify
+          gh release download "$TAG_NAME" --pattern latest.json --dir verify --clobber
+
+          if diff <(jq -S '.platforms | keys' latest.json) <(jq -S '.platforms | keys' verify/latest.json) > /dev/null; then
+            {
+              echo "### Updater manifest"
+              echo ""
+              jq -r '.platforms | keys[] | "- `\(.)`"' verify/latest.json
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::warning::latest.json changed underneath this publisher on attempt ${attempt}; merging again."
+        done
+
+        echo "::error::Could not publish a stable latest.json after 3 attempts."
+        exit 1

--- a/.github/actions/publish-updater-manifest/action.yml
+++ b/.github/actions/publish-updater-manifest/action.yml
@@ -33,39 +33,69 @@ runs:
       run: |
         set -euo pipefail
 
+        # Enumerate the release once per attempt. A download is skipped only
+        # when the asset genuinely is not published yet; anything else, an auth
+        # failure or a network blip, has to fail the job. Treating those as "no
+        # assets" would publish an empty manifest over a valid one.
+        download_release_state() {
+          local assets
+          assets="$(gh release view "$TAG_NAME" --json assets --jq '.assets[].name')"
+
+          rm -rf "$1" && mkdir -p "$1/signatures"
+
+          if printf '%s\n' "$assets" | grep -q '\.sig$'; then
+            gh release download "$TAG_NAME" --pattern '*.sig' --dir "$1/signatures" --clobber
+          fi
+
+          if printf '%s\n' "$assets" | grep -qx 'latest.json'; then
+            gh release download "$TAG_NAME" --pattern latest.json --dir "$1" --clobber
+          fi
+        }
+
         # Both release workflows run this. The manifest is derived from the
         # release's assets rather than from the platform this job happens to
         # have built, so whichever workflow finishes last sees everything and
-        # publishes a complete file. Publishers that overlap compute identical
-        # bytes, and a publisher that runs early carries forward the entries it
-        # cannot see yet, so a concurrent write can only ever add keys.
+        # publishes a complete file.
         for attempt in 1 2 3; do
-          rm -rf signatures published latest.json
-          mkdir -p signatures published
-
-          # No signatures yet is a legitimate state on the very first publisher.
-          gh release download "$TAG_NAME" --pattern '*.sig' --dir signatures --clobber 2>/dev/null || true
-          gh release download "$TAG_NAME" --pattern latest.json --dir published --clobber 2>/dev/null || true
+          download_release_state state
 
           published_manifest=""
-          if [ -f published/latest.json ]; then
-            published_manifest="published/latest.json"
+          if [ -f state/latest.json ]; then
+            published_manifest="state/latest.json"
           fi
 
           PUBLISHED_MANIFEST="$published_manifest" \
-          SIGNATURE_DIR=signatures \
+          SIGNATURE_DIR=state/signatures \
           OUTPUT_PATH=latest.json \
-            node .github/scripts/updater-manifest.mjs | tee build.log
+            node .github/scripts/updater-manifest.mjs
+
+          # Every publisher runs after its own platform's signatures are
+          # uploaded, so an empty result means the release state was misread
+          # rather than that there is nothing to publish.
+          if [ "$(jq '.platforms | length' latest.json)" -eq 0 ]; then
+            echo "::error::Refusing to publish a manifest with no platform entries."
+            exit 1
+          fi
 
           gh release upload "$TAG_NAME" latest.json --clobber
 
-          # Read back what actually landed. Another publisher may have written
-          # between this run's read and its upload, and the loser of that race
-          # is exactly the silent data loss this action exists to prevent.
-          rm -rf verify && mkdir -p verify
-          gh release download "$TAG_NAME" --pattern latest.json --dir verify --clobber
+          # Verify against what the release can support *now*, not against what
+          # this run built. Only one publisher can be blind to the other's
+          # signatures, but that blind one may still upload last and overwrite a
+          # more complete manifest. Comparing against its own build would happily
+          # confirm the truncated file it just wrote.
+          download_release_state verify
 
-          if diff <(jq -S '.platforms | keys' latest.json) <(jq -S '.platforms | keys' verify/latest.json) > /dev/null; then
+          SIGNATURE_DIR=verify/signatures \
+          OUTPUT_PATH=verify/expected.json \
+            node .github/scripts/updater-manifest.mjs > /dev/null
+
+          dropped="$(jq -r -n \
+            --slurpfile expected verify/expected.json \
+            --slurpfile actual verify/latest.json \
+            '(($expected[0].platforms | keys) - ($actual[0].platforms | keys)) | join(", ")')"
+
+          if [ -z "$dropped" ]; then
             {
               echo "### Updater manifest"
               echo ""
@@ -74,7 +104,7 @@ runs:
             exit 0
           fi
 
-          echo "::warning::latest.json changed underneath this publisher on attempt ${attempt}; merging again."
+          echo "::warning::Published manifest is missing ${dropped} that the release's signatures support; merging again (attempt ${attempt})."
         done
 
         echo "::error::Could not publish a stable latest.json after 3 attempts."

--- a/.github/agents/release.agent.md
+++ b/.github/agents/release.agent.md
@@ -126,8 +126,27 @@ and `.app.tar.gz`, the Linux `.AppImage` / `.deb` / `.rpm`, both SBOMs, and
 curl -sL https://github.com/adamgell/cmtraceopen/releases/download/vX.Y.Z/latest.json | jq '.platforms | keys'
 ```
 
-A missing `windows-aarch64` or `darwin-aarch64` key means those users get no
-update prompt at all, which is silent and easy to miss.
+Expect all eight targets: `windows-x86_64`, `windows-aarch64`,
+`darwin-aarch64`, `darwin-aarch64-app`, `linux-x86_64`,
+`linux-x86_64-appimage`, `linux-x86_64-deb`, `linux-x86_64-rpm`. A missing key
+means those users get no update prompt at all, which is silent and easy to miss.
+
+Note that the CDN caches release assets, so a `latest.json` fetched by download
+URL right after a release can be stale. Read it through the API when the answer
+matters:
+
+```bash
+gh release view vX.Y.Z --json assets \
+  --jq '.assets[] | select(.name=="latest.json") | .url' \
+  | xargs -I{} gh api -H "Accept: application/octet-stream" {} | jq '.platforms | keys'
+```
+
+`latest.json` is built by `.github/actions/publish-updater-manifest`, which both
+release workflows run once their builds finish. It derives every entry from the
+release's own `.sig` assets rather than from the platform that job built, so the
+workflow that finishes last publishes a complete manifest and an early one only
+ever adds keys. If a target is still missing after both workflows are green,
+that is a real gap rather than a race, and the build that owns it will be red.
 
 ### 7. Confirm with a release summary
 

--- a/.github/scripts/updater-manifest.mjs
+++ b/.github/scripts/updater-manifest.mjs
@@ -1,0 +1,158 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+// Every Tauri updater target this project ships, and the release artifact each
+// one points at. `darwin-aarch64` and `darwin-aarch64-app` intentionally share
+// an artifact: Tauri reads the first and the `{os}-{arch}-{bundle}` form is the
+// newer alias for the same download. Same story for the two AppImage keys.
+export const UPDATER_TARGETS = [
+  { key: "windows-x86_64", artifact: (v) => `CMTrace-Open_${v}_x64-setup.exe` },
+  { key: "windows-aarch64", artifact: (v) => `CMTrace-Open_${v}_arm64-setup.exe` },
+  { key: "darwin-aarch64", artifact: (v) => `CMTrace.Open_${v}_aarch64.app.tar.gz` },
+  { key: "darwin-aarch64-app", artifact: (v) => `CMTrace.Open_${v}_aarch64.app.tar.gz` },
+  { key: "linux-x86_64", artifact: (v) => `CMTrace.Open_${v}_amd64.AppImage` },
+  { key: "linux-x86_64-appimage", artifact: (v) => `CMTrace.Open_${v}_amd64.AppImage` },
+  { key: "linux-x86_64-deb", artifact: (v) => `CMTrace.Open_${v}_amd64.deb` },
+  { key: "linux-x86_64-rpm", artifact: (v) => `CMTrace.Open-${v}-1.x86_64.rpm` },
+];
+
+export const MANIFEST_FILENAME = "latest.json";
+
+function assetUrl(repository, tagName, fileName) {
+  return `https://github.com/${repository}/releases/download/${tagName}/${encodeURIComponent(fileName)}`;
+}
+
+/**
+ * Build the stable updater manifest from whatever the release already carries.
+ *
+ * Two properties matter, and both come from deriving entries out of the
+ * release's own assets rather than out of the job that happens to be running:
+ *
+ * - Convergent. Each release workflow sees the same assets, so the manifest
+ *   they compute for a given set of uploads is identical. Two publishers racing
+ *   is no longer a lost update, because they write the same bytes.
+ * - Monotonic. Entries already published are carried forward when this run
+ *   cannot see their artifact yet, so a publisher that runs before the other
+ *   platform has uploaded can only ever add keys, never remove them.
+ *
+ * `missing` is reported rather than thrown: the first workflow to finish is
+ * legitimately incomplete, and an entry that never arrives means its build job
+ * failed, which is already red.
+ */
+export function buildUpdaterManifest({
+  version,
+  tagName,
+  repository,
+  signatures,
+  publishedManifest = null,
+  pubDate,
+}) {
+  const platforms = { ...(publishedManifest?.platforms ?? {}) };
+  const missing = [];
+  const resolved = [];
+
+  for (const target of UPDATER_TARGETS) {
+    const artifact = target.artifact(version);
+    const signature = signatures.get(`${artifact}.sig`);
+
+    if (signature === undefined) {
+      if (!platforms[target.key]) missing.push(target.key);
+      continue;
+    }
+
+    platforms[target.key] = {
+      signature,
+      url: assetUrl(repository, tagName, artifact),
+      version: tagName,
+    };
+    resolved.push(target.key);
+  }
+
+  return {
+    manifest: {
+      version: tagName,
+      notes: `CMTrace Open ${tagName}`,
+      // Preserved so a later publisher does not restamp the release date.
+      pub_date: publishedManifest?.pub_date ?? pubDate,
+      platforms,
+    },
+    missing,
+    resolved,
+  };
+}
+
+/**
+ * Read `<name>.sig` files out of a directory listing into the map
+ * buildUpdaterManifest expects. Signatures are produced on Windows runners as
+ * well as Unix ones, so CR is stripped alongside LF.
+ */
+export async function readSignatures(directory, fileNames) {
+  const signatures = new Map();
+
+  for (const fileName of fileNames) {
+    if (!fileName.endsWith(".sig")) continue;
+    const contents = await readFile(path.join(directory, fileName), "utf8");
+    signatures.set(fileName, contents.replace(/[\r\n]/g, ""));
+  }
+
+  return signatures;
+}
+
+function requireValue(name, value) {
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function readJsonIfPresent(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function main() {
+  const signatureDir = process.env.SIGNATURE_DIR ?? "signatures";
+  const publishedPath = process.env.PUBLISHED_MANIFEST ?? "";
+  const outputPath = process.env.OUTPUT_PATH ?? MANIFEST_FILENAME;
+
+  const { readdir } = await import("node:fs/promises");
+  const entries = await readdir(signatureDir);
+
+  const { manifest, missing, resolved } = buildUpdaterManifest({
+    version: requireValue("VERSION", process.env.VERSION),
+    tagName: requireValue("TAG_NAME", process.env.TAG_NAME),
+    repository: requireValue("GITHUB_REPOSITORY", process.env.GITHUB_REPOSITORY),
+    signatures: await readSignatures(signatureDir, entries),
+    publishedManifest: publishedPath ? await readJsonIfPresent(publishedPath) : null,
+    pubDate: new Date().toISOString(),
+  });
+
+  await writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  console.log(`resolved: ${resolved.join(", ") || "none"}`);
+  console.log(`missing: ${missing.join(", ") || "none"}`);
+
+  if (missing.length > 0) {
+    // A warning rather than a failure. The workflow that finishes first has
+    // legitimately not seen the other platform's uploads yet, and a target that
+    // never arrives means its build job failed and is already reporting red.
+    console.log(
+      `::warning::Updater manifest is missing ${missing.join(", ")}. ` +
+        "This is expected until every platform has uploaded; if it persists, a build job failed.",
+    );
+  }
+}
+
+export function isMainModule(importMetaUrl, argvPath = process.argv[1]) {
+  if (!argvPath) return false;
+  return importMetaUrl === new URL(`file://${path.resolve(argvPath)}`).href;
+}
+
+if (isMainModule(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/updater-manifest.test.mjs
+++ b/.github/scripts/updater-manifest.test.mjs
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  UPDATER_TARGETS,
+  buildUpdaterManifest,
+  readSignatures,
+} from "./updater-manifest.mjs";
+
+const VERSION = "1.5.3";
+const TAG_NAME = "v1.5.3";
+const REPOSITORY = "adamgell/cmtraceopen";
+const PUB_DATE = "2026-08-14T00:00:00.000Z";
+
+function signaturesFor(keys) {
+  const signatures = new Map();
+  for (const target of UPDATER_TARGETS) {
+    if (!keys.includes(target.key)) continue;
+    signatures.set(`${target.artifact(VERSION)}.sig`, `sig-for-${target.key}`);
+  }
+  return signatures;
+}
+
+function build(overrides = {}) {
+  return buildUpdaterManifest({
+    version: VERSION,
+    tagName: TAG_NAME,
+    repository: REPOSITORY,
+    signatures: new Map(),
+    pubDate: PUB_DATE,
+    ...overrides,
+  });
+}
+
+const ALL_KEYS = UPDATER_TARGETS.map((target) => target.key);
+const WINDOWS_KEYS = ALL_KEYS.filter((key) => key.startsWith("windows-"));
+const UNIX_KEYS = ALL_KEYS.filter((key) => !key.startsWith("windows-"));
+
+test("resolves every updater target when all signatures are present", () => {
+  const { manifest, missing } = build({ signatures: signaturesFor(ALL_KEYS) });
+
+  assert.deepEqual(missing, []);
+  assert.deepEqual(Object.keys(manifest.platforms).sort(), [...ALL_KEYS].sort());
+  assert.equal(manifest.version, TAG_NAME);
+  assert.equal(manifest.notes, `CMTrace Open ${TAG_NAME}`);
+});
+
+test("points each target at its own artifact under the release tag", () => {
+  const { manifest } = build({ signatures: signaturesFor(ALL_KEYS) });
+
+  assert.equal(
+    manifest.platforms["windows-aarch64"].url,
+    `https://github.com/${REPOSITORY}/releases/download/${TAG_NAME}/CMTrace-Open_${VERSION}_arm64-setup.exe`,
+  );
+  assert.equal(
+    manifest.platforms["linux-x86_64-rpm"].url,
+    `https://github.com/${REPOSITORY}/releases/download/${TAG_NAME}/CMTrace.Open-${VERSION}-1.x86_64.rpm`,
+  );
+});
+
+test("aliased targets share one artifact", () => {
+  const { manifest } = build({ signatures: signaturesFor(ALL_KEYS) });
+
+  assert.equal(
+    manifest.platforms["darwin-aarch64"].url,
+    manifest.platforms["darwin-aarch64-app"].url,
+  );
+  assert.equal(
+    manifest.platforms["linux-x86_64"].url,
+    manifest.platforms["linux-x86_64-appimage"].url,
+  );
+});
+
+test("reports the targets it could not resolve instead of throwing", () => {
+  const { manifest, missing } = build({ signatures: signaturesFor(WINDOWS_KEYS) });
+
+  assert.deepEqual(missing.sort(), [...UNIX_KEYS].sort());
+  assert.deepEqual(Object.keys(manifest.platforms).sort(), [...WINDOWS_KEYS].sort());
+});
+
+// The property that makes concurrent publishers safe: the manifest is a
+// function of the release's assets, not of which workflow computed it.
+test("two publishers seeing the same assets produce identical manifests", () => {
+  const first = build({ signatures: signaturesFor(ALL_KEYS) });
+  const second = build({ signatures: signaturesFor(ALL_KEYS) });
+
+  assert.deepEqual(first.manifest, second.manifest);
+});
+
+// The property that makes an out-of-order publisher safe: a run that cannot see
+// the other platform's artifacts yet must not delete its entries. This is the
+// exact regression that shipped v1.5.2 without windows-aarch64 and then, on the
+// repair run, without any Linux key at all.
+test("carries published entries forward when their artifacts are not visible", () => {
+  const published = {
+    version: TAG_NAME,
+    notes: `CMTrace Open ${TAG_NAME}`,
+    pub_date: "2026-08-13T12:00:00Z",
+    platforms: Object.fromEntries(
+      UNIX_KEYS.map((key) => [
+        key,
+        { signature: "already-published", url: "https://example.invalid/asset", version: TAG_NAME },
+      ]),
+    ),
+  };
+
+  const { manifest, missing } = build({
+    signatures: signaturesFor(WINDOWS_KEYS),
+    publishedManifest: published,
+  });
+
+  assert.deepEqual(missing, []);
+  assert.deepEqual(Object.keys(manifest.platforms).sort(), [...ALL_KEYS].sort());
+  assert.equal(manifest.platforms["linux-x86_64-deb"].signature, "already-published");
+  assert.equal(manifest.platforms["windows-x86_64"].signature, "sig-for-windows-x86_64");
+});
+
+test("a freshly built entry replaces the published one for the same target", () => {
+  const published = {
+    pub_date: "2026-08-13T12:00:00Z",
+    platforms: {
+      "windows-x86_64": { signature: "stale", url: "https://example.invalid/old", version: "v1.5.2" },
+    },
+  };
+
+  const { manifest } = build({
+    signatures: signaturesFor(["windows-x86_64"]),
+    publishedManifest: published,
+  });
+
+  assert.equal(manifest.platforms["windows-x86_64"].signature, "sig-for-windows-x86_64");
+  assert.equal(manifest.platforms["windows-x86_64"].version, TAG_NAME);
+});
+
+test("keeps the original publication date across republishes", () => {
+  const { manifest } = build({
+    signatures: signaturesFor(ALL_KEYS),
+    publishedManifest: { pub_date: "2026-08-13T12:00:00Z", platforms: {} },
+  });
+
+  assert.equal(manifest.pub_date, "2026-08-13T12:00:00Z");
+});
+
+test("stamps a publication date on the first publish", () => {
+  const { manifest } = build({ signatures: signaturesFor(ALL_KEYS) });
+
+  assert.equal(manifest.pub_date, PUB_DATE);
+});
+
+test("strips the line endings Windows runners leave on signature files", async () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "updater-manifest-"));
+
+  try {
+    writeFileSync(path.join(directory, "windows.exe.sig"), "dGF1cmktc2ln\r\n");
+    writeFileSync(path.join(directory, "unix.AppImage.sig"), "dGF1cmktc2ln\n");
+    writeFileSync(path.join(directory, "not-a-signature.exe"), "ignored");
+
+    const signatures = await readSignatures(directory, [
+      "windows.exe.sig",
+      "unix.AppImage.sig",
+      "not-a-signature.exe",
+    ]);
+
+    assert.equal(signatures.get("windows.exe.sig"), "dGF1cmktc2ln");
+    assert.equal(signatures.get("unix.AppImage.sig"), "dGF1cmktc2ln");
+    assert.equal(signatures.has("not-a-signature.exe"), false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+// Guards the contract the Tauri updater actually reads. A renamed or dropped
+// key is silent at runtime: affected users simply stop being offered updates.
+test("target list matches the keys the updater expects", () => {
+  assert.deepEqual(
+    [...ALL_KEYS].sort(),
+    [
+      "darwin-aarch64",
+      "darwin-aarch64-app",
+      "linux-x86_64",
+      "linux-x86_64-appimage",
+      "linux-x86_64-deb",
+      "linux-x86_64-rpm",
+      "windows-aarch64",
+      "windows-x86_64",
+    ],
+  );
+});

--- a/.github/workflows/cmtrace-ci.yml
+++ b/.github/workflows/cmtrace-ci.yml
@@ -163,6 +163,11 @@ jobs:
       - name: CI bundle output contract tests
         run: node --test scripts/ci-bundle-outputs.test.mjs scripts/ci-windows-provenance.test.mjs
 
+      # Release-workflow helpers. nightly-channel.test.mjs existed but was wired
+      # into nothing, so it had never guarded a pull request.
+      - name: Release script tests
+        run: node --test .github/scripts/updater-manifest.test.mjs .github/scripts/nightly-channel.test.mjs
+
       - name: npm security audit
         run: npm audit --audit-level=high
         continue-on-error: true

--- a/.github/workflows/cmtrace-release.yml
+++ b/.github/workflows/cmtrace-release.yml
@@ -28,6 +28,11 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+    # Both matrix entries resolve these from the same inputs, so the usual
+    # last-writer-wins caveat on matrix outputs does not apply here.
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      tag_name: ${{ steps.resolve.outputs.tag_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -214,6 +219,12 @@ jobs:
           releaseDraft: ${{ steps.notes.outputs.draft }}
           prerelease: false
           args: --target ${{ matrix.target }}
+          # Each matrix entry would otherwise publish its own latest.json from a
+          # read taken minutes earlier. That is what dropped every Linux entry
+          # from v1.5.2 when the macOS upload landed second. The manifest is now
+          # published once per workflow by publish-updater-manifest, which
+          # derives it from the release's own signature assets.
+          uploadUpdaterJson: false
 
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
@@ -232,3 +243,18 @@ jobs:
             sbom-rust.cdx.json \
             sbom-npm.cdx.json \
             --clobber
+
+  publish-updater-manifest:
+    name: Publish updater manifest
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Publish updater manifest
+        uses: ./.github/actions/publish-updater-manifest
+        with:
+          version: ${{ needs.release.outputs.version }}
+          tag-name: ${{ needs.release.outputs.tag_name }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cmtrace-release.yml
+++ b/.github/workflows/cmtrace-release.yml
@@ -250,6 +250,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Shared with codesign.yml; see the note there for why grouping publisher
+    # jobs is safe when grouping build jobs would not be.
+    concurrency:
+      group: updater-manifest-${{ needs.release.outputs.tag_name }}
+      cancel-in-progress: false
 
     steps:
       - name: Publish updater manifest

--- a/.github/workflows/codesign.yml
+++ b/.github/workflows/codesign.yml
@@ -375,6 +375,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Shared with cmtrace-release.yml so the two publishers for a tag run one
+    # after the other rather than overlapping. Only publisher jobs are in this
+    # group: a concurrency group keeps a single pending entry and cancels the
+    # rest, which would silently drop a platform if build jobs were grouped, but
+    # is harmless here because a superseded publisher's work is redone by the
+    # one that replaces it.
+    concurrency:
+      group: updater-manifest-${{ needs.prepare-windows-release.outputs.tag_name }}
+      cancel-in-progress: false
 
     steps:
       - name: Publish updater manifest

--- a/.github/workflows/codesign.yml
+++ b/.github/workflows/codesign.yml
@@ -361,119 +361,25 @@ jobs:
           MSI_PATH: ${{ steps.verify_msi.outputs.msi_path }}
           NSIS_PATH: ${{ steps.stage_artifacts.outputs.nsis_path }}
         run: |
-          gh release upload $env:TAG_NAME $env:FULL_EXE_PATH $env:LITE_EXE_PATH $env:MSI_PATH $env:NSIS_PATH --clobber
+          # The NSIS updater signature ships as a release asset so the manifest
+          # publisher can rebuild the Windows entries from the release itself
+          # rather than from this run's workflow artifacts. macOS and Linux
+          # signatures are already published this way by tauri-action.
+          gh release upload $env:TAG_NAME $env:FULL_EXE_PATH $env:LITE_EXE_PATH $env:MSI_PATH $env:NSIS_PATH "$($env:NSIS_PATH).sig" --clobber
 
-  finalize-updater-manifest:
-    name: Finalize updater manifest
+  publish-updater-manifest:
+    name: Publish updater manifest
     needs:
       - prepare-windows-release
       - windows-signed-release
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    env:
-      VERSION: ${{ needs.prepare-windows-release.outputs.version }}
-      TAG_NAME: ${{ needs.prepare-windows-release.outputs.tag_name }}
 
     steps:
-      - name: Download signed Windows artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Publish updater manifest
+        uses: ./.github/actions/publish-updater-manifest
         with:
-          path: release-artifacts
-          merge-multiple: true
-
-      - name: Merge Windows platform entries into latest.json
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # This job deliberately skips actions/checkout, since it only needs the
-          # build artifacts and the release API. Without a working tree gh has no
-          # git remote to infer the repository from and every call fails with
-          # "not a git repository", so name it explicitly.
-          GH_REPO: ${{ github.repository }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          # The x64 and arm64 jobs each used to download, patch, and re-upload
-          # latest.json. With nothing having seeded the file the two reads raced
-          # and the loser's platform vanished, which is how v1.5.2 shipped with a
-          # windows-x86_64 entry and no windows-aarch64 one. Both arches are now
-          # merged by a single writer once the matrix has finished.
-          # Ask whether the manifest exists before downloading it. Treating any
-          # download failure as "no manifest yet" would turn a transient API
-          # error into a Windows-only manifest that deletes the macOS and Linux
-          # entries, which is the exact failure this job exists to prevent.
-          published_assets="$(gh release view "$TAG_NAME" --json assets --jq '.assets[].name')"
-          if printf '%s\n' "$published_assets" | grep -qx 'latest.json'; then
-            gh release download "$TAG_NAME" --pattern latest.json --dir . --clobber
-          else
-            echo '{}' > latest.json
-          fi
-
-          # macOS and Linux entries arrive from cmtrace-release.yml, so anything
-          # already in platforms is carried across untouched. Merge onto the
-          # existing object rather than rebuilding it so unrecognized top-level
-          # metadata survives too.
-          jq \
-            --arg version "v$VERSION" \
-            --arg notes "CMTrace Open v$VERSION" \
-            --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '. + {
-               version: $version,
-               notes: $notes,
-               pub_date: (.pub_date // $now),
-               platforms: (.platforms // {})
-             }' latest.json > latest.json.next
-          mv latest.json.next latest.json
-
-          for entry in x64:windows-x86_64 arm64:windows-aarch64; do
-            suffix="${entry%%:*}"
-            platform_key="${entry##*:}"
-            installer="CMTrace-Open_${VERSION}_${suffix}-setup.exe"
-            signature_path="release-artifacts/${installer}.sig"
-
-            if [ ! -f "$signature_path" ]; then
-              echo "::error::Updater signature missing for ${installer}."
-              exit 1
-            fi
-
-            # The signature is produced on a Windows runner, so strip CR as well
-            # as LF before it is embedded in JSON.
-            jq \
-              --arg key "$platform_key" \
-              --arg signature "$(tr -d '\r\n' < "$signature_path")" \
-              --arg url "https://github.com/${REPOSITORY}/releases/download/${TAG_NAME}/${installer}" \
-              --arg version "v$VERSION" \
-              '.platforms[$key] = {signature: $signature, url: $url, version: $version}' \
-              latest.json > latest.json.next
-            mv latest.json.next latest.json
-          done
-
-          gh release upload "$TAG_NAME" latest.json --clobber
-
-          # cmtrace-release.yml publishes the macOS and Linux entries from a
-          # separate workflow run, so a write there can still land between the
-          # read above and this upload. tauri-action merges rather than
-          # replaces, so the usual outcome is a complete manifest, but read the
-          # published file back rather than assuming: a Windows entry that lost
-          # the race would otherwise leave those users with no update prompt and
-          # nothing in the logs to say so.
-          gh release download "$TAG_NAME" --pattern latest.json --dir published --clobber
-          missing=""
-          for platform_key in windows-x86_64 windows-aarch64; do
-            if ! jq -e --arg key "$platform_key" '.platforms | has($key)' published/latest.json > /dev/null; then
-              missing="$missing $platform_key"
-            fi
-          done
-
-          {
-            echo "### Updater manifest"
-            echo ""
-            jq -r '.platforms | keys[] | "- `\(.)`"' published/latest.json
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ -n "$missing" ]; then
-            echo "::error::Published latest.json is missing:$missing. A concurrent manifest write clobbered it; re-run this job."
-            exit 1
-          fi
+          version: ${{ needs.prepare-windows-release.outputs.version }}
+          tag-name: ${{ needs.prepare-windows-release.outputs.tag_name }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #567.

## The problem

`latest.json` was written by three jobs across two independently triggered workflows, each doing a read-modify-write against the published asset. Two writers whose windows overlapped dropped the loser's keys.

The failure mode is what makes it serious: **every job goes green, every artifact is present, and one platform simply stops being offered updates.** There is no error anywhere.

It happened twice on `v1.5.2` alone:

| When | Lost |
|---|---|
| Original release | `windows-aarch64` (the two Windows jobs raced with nothing seeded) |
| The run that repaired it | every Linux key (macOS uploaded second and clobbered them) |

## The approach

Derive the manifest from **the release's own `.sig` assets** rather than from whichever platform the running job built. That buys two properties:

- **Convergent.** Both workflows compute the manifest from the same assets, so publishers that overlap write identical bytes instead of clobbering each other.
- **Monotonic.** Entries already published are carried forward when this run cannot see their artifact yet, so a publisher that runs before the other platform has uploaded can only ever *add* keys.

Together these make concurrency harmless rather than merely less likely, which is why this is preferred over the three options sketched in #567. No cross-workflow trigger, no `workflow_run` state machine, no merging the two pipelines.

Two supporting changes make it work:

- The Windows NSIS signature now ships as a **release asset**, so the Windows entries can be rebuilt from the release rather than from one run's workflow artifacts. macOS and Linux signatures were already published this way by `tauri-action`.
- `uploadUpdaterJson: false` on `tauri-action`, so each matrix entry stops publishing its own partial manifest.

### On failure handling

A publisher that cannot see every target **warns rather than fails**. The first workflow to finish is legitimately incomplete, and a target that never arrives means its build job failed, which is already red. Failing here would just make every release red until the slower workflow caught up.

After uploading, each publisher reads the manifest back and retries the merge if it changed underneath, so a lost update is repaired instead of shipped.

### Why a composite action

Both workflows need the identical publisher. The repo had no composite actions before, but duplicating ~30 lines of download/build/upload/verify YAML across two release workflows is exactly the kind of thing that drifts apart. The real logic lives in `.github/scripts/updater-manifest.mjs`.

### Why browser download URLs

The generated entries use `releases/download/<tag>/<file>` rather than `tauri-action`'s `api.github.com/.../releases/assets/<id>`. Both work (`updater.rs:659` sets `Accept: application/octet-stream`), and browser URLs are what `v1.5.1` published, but the real argument is robustness: an asset re-uploaded with `--clobber` gets a **new asset id**, so any manifest holding the old API URL starts 404ing. The browser URL is stable across re-uploads.

## Verification

Validated against the real `v1.5.2` release, not just synthetic fixtures. Feeding the script the actual published signatures reproduces the live manifest exactly:

```
resolved: windows-x86_64, windows-aarch64, darwin-aarch64, darwin-aarch64-app,
          linux-x86_64, linux-x86_64-appimage, linux-x86_64-deb, linux-x86_64-rpm
missing: none

keys identical: True
version match : True 'v1.5.2'
notes match   : True
signatures matching live manifest: 8/8
```

All eight signatures byte-identical to what is published today, which is what confirms the artifact-to-target mapping is right.

15 unit tests, including direct regression coverage for both `v1.5.2` incidents (an early publisher must not delete the other platform's entries; two publishers seeing the same assets must produce identical manifests). `actionlint` reports only the two pre-existing `SC2086` infos.

The mapping from artifact filename to updater target is the part that is silent when wrong, so it is unit tested rather than left to the workflow. `.github/scripts/nightly-channel.test.mjs` existed but was wired into nothing and had never guarded a pull request; both suites now run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated generation and publishing of updater manifests for releases.
  - Supports all updater platforms, preserves release metadata, and safely handles concurrent updates.
  - Windows releases now include the NSIS updater signature.

- **Release Process**
  - Manifests are published after all release jobs complete.
  - Release validation detects missing targets, CDN delays, and genuine release gaps.

- **Tests**
  - Added comprehensive coverage for manifest generation, signatures, platform resolution, and metadata preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->