### PR TITLE
fix(ci): keep shipping channels and nightly at 1.5.2 and cover QA UI gaps

### DIFF
--- a/.github/scripts/installer-policy.test.mjs
+++ b/.github/scripts/installer-policy.test.mjs
@@ -45,10 +45,10 @@ describe("MSI DISABLEUPDATECHECKS policy (#576)", () => {
       .join("\n");
 
     assert.doesNotMatch(executable, /Microsoft\.Win32\.RegistryKey/);
-    assert.match(script, /System32\\reg\.exe/);
-    assert.match(script, /\/reg:64/);
-    assert.match(script, /DisableUpdateChecks/);
-    assert.match(script, /HKLM\\Software\\CMTrace Open/);
-    assert.match(script, /exit 1/);
+    assert.match(executable, /System32\\reg\.exe/);
+    assert.match(executable, /\/reg:64/);
+    assert.match(executable, /DisableUpdateChecks/);
+    assert.match(executable, /HKLM\\Software\\CMTrace Open/);
+    assert.match(executable, /exit 1/);
   });
 });

--- a/.github/scripts/installer-policy.test.mjs
+++ b/.github/scripts/installer-policy.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+describe("MSI DISABLEUPDATECHECKS policy (#576)", () => {
+  it("exposes DISABLEUPDATECHECKS as a public property passed through SecureCustomProperties", async () => {
+    const pkg = JSON.parse(
+      await readFile(path.join(repoRoot, "src-tauri/installer/package.signed.json"), "utf8")
+    );
+
+    const properties = pkg.msi.properties ?? [];
+    const disable = properties.find((p) => p.name === "DISABLEUPDATECHECKS");
+    const secure = properties.find((p) => p.name === "SecureCustomProperties");
+
+    assert.equal(disable?.value, "0");
+    assert.equal(secure?.value, "DISABLEUPDATECHECKS");
+  });
+
+  it("schedules a failing-hard PowerShell CA only when DISABLEUPDATECHECKS=1", async () => {
+    const pkg = JSON.parse(
+      await readFile(path.join(repoRoot, "src-tauri/installer/package.signed.json"), "utf8")
+    );
+    const actions = pkg.msi.customActions?.powershell ?? [];
+    assert.equal(actions.length, 1);
+
+    const action = actions[0];
+    assert.match(action.filePath, /set-disable-update-checks-policy\.ps1$/);
+    assert.equal(action.condition, 'DISABLEUPDATECHECKS="1" AND REMOVE<>"ALL"');
+    assert.equal(action.sequence, "EndOfExecution");
+    assert.equal(action.continueOnError, false);
+  });
+
+  it("writes HKLM via System32 reg.exe /reg:64 so Constrained Language Mode cannot abort install", async () => {
+    const script = await readFile(
+      path.join(repoRoot, "src-tauri/installer/set-disable-update-checks-policy.ps1"),
+      "utf8"
+    );
+    const executable = script
+      .split(/\r?\n/)
+      .filter((line) => !line.trim().startsWith("#"))
+      .join("\n");
+
+    assert.doesNotMatch(executable, /Microsoft\.Win32\.RegistryKey/);
+    assert.match(script, /System32\\reg\.exe/);
+    assert.match(script, /\/reg:64/);
+    assert.match(script, /DisableUpdateChecks/);
+    assert.match(script, /HKLM\\Software\\CMTrace Open/);
+    assert.match(script, /exit 1/);
+  });
+});

--- a/.github/workflows/cmtrace-ci.yml
+++ b/.github/workflows/cmtrace-ci.yml
@@ -166,7 +166,7 @@ jobs:
       # Release-workflow helpers. nightly-channel.test.mjs existed but was wired
       # into nothing, so it had never guarded a pull request.
       - name: Release script tests
-        run: node --test .github/scripts/updater-manifest.test.mjs .github/scripts/nightly-channel.test.mjs
+        run: node --test .github/scripts/updater-manifest.test.mjs .github/scripts/nightly-channel.test.mjs .github/scripts/installer-policy.test.mjs
 
       - name: npm security audit
         run: npm audit --audit-level=high

--- a/.github/workflows/scoop-publish.yml
+++ b/.github/workflows/scoop-publish.yml
@@ -26,12 +26,13 @@ jobs:
       contents: write
     steps:
       # The release event checks out the tag, which cannot be pushed to, and the
-      # commit belongs on the default branch either way. Credentials are
-      # persisted here (unlike the winget job) because this job pushes.
+      # commit belongs on the default branch either way. Keep the write token
+      # unavailable to validation steps and expose it only to the final push.
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Derive version
         id: release
@@ -100,7 +101,8 @@ jobs:
           }
           exit 0
 
-      - name: Commit and push
+      - name: Commit manifest updates
+        id: commit
         shell: pwsh
         env:
           VERSION: ${{ steps.release.outputs.version }}
@@ -113,11 +115,23 @@ jobs:
           git diff --cached --quiet
           if ($LASTEXITCODE -eq 0) {
             Write-Host "bucket/ is already at $env:VERSION; nothing to commit"
+            "changed=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             exit 0
           }
 
           git commit -m "chore(scoop): bump bucket to $env:VERSION"
           if ($LASTEXITCODE -ne 0) { throw "git commit failed with exit code $LASTEXITCODE" }
 
-          git push
+          "changed=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Push manifest commit
+        if: steps.commit.outputs.changed == 'true'
+        shell: pwsh
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh auth setup-git
+
+          git push origin "HEAD:$env:DEFAULT_BRANCH"
           if ($LASTEXITCODE -ne 0) { throw "git push failed with exit code $LASTEXITCODE" }

--- a/.github/workflows/scoop-publish.yml
+++ b/.github/workflows/scoop-publish.yml
@@ -11,6 +11,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: scoop-publish
+  cancel-in-progress: false
+
 jobs:
   scoop:
     name: Update Scoop bucket

--- a/.github/workflows/scoop-publish.yml
+++ b/.github/workflows/scoop-publish.yml
@@ -2,11 +2,11 @@ name: "CMTrace Open: Publish to Scoop bucket"
 
 on:
   release:
-    types: [published]
+    types: [published, edited]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to publish (e.g. v1.5.0)"
+        description: "Release tag to publish (e.g. v1.5.2)"
         required: true
 
 permissions: {}

--- a/.github/workflows/scoop-publish.yml
+++ b/.github/workflows/scoop-publish.yml
@@ -29,7 +29,7 @@ jobs:
       # commit belongs on the default branch either way. Credentials are
       # persisted here (unlike the winget job) because this job pushes.
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
 

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -2,12 +2,16 @@ name: "CMTrace Open: Publish to winget"
 
 on:
   release:
-    types: [published]
+    types: [published, edited]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to test (e.g. v1.5.0)"
+        description: "Release tag to process (e.g. v1.5.2)"
         required: true
+      submit:
+        description: "Submit manifests to microsoft/winget-pkgs"
+        type: boolean
+        default: true
 
 permissions: {}
 
@@ -100,12 +104,10 @@ jobs:
           Get-Content -LiteralPath $manifest.FullName -Raw | Write-Host
           Write-Host "::endgroup::"
 
-      # Only a published release submits. workflow_dispatch is a rehearsal, which
-      # is what its own input description ("Release tag to test") always implied,
-      # and submitting from a manual run would open a duplicate pull request on
-      # microsoft/winget-pkgs for a version that is already published.
+      # Release events submit automatically. Manual runs submit by default and
+      # can opt into a rehearsal with submit=false.
       - name: Submit to winget-pkgs
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.submit
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -15,6 +15,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: winget-publish
+  cancel-in-progress: false
+
 jobs:
   winget:
     name: Update winget package

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "cmtrace-open"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "base64 0.23.0",

--- a/bucket/cmtrace-lite.json
+++ b/bucket/cmtrace-lite.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "Lite edition of CMTrace Open: a free, open-source CMTrace replacement for Windows log files with format auto-detection, real-time tailing, find and filter, and Windows error-code lookup.",
     "homepage": "https://cmtraceopen.com",
     "license": "MIT",
@@ -11,12 +11,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.1/CMTrace-Open-Lite_1.5.1_x64.exe#/cmtrace-lite.exe",
-            "hash": "e5ae9bf01b2194f19ae7a510b3292d58dbe84dd1eefca8d91beeaead7d42f35e"
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.2/CMTrace-Open-Lite_1.5.2_x64.exe#/cmtrace-lite.exe",
+            "hash": "bb688f434cf16882b45e32a3bc74ed90c3f51bd01d6621276a2f0eb771ab6aae"
         },
         "arm64": {
-            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.1/CMTrace-Open-Lite_1.5.1_arm64.exe#/cmtrace-lite.exe",
-            "hash": "8ab5887479cf79f07a7e0beff7aae6c7cacb045eae581ff08a6415cd5251bacc"
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.2/CMTrace-Open-Lite_1.5.2_arm64.exe#/cmtrace-lite.exe",
+            "hash": "89e98b5ed74facf628a7584b84c1df23c5455a5e1010c929ef0f4c87dd74b0b7"
         }
     },
     "bin": "cmtrace-lite.exe",

--- a/bucket/cmtrace.json
+++ b/bucket/cmtrace.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "Free, open-source CMTrace replacement for Windows log files: ConfigMgr/SCCM, Intune IME, and Autopilot ESP diagnostics, DSRegCmd triage, .evtx viewing, real-time tailing, and Windows error-code lookup.",
     "homepage": "https://cmtraceopen.com",
     "license": "MIT",
@@ -10,12 +10,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.1/CMTrace-Open_1.5.1_x64.exe#/cmtrace.exe",
-            "hash": "e87d6c70e4a673c259193439f1f65a84e903376f71bfb0d416c8a2d4aa2992dd"
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.2/CMTrace-Open_1.5.2_x64.exe#/cmtrace.exe",
+            "hash": "b052b2c6cc3dad05284326b141dd2102ae7cd515269278f324289d1949b2d921"
         },
         "arm64": {
-            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.1/CMTrace-Open_1.5.1_arm64.exe#/cmtrace.exe",
-            "hash": "d63d7cc0439794ecd845f2b71580d96c3787b41e105de60cb5c1d0c0d6ca6535"
+            "url": "https://github.com/adamgell/cmtraceopen/releases/download/v1.5.2/CMTrace-Open_1.5.2_arm64.exe#/cmtrace.exe",
+            "hash": "d70922bfbc8e77ed0ff029ecdcf764ae023e8a57611bb857ddbc15b2b1f27c63"
         }
     },
     "bin": "cmtrace.exe",

--- a/crates/cmtraceopen-parser/src/dsregcmd/extended.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/extended.rs
@@ -336,7 +336,7 @@ pub fn build_active_diagnostics_rules(
                 "Service Connection Point not found in Active Directory",
                 "The device is domain-joined but no SCP was found for hybrid join configuration. This prevents automatic tenant discovery.",
                 vec![
-                    format!("SCP found: NO"),
+                    "SCP found: NO".to_string(),
                     format!("Error: {}", scp.error.as_deref().unwrap_or("(none)")),
                 ],
                 vec![

--- a/crates/cmtraceopen-parser/src/event_payload/mod.rs
+++ b/crates/cmtraceopen-parser/src/event_payload/mod.rs
@@ -57,7 +57,7 @@ fn hex_to_bytes(hex: &str) -> Option<Vec<u8>> {
     }
 
     let mut bytes = Vec::with_capacity(digits.len() / 2);
-    for pair in digits.chunks_exact(2) {
+    for pair in digits.as_chunks::<2>().0 {
         let high = (pair[0] as char).to_digit(16)?;
         let low = (pair[1] as char).to_digit(16)?;
         bytes.push(((high << 4) | low) as u8);
@@ -92,7 +92,9 @@ fn decode_utf16le(bytes: &[u8]) -> Option<String> {
         return None;
     }
     let units: Vec<u16> = bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
         .collect();
     String::from_utf16(&units).ok()

--- a/crates/cmtraceopen-parser/src/parser/registry.rs
+++ b/crates/cmtraceopen-parser/src/parser/registry.rs
@@ -395,7 +395,9 @@ fn decode_utf16le_bytes(bytes: &[u8]) -> String {
         return String::new();
     }
     let u16_iter = bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]));
     let decoded: String = char::decode_utf16(u16_iter)
         .map(|r| r.unwrap_or('\u{FFFD}'))
@@ -409,7 +411,9 @@ fn decode_utf16le_multi_string(bytes: &[u8]) -> String {
         return String::new();
     }
     let u16_iter: Vec<u16> = bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
         .collect();
 

--- a/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
+++ b/crates/cmtraceopen-parser/src/sccm/server/windows/intake.rs
@@ -2816,7 +2816,9 @@ fn decode_server_payload(
                 return Err(SccmServerIntakeError::InvalidPayloadEncoding);
             }
             let units = bytes
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
                 .collect::<Vec<_>>();
             String::from_utf16(&units)

--- a/crates/cmtraceopen-parser/tests/sccm_client_task_sequence_fixture_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_task_sequence_fixture_contract.rs
@@ -197,7 +197,7 @@ fn sha256(bytes: &[u8]) -> [u8; 32] {
         0x5be0cd19,
     ];
 
-    for chunk in padded.chunks_exact(64) {
+    for chunk in padded.as_chunks::<64>().0.iter() {
         let mut words = [0u32; 64];
         for (index, word) in words.iter_mut().take(16).enumerate() {
             let offset = index * 4;

--- a/crates/cmtraceopen-parser/tests/sccm_client_updates_fixture_contract.rs
+++ b/crates/cmtraceopen-parser/tests/sccm_client_updates_fixture_contract.rs
@@ -2248,7 +2248,7 @@ fn sha256(bytes: &[u8]) -> [u8; 32] {
         0x1f83d9ab,
         0x5be0cd19,
     ];
-    for chunk in padded.chunks_exact(64) {
+    for chunk in padded.as_chunks::<64>().0.iter() {
         let mut words = [0u32; 64];
         for (index, word) in words.iter_mut().take(16).enumerate() {
             let offset = index * 4;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cmtrace-open",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cmtrace-open",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-charts": "^9.3.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmtrace-open",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "description": "Free, open-source CMTrace replacement: Windows log viewer with ConfigMgr/SCCM, Intune, and Autopilot ESP diagnostics",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,6 +63,9 @@ notify = "8"
 tokio = { version = "1", features = ["fs", "io-util", "sync", "rt", "net"] }
 rayon = "1.10"
 font-kit = "0.14"
+# evtx 0.12 uses Cargo's 2024 edition, which Cargo 1.77.2 could not parse.
+# The MSRV is now 1.88, so this exact pin is no longer MSRV-mandated; it is
+# retained deliberately and can be revisited separately.
 evtx = { version = "=0.12.2", optional = true }
 quick-xml = { version = "0.41", optional = true }
 glob = "0.3"
@@ -73,7 +76,14 @@ uuid = { version = "1", features = ["v4"] }
 anyhow = "1"
 zip = { version = "=8.6.0", default-features = false, features = ["deflate"], optional = true }
 cab = { version = "=0.6.0", optional = true }
+# Floor, not an exact pin: 0.3.47 carries the fixes for RUSTSEC-2026-0009 and
+# GHSA-r6v5-fh4h-64xc (stack exhaustion). Declared directly -- despite the code
+# using only std::time -- so the whole graph (cab, cookie, plist, simplelog,
+# tauri-plugin-log, tauri-plugin-updater) is held at or above the patched release.
 time = { version = "0.3.47", default-features = false, features = ["parsing"] }
+# Only the event-log modules use these, so they are optional and pulled in by that feature.
+# rusqlite carries "bundled", which compiles SQLite from source; an unrelated build should not pay
+# for it.
 serde_norway = { version = "0.9.42", optional = true }
 rusqlite = { version = "0.40.2", features = ["bundled"], optional = true }
 flate2 = { version = "1.1.9", optional = true }
@@ -86,8 +96,35 @@ plist = { version = "1", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.56"
-windows = { version = "=0.62.2", features = ["Win32_Foundation", "Win32_NetworkManagement_NetManagement", "Win32_Security_Cryptography", "Win32_Security_Authorization", "Win32_System_EventLog", "Win32_System_IO", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_Com", "Win32_System_Ole", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging", "Security_Authentication_Web_Core", "Security_Credentials", "Foundation", "Foundation_Collections", "Win32_System_WinRT", "Wdk_Foundation", "Wdk_Storage_FileSystem"] }
+windows = { version = "=0.62.2", features = [
+    "Win32_Foundation",
+    "Win32_NetworkManagement_NetManagement",
+    "Win32_Security_Cryptography",
+    "Win32_Security_Authorization",
+    "Win32_System_EventLog",
+    "Win32_System_IO",
+    "Win32_Storage_FileSystem",
+    "Win32_Security",
+    "Win32_System_Com",
+    "Win32_System_Ole",
+    "Win32_System_Registry",
+    "Win32_System_SystemInformation",
+    "Win32_System_Threading",
+    "Win32_System_Variant",
+    "Win32_System_Wmi",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+    "Security_Authentication_Web_Core",
+    "Security_Credentials",
+    "Foundation",
+    "Foundation_Collections",
+    "Win32_System_WinRT",
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
+] }
 windows-future = "=0.3.2"
+# ureq 3.3 uses Cargo's 2024 edition and requires Rust 1.85, which the old
+# 1.77.2 floor barred. The floor is now 1.88; this pin is kept for now.
 ureq = "=3.3.0"
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
@@ -99,6 +136,8 @@ tempfile = "3"
 plist = "1"
 tauri = { version = "2", features = ["test"] }
 
+# Timing harness for the live event-log scan. Declared so `--all-targets` does not try to build it
+# without the modules it measures.
 [[example]]
 name = "evtx_scan"
 required-features = ["event-log"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 # Cargo.toml); the single Cargo.lock lives at the workspace root.
 [package]
 name = "cmtrace-open"
-version = "1.5.1"
+version = "1.5.2"
 description = "Free, open-source CMTrace replacement: Windows log viewer with ConfigMgr/SCCM, Intune, and Autopilot ESP diagnostics, DSRegCmd triage, and real-time tailing."
 authors = ["Adam Gell"]
 license = "MIT"
@@ -63,9 +63,6 @@ notify = "8"
 tokio = { version = "1", features = ["fs", "io-util", "sync", "rt", "net"] }
 rayon = "1.10"
 font-kit = "0.14"
-# evtx 0.12 uses Cargo's 2024 edition, which Cargo 1.77.2 could not parse.
-# The MSRV is now 1.88, so this exact pin is no longer MSRV-mandated; it is
-# retained deliberately and can be revisited separately.
 evtx = { version = "=0.12.2", optional = true }
 quick-xml = { version = "0.41", optional = true }
 glob = "0.3"
@@ -76,14 +73,7 @@ uuid = { version = "1", features = ["v4"] }
 anyhow = "1"
 zip = { version = "=8.6.0", default-features = false, features = ["deflate"], optional = true }
 cab = { version = "=0.6.0", optional = true }
-# Floor, not an exact pin: 0.3.47 carries the fixes for RUSTSEC-2026-0009 and
-# GHSA-r6v5-fh4h-64xc (stack exhaustion). Declared directly -- despite the code
-# using only std::time -- so the whole graph (cab, cookie, plist, simplelog,
-# tauri-plugin-log, tauri-plugin-updater) is held at or above the patched release.
 time = { version = "0.3.47", default-features = false, features = ["parsing"] }
-# Only the event-log modules use these, so they are optional and pulled in by that feature.
-# rusqlite carries "bundled", which compiles SQLite from source; an unrelated build should not pay
-# for it.
 serde_norway = { version = "0.9.42", optional = true }
 rusqlite = { version = "0.40.2", features = ["bundled"], optional = true }
 flate2 = { version = "1.1.9", optional = true }
@@ -96,35 +86,8 @@ plist = { version = "1", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.56"
-windows = { version = "=0.62.2", features = [
-    "Win32_Foundation",
-    "Win32_NetworkManagement_NetManagement",
-    "Win32_Security_Cryptography",
-    "Win32_Security_Authorization",
-    "Win32_System_EventLog",
-    "Win32_System_IO",
-    "Win32_Storage_FileSystem",
-    "Win32_Security",
-    "Win32_System_Com",
-    "Win32_System_Ole",
-    "Win32_System_Registry",
-    "Win32_System_SystemInformation",
-    "Win32_System_Threading",
-    "Win32_System_Variant",
-    "Win32_System_Wmi",
-    "Win32_UI_Shell",
-    "Win32_UI_WindowsAndMessaging",
-    "Security_Authentication_Web_Core",
-    "Security_Credentials",
-    "Foundation",
-    "Foundation_Collections",
-    "Win32_System_WinRT",
-    "Wdk_Foundation",
-    "Wdk_Storage_FileSystem",
-] }
+windows = { version = "=0.62.2", features = ["Win32_Foundation", "Win32_NetworkManagement_NetManagement", "Win32_Security_Cryptography", "Win32_Security_Authorization", "Win32_System_EventLog", "Win32_System_IO", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_Com", "Win32_System_Ole", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_Variant", "Win32_System_Wmi", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging", "Security_Authentication_Web_Core", "Security_Credentials", "Foundation", "Foundation_Collections", "Win32_System_WinRT", "Wdk_Foundation", "Wdk_Storage_FileSystem"] }
 windows-future = "=0.3.2"
-# ureq 3.3 uses Cargo's 2024 edition and requires Rust 1.85, which the old
-# 1.77.2 floor barred. The floor is now 1.88; this pin is kept for now.
 ureq = "=3.3.0"
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
@@ -136,8 +99,6 @@ tempfile = "3"
 plist = "1"
 tauri = { version = "2", features = ["test"] }
 
-# Timing harness for the live event-log scan. Declared so `--all-targets` does not try to build it
-# without the modules it measures.
 [[example]]
 name = "evtx_scan"
 required-features = ["event-log"]

--- a/src-tauri/installer/package.signed.json
+++ b/src-tauri/installer/package.signed.json
@@ -37,6 +37,10 @@
       {
         "name": "DISABLEUPDATECHECKS",
         "value": "0"
+      },
+      {
+        "name": "SecureCustomProperties",
+        "value": "DISABLEUPDATECHECKS"
       }
     ],
     "customActions": {

--- a/src-tauri/installer/set-disable-update-checks-policy.ps1
+++ b/src-tauri/installer/set-disable-update-checks-policy.ps1
@@ -1,20 +1,32 @@
+# MSI custom action for DISABLEUPDATECHECKS=1.
+# Intentionally a CA (not a Registry table entry) so the HKLM policy survives
+# uninstall, matching README.md.
+#
+# The previous implementation used [Microsoft.Win32.RegistryKey]::OpenBaseKey.
+# Master Packager embeds this script and runs it in the elevated execute
+# sequence. On managed Windows 11 that session is often Constrained Language
+# Mode (WDAC/AppLocker), where those .NET types throw and — with
+# continueOnError: false — roll back the whole install (#576).
+#
+# System32\reg.exe is allowed in CLM. /reg:64 writes the native 64-bit hive
+# even when msiexec is 32-bit, matching the app's winreg HKLM lookup.
+
 $ErrorActionPreference = 'Stop'
 
-$policySubKey = 'Software\CMTrace Open'
-$policyName = 'DisableUpdateChecks'
+$regExe = Join-Path $env:SystemRoot 'System32\reg.exe'
+$regKey = 'HKLM\Software\CMTrace Open'
+
+if (-not (Test-Path -LiteralPath $regExe)) {
+    Write-Output "Failed to set CMTrace Open update policy: reg.exe not found at $regExe"
+    exit 1
+}
 
 try {
-    $registryView = [Microsoft.Win32.RegistryView]::Default
-    if ([Environment]::Is64BitOperatingSystem) {
-        $registryView = [Microsoft.Win32.RegistryView]::Registry64
+    $output = & $regExe add $regKey /v DisableUpdateChecks /t REG_DWORD /d 1 /reg:64 /f 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Output "Failed to set CMTrace Open update policy: $output"
+        exit 1
     }
-
-    $baseKey = [Microsoft.Win32.RegistryKey]::OpenBaseKey(
-        [Microsoft.Win32.RegistryHive]::LocalMachine,
-        $registryView
-    )
-    $policyKey = $baseKey.CreateSubKey($policySubKey)
-    $policyKey.SetValue($policyName, 1, [Microsoft.Win32.RegistryValueKind]::DWord)
 
     Write-Output "CMTrace Open update checks disabled by HKLM policy."
     exit 0
@@ -22,12 +34,4 @@ try {
 catch {
     Write-Output "Failed to set CMTrace Open update policy: $($_.Exception.Message)"
     exit 1
-}
-finally {
-    if ($null -ne $policyKey) {
-        $policyKey.Dispose()
-    }
-    if ($null -ne $baseKey) {
-        $baseKey.Dispose()
-    }
 }

--- a/src-tauri/src/dsregcmd/registry.rs
+++ b/src-tauri/src/dsregcmd/registry.rs
@@ -369,16 +369,20 @@ fn load_registry_map(path: &Path, artifact_paths: &mut Vec<String>) -> RegistryK
 fn decode_reg_content(bytes: &[u8]) -> Option<String> {
     if bytes.starts_with(&[0xFF, 0xFE]) {
         let units = bytes[2..]
-            .chunks_exact(2)
-            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| u16::from_le_bytes(*chunk))
             .collect::<Vec<u16>>();
         return Some(String::from_utf16_lossy(&units));
     }
 
     if bytes.starts_with(&[0xFE, 0xFF]) {
         let units = bytes[2..]
-            .chunks_exact(2)
-            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| u16::from_be_bytes(*chunk))
             .collect::<Vec<u16>>();
         return Some(String::from_utf16_lossy(&units));
     }

--- a/src-tauri/src/esp/archive.rs
+++ b/src-tauri/src/esp/archive.rs
@@ -1019,12 +1019,14 @@ fn decode_utf16(bytes: &[u8], little_endian: bool) -> Result<String, ArchiveErro
         });
     }
     let code_units = bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             if little_endian {
-                u16::from_le_bytes([pair[0], pair[1]])
+                u16::from_le_bytes(*pair)
             } else {
-                u16::from_be_bytes([pair[0], pair[1]])
+                u16::from_be_bytes(*pair)
             }
         })
         .collect::<Vec<_>>();

--- a/src-tauri/src/esp/registry.rs
+++ b/src-tauri/src/esp/registry.rs
@@ -1177,8 +1177,10 @@ fn decode_utf16_units(bytes: &[u8]) -> Option<Vec<u16>> {
     }
     Some(
         bytes
-            .chunks_exact(2)
-            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|pair| u16::from_le_bytes(*pair))
             .collect(),
     )
 }

--- a/src-tauri/src/esp/system.rs
+++ b/src-tauri/src/esp/system.rs
@@ -1346,13 +1346,13 @@ impl SystemQueryWorkerPool {
 
     #[cfg(test)]
     fn shutdown_and_join(&self) -> usize {
-        let workers = self
-            .state
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .workers
-            .drain(..)
-            .collect::<Vec<_>>();
+        let workers = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            std::mem::take(&mut state.workers)
+        };
         let joined = workers.len();
         for worker in workers {
             let SystemQueryWorker { sender, handle, .. } = worker;

--- a/src-tauri/src/esp/tailing.rs
+++ b/src-tauri/src/esp/tailing.rs
@@ -726,12 +726,16 @@ fn drop_leading_partial_record(bytes: &[u8], hint: EncodingHint) -> usize {
             .position(|byte| *byte == b'\n')
             .map_or(bytes.len(), |index| index + 1),
         EncodingHint::Utf16Le => bytes
-            .chunks_exact(2)
-            .position(|pair| pair == [b'\n', 0])
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .position(|pair| *pair == [b'\n', 0])
             .map_or(bytes.len(), |index| (index + 1) * 2),
         EncodingHint::Utf16Be => bytes
-            .chunks_exact(2)
-            .position(|pair| pair == [0, b'\n'])
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .position(|pair| *pair == [0, b'\n'])
             .map_or(bytes.len(), |index| (index + 1) * 2),
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CMTrace Open",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "com.cmtrace.open",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/dialogs/DiffConfigDialog.test.tsx
+++ b/src/components/dialogs/DiffConfigDialog.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setCachedTabSnapshot, clearAllTabSnapshots } from "../../stores/log-store";
+import type { TabState } from "../../stores/ui-store";
+import { useUiStore } from "../../stores/ui-store";
+import type { LogEntry } from "../../types/log";
+import { DiffConfigDialog } from "./DiffConfigDialog";
+
+function tab(filePath: string): TabState {
+  return {
+    id: filePath,
+    filePath,
+    fileName: filePath.split(/[\\/]/).pop() ?? filePath,
+    scrollPosition: 0,
+    selectedLineId: null,
+    sourceContext: null,
+    fileKind: "log",
+  };
+}
+
+function entry(id: number, filePath: string): LogEntry {
+  return {
+    id,
+    lineNumber: id,
+    message: `line ${id}`,
+    component: null,
+    timestamp: id,
+    timestampDisplay: null,
+    severity: "Info",
+    thread: null,
+    threadDisplay: null,
+    sourceFile: null,
+    format: "Plain",
+    filePath,
+    timezoneOffset: null,
+  };
+}
+
+describe("DiffConfigDialog (LOG-017)", () => {
+  beforeEach(() => {
+    clearAllTabSnapshots();
+    useUiStore.setState({ openTabs: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("requires two different log tabs before Compare is enabled", () => {
+    const onCompare = vi.fn();
+    const a = "C:/logs/before.log";
+    const b = "C:/logs/after.log";
+    useUiStore.setState({ openTabs: [tab(a), tab(b)] });
+    setCachedTabSnapshot(a, {
+      entries: [entry(1, a)],
+      formatDetected: "Plain",
+      parserSelection: null,
+      totalLines: 1,
+      byteOffset: 0,
+      selectedSourceFilePath: a,
+      sourceOpenMode: "single-file",
+      activeColumns: [],
+    });
+    setCachedTabSnapshot(b, {
+      entries: [entry(1, b), entry(2, b)],
+      formatDetected: "Plain",
+      parserSelection: null,
+      totalLines: 2,
+      byteOffset: 0,
+      selectedSourceFilePath: b,
+      sourceOpenMode: "single-file",
+      activeColumns: [],
+    });
+
+    render(<DiffConfigDialog isOpen onClose={() => {}} onCompare={onCompare} />);
+
+    expect(screen.getByRole("dialog", { name: "Compare Log Files" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Compare" })).toBeDisabled();
+
+    const selects = screen.getAllByRole("combobox");
+    fireEvent.change(selects[0], { target: { value: a } });
+    fireEvent.change(selects[1], { target: { value: b } });
+    expect(screen.getByRole("button", { name: "Compare" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Compare" }));
+    expect(onCompare).toHaveBeenCalledWith(
+      { filePath: a, label: "before.log" },
+      { filePath: b, label: "after.log" },
+    );
+  });
+});

--- a/src/components/dialogs/ErrorLookupDialog.test.tsx
+++ b/src/components/dialogs/ErrorLookupDialog.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { useUiStore } from "../../stores/ui-store";
+import { ErrorLookupDialog } from "./ErrorLookupDialog";
+
+const invokeMock = vi.mocked(invoke);
+const writeTextMock = vi.mocked(writeText);
+
+describe("ErrorLookupDialog (CHROME-016)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState({
+      errorLookupHistory: [],
+      lookupErrorCode: null,
+    });
+    invokeMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("searches immediately for a hex code and copies the result", async () => {
+    invokeMock.mockResolvedValue([
+      {
+        codeHex: "0x80070005",
+        codeDecimal: "-2147024891",
+        description: "Access is denied.",
+        category: "Windows",
+        found: true,
+      },
+    ]);
+
+    render(<ErrorLookupDialog isOpen onClose={() => {}} />);
+    expect(screen.getByRole("dialog", { name: "Error Code Lookup" })).toBeVisible();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Search by code (0x80070005) or description (access denied)"),
+      { target: { value: "0x80070005" } },
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText("0x80070005").length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText("Access is denied.").length).toBeGreaterThan(0);
+    expect(invokeMock).toHaveBeenCalledWith("search_error_codes", { query: "0x80070005" });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Copy to clipboard" })[0]);
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith("0x80070005 - Access is denied.");
+    });
+  });
+
+  it("reruns a lookup from recent history", async () => {
+    useUiStore.setState({
+      errorLookupHistory: [
+        {
+          codeHex: "0x80004005",
+          codeDecimal: "-2147467259",
+          description: "Unspecified error",
+          category: "Windows",
+          found: true,
+          timestamp: Date.now(),
+        },
+      ],
+    });
+    invokeMock.mockResolvedValue([
+      {
+        codeHex: "0x80004005",
+        codeDecimal: "-2147467259",
+        description: "Unspecified error",
+        category: "Windows",
+        found: true,
+      },
+    ]);
+
+    render(<ErrorLookupDialog isOpen onClose={() => {}} />);
+    expect(screen.getByText("Recent lookups")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: /0x80004005/ }));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("search_error_codes", { query: "0x80004005" });
+    });
+  });
+});

--- a/src/components/dialogs/GuidRegistryDialog.test.tsx
+++ b/src/components/dialogs/GuidRegistryDialog.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { useIntuneStore } from "../../workspaces/intune/intune-store";
+import { GuidRegistryDialog } from "./GuidRegistryDialog";
+
+const writeTextMock = vi.mocked(writeText);
+
+describe("GuidRegistryDialog (CHROME-017)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useIntuneStore.getState().clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the empty-state hint when no GUID registry has been built", () => {
+    render(<GuidRegistryDialog isOpen onClose={() => {}} />);
+    expect(screen.getByRole("dialog", { name: "GUID Registry" })).toBeVisible();
+    expect(
+      screen.getByText(
+        "No GUID registry data available. Run an Intune analysis or enable Graph API in Settings.",
+      ),
+    ).toBeVisible();
+  });
+
+  it("filters by name and copies the GUID on row click", async () => {
+    useIntuneStore.setState({
+      guidRegistry: {
+        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": {
+          name: "Company Portal",
+          source: "ApplicationName",
+          category: "app",
+          publisher: "Microsoft",
+        },
+        "11111111-2222-3333-4444-555555555555": {
+          name: "Remediate Disk",
+          source: "NameField",
+          category: "remediation",
+        },
+      },
+    });
+
+    render(<GuidRegistryDialog isOpen onClose={() => {}} />);
+    expect(screen.getByText("All (2)")).toBeVisible();
+    expect(screen.getByText("Company Portal")).toBeVisible();
+    expect(screen.getByText("Remediate Disk")).toBeVisible();
+
+    fireEvent.click(screen.getByText("Apps (1)"));
+    expect(screen.getByText("Company Portal")).toBeVisible();
+    expect(screen.queryByText("Remediate Disk")).not.toBeInTheDocument();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Filter by name, GUID, or publisher..."),
+      { target: { value: "zzzz" } },
+    );
+    expect(screen.getByText(/No matches for/)).toBeVisible();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Filter by name, GUID, or publisher..."),
+      { target: { value: "company" } },
+    );
+    expect(screen.getByText("Company Portal")).toBeVisible();
+
+    fireEvent.click(screen.getByLabelText("Copy GUID aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+    expect(writeTextMock).toHaveBeenCalledWith("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+  });
+});

--- a/src/components/dialogs/MergeTabsDialog.test.tsx
+++ b/src/components/dialogs/MergeTabsDialog.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TabState } from "../../stores/ui-store";
+import { useUiStore } from "../../stores/ui-store";
+import { MergeTabsDialog } from "./MergeTabsDialog";
+
+function tab(filePath: string, fileKind: TabState["fileKind"] = "log"): TabState {
+  return {
+    id: filePath,
+    filePath,
+    fileName: filePath.split(/[\\/]/).pop() ?? filePath,
+    scrollPosition: 0,
+    selectedLineId: null,
+    sourceContext: null,
+    fileKind,
+  };
+}
+
+describe("MergeTabsDialog (LOG-015)", () => {
+  beforeEach(() => {
+    useUiStore.setState({ openTabs: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("tells the user to open two logs when fewer than two mergeable tabs exist", () => {
+    useUiStore.setState({
+      openTabs: [tab("C:/logs/AppEnforce.log"), tab("C:/logs/hardware.reg", "registry")],
+    });
+    render(<MergeTabsDialog isOpen onClose={() => {}} onMerge={() => {}} />);
+
+    expect(screen.getByRole("dialog", { name: "Merge Tabs into Unified Timeline" })).toBeVisible();
+    expect(screen.getByText("Open at least two log files to use this feature.")).toBeVisible();
+    expect(screen.getByRole("button", { name: /Merge/ })).toBeDisabled();
+  });
+
+  it("enables Merge only after two log tabs are checked", () => {
+    const onMerge = vi.fn();
+    const onClose = vi.fn();
+    useUiStore.setState({
+      openTabs: [tab("C:/logs/AppEnforce.log"), tab("C:/logs/CIAgent.log")],
+    });
+    render(<MergeTabsDialog isOpen onClose={onClose} onMerge={onMerge} />);
+
+    expect(screen.getByRole("button", { name: "Merge (0 files)" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("checkbox", { name: "AppEnforce.log" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "CIAgent.log" }));
+    expect(screen.getByRole("button", { name: "Merge (2 files)" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Merge (2 files)" }));
+    expect(onMerge).toHaveBeenCalledWith(
+      expect.arrayContaining(["C:/logs/AppEnforce.log", "C:/logs/CIAgent.log"]),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/FindBar.test.tsx
+++ b/src/components/layout/FindBar.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LogEntry } from "../../types/log";
+import { useLogStore } from "../../stores/log-store";
+import { FindBar } from "./FindBar";
+
+function entry(id: number, message: string): LogEntry {
+  return {
+    id,
+    lineNumber: id,
+    message,
+    component: null,
+    timestamp: null,
+    timestampDisplay: null,
+    severity: "Info",
+    thread: null,
+    threadDisplay: null,
+    sourceFile: null,
+    format: "Plain",
+    filePath: "/test.log",
+    timezoneOffset: null,
+  };
+}
+
+describe("FindBar (CHROME-007)", () => {
+  beforeEach(() => {
+    useLogStore.getState().clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("focuses the find field and exposes match-case and regex toggles", () => {
+    render(<FindBar onClose={() => {}} />);
+
+    expect(screen.getByPlaceholderText("Find...")).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Match case" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "Use regular expression" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("shows match index, no-results, and invalid regex status", () => {
+    useLogStore.setState({
+      findQuery: "error",
+      findMatchIds: [1, 2, 3],
+      findCurrentIndex: 0,
+      findRegexError: null,
+    });
+    const { rerender } = render(<FindBar onClose={() => {}} />);
+    expect(screen.getByText("1 of 3")).toBeVisible();
+
+    useLogStore.setState({
+      findQuery: "zzz",
+      findMatchIds: [],
+      findCurrentIndex: -1,
+      findRegexError: null,
+    });
+    rerender(<FindBar onClose={() => {}} />);
+    expect(screen.getByText("No results")).toBeVisible();
+
+    useLogStore.setState({
+      findQuery: "[",
+      findUseRegex: true,
+      findMatchIds: [],
+      findCurrentIndex: -1,
+      findRegexError: "Invalid regular expression",
+    });
+    rerender(<FindBar onClose={() => {}} />);
+    expect(screen.getByText("Invalid regex")).toBeVisible();
+  });
+
+  it("Enter/F3 find next, Shift+Enter previous, Escape closes", () => {
+    const onClose = vi.fn();
+    useLogStore.setState({
+      entries: [entry(1, "error one"), entry(2, "error two")],
+      findQuery: "error",
+      findMatchIds: [1, 2],
+      findCurrentIndex: 0,
+      selectedId: 1,
+    });
+
+    render(<FindBar onClose={onClose} />);
+    const input = screen.getByPlaceholderText("Find...");
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(useLogStore.getState().findCurrentIndex).toBe(1);
+    expect(useLogStore.getState().selectedId).toBe(2);
+
+    fireEvent.keyDown(input, { key: "F3", shiftKey: true });
+    expect(useLogStore.getState().findCurrentIndex).toBe(0);
+    expect(useLogStore.getState().selectedId).toBe(1);
+
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("toggles match case from the toolbar", () => {
+    render(<FindBar onClose={() => {}} />);
+    const matchCase = screen.getByRole("button", { name: "Match case" });
+    fireEvent.click(matchCase);
+    expect(useLogStore.getState().findCaseSensitive).toBe(true);
+    expect(matchCase).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/src/components/layout/FindBar.test.tsx
+++ b/src/components/layout/FindBar.test.tsx
@@ -72,7 +72,7 @@ describe("FindBar (CHROME-007)", () => {
     expect(screen.getByText("Invalid regex")).toBeVisible();
   });
 
-  it("Enter/F3 find next, Shift+Enter previous, Escape closes", () => {
+  it("Enter/F3 find next, Shift+Enter/Shift+F3 previous, Escape closes", () => {
     const onClose = vi.fn();
     useLogStore.setState({
       entries: [entry(1, "error one"), entry(2, "error two")],
@@ -86,6 +86,14 @@ describe("FindBar (CHROME-007)", () => {
     const input = screen.getByPlaceholderText("Find...");
 
     fireEvent.keyDown(input, { key: "Enter" });
+    expect(useLogStore.getState().findCurrentIndex).toBe(1);
+    expect(useLogStore.getState().selectedId).toBe(2);
+
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+    expect(useLogStore.getState().findCurrentIndex).toBe(0);
+    expect(useLogStore.getState().selectedId).toBe(1);
+
+    fireEvent.keyDown(input, { key: "F3" });
     expect(useLogStore.getState().findCurrentIndex).toBe(1);
     expect(useLogStore.getState().selectedId).toBe(2);
 

--- a/src/components/log-view/DiffView.test.tsx
+++ b/src/components/log-view/DiffView.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { classifyEntries } from "../../lib/diff-entries";
+import { useLogStore } from "../../stores/log-store";
+import type { LogEntry } from "../../types/log";
+import { createTestVirtualizer } from "../../test-utils/virtualizer";
+import { DiffView } from "./DiffView";
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: (options: { count: number }) => createTestVirtualizer(options),
+}));
+
+function entry(id: number, message: string, filePath: string): LogEntry {
+  return {
+    id,
+    lineNumber: id,
+    message,
+    component: "CIAgent",
+    timestamp: id,
+    timestampDisplay: "2026-08-29 12:00:00.000",
+    severity: "Info",
+    thread: null,
+    threadDisplay: null,
+    sourceFile: null,
+    format: "Ccm",
+    filePath,
+    timezoneOffset: null,
+  };
+}
+
+describe("DiffView (LOG-017)", () => {
+  beforeEach(() => {
+    useLogStore.getState().clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows common/only-A/only-B counts and switches to unified", () => {
+    const entriesA = [
+      entry(1, "only in A", "C:/logs/a.log"),
+      entry(2, "shared line", "C:/logs/a.log"),
+    ];
+    const entriesB = [
+      entry(10, "only in B", "C:/logs/b.log"),
+      entry(11, "shared line", "C:/logs/b.log"),
+    ];
+    const classified = classifyEntries(entriesA, entriesB);
+    useLogStore.setState({
+      diffState: {
+        mode: "two-file",
+        sourceA: { filePath: "C:/logs/a.log", label: "a.log" },
+        sourceB: { filePath: "C:/logs/b.log", label: "b.log" },
+        displayMode: "side-by-side",
+        entriesA,
+        entriesB,
+        ...classified,
+      },
+    });
+
+    render(<DiffView />);
+
+    expect(screen.getByText(/Diff: a.log vs b.log/)).toBeVisible();
+    expect(screen.getByText("1 common")).toBeVisible();
+    expect(screen.getByText("1 only A")).toBeVisible();
+    expect(screen.getByText("1 only B")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Side-by-side" })).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Unified" }));
+    expect(useLogStore.getState().diffState?.displayMode).toBe("unified");
+
+    fireEvent.click(screen.getByRole("button", { name: "Close diff" }));
+    expect(useLogStore.getState().diffState).toBeNull();
+  });
+});

--- a/src/hooks/use-keyboard.test.tsx
+++ b/src/hooks/use-keyboard.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useUiStore } from "../stores/ui-store";
+import { useKeyboard } from "./use-keyboard";
+
+const actions = vi.hoisted(() => ({
+  commandState: { canAdjustTextSize: false },
+  openSourceFileDialog: vi.fn(),
+  showFindBar: vi.fn(),
+  findNext: vi.fn(),
+  findPrevious: vi.fn(),
+  showFilterDialog: vi.fn(),
+  showErrorLookupDialog: vi.fn(),
+  increaseLogListTextSize: vi.fn(),
+  decreaseLogListTextSize: vi.fn(),
+  resetLogListTextSize: vi.fn(),
+  togglePauseResume: vi.fn(),
+  refreshActiveSource: vi.fn(),
+  toggleSidebar: vi.fn(),
+  toggleDetailsPane: vi.fn(),
+  dismissTransientDialogs: vi.fn(),
+}));
+
+vi.mock("./use-app-actions", () => ({
+  useAppActions: () => actions,
+}));
+
+function Harness() {
+  useKeyboard();
+  return <div data-testid="keyboard-harness">ready</div>;
+}
+
+describe("useKeyboard (CHROME-007)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUiStore.setState({
+      showFindBar: false,
+      showFilterDialog: false,
+      showErrorLookupDialog: false,
+      showAboutDialog: false,
+      showSettingsDialog: false,
+      showEvidenceBundleDialog: false,
+      showGuidRegistryDialog: false,
+      showMergeTabsDialog: false,
+      showDiffConfigDialog: false,
+      showFileAssociationPrompt: false,
+      showCollectDiagnosticsDialog: false,
+      showUpdateDialog: false,
+      collectionResult: null,
+      elevationPrompt: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("opens Find with Ctrl+F and walks matches with F3 / Shift+F3", () => {
+    render(<Harness />);
+
+    fireEvent.keyDown(window, { key: "f", ctrlKey: true });
+    expect(actions.showFindBar).toHaveBeenCalled();
+
+    fireEvent.keyDown(window, { key: "F3" });
+    expect(actions.findNext).toHaveBeenCalledWith("keyboard.f3");
+
+    fireEvent.keyDown(window, { key: "F3", shiftKey: true });
+    expect(actions.findPrevious).toHaveBeenCalledWith("keyboard.shift-f3");
+  });
+
+  it("does not steal find shortcuts while a modal dialog is open", () => {
+    useUiStore.setState({ showErrorLookupDialog: true });
+    render(<Harness />);
+
+    fireEvent.keyDown(window, { key: "f", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "F3" });
+    expect(actions.showFindBar).not.toHaveBeenCalled();
+    expect(actions.findNext).not.toHaveBeenCalled();
+  });
+});

--- a/src/workspaces/dns-dhcp/DnsDhcpWorkspace.test.tsx
+++ b/src/workspaces/dns-dhcp/DnsDhcpWorkspace.test.tsx
@@ -4,27 +4,38 @@ import type { LogEntry } from "../../types/log";
 import { DnsDhcpWorkspace } from "./DnsDhcpWorkspace";
 import { useDnsDhcpStore } from "./dns-dhcp-store";
 
-const checkDnsLoggingStatus = vi.fn();
-const inspectPathKind = vi.fn();
-const listLogFolder = vi.fn();
-const openLogFile = vi.fn();
-const collectDnsDhcpFromDomain = vi.fn();
-const enableDnsDebugLogging = vi.fn();
-const openDialog = vi.fn();
-const confirmDialog = vi.fn();
+const {
+  checkDnsLoggingStatus,
+  inspectPathKind,
+  listLogFolder,
+  openLogFile,
+  collectDnsDhcpFromDomain,
+  enableDnsDebugLogging,
+  openDialog,
+  confirmDialog,
+} = vi.hoisted(() => ({
+  checkDnsLoggingStatus: vi.fn(),
+  inspectPathKind: vi.fn(),
+  listLogFolder: vi.fn(),
+  openLogFile: vi.fn(),
+  collectDnsDhcpFromDomain: vi.fn(),
+  enableDnsDebugLogging: vi.fn(),
+  openDialog: vi.fn(),
+  confirmDialog: vi.fn(),
+}));
 
 vi.mock("../../lib/commands", () => ({
-  checkDnsLoggingStatus: (...args: unknown[]) => checkDnsLoggingStatus(...args),
-  inspectPathKind: (...args: unknown[]) => inspectPathKind(...args),
-  listLogFolder: (...args: unknown[]) => listLogFolder(...args),
-  openLogFile: (...args: unknown[]) => openLogFile(...args),
-  collectDnsDhcpFromDomain: (...args: unknown[]) => collectDnsDhcpFromDomain(...args),
-  enableDnsDebugLogging: (...args: unknown[]) => enableDnsDebugLogging(...args),
+  checkDnsLoggingStatus,
+  inspectPathKind,
+  listLogFolder,
+  openLogFile,
+  collectDnsDhcpFromDomain,
+  enableDnsDebugLogging,
 }));
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
-  open: (...args: unknown[]) => openDialog(...args),
-  confirm: (...args: unknown[]) => confirmDialog(...args),
+  open: openDialog,
+  confirm: confirmDialog,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({

--- a/src/workspaces/dns-dhcp/DnsDhcpWorkspace.test.tsx
+++ b/src/workspaces/dns-dhcp/DnsDhcpWorkspace.test.tsx
@@ -1,0 +1,146 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LogEntry } from "../../types/log";
+import { DnsDhcpWorkspace } from "./DnsDhcpWorkspace";
+import { useDnsDhcpStore } from "./dns-dhcp-store";
+
+const checkDnsLoggingStatus = vi.fn();
+const inspectPathKind = vi.fn();
+const listLogFolder = vi.fn();
+const openLogFile = vi.fn();
+const collectDnsDhcpFromDomain = vi.fn();
+const enableDnsDebugLogging = vi.fn();
+const openDialog = vi.fn();
+const confirmDialog = vi.fn();
+
+vi.mock("../../lib/commands", () => ({
+  checkDnsLoggingStatus: (...args: unknown[]) => checkDnsLoggingStatus(...args),
+  inspectPathKind: (...args: unknown[]) => inspectPathKind(...args),
+  listLogFolder: (...args: unknown[]) => listLogFolder(...args),
+  openLogFile: (...args: unknown[]) => openLogFile(...args),
+  collectDnsDhcpFromDomain: (...args: unknown[]) => collectDnsDhcpFromDomain(...args),
+  enableDnsDebugLogging: (...args: unknown[]) => enableDnsDebugLogging(...args),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: (...args: unknown[]) => openDialog(...args),
+  confirm: (...args: unknown[]) => confirmDialog(...args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+function entry(overrides: Partial<LogEntry> & { id: number }): LogEntry {
+  return {
+    lineNumber: overrides.id,
+    message: `message ${overrides.id}`,
+    component: null,
+    timestamp: 1_700_000_000_000 + overrides.id,
+    timestampDisplay: null,
+    severity: "Info",
+    thread: null,
+    threadDisplay: null,
+    sourceFile: null,
+    format: "Plain",
+    filePath: "/dns.log",
+    timezoneOffset: null,
+    ...overrides,
+  };
+}
+
+describe("DnsDhcpWorkspace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDnsDhcpStore.getState().clear();
+    inspectPathKind.mockRejectedValue(new Error("missing"));
+    listLogFolder.mockRejectedValue(new Error("missing"));
+    openLogFile.mockRejectedValue(new Error("missing"));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows Scan this server, Collect from domain, and Open files on the empty state (DNS-001/002/003)", () => {
+    render(<DnsDhcpWorkspace />);
+    expect(screen.getByRole("button", { name: "Scan this server" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Collect from domain" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Open files..." })).toBeVisible();
+  });
+
+  it("scans this server, surfaces debug-logging status, and offers to enable it (DNS-001)", async () => {
+    checkDnsLoggingStatus.mockResolvedValue({
+      dnsServerInstalled: true,
+      dhcpServerInstalled: false,
+      debugLoggingEnabled: false,
+      logFilePath: null,
+    });
+
+    render(<DnsDhcpWorkspace />);
+    fireEvent.click(screen.getByRole("button", { name: "Scan this server" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Server Status")).toBeVisible();
+    });
+    expect(screen.getByText("DNS Server")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Enable DNS debug logging" })).toBeEnabled();
+    expect(checkDnsLoggingStatus).toHaveBeenCalled();
+  });
+
+  it("prompts before collecting from domain DCs (DNS-002)", async () => {
+    confirmDialog.mockResolvedValue(false);
+
+    render(<DnsDhcpWorkspace />);
+    fireEvent.click(screen.getByRole("button", { name: "Collect from domain" }));
+
+    await waitFor(() => {
+      expect(confirmDialog).toHaveBeenCalled();
+    });
+    expect(collectDnsDhcpFromDomain).not.toHaveBeenCalled();
+  });
+
+  it("opens DNS/DHCP files and correlates devices by IP (DNS-003)", async () => {
+    openDialog.mockResolvedValue(["C:\\\\logs\\\\dns.log", "C:\\\\logs\\\\DhcpSrvLog-Mon.log"]);
+    openLogFile.mockImplementation(async (path: string) => {
+      if (path.endsWith("dns.log")) {
+        return {
+          formatDetected: "DnsDebug",
+          entries: [
+            entry({
+              id: 1,
+              format: "DnsDebug",
+              filePath: path,
+              sourceIp: "10.0.0.8:53",
+              queryName: "host.contoso.com",
+              queryType: "A",
+              responseCode: "NXDOMAIN",
+            }),
+          ],
+        };
+      }
+      return {
+        formatDetected: "Plain",
+        entries: [
+          entry({
+            id: 2,
+            filePath: path,
+            ipAddress: "10.0.0.8",
+            hostName: "PC01",
+            macAddress: "aa:bb:cc:dd:ee:ff",
+          }),
+        ],
+      };
+    });
+
+    render(<DnsDhcpWorkspace />);
+    fireEvent.click(screen.getByRole("button", { name: "Open files..." }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("PC01").length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText(/10\.0\.0\.8/).length).toBeGreaterThan(0);
+    expect(useDnsDhcpStore.getState().devices).toHaveLength(1);
+    expect(useDnsDhcpStore.getState().devices[0].isEnriched).toBe(true);
+  });
+});

--- a/src/workspaces/dns-dhcp/dns-dhcp-store.test.ts
+++ b/src/workspaces/dns-dhcp/dns-dhcp-store.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { LogEntry } from "../../types/log";
+import { useDnsDhcpStore } from "./dns-dhcp-store";
+
+function entry(overrides: Partial<LogEntry> & { id: number }): LogEntry {
+  return {
+    lineNumber: overrides.id,
+    message: `message ${overrides.id}`,
+    component: null,
+    timestamp: 1_700_000_000_000 + overrides.id,
+    timestampDisplay: null,
+    severity: "Info",
+    thread: null,
+    threadDisplay: null,
+    sourceFile: null,
+    format: "Plain",
+    filePath: "/dns.log",
+    timezoneOffset: null,
+    ...overrides,
+  };
+}
+
+describe("dns-dhcp-store (DNS-003)", () => {
+  beforeEach(() => {
+    useDnsDhcpStore.getState().clear();
+  });
+
+  it("joins DNS queries and DHCP leases onto one device by IPv4, stripping the query port", () => {
+    const dns = entry({
+      id: 1,
+      format: "DnsDebug",
+      filePath: "C:\\\\Windows\\\\System32\\\\dns\\\\dns.log",
+      sourceIp: "192.168.2.9:54159",
+      queryName: "host.contoso.com",
+      queryType: "A",
+      responseCode: "NXDOMAIN",
+    });
+    const dhcp = entry({
+      id: 2,
+      format: "Plain",
+      filePath: "C:\\\\Windows\\\\System32\\\\dhcp\\\\DhcpSrvLog-Mon.log",
+      ipAddress: "192.168.2.9",
+      hostName: "PC01",
+      macAddress: "aa:bb:cc:dd:ee:ff",
+    });
+
+    useDnsDhcpStore.getState().addSource(
+      dns.filePath,
+      "dns.log",
+      "DnsDebug",
+      [dns],
+    );
+    useDnsDhcpStore.getState().addSource(
+      dhcp.filePath,
+      "DhcpSrvLog-Mon.log",
+      "Plain",
+      [dhcp],
+    );
+
+    const { devices, selectedDeviceIp } = useDnsDhcpStore.getState();
+    expect(devices).toHaveLength(1);
+    expect(devices[0].ip).toBe("192.168.2.9");
+    expect(devices[0].hostname).toBe("PC01");
+    expect(devices[0].mac).toBe("aa:bb:cc:dd:ee:ff");
+    expect(devices[0].isEnriched).toBe(true);
+    expect(devices[0].nxdomainCount).toBe(1);
+    expect(devices[0].totalQueries).toBe(1);
+    expect(selectedDeviceIp).toBe("192.168.2.9");
+  });
+
+  it("does not strip IPv6 addresses that contain colons", () => {
+    useDnsDhcpStore.getState().addSource("dns.log", "dns.log", "DnsDebug", [
+      entry({
+        id: 1,
+        format: "DnsDebug",
+        filePath: "dns.log",
+        sourceIp: "fe80::1234",
+        queryName: "ipv6.contoso.com",
+        queryType: "AAAA",
+        responseCode: "NOERROR",
+      }),
+    ]);
+
+    expect(useDnsDhcpStore.getState().devices[0].ip).toBe("fe80::1234");
+  });
+
+  it("filters the device list by hostname, IP, or MAC search", () => {
+    useDnsDhcpStore.getState().addSource("dns.log", "dns.log", "DnsDebug", [
+      entry({
+        id: 1,
+        format: "DnsDebug",
+        filePath: "dns.log",
+        sourceIp: "10.0.0.2",
+        queryName: "a.contoso.com",
+        responseCode: "NOERROR",
+      }),
+      entry({
+        id: 2,
+        format: "DnsDebug",
+        filePath: "dns.log",
+        sourceIp: "10.0.0.3",
+        queryName: "b.contoso.com",
+        responseCode: "SERVFAIL",
+      }),
+    ]);
+    useDnsDhcpStore.getState().addSource("dhcp.log", "dhcp.log", "Plain", [
+      entry({
+        id: 3,
+        filePath: "dhcp.log",
+        ipAddress: "10.0.0.2",
+        hostName: "LAPTOP-A",
+        macAddress: "00:11:22:33:44:55",
+      }),
+    ]);
+
+    expect(useDnsDhcpStore.getState().devices).toHaveLength(2);
+    useDnsDhcpStore.getState().setSearchQuery("laptop");
+    expect(useDnsDhcpStore.getState().searchQuery).toBe("laptop");
+  });
+});


### PR DESCRIPTION
## Summary

Finishes the 1.5.2 shipping-channel work and the requested QA coverage on the existing release PR.

Functional scope remains limited: this PR does not implement DsRegCmd/Autopilot redaction (#556/#564) or Event Viewer #583. The Rust 1.98 follow-up contains only behavior-preserving compiler-lint substitutions needed to keep the repository's rolling stable-Clippy jobs green; no redaction or Event Viewer behavior, models, or interfaces changed.

## Changes

### Shipping channels

- Bumps Scoop Full and Lite manifests to 1.5.2 with the live release hashes.
- Runs Scoop and WinGet publishers on release publication or edit, so clobbered release assets can be republished.
- Adds a manual WinGet submit switch, defaulting to true.
- Runs the MSI installer-policy test in the release-script test step.
- Pins checkout to the repository-standard immutable v7.0.1 commit.
- Keeps the Scoop write credential out of checkout, downloaded installer, and validation steps; authentication is available only to the conditional final push.

Live 1.5.2 hashes:

- x64.exe: b052b2c6cc3dad05284326b141dd2102ae7cd515269278f324289d1949b2d921
- arm64.exe: d70922bfbc8e77ed0ff029ecdcf764ae023e8a57611bb857ddbc15b2b1f27c63
- x64.msi: 6986dd46d43a6f2aaaba551729535da6f5781491b4f076bbd59cbfdd3465b17c
- arm64.msi: c3e791c9106de20bcaa7dab627edb9b7098ebb7813d535325fb934d62b99e364
- Lite x64.exe: bb688f434cf16882b45e32a3bc74ed90c3f51bd01d6621276a2f0eb771ab6aae
- Lite arm64.exe: 89e98b5ed74facf628a7584b84c1df23c5455a5e1010c929ef0f4c87dd74b0b7

### Version and installer

- Aligns package.json, Cargo.toml, Cargo.lock, and tauri.conf.json on 1.5.2.
- Replaces the Constrained Language Mode-incompatible registry API in the MSI custom action with native 64-bit System32 reg.exe writes, preserving fail-hard behavior.

### QA coverage

Adds Vitest/RTL coverage for DNS/DHCP, FindBar, keyboard shortcuts, MergeTabsDialog, DiffConfigDialog, DiffView, ErrorLookupDialog, and GuidRegistryDialog.

## Verification

- Rust 1.98 Clippy: parser, Lite app, and Full app
- Rust tests: parser, Lite app, and Full app
- Rust 1.88 MSRV: all-feature workspace and parser WebAssembly target
- Frontend: 1,075 tests passed
- TypeScript: no-emit check passed
- Release helpers: 18 tests passed
- Workflow syntax and scoped Rust formatting passed

## Remaining outside this PR

- Submit 1.5.2 to microsoft/winget-pkgs after merge, either by running **CMTrace Open: Publish to winget** for tag v1.5.2 with submit=true or with Komac.
- A real Windows msiexec run with DISABLEUPDATECHECKS=1 remains the native installer-runtime acceptance check.
