### PR TITLE
fix(dsregcmd): address review findings across parser, backend, and UI

### DIFF
--- a/crates/cmtraceopen-parser/src/dsregcmd/derive.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/derive.rs
@@ -411,18 +411,21 @@ pub(super) fn has_any_code(facts: &DsregcmdFacts, codes: &[&str]) -> bool {
     codes.iter().any(|code| has_code(facts, code))
 }
 /// Match a Win32 error by decimal value or lowercase hex form (`1312` or
-/// `0x520`) as a whole token, so codes embedded in larger numbers or hex
-/// HRESULTs do not false-positive. Surrounding punctuation such as brackets
-/// or commas is ignored.
+/// `0x520`) as a whole token, so codes embedded in larger numbers, hex
+/// HRESULTs, or names like `ERROR_1312` do not false-positive. Comma- and
+/// slash-delimited code lists (e.g. `0x801c0021/0x80072ee2`) are evaluated
+/// per code, and surrounding punctuation such as brackets is ignored.
 pub(super) fn contains_win32_code(aggregated: &str, decimal: u32) -> bool {
     let decimal_text = decimal.to_string();
     aggregated.split_whitespace().any(|token| {
-        let token = token.trim_matches(|c: char| !c.is_ascii_alphanumeric());
-        token == decimal_text
-            || token
-                .strip_prefix("0x")
-                .and_then(|hex| u32::from_str_radix(hex, 16).ok())
-                .is_some_and(|value| value == decimal)
+        token.split(['/', ',']).any(|part| {
+            let part = part.trim_matches(|c: char| !c.is_ascii_alphanumeric());
+            part == decimal_text
+                || part
+                    .strip_prefix("0x")
+                    .and_then(|hex| u32::from_str_radix(hex, 16).ok())
+                    .is_some_and(|value| value == decimal)
+        })
     })
 }
 

--- a/crates/cmtraceopen-parser/src/dsregcmd/derive.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/derive.rs
@@ -416,10 +416,13 @@ pub(super) fn has_any_code(facts: &DsregcmdFacts, codes: &[&str]) -> bool {
 /// or commas is ignored.
 pub(super) fn contains_win32_code(aggregated: &str, decimal: u32) -> bool {
     let decimal_text = decimal.to_string();
-    let hex_text = format!("0x{decimal:x}");
     aggregated.split_whitespace().any(|token| {
         let token = token.trim_matches(|c: char| !c.is_ascii_alphanumeric());
-        token == decimal_text || token == hex_text
+        token == decimal_text
+            || token
+                .strip_prefix("0x")
+                .and_then(|hex| u32::from_str_radix(hex, 16).ok())
+                .is_some_and(|value| value == decimal)
     })
 }
 
@@ -454,6 +457,22 @@ pub(super) fn render_phase_code_evidence(facts: &DsregcmdFacts, code: &str) -> S
         (
             "Token Acquisition Test",
             facts.pre_join_tests.token_acquisition_test.as_deref(),
+        ),
+        (
+            "DRS Discovery Test",
+            facts.pre_join_tests.drs_discovery_test.as_deref(),
+        ),
+        (
+            "AD Configuration Test",
+            facts.pre_join_tests.ad_configuration_test.as_deref(),
+        ),
+        (
+            "DRS Connectivity Test",
+            facts.pre_join_tests.drs_connectivity_test.as_deref(),
+        ),
+        (
+            "AD Connectivity Test",
+            facts.pre_join_tests.ad_connectivity_test.as_deref(),
         ),
     ];
 

--- a/crates/cmtraceopen-parser/src/dsregcmd/derive.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/derive.rs
@@ -63,8 +63,7 @@ pub(super) fn derive_facts(facts: &DsregcmdFacts, raw_input: &str) -> DsregcmdDe
         .diagnostics
         .client_time
         .as_deref()
-        .and_then(parse_dsregcmd_timestamp)
-        .or_else(|| Some(Utc::now()));
+        .and_then(parse_dsregcmd_timestamp);
     let prt_last_update = facts
         .sso_state
         .azure_ad_prt_update_time
@@ -170,9 +169,13 @@ fn derive_dominant_phase(facts: &DsregcmdFacts) -> DsregcmdDiagnosticPhase {
         return phase;
     }
 
-    if facts.diagnostics.attempt_status.is_some()
-        || facts.diagnostics.previous_prt_attempt.is_some()
-        || facts.sso_state.acquire_prt_diagnostics.is_some()
+    // PRT attempt fields are post-join evidence. On a joined device they are
+    // the freshest signal; on a not-joined device pre-join failures dominate
+    // because the join flow cannot reach post-join while they are failing.
+    if facts.join_state.azure_ad_joined == Some(true)
+        && (facts.diagnostics.attempt_status.is_some()
+            || facts.diagnostics.previous_prt_attempt.is_some()
+            || facts.sso_state.acquire_prt_diagnostics.is_some())
     {
         return DsregcmdDiagnosticPhase::PostJoin;
     }
@@ -360,7 +363,6 @@ fn parse_certificate_validity(value: &str) -> (Option<DateTime<Utc>>, Option<Dat
 
     match timestamps.as_slice() {
         [valid_from, valid_to, ..] => (Some(*valid_from), Some(*valid_to)),
-        [valid_to] => (None, Some(*valid_to)),
         _ => (None, None),
     }
 }
@@ -401,10 +403,22 @@ pub(super) fn has_code(facts: &DsregcmdFacts, code: &str) -> bool {
         || contains_text(&facts.pre_join_tests.token_acquisition_test, code)
         || contains_text(&facts.pre_join_tests.drs_discovery_test, code)
         || contains_text(&facts.pre_join_tests.ad_configuration_test, code)
+        || contains_text(&facts.pre_join_tests.drs_connectivity_test, code)
+        || contains_text(&facts.pre_join_tests.ad_connectivity_test, code)
 }
 
 pub(super) fn has_any_code(facts: &DsregcmdFacts, codes: &[&str]) -> bool {
     codes.iter().any(|code| has_code(facts, code))
+}
+/// Match a Win32 error by decimal value or lowercase hex form (`1312` or
+/// `0x520`) as a whole token, so codes embedded in larger numbers or hex
+/// HRESULTs do not false-positive.
+pub(super) fn contains_win32_code(aggregated: &str, decimal: u32) -> bool {
+    let decimal_text = decimal.to_string();
+    let hex_text = format!("0x{decimal:x}");
+    aggregated
+        .split_whitespace()
+        .any(|token| token == decimal_text || token == hex_text)
 }
 
 pub(super) fn is_failure(field: &Option<String>) -> bool {

--- a/crates/cmtraceopen-parser/src/dsregcmd/derive.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/derive.rs
@@ -412,13 +412,15 @@ pub(super) fn has_any_code(facts: &DsregcmdFacts, codes: &[&str]) -> bool {
 }
 /// Match a Win32 error by decimal value or lowercase hex form (`1312` or
 /// `0x520`) as a whole token, so codes embedded in larger numbers or hex
-/// HRESULTs do not false-positive.
+/// HRESULTs do not false-positive. Surrounding punctuation such as brackets
+/// or commas is ignored.
 pub(super) fn contains_win32_code(aggregated: &str, decimal: u32) -> bool {
     let decimal_text = decimal.to_string();
     let hex_text = format!("0x{decimal:x}");
-    aggregated
-        .split_whitespace()
-        .any(|token| token == decimal_text || token == hex_text)
+    aggregated.split_whitespace().any(|token| {
+        let token = token.trim_matches(|c: char| !c.is_ascii_alphanumeric());
+        token == decimal_text || token == hex_text
+    })
 }
 
 pub(super) fn is_failure(field: &Option<String>) -> bool {

--- a/crates/cmtraceopen-parser/src/dsregcmd/extended.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/extended.rs
@@ -328,7 +328,7 @@ pub fn build_active_diagnostics_rules(
     if let Some(scp) = active.scp_query.as_ref() {
         let is_domain_joined = result.facts.join_state.domain_joined == Some(true);
 
-        if !scp.scp_found && is_domain_joined {
+        if !scp.scp_found && is_domain_joined && scp.error.is_none() {
             diagnostics.push(issue(
                 "scp-not-found",
                 IntuneDiagnosticSeverity::Error,
@@ -400,8 +400,7 @@ pub fn build_event_log_diagnostics(
         let message_lower = e.message.to_ascii_lowercase();
         (channel_display.contains("time service") || channel_display.contains("system"))
             && (message_lower.contains("time skew")
-                || message_lower.contains("time synchronization")
-                || message_lower.contains("clock"))
+                || message_lower.contains("time synchronization"))
     });
 
     if time_sync_errors && has_join_failures {

--- a/crates/cmtraceopen-parser/src/dsregcmd/extended.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/extended.rs
@@ -328,7 +328,16 @@ pub fn build_active_diagnostics_rules(
     if let Some(scp) = active.scp_query.as_ref() {
         let is_domain_joined = result.facts.join_state.domain_joined == Some(true);
 
-        if !scp.scp_found && is_domain_joined && scp.error.is_none() {
+        // A query that found the SCP object but no keywords is a real
+        // configuration signal, not a tooling failure: report it. Other query
+        // errors (missing AD module, nltest/PowerShell failures) are coverage
+        // gaps and must not be reported as SCP absence. The sentinel text is
+        // produced by the single keywordless path in connectivity::query_scp.
+        let scp_query_failed = scp
+            .error
+            .as_deref()
+            .is_some_and(|error| !error.contains("no keywords"));
+        if !scp.scp_found && is_domain_joined && !scp_query_failed {
             diagnostics.push(issue(
                 "scp-not-found",
                 IntuneDiagnosticSeverity::Error,

--- a/crates/cmtraceopen-parser/src/dsregcmd/models.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/models.rs
@@ -287,7 +287,6 @@ pub struct DsregcmdProxyEvidence {
     pub proxy_override: Option<String>,
     pub auto_config_url: Option<String>,
     pub wpad_detected: bool,
-    pub winhttp_proxy: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]

--- a/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
@@ -2148,6 +2148,24 @@ mod tests {
             "bracket-adjacent 1312 token should fire the replication rule"
         );
     }
+    #[test]
+    fn ad_replication_rule_matches_zero_padded_hex_form() {
+        let sample = r#"
+ AzureAdJoined : NO
+ DomainJoined : YES
+ AzureAdPrt : NO
+ Server ErrorCode : 0x00000520
+"#;
+        let facts = parse_dsregcmd(sample).expect("parse sample");
+        let analysis = analyze_facts(facts, sample);
+        assert!(
+            analysis
+                .diagnostics
+                .iter()
+                .any(|d| d.id == "ad-replication-issue"),
+            "zero-padded hex form of 1312 should fire the replication rule"
+        );
+    }
 
     #[test]
     fn has_code_matches_ad_connectivity_test_field() {

--- a/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
@@ -858,16 +858,42 @@ fn build_diagnostics(
     if contains_win32_code(&aggregated_errors, 1312)
         || contains_win32_code(&aggregated_errors, 1317)
     {
+        let mut evidence = Vec::new();
+        for (label, value) in [
+            (
+                "Client ErrorCode",
+                facts.registration.client_error_code.as_deref(),
+            ),
+            (
+                "Server ErrorCode",
+                facts.registration.server_error_code.as_deref(),
+            ),
+            (
+                "Server Message",
+                facts.registration.server_message.as_deref(),
+            ),
+            (
+                "Server Error Description",
+                facts.registration.server_error_description.as_deref(),
+            ),
+            ("Attempt Status", facts.diagnostics.attempt_status.as_deref()),
+            ("HTTP Error", facts.diagnostics.http_error.as_deref()),
+        ] {
+            if let Some(value) = value {
+                let lower = value.to_ascii_lowercase();
+                if contains_win32_code(&lower, 1312) || contains_win32_code(&lower, 1317) {
+                    evidence.push(format!("{label}: {value}"));
+                }
+            }
+        }
+
         diagnostics.push(issue(
             "ad-replication-issue",
             IntuneDiagnosticSeverity::Error,
             "dynamic",
             "AD object lookup or logon-session error detected",
             "The aggregated registration errors contain 1312 (ERROR_NO_SUCH_LOGON_SESSION) or 1317 (ERROR_NO_SUCH_DOMAIN), which point to an AD object lookup or logon-session problem during hybrid join.",
-            vec![
-                render_optional("Client ErrorCode", &facts.registration.client_error_code),
-                render_optional("Server ErrorCode", &facts.registration.server_error_code),
-            ],
+            evidence,
             vec![
                 "Verify the computer account exists and is consistent across domain controllers.".to_string(),
                 "Confirm the domain is reachable and resolves correctly from the device.".to_string(),

--- a/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
@@ -4,9 +4,9 @@ use crate::dsregcmd::models::{
 use crate::intune::models::IntuneDiagnosticSeverity;
 
 use super::derive::{
-    aggregated_error_text, contains_text, derive_facts, equals_text, has_code, is_failure,
-    is_failure_text, is_missing, issue, push_test_failure, render_bool, render_optional,
-    render_phase_code_evidence,
+    aggregated_error_text, contains_text, contains_win32_code, derive_facts, equals_text, has_code,
+    is_failure, is_failure_text, is_missing, issue, push_test_failure, render_bool,
+    render_optional, render_phase_code_evidence,
 };
 
 // Re-export public items that external callers depend on.
@@ -744,17 +744,22 @@ fn build_diagnostics(
         ));
     }
 
-    if contains_text(&facts.registration.server_error_description, "aadsts50126") {
+    if contains_text(&facts.registration.server_error_description, "aadsts50126")
+        || contains_text(&facts.registration.server_message, "aadsts50126")
+    {
         diagnostics.push(issue(
             "aadsts50126-detailed",
             IntuneDiagnosticSeverity::Error,
             "credentials",
             "Server error description reports AADSTS50126",
             "The detailed server error description indicates invalid username or password during authentication.",
-            vec![render_optional(
-                "Server Error Description",
-                &facts.registration.server_error_description,
-            )],
+            vec![
+                render_optional("Server Message", &facts.registration.server_message),
+                render_optional(
+                    "Server Error Description",
+                    &facts.registration.server_error_description,
+                ),
+            ],
             vec![
                 "Compare the user identity in dsregcmd with the expected sign-in account.".to_string(),
                 "Review conditional access or federation prompts that may have redirected the flow.".to_string(),
@@ -850,7 +855,9 @@ fn build_diagnostics(
         ));
     }
 
-    if aggregated_errors.contains("1312") || aggregated_errors.contains("1317") {
+    if contains_win32_code(&aggregated_errors, 1312)
+        || contains_win32_code(&aggregated_errors, 1317)
+    {
         diagnostics.push(issue(
             "ad-replication-issue",
             IntuneDiagnosticSeverity::Error,
@@ -944,21 +951,6 @@ fn build_diagnostics(
                 "Review whether the user is fully signed in to Windows with a work account.".to_string(),
             ],
             vec!["Refresh the account session or sign in again to restore WAM defaults.".to_string()],
-        ));
-    }
-
-    if contains_text(&facts.registration.server_message, "aadsts50126") {
-        diagnostics.push(issue(
-            "aadsts50126",
-            IntuneDiagnosticSeverity::Warning,
-            "credentials",
-            "Server message reports AADSTS50126",
-            "The high-level server message indicates invalid credentials or an authentication mismatch.",
-            vec![render_optional("Server Message", &facts.registration.server_message)],
-            vec![
-                "Compare the user identity, credential type, and endpoint URI in the diagnostics block.".to_string(),
-            ],
-            vec!["Retry sign-in with the correct account and credentials.".to_string()],
         ));
     }
 
@@ -1381,32 +1373,6 @@ fn build_diagnostics(
         }
     }
 
-    // Enhanced SCP heuristic — SCP tenant mismatch hint
-    if is_failure(&facts.pre_join_tests.drs_discovery_test)
-        && is_failure(&facts.pre_join_tests.ad_configuration_test)
-        && facts.tenant_details.tenant_id.is_some()
-    {
-        diagnostics.push(issue(
-            "scp-tenant-mismatch-hint",
-            IntuneDiagnosticSeverity::Warning,
-            "configuration",
-            "Check SCP tenant alignment after migration or reconfiguration",
-            "Both DRS discovery and AD configuration tests failed while tenant details are present. This pattern can occur when the SCP points to a different tenant than expected, such as after a tenant migration or domain reconfiguration.",
-            vec![
-                render_optional("DRS Discovery Test", &facts.pre_join_tests.drs_discovery_test),
-                render_optional("AD Configuration Test", &facts.pre_join_tests.ad_configuration_test),
-                render_optional("TenantId", &facts.tenant_details.tenant_id),
-            ],
-            vec![
-                "Compare the tenant ID in the SCP with the expected target tenant.".to_string(),
-                "Check if the organization recently migrated tenants or reconfigured hybrid join.".to_string(),
-            ],
-            vec![
-                "Update the SCP to point to the correct tenant domain and re-run Azure AD Connect.".to_string(),
-            ],
-        ));
-    }
-
     diagnostics
 }
 
@@ -1545,7 +1511,6 @@ mod tests {
             "ad-connectivity-failed",
             "invalid-credentials",
             "aadsts50126-detailed",
-            "aadsts50126",
             "network-issue",
             "stale-prt",
             "no-tpm-protection",
@@ -1935,53 +1900,6 @@ mod tests {
     }
 
     #[test]
-    fn emits_scp_tenant_mismatch_hint_when_both_tests_fail() {
-        let sample = r#"
- AzureAdJoined : NO
- DomainJoined : YES
- WorkplaceJoined : NO
- TenantId : 11111111-2222-3333-4444-555555555555
- AzureAdPrt : NO
- DRS Discovery Test : FAIL [0x801c0021]
- AD Configuration Test : FAIL [0x801c001d]
-"#;
-        let facts = parse_dsregcmd(sample).expect("parse tenant mismatch sample");
-        let analysis = analyze_facts(facts, sample);
-        let ids: Vec<&str> = analysis.diagnostics.iter().map(|i| i.id.as_str()).collect();
-
-        assert!(
-            ids.contains(&"scp-tenant-mismatch-hint"),
-            "missing scp-tenant-mismatch-hint"
-        );
-        let rule = analysis
-            .diagnostics
-            .iter()
-            .find(|i| i.id == "scp-tenant-mismatch-hint")
-            .unwrap();
-        assert_eq!(rule.severity, IntuneDiagnosticSeverity::Warning);
-    }
-
-    #[test]
-    fn does_not_emit_scp_tenant_mismatch_without_tenant_id() {
-        let sample = r#"
- AzureAdJoined : NO
- DomainJoined : YES
- WorkplaceJoined : NO
- AzureAdPrt : NO
- DRS Discovery Test : FAIL [0x801c0021]
- AD Configuration Test : FAIL [0x801c001d]
-"#;
-        let facts = parse_dsregcmd(sample).expect("parse no tenant sample");
-        let analysis = analyze_facts(facts, sample);
-        let ids: Vec<&str> = analysis.diagnostics.iter().map(|i| i.id.as_str()).collect();
-
-        assert!(
-            !ids.contains(&"scp-tenant-mismatch-hint"),
-            "should not fire without tenant ID"
-        );
-    }
-
-    #[test]
     fn mdm_confirmed_via_registry_diagnostic_fires_when_cross_referenced() {
         use super::{apply_enrollment_cross_reference, build_extended_diagnostics};
         use crate::dsregcmd::models::{
@@ -2104,6 +2022,197 @@ mod tests {
                 .iter()
                 .any(|d| d.id == "enrollment-missing-on-joined"),
             "enrollment-missing-on-joined should be suppressed when cross-reference confirms MDM"
+        );
+    }
+    #[test]
+    fn scp_not_found_suppressed_when_scp_query_errored() {
+        use super::build_active_diagnostics_rules;
+        use crate::dsregcmd::models::{DsregcmdActiveEvidence, DsregcmdScpQueryResult};
+
+        let facts = parse_dsregcmd(NOT_JOINED_SAMPLE).expect("parse sample");
+        let mut result = analyze_facts(facts, NOT_JOINED_SAMPLE);
+        result.facts.join_state.domain_joined = Some(true);
+        result.active_evidence = Some(DsregcmdActiveEvidence {
+            connectivity_tests: Vec::new(),
+            scp_query: Some(DsregcmdScpQueryResult {
+                scp_found: false,
+                tenant_domain: None,
+                azuread_id: None,
+                keywords: Vec::new(),
+                domain_controller: None,
+                error: Some("Get-ADForest is not available on this device".to_string()),
+            }),
+        });
+
+        let extended = build_active_diagnostics_rules(&result);
+        assert!(
+            !extended.iter().any(|d| d.id == "scp-not-found"),
+            "scp-not-found must not fire when the SCP query itself failed"
+        );
+    }
+
+    #[test]
+    fn stale_prt_not_derived_without_client_time() {
+        let sample = r#"
+ AzureAdJoined : YES
+ DomainJoined : NO
+ AzureAdPrt : YES
+ AzureAdPrtUpdateTime : 2025-03-10 05:00:00.000 UTC
+"#;
+        let facts = parse_dsregcmd(sample).expect("parse sample");
+        let analysis = analyze_facts(facts, sample);
+
+        assert_eq!(analysis.derived.prt_age_hours, None);
+        assert_eq!(analysis.derived.stale_prt, None);
+        assert_eq!(analysis.derived.certificate_days_remaining, None);
+    }
+
+    #[test]
+    fn ad_replication_rule_does_not_match_substring_codes() {
+        let sample = r#"
+ AzureAdJoined : NO
+ DomainJoined : YES
+ AzureAdPrt : NO
+ Server ErrorCode : 0x80071312
+"#;
+        let facts = parse_dsregcmd(sample).expect("parse sample");
+        let analysis = analyze_facts(facts, sample);
+        assert!(
+            !analysis
+                .diagnostics
+                .iter()
+                .any(|d| d.id == "ad-replication-issue"),
+            "0x80071312 must not match the 1312 replication rule"
+        );
+    }
+
+    #[test]
+    fn ad_replication_rule_fires_on_exact_1312_token() {
+        let sample = r#"
+ AzureAdJoined : NO
+ DomainJoined : YES
+ AzureAdPrt : NO
+ Server ErrorCode : 1312
+"#;
+        let facts = parse_dsregcmd(sample).expect("parse sample");
+        let analysis = analyze_facts(facts, sample);
+        assert!(
+            analysis
+                .diagnostics
+                .iter()
+                .any(|d| d.id == "ad-replication-issue"),
+            "exact 1312 token should fire the replication rule"
+        );
+    }
+
+    #[test]
+    fn has_code_matches_ad_connectivity_test_field() {
+        let sample = r#"
+ AzureAdJoined : NO
+ DomainJoined : YES
+ AzureAdPrt : NO
+ AD Connectivity Test : FAIL [0xcaa90017]
+"#;
+        let facts = parse_dsregcmd(sample).expect("parse sample");
+        let analysis = analyze_facts(facts, sample);
+        assert!(
+            analysis
+                .diagnostics
+                .iter()
+                .any(|d| d.id == "adal-protocol-not-supported"),
+            "ADAL codes in AD Connectivity Test should match has_code rules"
+        );
+    }
+
+    #[test]
+    fn certificate_validity_with_single_timestamp_not_parsed_as_expiry() {
+        let sample = r#"
+ AzureAdJoined : YES
+ DomainJoined : NO
+ AzureAdPrt : YES
+ DeviceCertificateValidity : [ 2025-03-01 00:00:00.000 UTC -- ]
+"#;
+        let facts = parse_dsregcmd(sample).expect("parse sample");
+        let analysis = analyze_facts(facts, sample);
+        assert_eq!(analysis.derived.certificate_valid_from, None);
+        assert_eq!(analysis.derived.certificate_valid_to, None);
+    }
+
+    #[test]
+    fn aadsts50126_fires_from_server_message_alone() {
+        let sample = r#"
+ AzureAdJoined : NO
+ DomainJoined : YES
+ AzureAdPrt : NO
+ Server Message : AADSTS50126 Invalid username or password
+"#;
+        let facts = parse_dsregcmd(sample).expect("parse sample");
+        let analysis = analyze_facts(facts, sample);
+        assert!(
+            analysis
+                .diagnostics
+                .iter()
+                .any(|d| d.id == "aadsts50126-detailed"),
+            "server message AADSTS50126 should fire the detailed rule"
+        );
+    }
+
+    #[test]
+    fn time_skew_rule_requires_time_specific_messages() {
+        use super::build_event_log_diagnostics;
+        use crate::intune::models::{
+            EventLogAnalysis, EventLogAnalysisSource, EventLogChannel, EventLogEntry,
+            EventLogSeverity,
+        };
+
+        let facts = parse_dsregcmd(NOT_JOINED_SAMPLE).expect("parse sample");
+        let mut result = analyze_facts(facts, NOT_JOINED_SAMPLE);
+        result.event_log_analysis = Some(EventLogAnalysis {
+            source_kind: EventLogAnalysisSource::Bundle,
+            entries: vec![EventLogEntry {
+                id: 1,
+                channel: EventLogChannel::SystemLog,
+                channel_display: "System".to_string(),
+                provider: "SomeProvider".to_string(),
+                event_id: 100,
+                severity: EventLogSeverity::Warning,
+                timestamp: "2026-01-01T00:00:00.000Z".to_string(),
+                computer: None,
+                message: "The service clocked a new request".to_string(),
+                correlation_activity_id: None,
+                source_file: "System.evtx".to_string(),
+            }],
+            channel_summaries: Vec::new(),
+            correlation_links: Vec::new(),
+            parsed_file_count: 1,
+            total_entry_count: 1,
+            error_entry_count: 0,
+            warning_entry_count: 1,
+            timestamp_bounds: None,
+            live_query: None,
+        });
+
+        let extended = build_event_log_diagnostics(&result);
+        assert!(
+            !extended.iter().any(|d| d.id == "event-log-time-skew"),
+            "a System entry mentioning 'clock' without time-sync context must not fire the rule"
+        );
+    }
+
+    #[test]
+    fn pre_join_failures_dominate_prt_fields_on_not_joined_device() {
+        let sample = r#"
+ AzureAdJoined : NO
+ DomainJoined : YES
+ AzureAdPrt : NO
+ DRS Discovery Test : FAIL [0x801c0021]
+ Attempt Status : 0xc000006d
+"#;
+        let facts = parse_dsregcmd(sample).expect("parse sample");
+        let analysis = analyze_facts(facts, sample);
+        assert_eq!(
+            analysis.derived.dominant_phase,
+            DsregcmdDiagnosticPhase::Discover
         );
     }
 }

--- a/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
@@ -751,8 +751,8 @@ fn build_diagnostics(
             "aadsts50126-detailed",
             IntuneDiagnosticSeverity::Error,
             "credentials",
-            "Server error description reports AADSTS50126",
-            "The detailed server error description indicates invalid username or password during authentication.",
+            "Server error reports AADSTS50126",
+            "The server error fields indicate invalid username or password during authentication.",
             vec![
                 render_optional("Server Message", &facts.registration.server_message),
                 render_optional(
@@ -2102,6 +2102,24 @@ mod tests {
                 .iter()
                 .any(|d| d.id == "ad-replication-issue"),
             "exact 1312 token should fire the replication rule"
+        );
+    }
+    #[test]
+    fn ad_replication_rule_matches_punctuation_adjacent_tokens() {
+        let sample = r#"
+ AzureAdJoined : NO
+ DomainJoined : YES
+ AzureAdPrt : NO
+ Server ErrorCode : [1312]
+"#;
+        let facts = parse_dsregcmd(sample).expect("parse sample");
+        let analysis = analyze_facts(facts, sample);
+        assert!(
+            analysis
+                .diagnostics
+                .iter()
+                .any(|d| d.id == "ad-replication-issue"),
+            "bracket-adjacent 1312 token should fire the replication rule"
         );
     }
 

--- a/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
@@ -2050,6 +2050,32 @@ mod tests {
             "scp-not-found must not fire when the SCP query itself failed"
         );
     }
+    #[test]
+    fn scp_not_found_fires_for_keywordless_scp_object() {
+        use super::build_active_diagnostics_rules;
+        use crate::dsregcmd::models::{DsregcmdActiveEvidence, DsregcmdScpQueryResult};
+
+        let facts = parse_dsregcmd(NOT_JOINED_SAMPLE).expect("parse sample");
+        let mut result = analyze_facts(facts, NOT_JOINED_SAMPLE);
+        result.facts.join_state.domain_joined = Some(true);
+        result.active_evidence = Some(DsregcmdActiveEvidence {
+            connectivity_tests: Vec::new(),
+            scp_query: Some(DsregcmdScpQueryResult {
+                scp_found: false,
+                tenant_domain: None,
+                azuread_id: None,
+                keywords: Vec::new(),
+                domain_controller: None,
+                error: Some("SCP object exists but has no keywords.".to_string()),
+            }),
+        });
+
+        let extended = build_active_diagnostics_rules(&result);
+        assert!(
+            extended.iter().any(|d| d.id == "scp-not-found"),
+            "a keywordless SCP object is a configuration signal and must fire"
+        );
+    }
 
     #[test]
     fn stale_prt_not_derived_without_client_time() {

--- a/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
@@ -862,17 +862,17 @@ fn build_diagnostics(
             "ad-replication-issue",
             IntuneDiagnosticSeverity::Error,
             "dynamic",
-            "Directory replication or lookup issue detected",
-            "The aggregated registration errors contain 1312 or 1317, which commonly show up during AD replication or object lookup problems.",
+            "AD object lookup or logon-session error detected",
+            "The aggregated registration errors contain 1312 (ERROR_NO_SUCH_LOGON_SESSION) or 1317 (ERROR_NO_SUCH_DOMAIN), which point to an AD object lookup or logon-session problem during hybrid join.",
             vec![
                 render_optional("Client ErrorCode", &facts.registration.client_error_code),
                 render_optional("Server ErrorCode", &facts.registration.server_error_code),
             ],
             vec![
-                "Check the health of the on-premises AD object and replication status.".to_string(),
                 "Verify the computer account exists and is consistent across domain controllers.".to_string(),
+                "Confirm the domain is reachable and resolves correctly from the device.".to_string(),
             ],
-            vec!["Resolve the directory replication issue, then retry hybrid join.".to_string()],
+            vec!["Resolve the directory lookup or logon-session issue, then retry hybrid join.".to_string()],
         ));
     }
 

--- a/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
+++ b/crates/cmtraceopen-parser/src/dsregcmd/rules.rs
@@ -2192,6 +2192,43 @@ mod tests {
             "zero-padded hex form of 1312 should fire the replication rule"
         );
     }
+    #[test]
+    fn ad_replication_rule_matches_slash_delimited_code_lists() {
+        let sample = r#"
+ AzureAdJoined : NO
+ DomainJoined : YES
+ AzureAdPrt : NO
+ Server ErrorCode : 0x801c0021/1312
+"#;
+        let facts = parse_dsregcmd(sample).expect("parse sample");
+        let analysis = analyze_facts(facts, sample);
+        assert!(
+            analysis
+                .diagnostics
+                .iter()
+                .any(|d| d.id == "ad-replication-issue"),
+            "slash-delimited code lists should be evaluated per code"
+        );
+    }
+
+    #[test]
+    fn ad_replication_rule_does_not_match_embedded_name() {
+        let sample = r#"
+ AzureAdJoined : NO
+ DomainJoined : YES
+ AzureAdPrt : NO
+ Server Message : ERROR_1312 occurred
+"#;
+        let facts = parse_dsregcmd(sample).expect("parse sample");
+        let analysis = analyze_facts(facts, sample);
+        assert!(
+            !analysis
+                .diagnostics
+                .iter()
+                .any(|d| d.id == "ad-replication-issue"),
+            "ERROR_1312 is a name, not a standalone code"
+        );
+    }
 
     #[test]
     fn has_code_matches_ad_connectivity_test_field() {

--- a/src-tauri/src/commands/dsregcmd.rs
+++ b/src-tauri/src/commands/dsregcmd.rs
@@ -75,16 +75,6 @@ pub fn analyze_dsregcmd(
     extended.append(&mut rules::build_event_log_diagnostics(&result));
     result.diagnostics.append(&mut extended);
 
-    // A specific endpoint-unreachable rule is stronger evidence than the
-    // generic network marker warning; drop the generic one when it fired.
-    if result
-        .diagnostics
-        .iter()
-        .any(|d| d.id.starts_with("endpoint-unreachable-"))
-    {
-        result.diagnostics.retain(|d| d.id != "network-issue");
-    }
-
     log::info!(
         "event=dsregcmd_analysis_complete diagnostics_count={} join_type={:?}",
         result.diagnostics.len(),
@@ -1152,7 +1142,7 @@ mod tests {
         assert!(error.to_string().contains("only supported on Windows"));
     }
     #[test]
-    fn network_issue_suppressed_when_endpoint_unreachable_diagnostic_present() {
+    fn network_issue_and_endpoint_unreachable_both_fire() {
         use super::analyze_dsregcmd;
 
         let temp_dir = tempfile::tempdir().expect("create temp dir");
@@ -1186,8 +1176,8 @@ mod tests {
             "endpoint-unreachable-drs should fire for the unreachable DRS endpoint"
         );
         assert!(
-            !result.diagnostics.iter().any(|d| d.id == "network-issue"),
-            "network-issue should be suppressed when a specific endpoint rule fired"
+            result.diagnostics.iter().any(|d| d.id == "network-issue"),
+            "network-issue carries the marker code from the capture text and is independent evidence"
         );
     }
 }

--- a/src-tauri/src/commands/dsregcmd.rs
+++ b/src-tauri/src/commands/dsregcmd.rs
@@ -75,6 +75,16 @@ pub fn analyze_dsregcmd(
     extended.append(&mut rules::build_event_log_diagnostics(&result));
     result.diagnostics.append(&mut extended);
 
+    // A specific endpoint-unreachable rule is stronger evidence than the
+    // generic network marker warning; drop the generic one when it fired.
+    if result
+        .diagnostics
+        .iter()
+        .any(|d| d.id.starts_with("endpoint-unreachable-"))
+    {
+        result.diagnostics.retain(|d| d.id != "network-issue");
+    }
+
     log::info!(
         "event=dsregcmd_analysis_complete diagnostics_count={} join_type={:?}",
         result.diagnostics.len(),
@@ -93,15 +103,36 @@ fn load_active_evidence_from_bundle(
     let scp_path = connectivity_dir.join("scp-query.json");
 
     let connectivity_tests: Vec<crate::dsregcmd::DsregcmdConnectivityResult> =
-        std::fs::read_to_string(&tests_path)
-            .ok()
-            .and_then(|json| serde_json::from_str(&json).ok())
-            .unwrap_or_default();
+        match std::fs::read_to_string(&tests_path) {
+            Ok(json) => match serde_json::from_str(&json) {
+                Ok(tests) => tests,
+                Err(error) => {
+                    log::warn!(
+                        "event=dsregcmd_connectivity_tests_parse_failed path={} error={}",
+                        tests_path.display(),
+                        error
+                    );
+                    Vec::new()
+                }
+            },
+            Err(_) => Vec::new(),
+        };
 
     let scp_query: Option<crate::dsregcmd::DsregcmdScpQueryResult> =
-        std::fs::read_to_string(&scp_path)
-            .ok()
-            .and_then(|json| serde_json::from_str(&json).ok());
+        match std::fs::read_to_string(&scp_path) {
+            Ok(json) => match serde_json::from_str(&json) {
+                Ok(query) => Some(query),
+                Err(error) => {
+                    log::warn!(
+                        "event=dsregcmd_scp_query_parse_failed path={} error={}",
+                        scp_path.display(),
+                        error
+                    );
+                    None
+                }
+            },
+            Err(_) => None,
+        };
 
     if connectivity_tests.is_empty() && scp_query.is_none() {
         return None;
@@ -120,9 +151,20 @@ fn load_event_log_from_bundle(
         .join("evidence")
         .join("event-logs")
         .join("dsregcmd-events.json");
-    std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|json| serde_json::from_str(&json).ok())
+    match std::fs::read_to_string(&path) {
+        Ok(json) => match serde_json::from_str(&json) {
+            Ok(analysis) => Some(analysis),
+            Err(error) => {
+                log::warn!(
+                    "event=dsregcmd_event_log_parse_failed path={} error={}",
+                    path.display(),
+                    error
+                );
+                None
+            }
+        },
+        Err(_) => None,
+    }
 }
 
 fn load_scheduled_task_evidence_from_bundle(
@@ -132,9 +174,20 @@ fn load_scheduled_task_evidence_from_bundle(
         .join("evidence")
         .join("scheduled-tasks")
         .join("enterprise-mgmt-tasks.json");
-    std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|json| serde_json::from_str(&json).ok())
+    match std::fs::read_to_string(&path) {
+        Ok(json) => match serde_json::from_str(&json) {
+            Ok(evidence) => Some(evidence),
+            Err(error) => {
+                log::warn!(
+                    "event=dsregcmd_scheduled_tasks_parse_failed path={} error={}",
+                    path.display(),
+                    error
+                );
+                None
+            }
+        },
+        Err(_) => None,
+    }
 }
 
 #[tauri::command]
@@ -719,6 +772,8 @@ fn verify_dsregcmd_signature(dsregcmd_path: &Path) -> Result<(), crate::error::A
         pg_known_subject: null(),
     };
 
+    // WTD_REVOKE_NONE: no revocation network check. Acceptable for a local
+    // signed system binary; keeps verification offline and deterministic.
     let mut trust_data = WinTrustData {
         cb_struct: std::mem::size_of::<WinTrustData>() as u32,
         p_policy_callback_data: null_mut(),
@@ -1095,5 +1150,44 @@ mod tests {
     fn capture_command_returns_clear_error_on_unsupported_platform() {
         let error = capture_dsregcmd().expect_err("expected unsupported platform error");
         assert!(error.to_string().contains("only supported on Windows"));
+    }
+    #[test]
+    fn network_issue_suppressed_when_endpoint_unreachable_diagnostic_present() {
+        use super::analyze_dsregcmd;
+
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let connectivity_dir = temp_dir.path().join("evidence").join("connectivity");
+        std::fs::create_dir_all(&connectivity_dir).expect("create connectivity dir");
+        std::fs::write(
+            connectivity_dir.join("endpoint-tests.json"),
+            r#"[{"endpoint":"https://enterpriseregistration.windows.net","reachable":false,"statusCode":null,"latencyMs":100,"errorMessage":"timeout","timestamp":"2026-01-01T00:00:00Z"}]"#,
+        )
+        .expect("write endpoint tests");
+
+        let input = r#"
+ AzureAdJoined : NO
+ DomainJoined : YES
+ AzureAdPrt : NO
+ DRS Discovery Test : FAIL [0x801c0021]
+ Server Message : ERROR_WINHTTP_TIMEOUT
+"#;
+
+        let result = analyze_dsregcmd(
+            input.to_string(),
+            Some(temp_dir.path().to_string_lossy().to_string()),
+        )
+        .expect("analyze dsregcmd");
+
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|d| d.id == "endpoint-unreachable-drs"),
+            "endpoint-unreachable-drs should fire for the unreachable DRS endpoint"
+        );
+        assert!(
+            !result.diagnostics.iter().any(|d| d.id == "network-issue"),
+            "network-issue should be suppressed when a specific endpoint rule fired"
+        );
     }
 }

--- a/src-tauri/src/dsregcmd/connectivity.rs
+++ b/src-tauri/src/dsregcmd/connectivity.rs
@@ -60,8 +60,10 @@ pub fn test_endpoint_connectivity() -> Vec<DsregcmdConnectivityResult> {
 #[cfg(target_os = "windows")]
 pub fn query_scp() -> DsregcmdScpQueryResult {
     let mut result = DsregcmdScpQueryResult::default();
+    let mut nltest_error: Option<String> = None;
 
-    // Try to find a domain controller via nltest
+    // Try to find a domain controller via nltest. Failure here is not fatal:
+    // the PowerShell SCP query below can still succeed without a DC name.
     let dc_output = crate::process_util::hidden_command("nltest")
         .arg("/dsgetdc:")
         .output();
@@ -86,7 +88,7 @@ pub fn query_scp() -> DsregcmdScpQueryResult {
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
             let exit_code = output.status.code().unwrap_or_default();
-            result.error = Some(format!(
+            nltest_error = Some(format!(
                 "nltest /dsgetdc: failed (exit code {}): {}",
                 exit_code,
                 if stderr.is_empty() {
@@ -95,11 +97,9 @@ pub fn query_scp() -> DsregcmdScpQueryResult {
                     &stderr
                 }
             ));
-            return result;
         }
         Err(e) => {
-            result.error = Some(format!("nltest not available: {e}"));
-            return result;
+            nltest_error = Some(format!("nltest not available: {e}"));
         }
     }
 
@@ -154,10 +154,16 @@ try {
         }
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-            result.error = Some(format!("PowerShell SCP query failed: {stderr}"));
+            result.error = Some(match nltest_error {
+                Some(nltest) => format!("{nltest}; PowerShell SCP query failed: {stderr}"),
+                None => format!("PowerShell SCP query failed: {stderr}"),
+            });
         }
         Err(e) => {
-            result.error = Some(format!("PowerShell not available: {e}"));
+            result.error = Some(match nltest_error {
+                Some(nltest) => format!("{nltest}; PowerShell not available: {e}"),
+                None => format!("PowerShell not available: {e}"),
+            });
         }
     }
 

--- a/src-tauri/src/dsregcmd/registry.rs
+++ b/src-tauri/src/dsregcmd/registry.rs
@@ -19,7 +19,6 @@ const HKCU_MICROSOFT_POLICIES_FILE: &str = "hkcu-microsoft-policies.reg";
 const HKLM_MICROSOFT_POLICIES_FILE: &str = "hklm-microsoft-policies.reg";
 const OS_VERSION_FILE: &str = "os-version.reg";
 const PROXY_INTERNET_SETTINGS_FILE: &str = "proxy-internet-settings.reg";
-const PROXY_CONNECTIONS_FILE: &str = "proxy-connections.reg";
 const ENROLLMENTS_FILE: &str = "enrollments.reg";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -210,11 +209,9 @@ pub fn load_os_version_evidence(bundle_path: &Path) -> Option<DsregcmdOsVersionE
 
 pub fn load_proxy_evidence(bundle_path: &Path) -> Option<DsregcmdProxyEvidence> {
     let ie_path = registry_file_path(bundle_path, PROXY_INTERNET_SETTINGS_FILE);
-    let conn_path = registry_file_path(bundle_path, PROXY_CONNECTIONS_FILE);
 
     let mut artifact_paths = Vec::new();
     let ie_registry = load_registry_map(&ie_path, &mut artifact_paths);
-    let conn_registry = load_registry_map(&conn_path, &mut artifact_paths);
 
     if artifact_paths.is_empty() {
         return None;
@@ -234,18 +231,8 @@ pub fn load_proxy_evidence(bundle_path: &Path) -> Option<DsregcmdProxyEvidence> 
         break;
     }
 
-    if let Some(ref url) = evidence.auto_config_url {
+    if let Some(url) = &evidence.auto_config_url {
         evidence.wpad_detected = url.to_ascii_lowercase().contains("wpad");
-    }
-
-    // Check for WinHTTP proxy in connections registry
-    for (key_path, values) in &conn_registry {
-        let lower = key_path.to_ascii_lowercase();
-        if lower.contains("\\internet settings\\connections") {
-            evidence.winhttp_proxy = extract_string_value(values, "WinHttpSettings")
-                .or_else(|| extract_string_value(values, "DefaultConnectionSettings"));
-            break;
-        }
     }
 
     Some(evidence)
@@ -313,7 +300,14 @@ fn extract_dword_value(values: &HashMap<String, RegistryValue>, value_name: &str
     let key = value_name.to_ascii_lowercase();
     values.get(&key).and_then(|v| match v {
         RegistryValue::Dword(d) => Some(*d),
-        RegistryValue::String(s) => s.trim().parse().ok(),
+        RegistryValue::String(s) => {
+            let trimmed = s.trim();
+            if let Some(hex) = trimmed.strip_prefix("0x") {
+                u32::from_str_radix(hex, 16).ok()
+            } else {
+                trimmed.parse().ok()
+            }
+        }
     })
 }
 
@@ -327,14 +321,17 @@ fn annotate_missing_policy_evidence(evidence: &mut DsregcmdWhfbPolicyEvidence) {
         "Registry artifacts were captured, but no mapped PassportForWork policy values were present in this bundle.".to_string(),
     );
 
-    if evidence.policy_enabled.display_value.is_none() && evidence.policy_enabled.note.is_none() {
-        evidence.policy_enabled.note = missing_note.clone();
-    }
-
-    if evidence.post_logon_enabled.display_value.is_none()
-        && evidence.post_logon_enabled.note.is_none()
-    {
-        evidence.post_logon_enabled.note = missing_note;
+    for field in [
+        &mut evidence.policy_enabled,
+        &mut evidence.post_logon_enabled,
+        &mut evidence.pin_recovery_enabled,
+        &mut evidence.require_security_device,
+        &mut evidence.use_certificate_for_on_prem_auth,
+        &mut evidence.use_cloud_trust_for_on_prem_auth,
+    ] {
+        if field.display_value.is_none() && field.note.is_none() {
+            field.note = missing_note.clone();
+        }
     }
 }
 
@@ -628,7 +625,9 @@ fn parse_registry_value(value: &str) -> Option<RegistryValue> {
 
     if value.starts_with('"') && value.ends_with('"') && value.len() >= 2 {
         return Some(RegistryValue::String(
-            value[1..value.len() - 1].replace("\\\\", "\\"),
+            value[1..value.len() - 1]
+                .replace("\\\\", "\\")
+                .replace("\\\"", "\""),
         ));
     }
 
@@ -654,6 +653,9 @@ mod tests {
         parse_reg_snapshot,
     };
     use crate::dsregcmd::models::DsregcmdEvidenceSource;
+    use std::collections::HashMap;
+
+    use super::{extract_dword_value, RegistryValue};
 
     #[test]
     fn parses_registry_snapshot_values() {
@@ -902,5 +904,63 @@ mod tests {
             admin_entry.guid.as_deref(),
             Some("{22222222-3333-4444-5555-666666666666}")
         );
+    }
+    #[test]
+    fn parses_escaped_quotes_in_registry_strings() {
+        let sample = r#"[HKEY_LOCAL_MACHINE\SOFTWARE\Test]
+"Value"="C:\\path with \"quotes\""
+"#;
+        let registry = parse_reg_snapshot(sample);
+        let values = registry
+            .get(r"HKEY_LOCAL_MACHINE\SOFTWARE\Test")
+            .expect("expected parsed key");
+        match values.get("value") {
+            Some(RegistryValue::String(value)) => {
+                assert_eq!(value, r#"C:\path with "quotes""#);
+            }
+            other => panic!("expected string value, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extracts_dword_from_hex_string() {
+        let mut values = HashMap::new();
+        values.insert(
+            "ubr".to_string(),
+            RegistryValue::String("0x00000FA0".to_string()),
+        );
+        assert_eq!(extract_dword_value(&values, "UBR"), Some(4000));
+    }
+
+    #[test]
+    fn annotates_missing_note_on_all_policy_fields() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let registry_dir = temp_dir.path().join("evidence").join("registry");
+        std::fs::create_dir_all(&registry_dir).expect("create registry dir");
+
+        std::fs::write(
+            registry_dir.join("policymanager-device.reg"),
+            r#"Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PolicyManager\Current\Device\SomeOtherPolicy]
+"Value"=dword:00000001
+"#,
+        )
+        .expect("write registry sample");
+
+        let evidence = load_whfb_policy_evidence(temp_dir.path());
+        for field in [
+            &evidence.policy_enabled,
+            &evidence.post_logon_enabled,
+            &evidence.pin_recovery_enabled,
+            &evidence.require_security_device,
+            &evidence.use_certificate_for_on_prem_auth,
+            &evidence.use_cloud_trust_for_on_prem_auth,
+        ] {
+            assert!(
+                field.note.is_some(),
+                "missing-note annotation should cover every policy field"
+            );
+        }
     }
 }

--- a/src-tauri/src/dsregcmd/registry.rs
+++ b/src-tauri/src/dsregcmd/registry.rs
@@ -921,6 +921,24 @@ mod tests {
             other => panic!("expected string value, got {other:?}"),
         }
     }
+    #[test]
+    fn preserves_literal_backslashes_before_escaped_quotes() {
+        // Encodes C:\dir + two literal backslashes + "quoted": the .reg
+        // escape chain is \\ for each literal backslash and \" for the quote.
+        let sample = r#"[HKEY_LOCAL_MACHINE\SOFTWARE\Test]
+"Value"="C:\\dir\\\\\"quoted\""
+"#;
+        let registry = parse_reg_snapshot(sample);
+        let values = registry
+            .get(r"HKEY_LOCAL_MACHINE\SOFTWARE\Test")
+            .expect("expected parsed key");
+        match values.get("value") {
+            Some(RegistryValue::String(value)) => {
+                assert_eq!(value, r#"C:\dir\\"quoted""#);
+            }
+            other => panic!("expected string value, got {other:?}"),
+        }
+    }
 
     #[test]
     fn extracts_dword_from_hex_string() {

--- a/src/workspaces/dsregcmd/DsregcmdEventLogSurface.tsx
+++ b/src/workspaces/dsregcmd/DsregcmdEventLogSurface.tsx
@@ -23,18 +23,17 @@ function channelKey(channel: EventLogChannel): string {
 }
 
 function formatTimestamp(iso: string): string {
-  try {
-    const date = new Date(iso);
-    return date.toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-  } catch {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
     return iso;
   }
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
 }
 
 function getFileName(path: string): string {
@@ -86,15 +85,15 @@ export function DsregcmdEventLogSurface({ eventLogAnalysis }: DsregcmdEventLogSu
   const uniqueChannels = useMemo(() => {
     const seen = new Set<string>();
     const channels: { key: string; display: string }[] = [];
-    for (const entry of eventLogAnalysis.entries) {
-      const key = channelKey(entry.channel);
+    for (const summary of eventLogAnalysis.channelSummaries) {
+      const key = channelKey(summary.channel);
       if (!seen.has(key)) {
         seen.add(key);
-        channels.push({ key, display: entry.channelDisplay });
+        channels.push({ key, display: summary.channelDisplay });
       }
     }
     return channels;
-  }, [eventLogAnalysis.entries]);
+  }, [eventLogAnalysis.channelSummaries]);
 
   if (eventLogAnalysis.entries.length === 0) {
     return (

--- a/src/workspaces/dsregcmd/DsregcmdSidebar.tsx
+++ b/src/workspaces/dsregcmd/DsregcmdSidebar.tsx
@@ -1,6 +1,7 @@
 import { tokens } from "@fluentui/react-components";
 import { useDsregcmdStore } from "./dsregcmd-store";
 import { useAppActions } from "../../hooks/use-app-actions";
+import type { DsregcmdSeverity } from "./types";
 import {
   EmptyState,
   SectionHeader,
@@ -24,6 +25,16 @@ export function DsregcmdSidebar() {
   const errorCount = diagnostics.filter((item) => item.severity === "Error").length;
   const warningCount = diagnostics.filter((item) => item.severity === "Warning").length;
   const infoCount = diagnostics.filter((item) => item.severity === "Info").length;
+function severityRank(severity: DsregcmdSeverity): number {
+  switch (severity) {
+    case "Error":
+      return 0;
+    case "Warning":
+      return 1;
+    case "Info":
+      return 2;
+  }
+}
 
   return (
     <>
@@ -84,7 +95,13 @@ export function DsregcmdSidebar() {
             {diagnostics.length === 0 ? (
               <EmptyState title="No diagnostics" body="The backend parser did not emit diagnostic findings for this capture." />
             ) : (
-              diagnostics.slice(0, 8).map((item) => (
+              [...diagnostics]
+                .sort(
+                  (left, right) =>
+                    severityRank(left.severity) - severityRank(right.severity),
+                )
+                .slice(0, 8)
+                .map((item) => (
                 <div key={item.id} style={{ padding: "8px 10px", borderBottom: `1px solid ${tokens.colorNeutralStroke2}`, backgroundColor: item.severity === 'Error' ? tokens.colorPaletteRedBackground1 : item.severity === 'Warning' ? tokens.colorPaletteYellowBackground1 : tokens.colorPaletteBlueBackground2 }}>
                   <div style={{ fontSize: "inherit", textTransform: "uppercase", fontWeight: 700, color: item.severity === 'Error' ? tokens.colorPaletteRedForeground2 : item.severity === 'Warning' ? tokens.colorPaletteMarigoldForeground2 : tokens.colorPaletteBlueForeground2 }}>{item.severity}</div>
                   <div style={{ marginTop: "4px", fontSize: "inherit", fontWeight: 600, color: tokens.colorNeutralForeground1 }}>{item.title}</div>

--- a/src/workspaces/dsregcmd/DsregcmdWorkspace.test.tsx
+++ b/src/workspaces/dsregcmd/DsregcmdWorkspace.test.tsx
@@ -279,7 +279,6 @@ function analysisResult(): DsregcmdAnalysisResult {
       proxyOverride: null,
       autoConfigUrl: null,
       wpadDetected: false,
-      winhttpProxy: null,
     },
     enrollmentEvidence: {
       enrollmentCount: 1,
@@ -415,5 +414,41 @@ describe("DsregcmdWorkspace fixtures", () => {
     expect(screen.getByRole("button", { name: "Save JSON..." })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save summary..." })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Show raw input" })).toBeInTheDocument();
+  });
+  it("DSREG-007 sidebar top findings are severity-sorted", () => {
+    const result = analysisResult();
+    result.diagnostics = [
+      {
+        id: "info-finding",
+        severity: "Info",
+        category: "test",
+        title: "Info finding",
+        summary: "info summary",
+        evidence: [],
+        nextChecks: [],
+        suggestedFixes: [],
+      },
+      {
+        id: "error-finding",
+        severity: "Error",
+        category: "test",
+        title: "Error finding",
+        summary: "error summary",
+        evidence: [],
+        nextChecks: [],
+        suggestedFixes: [],
+      },
+    ];
+    useDsregcmdStore
+      .getState()
+      .setResults("AzureAdJoined : YES", result, sourceContext());
+    render(<DsregcmdSidebar />);
+
+    const titles = screen
+      .getAllByText(/finding/)
+      .map((element) => element.textContent ?? "");
+    expect(titles.indexOf("Error finding")).toBeLessThan(
+      titles.indexOf("Info finding"),
+    );
   });
 });

--- a/src/workspaces/dsregcmd/dsregcmd-formatters.test.ts
+++ b/src/workspaces/dsregcmd/dsregcmd-formatters.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { toneForPrtState } from "./dsregcmd-formatters";
+
+describe("toneForPrtState", () => {
+  it("is neutral when PRT presence is unknown", () => {
+    expect(toneForPrtState(null, null)).toBe("neutral");
+  });
+
+  it("is bad when no PRT is present", () => {
+    expect(toneForPrtState(false, null)).toBe("bad");
+  });
+
+  it("is warn when the PRT is stale", () => {
+    expect(toneForPrtState(true, true)).toBe("warn");
+  });
+
+  it("is good when the PRT is present and fresh", () => {
+    expect(toneForPrtState(true, false)).toBe("good");
+  });
+
+  it("is neutral when freshness is unknown instead of claiming health", () => {
+    expect(toneForPrtState(true, null)).toBe("neutral");
+    expect(toneForPrtState(true, undefined)).toBe("neutral");
+  });
+});

--- a/src/workspaces/dsregcmd/dsregcmd-formatters.ts
+++ b/src/workspaces/dsregcmd/dsregcmd-formatters.ts
@@ -362,6 +362,12 @@ export function toneForPrtState(
     return "bad";
   }
 
+  if (stalePrt === null || stalePrt === undefined) {
+    // Freshness is unknown (no Client Time in the capture): do not claim
+    // the PRT is healthy.
+    return "neutral";
+  }
+
   return stalePrt ? "warn" : "good";
 }
 

--- a/src/workspaces/dsregcmd/fact-group-builders.test.ts
+++ b/src/workspaces/dsregcmd/fact-group-builders.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEndpointConnectivityGroup,
+  buildProxyConfigGroup,
+} from "./fact-group-builders";
+import type { DsregcmdAnalysisResult } from "./types";
+
+function resultWith(
+  overrides: Partial<DsregcmdAnalysisResult>,
+): DsregcmdAnalysisResult {
+  return {
+    facts: {} as unknown as DsregcmdAnalysisResult["facts"],
+    derived: {} as unknown as DsregcmdAnalysisResult["derived"],
+    diagnostics: [],
+    policyEvidence: {} as unknown as DsregcmdAnalysisResult["policyEvidence"],
+    osVersion: null,
+    proxyEvidence: null,
+    enrollmentEvidence: null,
+    activeEvidence: null,
+    scheduledTaskEvidence: null,
+    eventLogAnalysis: null,
+    ...overrides,
+  };
+}
+
+describe("buildEndpointConnectivityGroup", () => {
+  it("renders malformed endpoint strings without throwing", () => {
+    const result = resultWith({
+      activeEvidence: {
+        connectivityTests: [
+          {
+            endpoint: "not a url",
+            reachable: false,
+            statusCode: null,
+            latencyMs: null,
+            errorMessage: "boom",
+            timestamp: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        scpQuery: null,
+      },
+    });
+
+    const groups = buildEndpointConnectivityGroup(result);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].rows[0].label).toBe("not a url");
+  });
+});
+
+describe("buildProxyConfigGroup", () => {
+  it("does not expose the binary WinHTTP row", () => {
+    const result = resultWith({
+      proxyEvidence: {
+        proxyEnabled: true,
+        proxyServer: "http://proxy.contoso.com:8080",
+        proxyOverride: null,
+        autoConfigUrl: null,
+        wpadDetected: false,
+      },
+    });
+
+    const groups = buildProxyConfigGroup(result);
+    expect(groups).toHaveLength(1);
+    expect(
+      groups[0].rows.some((row) => row.label === "WinHTTP Proxy"),
+    ).toBe(false);
+  });
+});

--- a/src/workspaces/dsregcmd/fact-group-builders.test.ts
+++ b/src/workspaces/dsregcmd/fact-group-builders.test.ts
@@ -45,6 +45,26 @@ describe("buildEndpointConnectivityGroup", () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].rows[0].label).toBe("not a url");
   });
+  it("falls back to the endpoint text when the parsed hostname is empty", () => {
+    const result = resultWith({
+      activeEvidence: {
+        connectivityTests: [
+          {
+            endpoint: "file:///path",
+            reachable: false,
+            statusCode: null,
+            latencyMs: null,
+            errorMessage: "boom",
+            timestamp: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        scpQuery: null,
+      },
+    });
+
+    const groups = buildEndpointConnectivityGroup(result);
+    expect(groups[0].rows[0].label).toBe("file:///path");
+  });
 });
 
 describe("buildProxyConfigGroup", () => {

--- a/src/workspaces/dsregcmd/fact-group-builders.ts
+++ b/src/workspaces/dsregcmd/fact-group-builders.ts
@@ -861,7 +861,8 @@ export function buildEnterpriseMgmtTasksGroup(
 // ---------------------------------------------------------------------------
 function endpointHostname(endpoint: string): string {
   try {
-    return new URL(endpoint).hostname;
+    const hostname = new URL(endpoint).hostname;
+    return hostname || endpoint;
   } catch {
     return endpoint;
   }

--- a/src/workspaces/dsregcmd/fact-group-builders.ts
+++ b/src/workspaces/dsregcmd/fact-group-builders.ts
@@ -731,10 +731,6 @@ export function buildProxyConfigGroup(
             ? ("warn" as const)
             : ("neutral" as const),
         },
-        {
-          label: "WinHTTP Proxy",
-          value: formatValue(result.proxyEvidence.winhttpProxy),
-        },
       ]),
     },
   ];
@@ -863,6 +859,14 @@ export function buildEnterpriseMgmtTasksGroup(
 // ---------------------------------------------------------------------------
 // Endpoint Connectivity (conditional)
 // ---------------------------------------------------------------------------
+function endpointHostname(endpoint: string): string {
+  try {
+    return new URL(endpoint).hostname;
+  } catch {
+    return endpoint;
+  }
+}
+
 
 export function buildEndpointConnectivityGroup(
   result: DsregcmdAnalysisResult,
@@ -876,7 +880,7 @@ export function buildEndpointConnectivityGroup(
       title: "Endpoint Connectivity",
       caption: "Live reachability tests to required Microsoft Entra endpoints.",
       rows: result.activeEvidence.connectivityTests.map((test) => ({
-        label: new URL(test.endpoint).hostname,
+        label: endpointHostname(test.endpoint),
         value: test.reachable
           ? `Reachable${test.statusCode ? ` (${test.statusCode})` : ""}${test.latencyMs != null ? ` — ${test.latencyMs}ms` : ""}`
           : `Unreachable${test.errorMessage ? ` — ${test.errorMessage}` : ""}`,

--- a/src/workspaces/dsregcmd/types.ts
+++ b/src/workspaces/dsregcmd/types.ts
@@ -228,7 +228,6 @@ export interface DsregcmdProxyEvidence {
   proxyOverride: string | null;
   autoConfigUrl: string | null;
   wpadDetected: boolean;
-  winhttpProxy: string | null;
 }
 
 export interface DsregcmdEnrollmentEntry {


### PR DESCRIPTION
## What

Fixes the findings from the dsregcmd standing-code review (P1 false-story risks, P2 correctness, P3 minor). One seam: the dsregcmd module stack.

## Changes

**Parser crate (`cmtraceopen-parser/src/dsregcmd/`)**
- `scp-not-found` no longer fires when the SCP query itself failed — tooling failure (e.g. missing AD PowerShell module) is a coverage state, not SCP absence
- PRT age / certificate lifetime no longer computed against analysis wall-clock when `Client Time` is absent; missing timing stays a gap
- `ad-replication-issue` matches 1312/1317 as whole tokens (decimal or `0x520`/`0x525`) instead of substring; `0x80071312` no longer false-positives
- `has_code` now scans DRS/AD connectivity test fields consistently
- lone certificate validity timestamp no longer guessed as the expiry bound
- removed `scp-tenant-mismatch-hint` (fired on the common SCP-missing pattern while asserting a migration story)
- merged duplicate `aadsts50126` Warning into the detailed Error rule
- `event-log-time-skew` requires time-sync-specific messages (dropped bare "clock" matches)
- dominant phase: PRT attempt fields only dominate on joined devices; pre-join failures win on not-joined devices

**Backend (`src-tauri/`)**
- removed `winhttp_proxy` evidence: `WinHttpSettings`/`DefaultConnectionSettings` are REG_BINARY blobs that rendered as hex garbage; clean cutover from model, loader, TS type, and UI row
- `network-issue` warning suppressed when a specific `endpoint-unreachable-*` rule fired
- bundle JSON parse failures now log instead of silently dropping evidence
- SCP query continues past nltest failure instead of aborting
- registry string parsing unescapes `\"`; dword extraction accepts `0x`-prefixed strings; missing-policy annotation covers all six fields

**Frontend (`src/workspaces/dsregcmd/`)**
- endpoint hostname rendering guards malformed bundle endpoints (no render crash)
- sidebar Top Findings sorted by severity (Error > Warning > Info)
- event log timestamp formatting guards invalid dates; channel filter built from channel summaries

## Deliberately not changed

- `DsregcmdWorkspace` `stage` fallback: defensive fallback required for TS narrowing; removing it would add a non-null assertion
- `machine_policy_value`/`user_policy_value` duplication: identical predicates over different inputs, refactor risk without behavior gain
- `connectivity.rs`/`event_logs.rs` Windows-only paths: statically reviewed only, no Windows lab run in this PR

## Verification

- 15 RED tests written first (8 parser, 4 src-tauri, 3 frontend), all confirmed failing, then green
- `cargo check --workspace --all-targets` clean
- `cargo test --workspace` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean (default + no-default-features)
- `cargo check -p cmtraceopen-parser --target wasm32-unknown-unknown` clean
- `npx tsc --noEmit` clean
- `git diff --check` clean
- Parser: 35/35 dsregcmd tests; src-tauri: 14/14 dsregcmd tests; frontend: 7/7

Draft — not merge-ready. CodeRabbit + independent review pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic accuracy for device join, connectivity, authentication, certificate, time-sync, and Active Directory replication findings.
  * Preserved and combined SCP lookup errors while preventing misleading diagnostics.
  * Improved handling of malformed timestamps, registry values, escaped strings, and endpoint addresses.
  * Added broader connectivity evidence and more precise error-code matching.
  * Corrected unknown PRT freshness states to display neutrally.

* **Improvements**
  * Diagnostics are sorted by severity.
  * Proxy evidence omits WinHTTP details.
  * Event-log filtering and timestamp display are more reliable.
  * Registry policy annotations and fallback behavior are more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->