### PR TITLE
test(metrics): align release link checks with workflows

### DIFF
--- a/tools/download-metrics/tests/project-links.test.ts
+++ b/tools/download-metrics/tests/project-links.test.ts
@@ -13,18 +13,26 @@ function read(path: string): string {
 describe("project-controlled download link boundaries", () => {
   it("routes human-facing stable and nightly links through their branded pages", () => {
     const readme = read("README.md");
+    const stableReleaseNotes = read(".github/release-notes/template.md");
     const stableReleaseWorkflow = read(".github/workflows/cmtrace-release.yml");
     const windowsReleaseWorkflow = read(".github/workflows/codesign.yml");
     const nightlyReleaseWorkflow = read(".github/workflows/cmtrace-nightly-signed.yml");
 
     expect(readme).toContain("https://download.cmtraceopen.com/?source=github-readme");
     expect(readme).not.toContain("https://github.com/adamgell/CMTraceOpen/releases/latest");
-    expect(stableReleaseWorkflow).toMatch(
-      /releaseBody: \|\n\s+Stable downloads: https:\/\/download\.cmtraceopen\.com\/\?source=github-release/,
+    expect(stableReleaseNotes).toContain(
+      "Stable downloads: https://download.cmtraceopen.com/?source=github-release",
     );
-    expect(windowsReleaseWorkflow).toMatch(
-      /\$releaseNotes = @"\n\s+Stable downloads: https:\/\/download\.cmtraceopen\.com\/\?source=github-release/,
+    expect(stableReleaseWorkflow).toContain(
+      'template=".github/release-notes/template.md"',
     );
+    expect(stableReleaseWorkflow).toContain(
+      "releaseBody: ${{ steps.notes.outputs.body }}",
+    );
+    expect(windowsReleaseWorkflow).toContain(
+      '$templatePath = ".github/release-notes/template.md"',
+    );
+    expect(windowsReleaseWorkflow).toContain("--notes-file release-notes.md");
     expect(nightlyReleaseWorkflow).toMatch(
       /cat > release-notes\.md <<EOF\n\s+Nightly build status and downloads: https:\/\/adamgell\.com\/cmtraceopen\//,
     );
@@ -34,6 +42,9 @@ describe("project-controlled download link boundaries", () => {
     const stableTauriConfig = read("src-tauri/tauri.conf.json");
     const nightlyChannelScript = read(".github/scripts/nightly-channel.mjs");
     const windowsReleaseWorkflow = read(".github/workflows/codesign.yml");
+    const manifestPublisher = read(
+      ".github/actions/publish-updater-manifest/action.yml",
+    );
 
     expect(stableTauriConfig).toContain(
       "https://github.com/adamgell/cmtraceopen/releases/latest/download/latest.json",
@@ -45,13 +56,17 @@ describe("project-controlled download link boundaries", () => {
       "https://github.com/${repository}/releases/download/${tagName}/${encodeURIComponent(fileName)}",
     );
     expect(windowsReleaseWorkflow).toContain(
-      'https://github.com/${{ github.repository }}/releases/download/$env:TAG_NAME/$nsisFileName',
+      "gh release upload $env:TAG_NAME",
+    );
+    expect(manifestPublisher).toContain(
+      'gh release upload "$TAG_NAME" latest.json --clobber',
     );
 
     for (const updaterContent of [
       stableTauriConfig,
       nightlyChannelScript,
       windowsReleaseWorkflow,
+      manifestPublisher,
     ]) {
       expect(updaterContent).not.toMatch(/download\.cmtraceopen\.com.*latest\.json/);
     }

--- a/tools/download-metrics/tests/project-links.test.ts
+++ b/tools/download-metrics/tests/project-links.test.ts
@@ -57,7 +57,7 @@ describe("project-controlled download link boundaries", () => {
       "https://github.com/${repository}/releases/download/${tagName}/${encodeURIComponent(fileName)}",
     );
     expect(windowsReleaseWorkflow).toContain(
-      "gh release upload $env:TAG_NAME",
+      'gh release upload $env:TAG_NAME $env:FULL_EXE_PATH $env:LITE_EXE_PATH $env:MSI_PATH $env:NSIS_PATH "$($env:NSIS_PATH).sig" --clobber',
     );
     expect(manifestPublisher).toContain(
       'gh release upload "$TAG_NAME" latest.json --clobber',

--- a/tools/download-metrics/tests/project-links.test.ts
+++ b/tools/download-metrics/tests/project-links.test.ts
@@ -29,6 +29,15 @@ describe("project-controlled download link boundaries", () => {
     expect(stableReleaseWorkflow).toContain(
       "releaseBody: ${{ steps.notes.outputs.body }}",
     );
+    expect(stableReleaseWorkflow).toContain(
+      'sed -e "s|{{TAG}}|$TAG_NAME|g" -e "s|{{VERSION}}|$VERSION|g"',
+    );
+    expect(windowsReleaseWorkflow).toContain(
+      '$releaseNotes = $releaseNotes.Replace("{{TAG}}", $env:TAG_NAME)',
+    );
+    expect(windowsReleaseWorkflow).toContain(
+      '$releaseNotes = $releaseNotes.Replace("{{VERSION}}", $env:VERSION)',
+    );
     expect(windowsReleaseWorkflow).toContain(
       '$templatePath = ".github/release-notes/template.md"',
     );
@@ -71,6 +80,7 @@ describe("project-controlled download link boundaries", () => {
       nightlyChannelScript,
       windowsReleaseWorkflow,
       manifestPublisher,
+      updaterManifest,
     ]) {
       expect(updaterContent).not.toMatch(/download\.cmtraceopen\.com.*latest\.json/);
     }

--- a/tools/download-metrics/tests/project-links.test.ts
+++ b/tools/download-metrics/tests/project-links.test.ts
@@ -45,6 +45,7 @@ describe("project-controlled download link boundaries", () => {
     const manifestPublisher = read(
       ".github/actions/publish-updater-manifest/action.yml",
     );
+    const updaterManifest = read(".github/scripts/updater-manifest.mjs");
 
     expect(stableTauriConfig).toContain(
       "https://github.com/adamgell/cmtraceopen/releases/latest/download/latest.json",
@@ -60,6 +61,9 @@ describe("project-controlled download link boundaries", () => {
     );
     expect(manifestPublisher).toContain(
       'gh release upload "$TAG_NAME" latest.json --clobber',
+    );
+    expect(updaterManifest).toContain(
+      "https://github.com/${repository}/releases/download/${tagName}/${encodeURIComponent(fileName)}",
     );
 
     for (const updaterContent of [


### PR DESCRIPTION
## What changed
The scheduled download-metrics job was red because project-links.test.ts still matched release-note and Windows upload syntax removed by the release workflow refactor.

## Why this seam
The test now checks the shared stable release-note template, the workflow template wiring, the current Windows GitHub Release upload command, and the existing direct updater endpoints without changing release behavior.

## Verification
- `npm run check` (tools/download-metrics)
- `npm test` (tools/download-metrics): 6 files, 127 tests passed
- Focused `npm test -- --run tests/project-links.test.ts`: 2 tests passed

Deliberately not changed: release workflows and application updater configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated release validation to confirm stable release-note templates are correctly configured.
  * Added verification for branded stable download links.
  * Expanded updater checks to confirm manifests and release downloads use the correct URLs.
  * Improved coverage for release and Windows signing workflows, helping ensure users receive accurate release information and reliable updater downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->