### PR TITLE
ci: review dependency pull requests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -36,15 +36,12 @@ reviews:
     drafts: true
     base_branches:
       - main
-    # Dependency bumps and release automation are machine-generated; skip them.
+    # Release automation is machine-generated; skip it.
     ignore_usernames:
-      - dependabot[bot]
       - github-actions[bot]
     ignore_title_keywords:
       - WIP
       - DO NOT MERGE
-      - chore(deps)
-      - chore(deps-dev)
 
   # Exclude generated, vendored, and binary-ish paths from review.
   path_filters:


### PR DESCRIPTION
## Summary
- stop ignoring Dependabot authors in CodeRabbit
- retain the GitHub Actions bot exclusion and generated-path filters

## Verification
- YAML parses successfully
- git diff --check passes

This unblocks the required current-head CodeRabbit approval for PR #575.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automatic review filtering to skip GitHub Actions-authored pull requests, work-in-progress pull requests, and pull requests titled “DO NOT MERGE.”
  * Removed exclusions for Dependabot and dependency-specific pull request titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->